### PR TITLE
[OID4VP] Initial verifier implementation

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -145,6 +145,7 @@ public class Profile {
         OID4VC_VCI("Support for the OID4VCI protocol as part of OID4VC.", Type.EXPERIMENTAL),
         OID4VC_VCI_PREAUTH_CODE("Support for credential offers with `pre-authorized_code` grant.", Type.EXPERIMENTAL, OID4VC_VCI),
         OID4VC_VCI_REST_CREDENTIAL_OFFER("Support for the REST endpoint to create credential offers.", Type.EXPERIMENTAL, OID4VC_VCI),
+        OID4VC_VP("Support for the OID4VP protocol as part of OID4VC.", Type.EXPERIMENTAL),
 
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),

--- a/core/src/main/java/org/keycloak/OID4VCConstants.java
+++ b/core/src/main/java/org/keycloak/OID4VCConstants.java
@@ -71,6 +71,18 @@ public class OID4VCConstants {
     public static final String CREDENTIAL_IDENTIFIERS = "credential_identifiers";
     public static final String CREDENTIAL_CONFIGURATION_ID = "credential_configuration_id";
 
+    // OID4VP - https://openid.net/specs/openid-4-verifiable-presentations-1_0.html
+    public static final String VP_TOKEN = "vp_token";
+    public static final String RESPONSE_CODE = "response_code";
+    public static final String VP_FORMATS_SUPPORTED = "vp_formats_supported";
+    public static final String SD_JWT_ALG_VALUES = "sd-jwt_alg_values";
+    public static final String KB_JWT_ALG_VALUES = "kb-jwt_alg_values";
+    public static final String RESPONSE_MODE_DIRECT_POST = "direct_post";
+    public static final String FORMAT_SD_JWT_VC = "dc+sd-jwt";
+    public static final String SELF_ISSUED_V2 = "https://self-issued.me/v2";
+    public static final String REQUEST_OBJECT_TYPE = "oauth-authz-req+jwt";
+    public static final String REQUEST_OBJECT_MEDIA_TYPE = "application/oauth-authz-req+jwt";
+
     private OID4VCConstants() {
     }
 

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
@@ -108,9 +108,10 @@ public class SdJwtVerificationContext {
      * @param issuerSignedJwtVerificationOpts Options to parameterize the Issuer-Signed JWT verification.
      * @param presentationRequirements        If set, the presentation requirements will be enforced upon fully
      *                                        disclosing the Issuer-signed JWT during the verification.
+     * @return the disclosed payload
      * @throws VerificationException if verification failed
      */
-    public void verifyIssuance(List<SignatureVerifierContext> issuerVerifyingKeys,
+    public JsonNode verifyIssuance(List<SignatureVerifierContext> issuerVerifyingKeys,
                                IssuerSignedJwtVerificationOpts issuerSignedJwtVerificationOpts,
                                PresentationRequirements presentationRequirements)
             throws VerificationException
@@ -131,6 +132,8 @@ public class SdJwtVerificationContext {
         if (presentationRequirements != null) {
             presentationRequirements.checkIfSatisfiedBy(disclosedPayload);
         }
+
+        return disclosedPayload;
     }
 
     /**
@@ -150,9 +153,10 @@ public class SdJwtVerificationContext {
      *                                        to check Key Binding.
      * @param presentationRequirements        If set, the presentation requirements will be enforced upon fully
      *                                        disclosing the Issuer-signed JWT during the verification.
+     * @return the fully disclosed Issuer-signed payload
      * @throws VerificationException if verification failed
      */
-    public void verifyPresentation(List<SignatureVerifierContext> issuerVerifyingKeys,
+    public JsonNode verifyPresentation(List<SignatureVerifierContext> issuerVerifyingKeys,
                                    IssuerSignedJwtVerificationOpts issuerSignedJwtVerificationOpts,
                                    KeyBindingJwtVerificationOpts keyBindingJwtVerificationOpts,
                                    PresentationRequirements presentationRequirements)
@@ -165,12 +169,15 @@ public class SdJwtVerificationContext {
         }
 
         // Upon receiving a Presentation, in addition to the checks in {@link #verifyIssuance}...
-        verifyIssuance(issuerVerifyingKeys, issuerSignedJwtVerificationOpts, presentationRequirements);
+        JsonNode disclosedPayload =
+                verifyIssuance(issuerVerifyingKeys, issuerSignedJwtVerificationOpts, presentationRequirements);
 
         // Validate Key Binding JWT if required
         if (keyBindingJwtVerificationOpts.isKeyBindingRequired()) {
             validateKeyBindingJwt(keyBindingJwtVerificationOpts);
         }
+
+        return disclosedPayload;
     }
 
     /**

--- a/core/src/main/java/org/keycloak/sdjwt/consumer/SdJwtPresentationConsumer.java
+++ b/core/src/main/java/org/keycloak/sdjwt/consumer/SdJwtPresentationConsumer.java
@@ -26,6 +26,9 @@ import org.keycloak.sdjwt.IssuerSignedJWT;
 import org.keycloak.sdjwt.IssuerSignedJwtVerificationOpts;
 import org.keycloak.sdjwt.vp.KeyBindingJwtVerificationOpts;
 import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.sdjwt.vp.SdJwtVpVerificationResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A component for consuming (verifying) SD-JWT presentations.
@@ -47,9 +50,10 @@ public class SdJwtPresentationConsumer {
      * @param trustedSdJwtIssuers             trusted issuers for the verification
      * @param issuerSignedJwtVerificationOpts policy for Issuer-signed JWT verification
      * @param keyBindingJwtVerificationOpts   policy for Key-binding JWT verification
+     * @return the verified presentation with its fully disclosed Issuer-signed payload
      * @throws VerificationException if the verification fails for some reason
      */
-    public void verifySdJwtPresentation(
+    public SdJwtVpVerificationResult verifySdJwtPresentation(
             SdJwtVP sdJwtVP,
             PresentationRequirements presentationRequirements,
             List<TrustedSdJwtIssuer> trustedSdJwtIssuers,
@@ -67,12 +71,13 @@ public class SdJwtPresentationConsumer {
 
         // Verify the SD-JWT token cryptographically
         // Pass presentation requirements to enforce that the presented token meets them
-        sdJwtVP.getSdJwtVerificationContext()
+        JsonNode disclosedPayload = sdJwtVP.getSdJwtVerificationContext()
                 .verifyPresentation(
                         issuerVerifyingKeys,
                         issuerSignedJwtVerificationOpts,
                         keyBindingJwtVerificationOpts,
                         presentationRequirements
                 );
+        return new SdJwtVpVerificationResult(disclosedPayload);
     }
 }

--- a/core/src/main/java/org/keycloak/sdjwt/vp/SdJwtVpVerificationResult.java
+++ b/core/src/main/java/org/keycloak/sdjwt/vp/SdJwtVpVerificationResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.sdjwt.vp;
+
+import org.keycloak.OID4VCConstants;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The outcome of a successful {@link org.keycloak.sdjwt.consumer.SdJwtPresentationConsumer} verification
+ */
+public class SdJwtVpVerificationResult {
+
+    private final JsonNode claims;
+
+    public SdJwtVpVerificationResult(JsonNode claims) {
+        this.claims = claims;
+    }
+
+    public JsonNode getClaims() {
+        return claims;
+    }
+
+    public String getIssuer() {
+        return text(OID4VCConstants.CLAIM_NAME_ISSUER);
+    }
+
+    public String getCredentialType() {
+        return text(OID4VCConstants.CLAIM_NAME_VCT);
+    }
+
+    private String text(String field) {
+        JsonNode value = claims.get(field);
+        return value != null && value.isTextual() ? value.textValue() : null;
+    }
+}

--- a/core/src/main/java/org/keycloak/sdjwt/vp/TrustedSdJwtIssuerResolver.java
+++ b/core/src/main/java/org/keycloak/sdjwt/vp/TrustedSdJwtIssuerResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.sdjwt.vp;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.consumer.TrustedSdJwtIssuer;
+
+/**
+ * Resolves the keys trusted to have issued a presented credential, e.g. against an issuer allowlist
+ * or a trust list.
+ */
+@FunctionalInterface
+public interface TrustedSdJwtIssuerResolver {
+    TrustedSdJwtIssuer resolve(IssuerSignedJWT issuerSignedJwt) throws VerificationException;
+}

--- a/js/apps/admin-ui/src/identity-providers/add/AddOid4Vp.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddOid4Vp.tsx
@@ -1,0 +1,96 @@
+import type IdentityProviderRepresentation from "@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation";
+import {
+  ActionGroup,
+  AlertVariant,
+  Button,
+  PageSection,
+} from "@patternfly/react-core";
+import { FormProvider, useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { Link, useNavigate } from "react-router-dom";
+import { useAdminClient } from "../../admin-client";
+import { useAlerts } from "@keycloak/keycloak-ui-shared";
+import { FormAccess } from "../../components/form/FormAccess";
+import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useRealm } from "../../context/realm-context/RealmContext";
+import { toIdentityProvider } from "../routes/IdentityProvider";
+import { toIdentityProviders } from "../routes/IdentityProviders";
+import Oid4VpSettings from "./Oid4VpSettings";
+
+export default function AddOid4Vp() {
+  const { adminClient } = useAdminClient();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const id = "oid4vp";
+
+  const form = useForm<IdentityProviderRepresentation>({
+    defaultValues: { alias: id },
+    mode: "onChange",
+  });
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = form;
+
+  const { addAlert, addError } = useAlerts();
+  const { realm } = useRealm();
+
+  const onSubmit = async (provider: IdentityProviderRepresentation) => {
+    try {
+      await adminClient.identityProviders.create({
+        ...provider,
+        providerId: id,
+      });
+      addAlert(t("createIdentityProviderSuccess"), AlertVariant.success);
+      navigate(
+        toIdentityProvider({
+          realm,
+          providerId: id,
+          alias: provider.alias!,
+          tab: "settings",
+        }),
+      );
+    } catch (error) {
+      addError("createIdentityProviderError", error);
+    }
+  };
+
+  return (
+    <>
+      <ViewHeader
+        titleKey={t("addIdentityProvider", { provider: "OpenID4VP" })}
+      />
+      <PageSection variant="light">
+        <FormProvider {...form}>
+          <FormAccess
+            role="manage-identity-providers"
+            isHorizontal
+            onSubmit={handleSubmit(onSubmit)}
+          >
+            <Oid4VpSettings />
+
+            <ActionGroup>
+              <Button
+                isDisabled={!isDirty}
+                variant="primary"
+                type="submit"
+                data-testid="createProvider"
+              >
+                {t("add")}
+              </Button>
+              <Button
+                variant="link"
+                data-testid="cancel"
+                component={(props) => (
+                  <Link {...props} to={toIdentityProviders({ realm })} />
+                )}
+              >
+                {t("cancel")}
+              </Button>
+            </ActionGroup>
+          </FormAccess>
+        </FormProvider>
+      </PageSection>
+    </>
+  );
+}

--- a/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -78,6 +78,7 @@ import JWTAuthorizationGrantSettings from "./JWTAuthorizationGrantSettings";
 import { DefaultSwitchControl } from "../../components/SwitchControl";
 import { GroupResourceContext } from "../../context/group-resource/GroupResourceContext";
 import DefaultTrustSettings from "./DefaultTrustSettings";
+import Oid4VpSettings from "./Oid4VpSettings";
 
 type HeaderProps = {
   onChange: (value: boolean) => void;
@@ -440,6 +441,7 @@ export default function DetailSettings() {
     "jwt-authorization-grant",
   );
   const isDefaultTrust = provider.providerId === "default-trust";
+  const isOid4vp = provider.providerId === "oid4vp";
   const isSocial = !isOIDC && !isSAML && !isOAuth2;
   const isJWTAuthorizationGrantSupported =
     (isOAuth2 || isOIDC) &&
@@ -478,7 +480,11 @@ export default function DetailSettings() {
     {
       title: t("generalSettings"),
       isHidden:
-        isSPIFFE || isKubernetes || isJWTAuthorizationGrant || isDefaultTrust,
+        isSPIFFE ||
+        isKubernetes ||
+        isJWTAuthorizationGrant ||
+        isDefaultTrust ||
+        isOid4vp,
       panel: (
         <FormAccess
           role="manage-identity-providers"
@@ -491,6 +497,19 @@ export default function DetailSettings() {
           {providerInfo && (
             <DynamicComponents stringify properties={providerInfo.properties} />
           )}
+        </FormAccess>
+      ),
+    },
+    {
+      title: t("generalSettings"),
+      isHidden: !isOid4vp,
+      panel: (
+        <FormAccess
+          role="manage-identity-providers"
+          isHorizontal
+          onSubmit={handleSubmit(save)}
+        >
+          <Oid4VpSettings />
         </FormAccess>
       ),
     },

--- a/js/apps/admin-ui/src/identity-providers/add/Oid4VpSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/Oid4VpSettings.tsx
@@ -1,0 +1,39 @@
+import { TextControl } from "@keycloak/keycloak-ui-shared";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import { DynamicComponents } from "../../components/dynamic/DynamicComponents";
+import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
+import type { IdentityProviderParams } from "../routes/IdentityProvider";
+
+const PROVIDER_ID = "oid4vp";
+
+export default function Oid4VpSettings() {
+  const { t } = useTranslation();
+  const { tab } = useParams<IdentityProviderParams>();
+  const serverInfo = useServerInfo();
+
+  const properties = useMemo(
+    () =>
+      serverInfo.componentTypes?.[
+        "org.keycloak.broker.provider.IdentityProvider"
+      ]?.find(({ id }) => id === PROVIDER_ID)?.properties ?? [],
+    [serverInfo],
+  );
+
+  return (
+    <>
+      <TextControl
+        name="alias"
+        label={t("alias")}
+        labelIcon={t("aliasHelp")}
+        readOnly={tab === "settings"}
+        rules={{
+          required: t("required"),
+        }}
+      />
+      <TextControl name="displayName" label={t("displayName")} />
+      <DynamicComponents stringify properties={properties} />
+    </>
+  );
+}

--- a/js/apps/admin-ui/src/identity-providers/routes.ts
+++ b/js/apps/admin-ui/src/identity-providers/routes.ts
@@ -6,6 +6,7 @@ import { IdentityProviderSamlRoute } from "./routes/IdentityProviderSaml";
 import { IdentityProviderSpiffeRoute } from "./routes/IdentityProviderSpiffe";
 import { IdentityProviderKubernetesRoute } from "./routes/IdentityProviderKubernetes";
 import { IdentityProviderDefaultTrustRoute } from "./routes/IdentityProviderDefaultTrust";
+import { IdentityProviderOid4VpRoute } from "./routes/IdentityProviderOid4Vp";
 import { IdentityProvidersRoute } from "./routes/IdentityProviders";
 import { IdentityProviderAddMapperRoute } from "./routes/AddMapper";
 import { IdentityProviderEditMapperRoute } from "./routes/EditMapper";
@@ -23,6 +24,7 @@ const routes: AppRouteObject[] = [
   IdentityProviderJWTAuthorizationGrantRoute,
   IdentityProviderKubernetesRoute,
   IdentityProviderDefaultTrustRoute,
+  IdentityProviderOid4VpRoute,
   IdentityProviderKeycloakOidcRoute,
   IdentityProviderCreateRoute,
   IdentityProviderRoute,

--- a/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderOid4Vp.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/IdentityProviderOid4Vp.tsx
@@ -1,0 +1,23 @@
+import { lazy } from "react";
+import type { Path } from "react-router-dom";
+import { generateEncodedPath } from "../../utils/generateEncodedPath";
+import type { AppRouteObject } from "../../routes";
+
+export type IdentityProviderOid4VpParams = { realm: string };
+
+const AddOid4Vp = lazy(() => import("../add/AddOid4Vp"));
+
+export const IdentityProviderOid4VpRoute: AppRouteObject = {
+  path: "/:realm/identity-providers/oid4vp/add",
+  element: <AddOid4Vp />,
+  handle: {
+    access: "manage-identity-providers",
+    breadcrumb: (t) => t("addProvider"),
+  },
+};
+
+export const toIdentityProviderOid4Vp = (
+  params: IdentityProviderOid4VpParams,
+): Partial<Path> => ({
+  pathname: generateEncodedPath(IdentityProviderOid4VpRoute.path, params),
+});

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/TrustMaterialSdJwtIssuerResolver.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/TrustMaterialSdJwtIssuerResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.provider;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.common.VerificationException;
+import org.keycloak.crypto.SignatureVerifierContext;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.JwkParsingUtils;
+import org.keycloak.sdjwt.consumer.StaticTrustedSdJwtIssuer;
+import org.keycloak.sdjwt.consumer.TrustedSdJwtIssuer;
+import org.keycloak.sdjwt.vp.TrustedSdJwtIssuerResolver;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Bridges a {@link TrustMaterialIdentityProvider} to a {@link TrustedSdJwtIssuerResolver}: it reads
+ * the issuer key hints (kid, alg, iss) from the credential's issuer signed JWT and looks up the
+ * matching trusted keys.
+ *
+ * TODO: This needs to be changed to either use the x5c-Header and do a Chain-Validation against
+ * a pre-configured cert / ETSI trust list (enforced in HAIP) OR look up the
+ * JWKS dynamically from .well-known/jwt-vc-issuer endpoint of the issuer in the credential
+ */
+public class TrustMaterialSdJwtIssuerResolver implements TrustedSdJwtIssuerResolver {
+
+    private final TrustMaterialIdentityProvider<?> trustMaterial;
+
+    public TrustMaterialSdJwtIssuerResolver(TrustMaterialIdentityProvider<?> trustMaterial) {
+        this.trustMaterial = trustMaterial;
+    }
+
+    @Override
+    public TrustedSdJwtIssuer resolve(IssuerSignedJWT issuerSignedJwt) throws VerificationException {
+        JWSHeader header = issuerSignedJwt.getJwsHeader();
+        JsonNode issuer = issuerSignedJwt.getPayload().get(OID4VCConstants.CLAIM_NAME_ISSUER);
+        TrustMaterialRequest request = TrustMaterialRequest.builder()
+                .kid(header.getKeyId())
+                .algorithm(header.getRawAlgorithm())
+                .issuer(issuer != null && issuer.isTextual() ? issuer.textValue() : null)
+                .build();
+        List<SignatureVerifierContext> verifiers = trustMaterial.resolveKeys(request)
+                .map(JwkParsingUtils::convertJwkToVerifierContext)
+                .collect(Collectors.toList());
+        if (verifiers.isEmpty()) {
+            throw new VerificationException("No trusted issuer key found for the presented SD-JWT credential");
+        }
+        return new StaticTrustedSdJwtIssuer(verifiers);
+    }
+}

--- a/server-spi/src/main/java/org/keycloak/models/KeyManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeyManager.java
@@ -40,6 +40,22 @@ public interface KeyManager {
     KeyWrapper getKey(RealmModel realm, String kid, KeyUse use, String algorithm);
 
     /**
+     * Returns the key for the given kid regardless of the key status, so unlike
+     * {@link #getKey(RealmModel, String, KeyUse, String)} it also returns disabled keys. Useful for
+     * features that reserve a dedicated realm key which should not serve regular realm signing.
+     */
+    default KeyWrapper getKeyIncludingDisabled(RealmModel realm, String kid, KeyUse use, String algorithm) {
+        if (kid == null) {
+            return null;
+        }
+        return getKeysStream(realm)
+                .filter(key -> kid.equals(key.getKid()) && use.equals(key.getUse())
+                        && algorithm.equals(key.getAlgorithmOrDefault()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
      * Returns all {@code KeyWrapper} for the given realm.
      * @param realm {@code RealmModel}.
      * @return Stream of all {@code KeyWrapper} in the realm. Never returns {@code null}.

--- a/services/src/main/java/org/keycloak/broker/oid4vp/ClientIdentifier.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/ClientIdentifier.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.security.cert.X509Certificate;
+
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.crypto.JavaAlgorithm;
+import org.keycloak.jose.jws.crypto.HashUtils;
+
+/**
+ * The OID4VP verifier {@code client_id}: a prefix that tells the wallet how to establish trust in the
+ * request, followed by a value derived from the verifier signing certificate.
+ *
+ * <p>TODO add the remaining certificate based prefixes such as {@code x509_san_dns}.
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.10">OID4VP 1.0 §5.10 — Client Identifier Prefixes</a>
+ */
+public enum ClientIdentifier {
+
+    X509_HASH("x509_hash") {
+        @Override
+        protected String value(X509Certificate leafCertificate) {
+            try {
+                return Base64Url.encode(HashUtils.hash(JavaAlgorithm.SHA256, leafCertificate.getEncoded()));
+            } catch (Exception e) {
+                throw new IdentityBrokerException("Failed to compute x509_hash client id", e);
+            }
+        }
+    };
+
+    private final String prefix;
+
+    ClientIdentifier(String prefix) {
+        this.prefix = prefix;
+    }
+
+    // The prefix specific value, e.g. the certificate hash for x509_hash.
+    protected abstract String value(X509Certificate leafCertificate);
+
+    public String forCertificate(X509Certificate leafCertificate) {
+        return prefix + ":" + value(leafCertificate);
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProvider.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.broker.provider.AbstractIdentityProvider;
+import org.keycloak.broker.provider.AuthenticationRequest;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.broker.provider.TrustMaterialIdentityProvider;
+import org.keycloak.broker.provider.TrustMaterialRequest;
+import org.keycloak.broker.provider.TrustMaterialSdJwtIssuerResolver;
+import org.keycloak.broker.trust.TrustKeyUtil;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.sdjwt.vp.TrustedSdJwtIssuerResolver;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Identity provider that authenticates users with an OpenID4VP (OID4VP) wallet presentation.
+ *
+ * <p>Supports the same device flow with a single SD-JWT VC. {@link #performLogin} renders a page with
+ * an {@code openid4vp://} link, the wallet fetches a signed request object and posts the presentation
+ * back to {@link OID4VPIdentityProviderEndpoint}, which verifies it and drives the normal broker
+ * machinery (existing or new user, first and post broker login).
+ *
+ * <p>The provider also acts as its own {@link TrustMaterialIdentityProvider}: the credential issuer
+ * signature is verified against the inline JWKS configured on this provider.
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html">OID4VP 1.0</a>
+ */
+public class OID4VPIdentityProvider extends AbstractIdentityProvider<OID4VPIdentityProviderConfig>
+        implements TrustMaterialIdentityProvider<OID4VPIdentityProviderConfig> {
+
+    private static final Logger logger = Logger.getLogger(OID4VPIdentityProvider.class);
+
+    // The flow object is written when the login page is rendered and read while serving the request
+    // object and the presentation. It holds the root authentication session id and tab id needed to
+    // recover that session, and the nonce the wallet must echo in the key binding JWT.
+    public static final String FLOW_PREFIX = "oid4vp.flow.";
+    // The deferred object is written once the presentation is verified and read when the browser
+    // returns to complete-auth. It marks that a verified identity, serialized under IDENTITY_NOTE in
+    // the authentication session, is waiting to finish the broker login.
+    public static final String DEFERRED_PREFIX = "oid4vp.deferred.";
+    public static final String IDENTITY_NOTE = "OID4VP_IDENTITY";
+    public static final String KEY_ROOT_SESSION_ID = "rootSessionId";
+    public static final String KEY_TAB_ID = "tabId";
+    public static final String KEY_NONCE = "nonce";
+
+    public OID4VPIdentityProvider(KeycloakSession session, OID4VPIdentityProviderConfig config) {
+        super(session, config);
+    }
+
+    @Override
+    public Response performLogin(AuthenticationRequest request) {
+        // TODO support the cross device flow (QR code and SSE polling).
+        try {
+            AuthenticationSessionModel authSession = request.getAuthenticationSession();
+            // The OID4VP state correlates the request object, the wallet's direct_post and complete-auth.
+            String state = UUID.randomUUID().toString();
+            String nonce = Base64Url.encode(SecretGenerator.getInstance().randomBytes(32));
+            String rootSessionId = authSession.getParentSession() != null
+                    ? authSession.getParentSession().getId()
+                    : null;
+
+            session.singleUseObjects().put(
+                    FLOW_PREFIX + state,
+                    loginTimeoutSeconds(),
+                    Map.of(
+                            KEY_ROOT_SESSION_ID, rootSessionId != null ? rootSessionId : "",
+                            KEY_TAB_ID, authSession.getTabId() != null ? authSession.getTabId() : "",
+                            KEY_NONCE, nonce));
+
+            URI requestUri = OID4VPIdentityProviderEndpoint
+                    .endpointBaseUri(request.getUriInfo().getBaseUriBuilder(), request.getRealm().getName(),
+                            getConfig().getAlias())
+                    .path(OID4VPIdentityProviderEndpoint.REQUEST_OBJECT_PATH).path(state)
+                    .build();
+            String walletUrl = buildWalletUrl(clientId(), requestUri);
+
+            return session.getProvider(LoginFormsProvider.class)
+                    .setAuthenticationSession(authSession)
+                    .setAttribute("sameDeviceWalletUrl", walletUrl)
+                    .createForm("login-oid4vp.ftl");
+        } catch (Exception e) {
+            logger.errorf(e, "Failed to initiate OID4VP login: %s", e.getMessage());
+            throw new IdentityBrokerException("Failed to initiate wallet login", e);
+        }
+    }
+
+    @Override
+    public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
+        return new OID4VPIdentityProviderEndpoint(session, realm, this, callback, event);
+    }
+
+    // TODO support delegating to an external trust material identity provider by alias.
+    @Override
+    public Stream<JWK> resolveKeys(TrustMaterialRequest request) {
+        String jwksJson = getConfig().getTrustedIssuerJwks();
+        if (StringUtil.isBlank(jwksJson)) {
+            return Stream.empty();
+        }
+        try {
+            JSONWebKeySet jwks = JsonSerialization.readValue(jwksJson, JSONWebKeySet.class);
+            return TrustKeyUtil.filterKeys(Arrays.stream(jwks.getKeys()), request);
+        } catch (Exception e) {
+            logger.warnf("Failed to parse OID4VP trusted issuer JWKS: %s", e.getMessage());
+            return Stream.empty();
+        }
+    }
+
+    // How trusted issuer keys are resolved for a presented credential. The default pins the inline
+    // trusted issuer JWKS through this provider's own trust material.
+    // TODO add a trust list backed resolver (e.g. ETSI), selected from configuration.
+    protected TrustedSdJwtIssuerResolver trustedIssuerResolver() {
+        return new TrustMaterialSdJwtIssuerResolver(this);
+    }
+
+    @Override
+    public Response retrieveToken(KeycloakSession session, FederatedIdentityModel identity) {
+        return null;
+    }
+
+    @Override
+    public Response retrieveToken(
+            KeycloakSession session, FederatedIdentityModel identity, UserSessionModel userSession, UserModel user) {
+        return null;
+    }
+
+    // The verifier signs request objects with a realm ES256 key, whose certificate also yields the
+    // client identifier. By default the realm's active key is used. Since the verifier certificate
+    // must be registered in the wallet ecosystem upfront and may need a lifecycle independent of
+    // realm keys, a dedicated key can be pinned by its kid. The pinned key may be passive or even
+    // disabled, so it can be reserved for the verifier without serving regular realm signing.
+    public KeyWrapper signingKey() {
+        RealmModel realm = session.getContext().getRealm();
+        String kid = getConfig().getSigningKeyId();
+        KeyWrapper key = StringUtil.isNotBlank(kid)
+                ? session.keys().getKeyIncludingDisabled(realm, kid, KeyUse.SIG, Algorithm.ES256)
+                : session.keys().getActiveKey(realm, KeyUse.SIG, Algorithm.ES256);
+        if (key == null) {
+            throw new IdentityBrokerException(StringUtil.isNotBlank(kid)
+                    ? "No ES256 realm key found for the configured OID4VP signing key id"
+                    : "No active ES256 realm signing key found for the OID4VP verifier");
+        }
+        if (key.getCertificate() == null) {
+            throw new IdentityBrokerException("The OID4VP verifier signing key has no certificate");
+        }
+        return key;
+    }
+
+    protected ClientIdentifier clientIdentifier() {
+        // TODO make the client identifier prefix configurable.
+        return ClientIdentifier.X509_HASH;
+    }
+
+    public String clientId() {
+        return clientIdentifier().forCertificate(signingKey().getCertificate());
+    }
+
+    protected String buildWalletUrl(String clientId, URI requestUri) {
+        String scheme = getConfig().getWalletScheme();
+        if (!scheme.endsWith("://")) {
+            scheme = scheme + "://";
+        }
+        return scheme + "?" + OAuth2Constants.CLIENT_ID + "=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+                + "&request_uri=" + URLEncoder.encode(requestUri.toString(), StandardCharsets.UTF_8);
+    }
+
+    protected int loginTimeoutSeconds() {
+        return session.getContext().getRealm().getAccessCodeLifespanLogin();
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderConfig.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.utils.StringUtil;
+
+public class OID4VPIdentityProviderConfig extends IdentityProviderModel {
+
+    public static final String DCQL_QUERY = "dcqlQuery";
+    public static final String TRUSTED_ISSUER_JWKS = "trustedIssuerJwks";
+    public static final String PRINCIPAL_ATTRIBUTE = "principalAttribute";
+    public static final String WALLET_SCHEME = "walletScheme";
+    public static final String SIGNING_KEY_ID = "signingKeyId";
+
+    public static final String DEFAULT_WALLET_SCHEME = "openid4vp://";
+
+    public OID4VPIdentityProviderConfig() {
+    }
+
+    public OID4VPIdentityProviderConfig(IdentityProviderModel model) {
+        super(model);
+    }
+
+    // TODO: Revisit if configuring DCQL by hand should stay or eliminated completely by mapper-inferred auto-generation
+    public String getDcqlQuery() {
+        return getConfig().get(DCQL_QUERY);
+    }
+
+    public void setDcqlQuery(String dcqlQuery) {
+        getConfig().put(DCQL_QUERY, dcqlQuery);
+    }
+
+    public String getTrustedIssuerJwks() {
+        return getConfig().get(TRUSTED_ISSUER_JWKS);
+    }
+
+    public void setTrustedIssuerJwks(String trustedIssuerJwks) {
+        getConfig().put(TRUSTED_ISSUER_JWKS, trustedIssuerJwks);
+    }
+
+    public String getPrincipalAttribute() {
+        return getConfig().get(PRINCIPAL_ATTRIBUTE);
+    }
+
+    public void setPrincipalAttribute(String principalAttribute) {
+        getConfig().put(PRINCIPAL_ATTRIBUTE, principalAttribute);
+    }
+
+    public String getSigningKeyId() {
+        return getConfig().get(SIGNING_KEY_ID);
+    }
+
+    public void setSigningKeyId(String signingKeyId) {
+        getConfig().put(SIGNING_KEY_ID, signingKeyId);
+    }
+
+    public String getWalletScheme() {
+        String value = getConfig().get(WALLET_SCHEME);
+        return StringUtil.isNotBlank(value) ? value : DEFAULT_WALLET_SCHEME;
+    }
+
+    public void setWalletScheme(String walletScheme) {
+        getConfig().put(WALLET_SCHEME, walletScheme);
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderEndpoint.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.OID4VCConstants;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.broker.provider.UserAuthenticationIdentityProvider.AuthenticationCallback;
+import org.keycloak.common.VerificationException;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.sdjwt.IssuerSignedJwtVerificationOpts;
+import org.keycloak.sdjwt.consumer.PresentationRequirements;
+import org.keycloak.sdjwt.consumer.SdJwtPresentationConsumer;
+import org.keycloak.sdjwt.consumer.TrustedSdJwtIssuer;
+import org.keycloak.sdjwt.vp.KeyBindingJWT;
+import org.keycloak.sdjwt.vp.KeyBindingJwtVerificationOpts;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.sdjwt.vp.SdJwtVpVerificationResult;
+import org.keycloak.services.ErrorPage;
+import org.keycloak.services.managers.AuthenticationSessionManager;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.services.util.CacheControlUtil;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
+
+/**
+ * JAX-RS endpoint backing the OID4VP wallet flow, routed at
+ * {@code /realms/{realm}/broker/{alias}/endpoint}.
+ *
+ * <ul>
+ *   <li>{@code GET /request-object/{handle}} serves the signed authorization request object.</li>
+ *   <li>{@code POST /} receives the wallet's {@code direct_post} presentation, verifies it, and
+ *       returns the browser redirect that finalizes login.</li>
+ *   <li>{@code GET /complete-auth} resolves the deferred identity and hands control back to Keycloak.</li>
+ * </ul>
+ *
+ * <p>TODO add the cross device flow and {@code direct_post.jwt} response encryption.
+ */
+public class OID4VPIdentityProviderEndpoint {
+
+    private static final Logger logger = Logger.getLogger(OID4VPIdentityProviderEndpoint.class);
+
+    private static final int CLOCK_SKEW_SECONDS = 60;
+    private static final int KB_JWT_MAX_AGE_SECONDS = 300;
+
+    // TODO the accepted presentation signature algorithms are hardcoded to match the advertised client
+    // metadata. Derive both from configuration or the available verification key material.
+    private static final List<String> ACCEPTED_ALGORITHMS = List.of(Algorithm.ES256);
+
+    // Broker-internal endpoint routing, not part of the OID4VP protocol.
+    public static final String REQUEST_OBJECT_PATH = "request-object";
+    public static final String COMPLETE_AUTH_PATH = "complete-auth";
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+    private final OID4VPIdentityProvider provider;
+    private final AuthenticationCallback callback;
+    private final EventBuilder event;
+
+    public OID4VPIdentityProviderEndpoint(
+            KeycloakSession session,
+            RealmModel realm,
+            OID4VPIdentityProvider provider,
+            AuthenticationCallback callback,
+            EventBuilder event) {
+        this.session = session;
+        this.realm = realm;
+        this.provider = provider;
+        this.callback = callback;
+        this.event = event;
+    }
+
+    @GET
+    @Path("/request-object/{state}")
+    public Response requestObject(@PathParam("state") String state) {
+        Map<String, String> flow = session.singleUseObjects().get(OID4VPIdentityProvider.FLOW_PREFIX + state);
+        if (flow == null) {
+            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                    "Unknown or expired state", Errors.INVALID_REQUEST);
+        }
+        String requestObject;
+        try {
+            requestObject = buildRequestObject(state, flow).sign(provider.signingKey());
+        } catch (RuntimeException e) {
+            logger.errorf(e, "Failed to build the OID4VP request object: %s", e.getMessage());
+            return loginError(Response.Status.INTERNAL_SERVER_ERROR, OAuthErrorException.SERVER_ERROR,
+                    "Failed to build the request object", Errors.IDENTITY_PROVIDER_ERROR);
+        }
+        return Response.ok(requestObject).type(OID4VCConstants.REQUEST_OBJECT_MEDIA_TYPE)
+                .cacheControl(CacheControlUtil.noCache()).build();
+    }
+
+    @POST
+    @Path("/")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response directPost(@FormParam(OID4VCConstants.VP_TOKEN) String vpToken,
+            @FormParam(OAuth2Constants.STATE) String state) {
+        if (StringUtil.isBlank(vpToken) || StringUtil.isBlank(state)) {
+            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                    "Missing vp_token or state", Errors.INVALID_REQUEST);
+        }
+        Map<String, String> flow = session.singleUseObjects().get(OID4VPIdentityProvider.FLOW_PREFIX + state);
+        if (flow == null) {
+            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                    "Unknown or expired state", Errors.INVALID_REQUEST);
+        }
+
+        AuthenticationSessionModel authSession =
+                resolveAuthSession(flow.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID), flow.get(OID4VPIdentityProvider.KEY_TAB_ID));
+        if (authSession == null) {
+            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                    "Authentication session not found", Errors.INVALID_REQUEST);
+        }
+
+        BrokeredIdentityContext context;
+        try {
+            SdJwtVpVerificationResult result = verifyPresentation(vpToken, flow.get(OID4VPIdentityProvider.KEY_NONCE));
+            context = toBrokeredContext(result, authSession);
+        } catch (Exception e) {
+            logger.warnf("OID4VP presentation rejected: %s", e.getMessage());
+            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.ACCESS_DENIED, e.getMessage(),
+                    Errors.IDENTITY_PROVIDER_LOGIN_FAILURE);
+        }
+
+        // The wallet cannot finish the browser login, so hand the verified identity to the browser.
+        // Stash it in the authentication session and key the deferred marker by a fresh response_code
+        // rather than reusing the state, which may have leaked through the request_uri. The browser
+        // gets the response_code only from this direct_post response (OID4VP session fixation defense).
+        String responseCode = UUID.randomUUID().toString();
+        SerializedBrokeredIdentityContext.serialize(context)
+                .saveToAuthenticationSession(authSession, OID4VPIdentityProvider.IDENTITY_NOTE);
+        session.singleUseObjects().put(
+                OID4VPIdentityProvider.DEFERRED_PREFIX + responseCode,
+                realm.getAccessCodeLifespanLogin(),
+                Map.of(
+                        OID4VPIdentityProvider.KEY_ROOT_SESSION_ID, flow.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID),
+                        OID4VPIdentityProvider.KEY_TAB_ID, flow.get(OID4VPIdentityProvider.KEY_TAB_ID)));
+        session.singleUseObjects().remove(OID4VPIdentityProvider.FLOW_PREFIX + state);
+
+        return Response.ok(Map.of(OAuth2Constants.REDIRECT_URI, completeAuthUrl(responseCode)))
+                .type(MediaType.APPLICATION_JSON_TYPE).cacheControl(CacheControlUtil.noCache()).build();
+    }
+
+    @GET
+    @Path("/complete-auth")
+    public Response completeAuth(@QueryParam(OID4VCConstants.RESPONSE_CODE) String responseCode) {
+        Map<String, String> deferred =
+                session.singleUseObjects().remove(OID4VPIdentityProvider.DEFERRED_PREFIX + responseCode);
+        if (deferred == null) {
+            return loginErrorPage(null, Messages.SESSION_NOT_ACTIVE);
+        }
+        AuthenticationSessionModel authSession = resolveAuthSession(
+                deferred.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID), deferred.get(OID4VPIdentityProvider.KEY_TAB_ID));
+        if (authSession == null) {
+            return loginErrorPage(null, Messages.SESSION_NOT_ACTIVE);
+        }
+
+        // Bind completion to the browser that started the login. Its authentication session cookie must
+        // match the session the request handle was issued for, so a leaked handle alone cannot finish it.
+        RootAuthenticationSessionModel cookieRootSession =
+                new AuthenticationSessionManager(session).getCurrentRootAuthenticationSession(realm);
+        if (cookieRootSession == null
+                || !cookieRootSession.getId().equals(deferred.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID))) {
+            return loginErrorPage(authSession, Messages.SESSION_NOT_ACTIVE);
+        }
+
+        SerializedBrokeredIdentityContext serialized = SerializedBrokeredIdentityContext.readFromAuthenticationSession(
+                authSession, OID4VPIdentityProvider.IDENTITY_NOTE);
+        if (serialized == null) {
+            return loginErrorPage(authSession, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+        }
+        authSession.removeAuthNote(OID4VPIdentityProvider.IDENTITY_NOTE);
+
+        session.getContext().setAuthenticationSession(authSession);
+        session.getContext().setClient(authSession.getClient());
+
+        BrokeredIdentityContext context = serialized.deserialize(session, authSession);
+        context.setAuthenticationSession(authSession);
+
+        return callback.authenticated(context);
+    }
+
+    protected RequestObject buildRequestObject(String state, Map<String, String> flow) {
+        String clientId = provider.clientId();
+        Instant now = Instant.now();
+
+        RequestObject requestObject = new RequestObject()
+                .clientId(clientId)
+                .responseType(OID4VCConstants.VP_TOKEN)
+                .responseMode(OID4VCConstants.RESPONSE_MODE_DIRECT_POST)
+                .responseUri(endpointBaseUrl())
+                .nonce(flow.get(OID4VPIdentityProvider.KEY_NONCE))
+                .state(state)
+                .clientMetadata(clientMetadata())
+                .dcqlQuery(dcqlQuery());
+        requestObject.id(UUID.randomUUID().toString());
+        requestObject.iat(now.getEpochSecond());
+        requestObject.exp(now.plusSeconds(realm.getAccessCodeLifespanLogin()).getEpochSecond());
+        requestObject.issuer(clientId);
+        requestObject.audience(OID4VCConstants.SELF_ISSUED_V2);
+        return requestObject;
+    }
+
+    // TODO infer the DCQL from identity provider mappers.
+    protected JsonNode dcqlQuery() {
+        String dcql = provider.getConfig().getDcqlQuery();
+        if (StringUtil.isBlank(dcql)) {
+            throw new IllegalStateException("No DCQL query configured on the OID4VP identity provider");
+        }
+        try {
+            return JsonSerialization.readValue(dcql, JsonNode.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("The configured OID4VP DCQL query is not valid JSON", e);
+        }
+    }
+
+    // TODO infer from configuration / available verification key material
+    protected Map<String, Object> clientMetadata() {
+        return Map.of(OID4VCConstants.VP_FORMATS_SUPPORTED, Map.of(
+                OID4VCConstants.FORMAT_SD_JWT_VC, Map.of(
+                        OID4VCConstants.SD_JWT_ALG_VALUES, ACCEPTED_ALGORITHMS,
+                        OID4VCConstants.KB_JWT_ALG_VALUES, ACCEPTED_ALGORITHMS)));
+    }
+
+    protected SdJwtVpVerificationResult verifyPresentation(String vpToken, String nonce) throws VerificationException {
+        SdJwtVP sdJwtVP;
+        try {
+            sdJwtVP = SdJwtVP.of(extractCredential(vpToken));
+        } catch (IllegalArgumentException e) {
+            throw new VerificationException("Malformed vp_token presentation", e);
+        }
+
+        requireAcceptedAlgorithm(sdJwtVP.getIssuerSignedJWT().getJwsHeader().getRawAlgorithm(), "issuer signed JWT");
+        Optional<KeyBindingJWT> keyBindingJwt = sdJwtVP.getKeyBindingJWT();
+        if (keyBindingJwt.isPresent()) {
+            requireAcceptedAlgorithm(keyBindingJwt.get().getJwsHeader().getRawAlgorithm(), "key binding JWT");
+        }
+
+        // Credentials can be arbitrarily old, so the issuer JWT iat is not bounded. Expiry is still
+        // enforced via exp. The key binding JWT must instead be fresh.
+        IssuerSignedJwtVerificationOpts issuerOpts = IssuerSignedJwtVerificationOpts.builder()
+                .withClockSkew(CLOCK_SKEW_SECONDS)
+                .withIatCheck(null)
+                .withExpCheck(true)
+                .withNbfCheck(true)
+                .build();
+        KeyBindingJwtVerificationOpts kbOpts = KeyBindingJwtVerificationOpts.builder()
+                .withKeyBindingRequired(true)
+                .withClockSkew(CLOCK_SKEW_SECONDS)
+                .withIatCheck(KB_JWT_MAX_AGE_SECONDS)
+                .withExpCheck(true)
+                .withNbfCheck(true)
+                .withAudCheck(provider.clientId())
+                .withNonceCheck(nonce)
+                .build();
+
+        // TODO bind the presentation to the requested credential type and claims, so that not any
+        // credential from a trusted issuer satisfies the login.
+        PresentationRequirements noAdditionalRequirements = disclosedPayload -> {
+        };
+        TrustedSdJwtIssuer trustedIssuer = provider.trustedIssuerResolver().resolve(sdJwtVP.getIssuerSignedJWT());
+        return new SdJwtPresentationConsumer().verifySdJwtPresentation(
+                sdJwtVP, noAdditionalRequirements, List.of(trustedIssuer), issuerOpts, kbOpts);
+    }
+
+    private static void requireAcceptedAlgorithm(String algorithm, String jwt) throws VerificationException {
+        if (!ACCEPTED_ALGORITHMS.contains(algorithm)) {
+            throw new VerificationException("Unsupported " + jwt + " signature algorithm " + algorithm);
+        }
+    }
+
+    // The DCQL vp_token is a JSON object keyed by credential id whose value is the presentation, or an
+    // array of them. A bare SD-JWT compact string is not valid JSON and is used as is.
+    // TODO support multiple credentials (mapped by credential id set in the DCQL).
+    static String extractCredential(String vpToken) throws VerificationException {
+        JsonNode token;
+        try {
+            token = JsonSerialization.readValue(vpToken, JsonNode.class);
+        } catch (IOException notJson) {
+            return vpToken.trim();
+        }
+
+        JsonNode presentation = token;
+        if (token.isObject()) {
+            if (token.size() != 1) {
+                throw new VerificationException("vp_token must carry exactly one credential");
+            }
+            presentation = token.elements().next();
+        }
+        if (presentation.isArray()) {
+            if (presentation.size() != 1) {
+                throw new VerificationException("vp_token must carry exactly one credential");
+            }
+            presentation = presentation.get(0);
+        }
+        if (!presentation.isTextual()) {
+            throw new VerificationException("vp_token does not contain a credential presentation");
+        }
+        return presentation.textValue();
+    }
+
+    protected BrokeredIdentityContext toBrokeredContext(SdJwtVpVerificationResult result, AuthenticationSessionModel authSession) {
+        JsonNode claims = result.getClaims();
+        JsonNode principal = claims.get(provider.getConfig().getPrincipalAttribute());
+        if (principal == null || principal.isNull() || !principal.isValueNode()
+                || StringUtil.isBlank(principal.asText())) {
+            throw new IllegalStateException(
+                    "Credential does not contain a usable value for the configured principal attribute '"
+                            + provider.getConfig().getPrincipalAttribute() + "'");
+        }
+        String subject = principal.asText();
+
+        BrokeredIdentityContext context = new BrokeredIdentityContext(subject, provider.getConfig());
+        context.setIdp(provider);
+        context.setUsername(subject);
+        context.setModelUsername(subject);
+        context.setBrokerUserId(provider.getConfig().getAlias() + "." + subject);
+        context.setAuthenticationSession(authSession);
+
+        JsonNode email = claims.get(IDToken.EMAIL);
+        if (email != null && email.isValueNode()) {
+            context.setEmail(email.asText());
+        }
+
+        // Expose disclosed claims so identity provider attribute mappers can consume them.
+        AbstractJsonUserAttributeMapper.storeUserProfileForMapper(context, claims, provider.getConfig().getAlias());
+        return context;
+    }
+
+    protected AuthenticationSessionModel resolveAuthSession(String rootSessionId, String tabId) {
+        if (StringUtil.isBlank(rootSessionId) || StringUtil.isBlank(tabId)) {
+            return null;
+        }
+        RootAuthenticationSessionModel root = session.authenticationSessions().getRootAuthenticationSession(realm, rootSessionId);
+        return root == null ? null : root.getAuthenticationSessions().get(tabId);
+    }
+
+    // The broker endpoint base, shared with the provider that builds the request_uri.
+    public static UriBuilder endpointBaseUri(UriBuilder baseUriBuilder, String realmName, String alias) {
+        return baseUriBuilder.path("realms").path(realmName).path("broker").path(alias).path("endpoint");
+    }
+
+    protected String endpointBaseUrl() {
+        return endpointBaseUri(session.getContext().getUri().getBaseUriBuilder(), realm.getName(),
+                provider.getConfig().getAlias()).build().toString();
+    }
+
+    protected String completeAuthUrl(String responseCode) {
+        return endpointBaseUri(session.getContext().getUri().getBaseUriBuilder(), realm.getName(),
+                provider.getConfig().getAlias())
+                .path(COMPLETE_AUTH_PATH)
+                .queryParam(OID4VCConstants.RESPONSE_CODE, responseCode)
+                .build().toString();
+    }
+
+    // Wallet facing failures, fired as a broker login error and returned as an OAuth error response.
+    protected Response loginError(Response.Status status, String error, String description, String eventError) {
+        event.event(EventType.IDENTITY_PROVIDER_LOGIN).detail(Details.REASON, description).error(eventError);
+        return errorResponse(status, error, description);
+    }
+
+    // Browser facing failures during complete-auth, fired as a broker login error and rendered as a
+    // localized error page from the given message bundle key.
+    protected Response loginErrorPage(AuthenticationSessionModel authSession, String messageKey) {
+        event.event(EventType.IDENTITY_PROVIDER_LOGIN).detail(Details.REASON, messageKey)
+                .error(Errors.IDENTITY_PROVIDER_LOGIN_FAILURE);
+        return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, messageKey);
+    }
+
+    protected static Response errorResponse(Response.Status status, String error, String description) {
+        return Response.status(status)
+                .entity(new OAuth2ErrorRepresentation(error, description))
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .cacheControl(CacheControlUtil.noCache())
+                .build();
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+public class OID4VPIdentityProviderFactory extends AbstractIdentityProviderFactory<OID4VPIdentityProvider>
+        implements EnvironmentDependentProviderFactory {
+
+    public static final String PROVIDER_ID = "oid4vp";
+
+    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
+            .property()
+                .name(OID4VPIdentityProviderConfig.DCQL_QUERY)
+                .label("DCQL Query (JSON)")
+                .helpText("Digital Credentials Query Language query describing the requested credential and claims.")
+                .type(ProviderConfigProperty.TEXT_TYPE)
+                .required(true)
+                .add()
+            .property()
+                .name(OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS)
+                .label("Trusted Issuer JWKS")
+                .helpText("Inline JWK Set of trusted credential issuer keys used to verify the credential signature.")
+                .type(ProviderConfigProperty.TEXT_TYPE)
+                .required(true)
+                .add()
+            .property()
+                .name(OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE)
+                .label("Principal Attribute")
+                .helpText("Credential claim used as the user principal, i.e. its id and username.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .required(true)
+                .add()
+            .property()
+                .name(OID4VPIdentityProviderConfig.SIGNING_KEY_ID)
+                .label("Signing Key ID")
+                .helpText("Kid of the realm ES256 key used to sign request objects and derive the client identifier. "
+                        + "When empty the active ES256 realm key is used. The referenced key may be passive or "
+                        + "disabled, so it can be reserved for this provider without serving regular realm signing. "
+                        + "Mind the certificate requirements of the wallet ecosystem: typically a leaf certificate "
+                        + "issued by a CA the wallets trust rather than self-signed, with extensions such as basic "
+                        + "constraints CA=false and digitalSignature key usage, e.g. supplied through a Java keystore "
+                        + "key provider.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+            .property()
+                .name(OID4VPIdentityProviderConfig.WALLET_SCHEME)
+                .label("Wallet URL Scheme")
+                .helpText("Custom URL scheme used in the wallet link (defaults to openid4vp://).")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue(OID4VPIdentityProviderConfig.DEFAULT_WALLET_SCHEME)
+                .required(true)
+                .add()
+            .build();
+
+    @Override
+    public String getName() {
+        return "OpenID4VP (Wallet Login)";
+    }
+
+    @Override
+    public OID4VPIdentityProvider create(KeycloakSession session, IdentityProviderModel model) {
+        return new OID4VPIdentityProvider(session, new OID4VPIdentityProviderConfig(model));
+    }
+
+    @Override
+    public OID4VPIdentityProviderConfig createConfig() {
+        return new OID4VPIdentityProviderConfig();
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return CONFIG_PROPERTIES;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.OID4VC_VP);
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/RequestObject.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/RequestObject.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.util.KeyWrapperUtil;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The OID4VP signed authorization request object: the standard JWT claims from {@link JsonWebToken}
+ * plus the OID4VP request parameters. It signs itself as a compact JWS that publishes the verifier's
+ * leaf certificate in the {@code x5c} header.
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5">OID4VP 1.0 §5 — Authorization Request</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RequestObject extends JsonWebToken {
+
+    @JsonProperty("client_id")
+    private String clientId;
+    @JsonProperty("response_type")
+    private String responseType;
+    @JsonProperty("response_mode")
+    private String responseMode;
+    @JsonProperty("response_uri")
+    private String responseUri;
+    @JsonProperty("nonce")
+    private String nonce;
+    @JsonProperty("state")
+    private String state;
+    @JsonProperty("dcql_query")
+    private JsonNode dcqlQuery;
+    @JsonProperty("client_metadata")
+    private Object clientMetadata;
+
+    public RequestObject clientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public RequestObject responseType(String responseType) {
+        this.responseType = responseType;
+        return this;
+    }
+
+    public RequestObject responseMode(String responseMode) {
+        this.responseMode = responseMode;
+        return this;
+    }
+
+    public RequestObject responseUri(String responseUri) {
+        this.responseUri = responseUri;
+        return this;
+    }
+
+    public RequestObject nonce(String nonce) {
+        this.nonce = nonce;
+        return this;
+    }
+
+    public RequestObject state(String state) {
+        this.state = state;
+        return this;
+    }
+
+    public RequestObject dcqlQuery(JsonNode dcqlQuery) {
+        this.dcqlQuery = dcqlQuery;
+        return this;
+    }
+
+    public RequestObject clientMetadata(Object clientMetadata) {
+        this.clientMetadata = clientMetadata;
+        return this;
+    }
+
+    public String sign(KeyWrapper signingKey) {
+        X509Certificate certificate = signingKey.getCertificate();
+        if (certificate == null) {
+            throw new IdentityBrokerException("The OID4VP verifier signing key has no X.509 certificate");
+        }
+        try {
+            return new JWSBuilder()
+                    .type(OID4VCConstants.REQUEST_OBJECT_TYPE)
+                    .kid(signingKey.getKid())
+                    .x5c(List.of(certificate))
+                    .jsonContent(this)
+                    .sign(KeyWrapperUtil.createSignatureSignerContext(signingKey));
+        } catch (Exception e) {
+            throw new IdentityBrokerException("Failed to sign OID4VP request object", e);
+        }
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderFactory
@@ -23,3 +23,4 @@ org.keycloak.broker.spiffe.SpiffeIdentityProviderFactory
 org.keycloak.broker.kubernetes.KubernetesIdentityProviderFactory
 org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantIdentityProviderFactory
 org.keycloak.broker.trust.DefaultTrustIdentityProviderFactory
+org.keycloak.broker.oid4vp.OID4VPIdentityProviderFactory

--- a/services/src/test/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import org.keycloak.broker.provider.TrustMaterialRequest;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.CertificateUtils;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.JavaAlgorithm;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jws.crypto.HashUtils;
+import org.keycloak.util.JsonSerialization;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OID4VPIdentityProviderTest {
+
+    @BeforeClass
+    public static void initCrypto() {
+        CryptoIntegration.init(OID4VPIdentityProviderTest.class.getClassLoader());
+    }
+
+    @Test
+    public void computesX509HashClientId() throws Exception {
+        KeyPair keyPair = KeyUtils.generateEcKeyPair("secp256r1");
+        X509Certificate cert = CertificateUtils.generateV1SelfSignedCertificate(keyPair, "oid4vp-verifier");
+
+        String clientId = ClientIdentifier.X509_HASH.forCertificate(cert);
+
+        String expected = "x509_hash:"
+                + Base64Url.encode(HashUtils.hash(JavaAlgorithm.SHA256, cert.getEncoded()));
+        Assert.assertEquals(expected, clientId);
+    }
+
+    @Test
+    public void resolveKeysFiltersByKid() throws Exception {
+        JWK first = jwk();
+        JWK second = jwk();
+        JSONWebKeySet jwks = new JSONWebKeySet();
+        jwks.setKeys(new JWK[] {first, second});
+
+        OID4VPIdentityProviderConfig config = new OID4VPIdentityProviderConfig();
+        config.setTrustedIssuerJwks(JsonSerialization.writeValueAsString(jwks));
+        OID4VPIdentityProvider provider = new OID4VPIdentityProvider(null, config);
+
+        List<JWK> matched = provider
+                .resolveKeys(TrustMaterialRequest.builder().kid(second.getKeyId()).build())
+                .toList();
+
+        Assert.assertEquals(1, matched.size());
+        Assert.assertEquals(second.getKeyId(), matched.get(0).getKeyId());
+    }
+
+    @Test
+    public void resolveKeysReturnsEmptyWhenNoJwksConfigured() {
+        OID4VPIdentityProvider provider = new OID4VPIdentityProvider(null, new OID4VPIdentityProviderConfig());
+        Assert.assertEquals(0, provider.resolveKeys(TrustMaterialRequest.builder().build()).count());
+    }
+
+    private static JWK jwk() {
+        KeyPair keyPair = KeyUtils.generateEcKeyPair("secp256r1");
+        KeyWrapper keyWrapper = new KeyWrapper();
+        keyWrapper.setKid(KeyUtils.createKeyId(keyPair.getPublic()));
+        keyWrapper.setType(KeyType.EC);
+        keyWrapper.setAlgorithm(Algorithm.ES256);
+        keyWrapper.setUse(KeyUse.SIG);
+        keyWrapper.setPublicKey(keyPair.getPublic());
+        return JWKBuilder.create().kid(keyWrapper.getKid()).ec(keyWrapper.getPublicKey());
+    }
+}

--- a/services/src/test/java/org/keycloak/broker/oid4vp/OID4VPVpTokenExtractionTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/OID4VPVpTokenExtractionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import org.keycloak.common.VerificationException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OID4VPVpTokenExtractionTest {
+
+    private static final String CREDENTIAL = "eyJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJ4In0.sig~WyJzIiwibiIsInYiXQ~";
+
+    @Test
+    public void unwrapsBareCompactSdJwt() throws Exception {
+        Assert.assertEquals(CREDENTIAL, OID4VPIdentityProviderEndpoint.extractCredential(CREDENTIAL));
+    }
+
+    @Test
+    public void unwrapsDcqlObject() throws Exception {
+        Assert.assertEquals(CREDENTIAL,
+                OID4VPIdentityProviderEndpoint.extractCredential("{\"identity\":\"" + CREDENTIAL + "\"}"));
+    }
+
+    @Test
+    public void unwrapsDcqlObjectWithArrayValue() throws Exception {
+        Assert.assertEquals(CREDENTIAL,
+                OID4VPIdentityProviderEndpoint.extractCredential("{\"identity\":[\"" + CREDENTIAL + "\"]}"));
+    }
+
+    @Test
+    public void unwrapsTopLevelArray() throws Exception {
+        Assert.assertEquals(CREDENTIAL,
+                OID4VPIdentityProviderEndpoint.extractCredential("[\"" + CREDENTIAL + "\"]"));
+    }
+
+    @Test(expected = VerificationException.class)
+    public void rejectsJsonWithoutPresentation() throws Exception {
+        OID4VPIdentityProviderEndpoint.extractCredential("{}");
+    }
+
+    @Test(expected = VerificationException.class)
+    public void rejectsNonTextualPresentation() throws Exception {
+        OID4VPIdentityProviderEndpoint.extractCredential("{\"identity\":123}");
+    }
+
+    @Test(expected = VerificationException.class)
+    public void rejectsMultipleCredentialsInObject() throws Exception {
+        OID4VPIdentityProviderEndpoint.extractCredential(
+                "{\"identity\":\"" + CREDENTIAL + "\",\"other\":\"" + CREDENTIAL + "\"}");
+    }
+
+    @Test(expected = VerificationException.class)
+    public void rejectsMultipleCredentialsInArray() throws Exception {
+        OID4VPIdentityProviderEndpoint.extractCredential(
+                "[\"" + CREDENTIAL + "\",\"" + CREDENTIAL + "\"]");
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -21,6 +21,7 @@ import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ClientAttestationPoPJwt;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.AsymmetricSignatureSignerContext;
+import org.keycloak.crypto.ECDSASignatureSignerContext;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.ECPublicJWK;
 import org.keycloak.jose.jwk.JWK;
@@ -45,6 +46,7 @@ import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentatio
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.tests.oid4vc.abca.OIDCClientAttester;
 import org.keycloak.tests.oid4vc.abca.OIDCMockClientAttester;
@@ -65,6 +67,8 @@ import org.keycloak.testsuite.util.oauth.oid4vc.PreAuthorizedCodeGrantRequest;
 import org.keycloak.util.DPoPGenerator;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_JWT_TYPE;
@@ -264,6 +268,19 @@ public class OID4VCBasicWallet {
         return Proofs.create(ProofType.JWT, proofValues);
     }
 
+    /**
+     * Builds an OID4VP presentation of an issued SD-JWT VC: it discloses every claim and adds a key
+     * binding JWT signed by {@code holderKey} and bound to the verifier ({@code audience}, {@code nonce}).
+     */
+    public String present(String sdJwtVc, KeyWrapper holderKey, String audience, String nonce) {
+        ObjectNode keyBindingClaims = JsonSerialization.mapper.createObjectNode();
+        keyBindingClaims.put("aud", audience);
+        keyBindingClaims.put("nonce", nonce);
+        keyBindingClaims.put("iat", Time.currentTimeSeconds());
+        return SdJwtVP.of(sdJwtVc)
+                .present(null, true, keyBindingClaims, new ECDSASignatureSignerContext(holderKey));
+    }
+
     public KeyWrapper getECKeyPair(OID4VCTestContext ctx) {
         return getECKeyPair(ctx, null);
     }
@@ -316,7 +333,7 @@ public class OID4VCBasicWallet {
                 UUID.randomUUID().toString(),
                 HttpMethod.POST,
                 htu,
-                (long) Time.currentTime(),
+                Time.currentTimeSeconds(),
                 jwsEcHeader, ecKey, accessToken);
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPFeatureDisabledTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPFeatureDisabledTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc.presentation;
+
+import java.util.Map;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderFactory;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest
+public class OID4VPFeatureDisabledTest {
+
+    @InjectRealm
+    ManagedRealm realm;
+
+    @Test
+    public void cannotCreateProviderWhenFeatureDisabled() {
+        IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
+        idp.setAlias("oid4vp");
+        idp.setProviderId(OID4VPIdentityProviderFactory.PROVIDER_ID);
+        idp.setEnabled(true);
+        idp.setConfig(Map.of());
+
+        try (Response response = realm.admin().identityProviders().create(idp)) {
+            Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPVerifierTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPVerifierTestBase.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc.presentation;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderFactory;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.keys.Attributes;
+import org.keycloak.keys.GeneratedEcdsaKeyProviderFactory;
+import org.keycloak.keys.KeyProvider;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.KeysMetadataRepresentation;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.tests.oid4vc.OID4VCTestContext;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.KeyWrapperUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.Header;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
+
+public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
+
+    protected static final String IDP_ALIAS = "oid4vp";
+    protected static final String REDIRECT_URI = "http://127.0.0.1:8500/callback";
+
+    @InjectHttpClient
+    protected CloseableHttpClient httpClient;
+
+    private String ecKeyComponentId;
+
+    @BeforeEach
+    void addVerifierSigningKey() {
+        ComponentRepresentation keyProvider = new ComponentRepresentation();
+        keyProvider.setName("oid4vp-verifier-signing-key");
+        keyProvider.setParentId(testRealm.getId());
+        keyProvider.setProviderId(GeneratedEcdsaKeyProviderFactory.ID);
+        keyProvider.setProviderType(KeyProvider.class.getName());
+        keyProvider.setConfig(new MultivaluedHashMap<>(Map.of(
+                Attributes.PRIORITY_KEY, List.of("100"),
+                Attributes.ENABLED_KEY, List.of("true"),
+                Attributes.ACTIVE_KEY, List.of("true"),
+                GeneratedEcdsaKeyProviderFactory.ECDSA_ELLIPTIC_CURVE_KEY, List.of("P-256"),
+                Attributes.EC_GENERATE_CERTIFICATE_KEY, List.of("true"))));
+
+        try (Response response = testRealm.admin().components().add(keyProvider)) {
+            Assertions.assertEquals(201, response.getStatus(), "Failed to add the verifier signing key");
+            String location = response.getHeaderString("Location");
+            ecKeyComponentId = location.substring(location.lastIndexOf('/') + 1);
+        }
+        testRealm.cleanup().add(r -> r.components().component(ecKeyComponentId).remove());
+    }
+
+    @BeforeEach
+    void signIssuedCredentialWithEs256() {
+        // The verifier enforces ES256, so the issued credential must be signed with it.
+        setCredentialScopeAttributes(sdJwtTypeCredentialScope, Map.of(VC_SIGNING_ALG, Algorithm.ES256));
+    }
+
+    protected record IssuedCredential(String sdJwtVc, KeyWrapper holderKey) {
+    }
+
+    protected IssuedCredential issueCredential() {
+        OID4VCTestContext ctx = new OID4VCTestContext(client, sdJwtTypeCredentialScope);
+        wallet.fetchCredentialByScope(ctx, ctx.getScope());
+        String sdJwtVc = (String) ctx.getCredentialResponse().getCredentials().get(0).getCredential();
+        Assertions.assertNotNull(sdJwtVc, "No SD-JWT VC issued");
+        IssuedCredential credential = new IssuedCredential(sdJwtVc, wallet.getECKeyPair(ctx));
+        wallet.logout();
+        driver.cookies().deleteAll();
+        driver.open("about:blank");
+        return credential;
+    }
+
+    protected void createVerifierIdp(Map<String, String> config) {
+        IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
+        idp.setAlias(IDP_ALIAS);
+        idp.setProviderId(OID4VPIdentityProviderFactory.PROVIDER_ID);
+        idp.setEnabled(true);
+        idp.setConfig(config);
+        try (Response response = testRealm.admin().identityProviders().create(idp)) {
+            Assertions.assertEquals(201, response.getStatus(), "Failed to create OID4VP identity provider");
+        }
+        testRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
+    }
+
+    protected String realmSigningJwks() {
+        try (CloseableHttpResponse response = httpClient.execute(
+                new HttpGet(testRealm.getBaseUrl() + "/protocol/openid-connect/certs"))) {
+            Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+            return EntityUtils.toString(response.getEntity());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Wallet exchange -------------------------------------------------------------------------------------------------
+
+    protected JsonNode requestObject() throws Exception {
+        return requestObjectClaims(requestUri(openWalletPage()));
+    }
+
+    protected String present(IssuedCredential credential, JsonNode request) {
+        return present(credential, request, request.path("nonce").asText());
+    }
+
+    protected String present(IssuedCredential credential, JsonNode request, String nonce) {
+        return wallet.present(credential.sdJwtVc(), credential.holderKey(),
+                request.path("client_id").asText(), nonce);
+    }
+
+    protected JsonNode directPost(JsonNode request, String vpToken, int expectedStatus) throws IOException {
+        HttpPost post = new HttpPost(request.path("response_uri").asText());
+        post.setEntity(new UrlEncodedFormEntity(List.of(
+                new BasicNameValuePair("vp_token", vpToken),
+                new BasicNameValuePair("state", request.path("state").asText()))));
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            int status = response.getStatusLine().getStatusCode();
+            JsonNode body = JsonSerialization.readValue(EntityUtils.toByteArray(response.getEntity()), JsonNode.class);
+            Assertions.assertEquals(expectedStatus, status, "Unexpected direct_post status, body: " + body);
+            assertNotCacheable(response);
+            return body;
+        }
+    }
+
+    protected static boolean verifyEs256(JWSInput jws, X509Certificate certificate) throws Exception {
+        KeyWrapper key = new KeyWrapper();
+        key.setType(KeyType.EC);
+        key.setAlgorithm(Algorithm.ES256);
+        key.setUse(KeyUse.SIG);
+        key.setPublicKey(certificate.getPublicKey());
+        return KeyWrapperUtil.createSignatureVerifierContext(key)
+                .verify(jws.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), jws.getSignature());
+    }
+
+    protected String authUrl() {
+        return testRealm.getBaseUrl() + "/protocol/openid-connect/auth"
+                + "?client_id=" + OID4VCI_CLIENT_ID
+                + "&redirect_uri=" + URLEncoder.encode(REDIRECT_URI, StandardCharsets.UTF_8)
+                + "&response_type=code&scope=openid&state=abc&kc_idp_hint=" + IDP_ALIAS;
+    }
+
+    protected String openWalletPage() {
+        driver.open(authUrl());
+        String html = driver.driver().getPageSource();
+        Matcher matcher = Pattern.compile("openid4vp://[^\"'\\s]+").matcher(html);
+        Assertions.assertTrue(matcher.find(), "Wallet login page did not contain an openid4vp:// link");
+        return matcher.group().replace("&amp;", "&");
+    }
+
+    // Adds an active ES256 key at higher priority than the verifier signing key but without a
+    // certificate, so it becomes the active key the verifier would try to derive the client id from.
+    protected void addActiveEs256KeyWithoutCertificate() {
+        ComponentRepresentation keyProvider = new ComponentRepresentation();
+        keyProvider.setName("oid4vp-key-without-certificate");
+        keyProvider.setParentId(testRealm.getId());
+        keyProvider.setProviderId(GeneratedEcdsaKeyProviderFactory.ID);
+        keyProvider.setProviderType(KeyProvider.class.getName());
+        keyProvider.setConfig(new MultivaluedHashMap<>(Map.of(
+                Attributes.PRIORITY_KEY, List.of("200"),
+                Attributes.ENABLED_KEY, List.of("true"),
+                Attributes.ACTIVE_KEY, List.of("true"),
+                GeneratedEcdsaKeyProviderFactory.ECDSA_ELLIPTIC_CURVE_KEY, List.of("P-256"),
+                Attributes.EC_GENERATE_CERTIFICATE_KEY, List.of("false"))));
+        try (Response response = testRealm.admin().components().add(keyProvider)) {
+            Assertions.assertEquals(201, response.getStatus(), "Failed to add the key without certificate");
+            String location = response.getHeaderString("Location");
+            String id = location.substring(location.lastIndexOf('/') + 1);
+            testRealm.cleanup().add(r -> r.components().component(id).remove());
+        }
+    }
+
+    protected void updatePrincipalAttribute(String attribute) {
+        updateIdpConfig(OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, attribute);
+    }
+
+    protected void updateIdpConfig(String key, String value) {
+        var idpResource = testRealm.admin().identityProviders().get(IDP_ALIAS);
+        IdentityProviderRepresentation idp = idpResource.toRepresentation();
+        idp.getConfig().put(key, value);
+        idpResource.update(idp);
+    }
+
+    protected void disableVerifierSigningKey() {
+        var componentResource = testRealm.admin().components().component(ecKeyComponentId);
+        ComponentRepresentation component = componentResource.toRepresentation();
+        component.getConfig().putSingle(Attributes.ENABLED_KEY, "false");
+        componentResource.update(component);
+    }
+
+    protected String verifierSigningKeyKid() {
+        return verifierSigningKeyMetadata().getKid();
+    }
+
+    protected String verifierSigningKeyPublicKeyPem() {
+        return verifierSigningKeyMetadata().getPublicKey();
+    }
+
+    private KeysMetadataRepresentation.KeyMetadataRepresentation verifierSigningKeyMetadata() {
+        return testRealm.admin().keys().getKeyMetadata().getKeys().stream()
+                .filter(key -> ecKeyComponentId.equals(key.getProviderId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Verifier signing key not found in the realm keys"));
+    }
+
+    protected static String requestUri(String walletUrl) {
+        Matcher matcher = Pattern.compile("request_uri=([^&]+)").matcher(walletUrl);
+        Assertions.assertTrue(matcher.find(), "Wallet link is missing request_uri: " + walletUrl);
+        return URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8);
+    }
+
+    protected JsonNode requestObjectClaims(String requestUri) throws Exception {
+        return JsonSerialization.readValue(new JWSInput(fetchRequestObject(requestUri)).getContent(), JsonNode.class);
+    }
+
+    protected String fetchRequestObject(String requestUri) throws IOException {
+        try (CloseableHttpResponse response = httpClient.execute(new HttpGet(requestUri))) {
+            Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+            assertNotCacheable(response);
+            return EntityUtils.toString(response.getEntity());
+        }
+    }
+
+    // Wallet facing responses carry login correlating secrets and must not be cacheable.
+    protected static void assertNotCacheable(CloseableHttpResponse response) {
+        Header cacheControl = response.getFirstHeader("Cache-Control");
+        Assertions.assertNotNull(cacheControl, "Wallet facing responses must send Cache-Control");
+        Assertions.assertTrue(cacheControl.getValue().contains("no-store"),
+                "Wallet facing responses must not be cacheable, was: " + cacheControl.getValue());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPX509HashDirectPostTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPX509HashDirectPostTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc.presentation;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
+
+/**
+ * Drives the OID4VP wallet login for the profile of an SD-JWT VC presented with an {@code x509_hash}
+ * client identifier, a signed request object fetched by {@code request_uri}, and an unencrypted
+ * {@code direct_post} response, same device.
+ */
+@KeycloakIntegrationTest(config = PresentationServerConfig.class)
+public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
+
+    @BeforeEach
+    void registerVerifier() {
+        createVerifierIdp(Map.of(
+                OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS, realmSigningJwks(),
+                OID4VPIdentityProviderConfig.DCQL_QUERY, dcqlQuery(),
+                OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "email"));
+    }
+
+    private static String dcqlQuery() {
+        return """
+                {
+                  "credentials": [
+                    {
+                      "id": "identity",
+                      "format": "dc+sd-jwt",
+                      "meta": { "vct_values": ["%s"] },
+                      "claims": [{ "path": ["email"] }, { "path": ["lastName"] }]
+                    }
+                  ]
+                }""".formatted(sdJwtTypeCredentialVct);
+    }
+
+    @Test
+    public void requestObjectIsSignedByRealmKeyAndWellFormed() throws Exception {
+        JWSInput signedRequest = new JWSInput(fetchRequestObject(requestUri(openWalletPage())));
+
+        JWSHeader header = signedRequest.getHeader();
+        Assertions.assertEquals(OID4VCConstants.REQUEST_OBJECT_TYPE, header.getType());
+        List<String> x5c = header.getX5c();
+        Assertions.assertNotNull(x5c, "Request object must publish the verifier certificate in x5c");
+        Assertions.assertFalse(x5c.isEmpty());
+        X509Certificate leaf = PemUtils.decodeCertificate(x5c.get(0));
+        Assertions.assertTrue(verifyEs256(signedRequest, leaf),
+                "Request object signature does not match the certificate in x5c");
+
+        JsonNode request = JsonSerialization.readValue(signedRequest.getContent(), JsonNode.class);
+        Assertions.assertTrue(request.path("client_id").asText().startsWith("x509_hash:"));
+        Assertions.assertEquals("vp_token", request.path("response_type").asText());
+        Assertions.assertEquals("direct_post", request.path("response_mode").asText());
+        Assertions.assertTrue(request.hasNonNull("nonce"));
+        Assertions.assertEquals(JsonSerialization.readValue(dcqlQuery(), JsonNode.class), request.path("dcql_query"));
+    }
+
+    @Test
+    public void happyFlowVerifiesPresentationAndContinuesLogin() throws Exception {
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+
+        driver.open(completeAuth);
+        assertLoginContinued();
+    }
+
+    @Test
+    public void completeAuthRejectsUnknownResponseCode() throws Exception {
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+
+        driver.open(completeAuth.replaceAll("response_code=[^&]+", "response_code=" + UUID.randomUUID()));
+        assertLoginRejected();
+    }
+
+    @Test
+    public void completeAuthRejectsMismatchedBrowserSession() throws Exception {
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+
+        driver.cookies().deleteAll();
+        driver.open(completeAuth);
+        assertLoginRejected();
+    }
+
+    @Test
+    public void completeAuthResponseCodeIsSingleUse() throws Exception {
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+
+        driver.open(completeAuth);
+        assertLoginContinued();
+        driver.open(completeAuth);
+        assertLoginRejected();
+    }
+
+    @Test
+    public void directPostRejectsPresentationWithWrongNonce() throws Exception {
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+
+        JsonNode body = directPost(request, present(credential, request, "not-the-issued-nonce"), 400);
+        Assertions.assertEquals("access_denied", body.path("error").asText());
+    }
+
+    @Test
+    public void requestObjectRejectsUnknownState() throws Exception {
+        String unknownStateUri = requestUri(openWalletPage()).replaceAll("[^/]+$", UUID.randomUUID().toString());
+
+        try (CloseableHttpResponse response = httpClient.execute(new HttpGet(unknownStateUri))) {
+            Assertions.assertEquals(400, response.getStatusLine().getStatusCode());
+            JsonNode body = JsonSerialization.readValue(EntityUtils.toByteArray(response.getEntity()), JsonNode.class);
+            Assertions.assertEquals("invalid_request", body.path("error").asText());
+        }
+    }
+
+    @Test
+    public void directPostRejectsMissingParameters() throws Exception {
+        JsonNode request = requestObject();
+
+        HttpPost post = new HttpPost(request.path("response_uri").asText());
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            Assertions.assertEquals(400, response.getStatusLine().getStatusCode());
+            JsonNode body = JsonSerialization.readValue(EntityUtils.toByteArray(response.getEntity()), JsonNode.class);
+            Assertions.assertEquals("invalid_request", body.path("error").asText());
+        }
+    }
+
+    @Test
+    public void directPostRejectsUnsupportedSignatureAlgorithm() throws Exception {
+        setCredentialScopeAttributes(sdJwtTypeCredentialScope, Map.of(VC_SIGNING_ALG, Algorithm.RS256));
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+
+        JsonNode body = directPost(request, present(credential, request), 400);
+        Assertions.assertEquals("access_denied", body.path("error").asText());
+        Assertions.assertTrue(body.path("error_description").asText().contains("algorithm"),
+                "Expected an unsupported algorithm error, was: " + body);
+    }
+
+    @Test
+    public void loginFailsWhenActiveSigningKeyHasNoCertificate() {
+        addActiveEs256KeyWithoutCertificate();
+
+        driver.open(authUrl());
+        Assertions.assertFalse(driver.driver().getPageSource().contains("openid4vp://"),
+                "Login must not start when the active ES256 key has no certificate");
+    }
+
+    @Test
+    public void configuredSigningKeyIdPinsTheRequestSigningKey() throws Exception {
+        IssuedCredential credential = issueCredential();
+        updateIdpConfig(OID4VPIdentityProviderConfig.SIGNING_KEY_ID, verifierSigningKeyKid());
+        disableVerifierSigningKey();
+        addActiveEs256KeyWithoutCertificate();
+
+        JWSInput signedRequest = new JWSInput(fetchRequestObject(requestUri(openWalletPage())));
+        X509Certificate leaf = PemUtils.decodeCertificate(signedRequest.getHeader().getX5c().get(0));
+        Assertions.assertEquals(verifierSigningKeyPublicKeyPem(), PemUtils.encodeKey(leaf.getPublicKey()),
+                "Request object is not signed with the pinned signing key");
+        Assertions.assertTrue(verifyEs256(signedRequest, leaf),
+                "Request object signature does not match the certificate in x5c");
+
+        JsonNode request = JsonSerialization.readValue(signedRequest.getContent(), JsonNode.class);
+        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+
+        driver.open(completeAuth);
+        assertLoginContinued();
+    }
+
+    @Test
+    public void loginFailsForUnknownSigningKeyId() {
+        updateIdpConfig(OID4VPIdentityProviderConfig.SIGNING_KEY_ID, "no-such-kid");
+
+        driver.open(authUrl());
+        Assertions.assertFalse(driver.driver().getPageSource().contains("openid4vp://"),
+                "Login must not start when the configured signing key id matches no realm key");
+    }
+
+    @Test
+    public void directPostRejectsMultipleCredentials() throws Exception {
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+        String vpToken = present(credential, request);
+
+        JsonNode body = directPost(request, "[\"" + vpToken + "\",\"" + vpToken + "\"]", 400);
+        Assertions.assertEquals("access_denied", body.path("error").asText());
+    }
+
+    @Test
+    public void directPostRejectsNonScalarPrincipal() throws Exception {
+        // address is an object claim, so configuring it as the principal must be rejected rather than
+        // mapped onto an empty user id.
+        updatePrincipalAttribute("address");
+        IssuedCredential credential = issueCredential();
+        JsonNode request = requestObject();
+
+        JsonNode body = directPost(request, present(credential, request), 400);
+        Assertions.assertEquals("access_denied", body.path("error").asText());
+        Assertions.assertTrue(body.path("error_description").asText().contains("principal attribute"),
+                "Expected a principal attribute error, was: " + body);
+    }
+
+    private void assertLoginContinued() {
+        // TODO assert the presented claims (email, given and family name) were mapped to the user
+        Assertions.assertTrue(driver.driver().getCurrentUrl().contains("login-actions"),
+                "Expected to continue into the login flow, was: " + driver.driver().getCurrentUrl());
+    }
+
+    private void assertLoginRejected() {
+        String page = driver.driver().getPageSource();
+        Assertions.assertTrue(page.contains("kc-error-message"),
+                "Expected the login error page, was: " + driver.driver().getCurrentUrl());
+        Assertions.assertTrue(page.contains("Session not active"),
+                "Expected the session not active error, was: " + page);
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/PresentationServerConfig.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/PresentationServerConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc.presentation;
+
+import org.keycloak.common.Profile;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+public class PresentationServerConfig implements KeycloakServerConfig {
+
+    @Override
+    public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+        return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_VP);
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/AbstractConformanceTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/AbstractConformanceTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.tests.conformance;
 
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.keycloak.testframework.https.CertificatesConfig;
@@ -30,6 +31,7 @@ import org.keycloak.tests.conformance.runner.BrowserInteraction;
 import org.keycloak.tests.conformance.runner.ConformanceModuleResult;
 import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
 import org.keycloak.tests.conformance.runner.ConformanceResult;
+import org.keycloak.tests.conformance.runner.ModuleRun;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.logging.Logger;
@@ -47,9 +49,8 @@ public abstract class AbstractConformanceTest {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractConformanceTest.class);
 
-    // Not used directly, but required to start the Keycloak server with TLS enabled
     @InjectCertificates(config = TlsCertificates.class)
-    ManagedCertificates certificates;
+    protected ManagedCertificates certificates;
 
     @InjectConformanceSuite
     protected OpenIdConformanceSuite suite;
@@ -76,10 +77,19 @@ public abstract class AbstractConformanceTest {
                         expectedResult, browserInteraction));
     }
 
+    /**
+     * Drives the system under test once the module waits for it, e.g. delivers an OID4VP verifier
+     * request.
+     */
+    protected Consumer<ModuleRun> interaction(ConformanceModuleVariant moduleVariant) {
+        return null;
+    }
+
     @ParameterizedTest
     @MethodSource("moduleVariants")
     public void conformance(ConformanceModuleVariant moduleVariant) {
-        ConformanceModuleResult result = suite.client().run(moduleVariant, suiteConfig(moduleVariant));
+        ConformanceModuleResult result = suite.client()
+                .run(moduleVariant, suiteConfig(moduleVariant), interaction(moduleVariant));
         if (!result.finishedWith(moduleVariant.expectedResult())) {
             LOGGER.errorf("Full logs of failed conformance module %s:%n%s", result.module(), result.logs().toPrettyString());
             Assertions.fail(result.failureSummary());

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/ConformanceSigningKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/ConformanceSigningKey.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.List;
+
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.CertificateUtils;
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.JavaAlgorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.def.DefaultCryptoProvider;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jwk.JWKUtil;
+import org.keycloak.jose.jws.crypto.HashUtils;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * EC signing material generated at runtime for conformance tests, so no private key is committed to
+ * the repository: a self-signed CA plus a CA-issued leaf certificate, exposed as the various PEM and
+ * JWK representations the conformance suite and Keycloak need. The conformance suite signs with the
+ * private JWK while Keycloak trusts the public JWKS and the CA certificate.
+ */
+public final class ConformanceSigningKey {
+
+    public static final String KEYSTORE_PASSWORD = "password";
+
+    private static final Path KEYSTORES_BASE_DIR;
+
+    static {
+        try {
+            KEYSTORES_BASE_DIR = Files.createTempDirectory("keycloak-conformance-keystores");
+            KEYSTORES_BASE_DIR.toFile().deleteOnExit();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final String realmName;
+    private final String kid;
+    private final KeyPair keyPair;
+    private final X509Certificate certificate;
+    private final X509Certificate caCertificate;
+    private String keyStorePath;
+
+    private ConformanceSigningKey(String realmName, String kid, KeyPair keyPair, X509Certificate certificate,
+            X509Certificate caCertificate) {
+        this.realmName = realmName;
+        this.kid = kid;
+        this.keyPair = keyPair;
+        this.certificate = certificate;
+        this.caCertificate = caCertificate;
+    }
+
+    // The Java keystore key provider only loads keystores under the realm's folder below the
+    // configured keystores path, so all conformance keystores live in per realm folders under this
+    // base directory and the test servers point the keystores path option at it.
+    public static String keystoresBaseDir() {
+        return KEYSTORES_BASE_DIR.toString();
+    }
+
+    public static synchronized Path realmKeystoreDir(String realmName) throws IOException {
+        Path realmDir = KEYSTORES_BASE_DIR.resolve(realmName);
+        if (!Files.exists(realmDir)) {
+            Files.createDirectory(realmDir);
+            realmDir.toFile().deleteOnExit();
+        }
+        return realmDir;
+    }
+
+    public static ConformanceSigningKey generate(String realmName, String kid, String name) {
+        try {
+            if (!CryptoIntegration.isInitialised()) {
+                CryptoIntegration.setProvider(new DefaultCryptoProvider());
+            }
+            KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("EC");
+            keyGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair caKeyPair = keyGenerator.generateKeyPair();
+            KeyPair keyPair = keyGenerator.generateKeyPair();
+
+            X509Certificate caCertificate =
+                    CertificateUtils.generateV1SelfSignedCertificate(caKeyPair, name + " CA");
+            X509Certificate certificate =
+                    CertificateUtils.generateV3Certificate(keyPair, caKeyPair.getPrivate(), caCertificate, name);
+            return new ConformanceSigningKey(realmName, kid, keyPair, certificate, caCertificate);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create conformance signing key " + kid, e);
+        }
+    }
+
+    public JsonNode publicJwks() {
+        return jwks(jwk(false));
+    }
+
+    public JsonNode privateJwks() {
+        return jwks(jwk(true));
+    }
+
+    public JsonNode privateJwk() {
+        return JsonSerialization.writeValueAsNode(jwk(true));
+    }
+
+    public String caCertificatePem() {
+        return PemUtils.addCertificateBeginEnd(PemUtils.encodeCertificate(caCertificate));
+    }
+
+    public String x509Hash() {
+        try {
+            return Base64Url.encode(HashUtils.hash(JavaAlgorithm.SHA256, certificate.getEncoded()));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to compute x509_hash", e);
+        }
+    }
+
+    public String keyAlias() {
+        return kid;
+    }
+
+    // A PKCS12 keystore holding the leaf key and its certificate chain, e.g. to back a realm key provider.
+    public synchronized String keyStorePath() {
+        if (keyStorePath == null) {
+            try {
+                KeyStore keyStore = KeyStore.getInstance("PKCS12");
+                keyStore.load(null, null);
+                keyStore.setKeyEntry(kid, keyPair.getPrivate(), KEYSTORE_PASSWORD.toCharArray(),
+                        new Certificate[] {certificate, caCertificate});
+                Path path = Files.createTempFile(realmKeystoreDir(realmName), "keycloak-conformance-" + kid, ".p12");
+                try (OutputStream output = Files.newOutputStream(path)) {
+                    keyStore.store(output, KEYSTORE_PASSWORD.toCharArray());
+                }
+                path.toFile().deleteOnExit();
+                keyStorePath = path.toString();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to create conformance keystore", e);
+            }
+        }
+        return keyStorePath;
+    }
+
+    private JWK jwk(boolean includePrivateKey) {
+        JWK jwk = JWKBuilder.create().kid(kid).algorithm(Algorithm.ES256)
+                .ec(keyPair.getPublic(), List.of(certificate), KeyUse.SIG);
+        if (includePrivateKey) {
+            ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
+            int fieldSize = privateKey.getParams().getCurve().getField().getFieldSize();
+            jwk.setOtherClaims("d", Base64Url.encode(JWKUtil.toIntegerBytes(privateKey.getS(), fieldSize)));
+        }
+        return jwk;
+    }
+
+    private static JsonNode jwks(JWK key) {
+        JSONWebKeySet keySet = new JSONWebKeySet();
+        keySet.setKeys(new JWK[] {key});
+        return JsonSerialization.writeValueAsNode(keySet);
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/OpenIdConformanceSuite.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/OpenIdConformanceSuite.java
@@ -57,13 +57,17 @@ public final class OpenIdConformanceSuite implements AutoCloseable {
     private final GenericContainer<?> server;
     private final GenericContainer<?> nginx;
     private final ConformanceApiClient client;
+    private final URI baseUri;
+    private final X509Certificate nginxCertificate;
 
     private OpenIdConformanceSuite(Network network, GenericContainer<?> mongo, GenericContainer<?> server,
-            GenericContainer<?> nginx, URI baseUri, SSLContext sslContext) {
+            GenericContainer<?> nginx, URI baseUri, SSLContext sslContext, X509Certificate nginxCertificate) {
         this.network = network;
         this.mongo = mongo;
         this.server = server;
         this.nginx = nginx;
+        this.baseUri = baseUri;
+        this.nginxCertificate = nginxCertificate;
         this.client = new ConformanceApiClient(baseUri, sslContext);
     }
 
@@ -120,8 +124,10 @@ public final class OpenIdConformanceSuite implements AutoCloseable {
             nginx.start();
 
             URI baseUri = URI.create("https://" + nginx.getHost() + ":" + nginx.getMappedPort(8443));
-            SSLContext sslContext = sslContextTrusting(nginxCertificate(nginx));
-            OpenIdConformanceSuite suite = new OpenIdConformanceSuite(network, mongo, server, nginx, baseUri, sslContext);
+            X509Certificate nginxCertificate = nginxCertificate(nginx);
+            SSLContext sslContext = sslContextTrusting(nginxCertificate);
+            OpenIdConformanceSuite suite =
+                    new OpenIdConformanceSuite(network, mongo, server, nginx, baseUri, sslContext, nginxCertificate);
             suite.client().waitUntilAvailable(Duration.ofMinutes(4));
             return suite;
         } catch (RuntimeException e) {
@@ -133,6 +139,20 @@ public final class OpenIdConformanceSuite implements AutoCloseable {
 
     public ConformanceApiClient client() {
         return client;
+    }
+
+    // The suite's nginx TLS certificate, so a client can trust it without disabling verification.
+    public X509Certificate nginxCertificate() {
+        return nginxCertificate;
+    }
+
+    // Rewrites a suite internal URI to one reachable from the test JVM.
+    public URI externalUri(URI internalUri) {
+        if (!INTERNAL_BASE_URI.getHost().equals(internalUri.getHost())) {
+            return internalUri;
+        }
+        String query = internalUri.getRawQuery() != null ? "?" + internalUri.getRawQuery() : "";
+        return URI.create(baseUri + internalUri.getRawPath() + query);
     }
 
     @Override

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceApiClient.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceApiClient.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 
@@ -93,6 +94,16 @@ public final class ConformanceApiClient {
     }
 
     public ConformanceModuleResult run(ConformanceModuleVariant module, JsonNode suiteConfig) {
+        return run(module, suiteConfig, null);
+    }
+
+    /**
+     * Runs a module, optionally driving the system under test through {@code interaction} once the
+     * module waits for it. The issuer (VCI) modules are driven by the suite's own browser and pass
+     * {@code null}. The verifier (OID4VP) modules deliver the authorization request from here.
+     */
+    public ConformanceModuleResult run(ConformanceModuleVariant module, JsonNode suiteConfig,
+            Consumer<ModuleRun> interaction) {
         JsonNode plan = createPlan(module.plan(), suiteConfig, module.planVariant());
         String planId = requiredText(plan, "id");
 
@@ -101,6 +112,12 @@ public final class ConformanceApiClient {
         JsonNode info = waitForRunnableOrFinished(planId, moduleId);
         if ("CONFIGURED".equals(info.path("status").asText())) {
             startModule(planId, moduleId);
+        }
+        if (interaction != null) {
+            info = waitForState(planId, moduleId, List.of("WAITING", "FINISHED"), Duration.ofMinutes(4));
+            if (!"FINISHED".equals(info.path("status").asText())) {
+                interaction.accept(new ModuleRun(moduleNode, info));
+            }
         }
         info = waitForFinished(planId, moduleId);
         JsonNode logs = getLogs(planId, moduleId);

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ModuleRun.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ModuleRun.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * A running conformance module: the runner creation response and the latest module info. Passed to
+ * the interaction callback so a test can drive the system under test once the module waits for it.
+ */
+public record ModuleRun(JsonNode created, JsonNode info) {
+
+    /**
+     * The authorization endpoint of the module's wallet, used to deliver an OID4VP verifier request.
+     * Derived from the module URL in the runner creation response.
+     */
+    public URI authorizationEndpoint() {
+        String url = created.path("url").asText(created.path("testUrl").asText(""));
+        if (url.isBlank()) {
+            throw new IllegalStateException("Conformance module exposes no authorization endpoint. Creation response: "
+                    + created + ", module info: " + info);
+        }
+        URI uri = URI.create(url);
+        String path = uri.getPath() != null ? uri.getPath() : "";
+        return path.endsWith("/authorize") ? uri : URI.create(url.replaceAll("/$", "") + "/authorize");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
@@ -52,6 +52,7 @@ import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.tests.conformance.ConformanceSigningKey;
 import org.keycloak.tests.conformance.containers.OpenIdConformanceSuite;
 import org.keycloak.util.JsonSerialization;
 
@@ -230,7 +231,8 @@ public class VciConformanceRealmConfig implements RealmConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
             return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.CLIENT_AUTH_ABCA)
-                    .option("hostname", OpenIdConformanceSuite.KEYCLOAK_BASE_URI.toString());
+                    .option("hostname", OpenIdConformanceSuite.KEYCLOAK_BASE_URI.toString())
+                    .spiOption("keys", "java-keystore", "keystores-path", ConformanceSigningKey.keystoresBaseDir());
         }
     }
 }

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciTestSigningKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciTestSigningKey.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.def.DefaultCryptoProvider;
+import org.keycloak.tests.conformance.ConformanceSigningKey;
 
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.BasicConstraints;
@@ -77,7 +78,9 @@ final class VciTestSigningKey {
             keyStore.setKeyEntry(KEY_ALIAS, leafKeyPair.getPrivate(), PASSWORD.toCharArray(),
                     new Certificate[] { leafCertificate, caCertificate });
 
-            Path keyStorePath = Files.createTempFile("keycloak-oid4vci-conformance-signing", ".p12");
+            Path keyStorePath = Files.createTempFile(
+                    ConformanceSigningKey.realmKeystoreDir(VciConformanceRealmConfig.REALM),
+                    "keycloak-oid4vci-conformance-signing", ".p12");
             try (OutputStream output = Files.newOutputStream(keyStorePath)) {
                 keyStore.store(output, PASSWORD.toCharArray());
             }

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/AbstractVpConformanceTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/AbstractVpConformanceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.function.Consumer;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.tests.conformance.AbstractConformanceTest;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+import org.keycloak.tests.conformance.runner.ModuleRun;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+abstract class AbstractVpConformanceTest extends AbstractConformanceTest {
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @Override
+    protected JsonNode suiteConfig(ConformanceModuleVariant moduleVariant) {
+        return VpSuiteConfig.create(
+                        "keycloak-oid4vp",
+                        VpVerifierKey.clientId(),
+                        VpVerifierKey.caCertificatePem(),
+                        VpVerifierKey.privateJwk())
+                .toJson();
+    }
+
+    @Override
+    protected Consumer<ModuleRun> interaction(ConformanceModuleVariant moduleVariant) {
+        return moduleRun -> new KeycloakVerifierBrowser(suite, keycloakUrls.getBase(), browserSslContext())
+                .login(VpConformanceRealmConfig.REALM, VpConformanceRealmConfig.CLIENT_ID,
+                        VpConformanceRealmConfig.IDP_ALIAS, moduleRun);
+    }
+
+    // The browser visits both Keycloak and the suite over TLS, so it trusts the Keycloak server
+    // certificate and the suite's nginx certificate.
+    private SSLContext browserSslContext() {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("conformance-suite", suite.nginxCertificate());
+
+            KeyStore serverKeyStore = KeyStore.getInstance(certificates.getKeystoreFormat().name());
+            try (InputStream in = Files.newInputStream(Path.of(certificates.getServerKeyStorePath()))) {
+                serverKeyStore.load(in, certificates.getServerKeyStorePassword().toCharArray());
+            }
+            for (String alias : Collections.list(serverKeyStore.aliases())) {
+                Certificate certificate = serverKeyStore.getCertificate(alias);
+                if (certificate instanceof X509Certificate) {
+                    trustStore.setCertificateEntry("keycloak-" + alias, certificate);
+                }
+            }
+
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+            return sslContext;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build the verifier browser trust store", e);
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/KeycloakVerifierBrowser.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/KeycloakVerifierBrowser.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.net.ssl.SSLContext;
+
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.common.util.UriUtils;
+import org.keycloak.protocol.oidc.utils.PkceUtils;
+import org.keycloak.tests.conformance.containers.OpenIdConformanceSuite;
+import org.keycloak.tests.conformance.runner.ModuleRun;
+
+/**
+ * Plays the user's browser in the same device flow. It starts a Keycloak login, extracts the wallet
+ * link parameters from the OID4VP login page, hands them to the conformance suite's wallet, and
+ * follows redirects back to Keycloak over one cookie session.
+ */
+final class KeycloakVerifierBrowser {
+
+    // Matches the wallet link by its scheme so it does not depend on the login page markup.
+    private static final Pattern WALLET_LINK = Pattern.compile("openid4vp://[^\"'\\s]+");
+
+    private final OpenIdConformanceSuite suite;
+    private final String keycloakLocalBaseUrl;
+    private final HttpClient httpClient;
+
+    KeycloakVerifierBrowser(OpenIdConformanceSuite suite, String keycloakLocalBaseUrl, SSLContext sslContext) {
+        this.suite = suite;
+        this.keycloakLocalBaseUrl = keycloakLocalBaseUrl;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(20))
+                .cookieHandler(new CookieManager(null, CookiePolicy.ACCEPT_ALL))
+                .sslContext(sslContext)
+                .build();
+    }
+
+    void login(String realm, String clientId, String idpAlias, ModuleRun moduleRun) {
+        WalletLink walletLink = fetchWalletLink(realm, clientId, idpAlias);
+        deliverToWallet(moduleRun, walletLink);
+    }
+
+    private record WalletLink(String clientId, String requestUri) {
+    }
+
+    private WalletLink fetchWalletLink(String realm, String clientId, String idpAlias) {
+        String codeVerifier = PkceUtils.generateCodeVerifier();
+        String loginUrl = keycloakLocalBaseUrl + "/realms/" + realm + "/protocol/openid-connect/auth"
+                + "?client_id=" + urlEncode(clientId)
+                + "&response_type=code"
+                + "&scope=openid"
+                + "&redirect_uri=" + urlEncode(OpenIdConformanceSuite.KEYCLOAK_BASE_URI + "/callback")
+                + "&code_challenge=" + urlEncode(PkceUtils.generateS256CodeChallenge(codeVerifier))
+                + "&code_challenge_method=S256"
+                + "&kc_idp_hint=" + urlEncode(idpAlias);
+
+        HttpResponse<String> response = getFollowingRedirects(URI.create(loginUrl));
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException(
+                    "Keycloak login page returned HTTP " + response.statusCode() + ": " + response.body());
+        }
+        Matcher matcher = WALLET_LINK.matcher(response.body());
+        if (!matcher.find()) {
+            throw new IllegalStateException("Keycloak login page did not contain the same device wallet link");
+        }
+        String walletUrl = matcher.group().replace("&amp;", "&");
+        String query = walletUrl.contains("?") ? walletUrl.substring(walletUrl.indexOf('?') + 1) : "";
+        MultivaluedHashMap<String, String> parameters = UriUtils.parseQueryParameters(query, true);
+        return new WalletLink(required(parameters, "client_id", walletUrl), required(parameters, "request_uri", walletUrl));
+    }
+
+    private void deliverToWallet(ModuleRun moduleRun, WalletLink walletLink) {
+        URI authorizationEndpoint = suite.externalUri(moduleRun.authorizationEndpoint());
+        String url = authorizationEndpoint
+                + (authorizationEndpoint.getQuery() != null ? "&" : "?")
+                + "client_id=" + urlEncode(walletLink.clientId())
+                + "&request_uri=" + urlEncode(walletLink.requestUri());
+        getFollowingRedirects(URI.create(url));
+    }
+
+    private HttpResponse<String> get(URI uri) {
+        try {
+            return httpClient.send(
+                    HttpRequest.newBuilder(uri)
+                            .timeout(Duration.ofMinutes(1))
+                            .header("Accept", "text/html,application/json,application/oauth-authz-req+jwt")
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new RuntimeException("Request failed: " + uri, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while requesting " + uri, e);
+        }
+    }
+
+    // Redirects are followed by hand rather than with HttpClient.followRedirects, because Keycloak
+    // and the suite emit Location headers with their container network hostnames
+    // (host.testcontainers.internal, nginx) that the test JVM cannot reach. Each hop is rewritten to
+    // a host-reachable URL.
+    private HttpResponse<String> getFollowingRedirects(URI uri) {
+        URI current = uri;
+        for (int redirects = 0; redirects < 10; redirects++) {
+            HttpResponse<String> response = get(current);
+            if (response.statusCode() >= 400) {
+                throw new IllegalStateException("Authorization flow returned HTTP " + response.statusCode()
+                        + " for " + current + ": " + response.body());
+            }
+            if (response.statusCode() < 300) {
+                return response;
+            }
+            URI next = current.resolve(response.headers().firstValue("Location")
+                    .orElseThrow(() -> new IllegalStateException("Redirect without Location header")));
+            // A redirect to the suite results page means the wallet interaction is complete. The
+            // module verdict is read from the suite module status, not from the browser response.
+            if (next.getPath() != null && next.getPath().contains("log-detail")) {
+                return response;
+            }
+            current = rewriteToHostReachable(next);
+        }
+        throw new IllegalStateException("Too many redirects, last URL: " + current);
+    }
+
+    private URI rewriteToHostReachable(URI uri) {
+        if (OpenIdConformanceSuite.KEYCLOAK_BASE_URI.getHost().equals(uri.getHost())) {
+            return URI.create(keycloakLocalBaseUrl + uri.getRawPath()
+                    + (uri.getRawQuery() != null ? "?" + uri.getRawQuery() : ""));
+        }
+        return suite.externalUri(uri);
+    }
+
+    private static String required(MultivaluedHashMap<String, String> parameters, String name, String url) {
+        String value = parameters.getFirst(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Wallet link did not contain " + name + ": " + url);
+        }
+        return value;
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidCredentialSignatureTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidCredentialSignatureTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a credential with an invalid issuer signature.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierInvalidCredentialSignatureTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-invalid-credential-signature");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidKbJwtAudTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidKbJwtAudTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT carrying the wrong audience.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierInvalidKbJwtAudTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-invalid-kb-jwt-aud");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidKbJwtNonceTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidKbJwtNonceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT carrying the wrong nonce.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierInvalidKbJwtNonceTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-invalid-kb-jwt-nonce");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidKbJwtSignatureTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidKbJwtSignatureTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT with an invalid signature.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierInvalidKbJwtSignatureTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-invalid-kb-jwt-signature");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidSdHashTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierInvalidSdHashTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT whose sd_hash does not match the presentation.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierInvalidSdHashTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-invalid-sd-hash");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierKbJwtIatInFutureTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierKbJwtIatInFutureTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT issued in the future.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierKbJwtIatInFutureTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-kb-jwt-iat-in-future");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierKbJwtIatInPastTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierKbJwtIatInPastTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT issued too far in the past.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierKbJwtIatInPastTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-kb-jwt-iat-in-past");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierMinimalCnfJwkTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierMinimalCnfJwkTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier accepts a presentation whose credential carries a minimal holder cnf jwk.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierMinimalCnfJwkTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-minimal-cnf-jwk");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierRequestUriMethodPostTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierRequestUriMethodPostTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+import org.junit.jupiter.api.Disabled;
+
+/**
+ * The verifier serves the authorization request object when the wallet retrieves request_uri through
+ * POST.
+ */
+// TODO serve request_uri through POST so this module passes. The request object endpoint only
+// answers GET, so the suite skips the module.
+@Disabled("request_uri retrieval through POST is not implemented, the request object endpoint answers GET only")
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierRequestUriMethodPostTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-request-uri-method-post");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierSameDeviceHappyFlowTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierSameDeviceHappyFlowTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier accepts a valid same device SD-JWT VC presentation.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierSameDeviceHappyFlowTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post"),
+                "oid4vp-1final-verifier-happy-flow");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpConformanceRealmConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.keys.Attributes;
+import org.keycloak.keys.JavaKeystoreKeyProviderFactory;
+import org.keycloak.keys.KeyProvider;
+import org.keycloak.representations.idm.ComponentExportRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.tests.conformance.ConformanceSigningKey;
+import org.keycloak.tests.conformance.containers.OpenIdConformanceSuite;
+
+public class VpConformanceRealmConfig implements RealmConfig {
+
+    public static final String REALM = "oid4vp-verifier";
+    public static final String CLIENT_ID = "wallet-mock";
+    public static final String IDP_ALIAS = "oid4vp";
+
+    // The suite presents a PID SD-JWT VC and discloses given_name and family_name. given_name is the
+    // principal because the presented credential carries no stable subject claim.
+    static final String DCQL_QUERY = """
+            {
+              "credentials": [
+                {
+                  "id": "pid_sd_jwt",
+                  "format": "dc+sd-jwt",
+                  "meta": { "vct_values": ["urn:eudi:pid:1"] },
+                  "claims": [{ "path": ["given_name"] }, { "path": ["family_name"] }]
+                }
+              ],
+              "credential_sets": [{ "options": [["pid_sd_jwt"]], "required": true }]
+            }
+            """;
+
+    @Override
+    public RealmBuilder configure(RealmBuilder realm) {
+        return realm.name(REALM)
+                .clients(ClientBuilder.create(CLIENT_ID).publicClient().redirectUris("*"))
+                .update(rep -> {
+                    rep.setIdentityProviders(List.of(identityProvider()));
+                    MultivaluedHashMap<String, ComponentExportRepresentation> components = new MultivaluedHashMap<>();
+                    components.add(KeyProvider.class.getName(), verifierSigningKeyProvider());
+                    rep.setComponents(components);
+                });
+    }
+
+    private IdentityProviderRepresentation identityProvider() {
+        IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
+        idp.setAlias(IDP_ALIAS);
+        idp.setProviderId(OID4VPIdentityProviderFactory.PROVIDER_ID);
+        idp.setEnabled(true);
+        idp.setFirstBrokerLoginFlowAlias("first broker login");
+        idp.setConfig(Map.of(
+                OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS, VpVerifierKey.publicJwks().toString(),
+                OID4VPIdentityProviderConfig.DCQL_QUERY, DCQL_QUERY,
+                OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "given_name"));
+        return idp;
+    }
+
+    // The verifier's request-signing key, holding the CA-issued certificate the suite trusts.
+    private ComponentExportRepresentation verifierSigningKeyProvider() {
+        ComponentExportRepresentation keyProvider = new ComponentExportRepresentation();
+        keyProvider.setName("oid4vp-verifier-signing-key");
+        keyProvider.setId(UUID.randomUUID().toString());
+        keyProvider.setProviderId(JavaKeystoreKeyProviderFactory.ID);
+        keyProvider.setConfig(new MultivaluedHashMap<>(Map.of(
+                Attributes.PRIORITY_KEY, List.of("100"),
+                Attributes.ENABLED_KEY, List.of("true"),
+                Attributes.ACTIVE_KEY, List.of("true"),
+                Attributes.ALGORITHM_KEY, List.of(Algorithm.ES256),
+                Attributes.KEY_USE, List.of(KeyUse.SIG.name()),
+                JavaKeystoreKeyProviderFactory.KEYSTORE_KEY, List.of(VpVerifierKey.keyStorePath()),
+                JavaKeystoreKeyProviderFactory.KEYSTORE_PASSWORD_KEY, List.of(VpVerifierKey.keyStorePassword()),
+                JavaKeystoreKeyProviderFactory.KEYSTORE_TYPE_KEY, List.of("PKCS12"),
+                JavaKeystoreKeyProviderFactory.KEY_ALIAS_KEY, List.of(VpVerifierKey.keyAlias()),
+                JavaKeystoreKeyProviderFactory.KEY_PASSWORD_KEY, List.of(VpVerifierKey.keyStorePassword()))));
+        return keyProvider;
+    }
+
+    public static class ServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.OID4VC_VP)
+                    .option("hostname", OpenIdConformanceSuite.KEYCLOAK_BASE_URI.toString())
+                    .spiOption("keys", "java-keystore", "keystores-path", ConformanceSigningKey.keystoresBaseDir());
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpSuiteConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpSuiteConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The test configuration uploaded to the conformance suite for an OID4VP verifier plan: the
+ * verifier's client id, the trust anchor used to validate the request object chain, and the signing
+ * JWK the suite uses to sign the presented credential.
+ */
+record VpSuiteConfig(String alias, String description, String publish, Client client, Credential credential) {
+
+    static VpSuiteConfig create(String alias, String clientId, String requestObjectTrustAnchorPem, JsonNode signingJwk) {
+        return new VpSuiteConfig(
+                alias,
+                "Keycloak OID4VP verifier conformance",
+                "private",
+                new Client(clientId, requestObjectTrustAnchorPem),
+                new Credential(signingJwk));
+    }
+
+    JsonNode toJson() {
+        return JsonSerialization.writeValueAsNode(this);
+    }
+
+    record Client(
+            @JsonProperty("client_id") String clientId,
+            @JsonProperty("request_object_trust_anchor_pem") String requestObjectTrustAnchorPem) {
+    }
+
+    record Credential(@JsonProperty("signing_jwk") JsonNode signingJwk) {
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpVerifierKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpVerifierKey.java
@@ -15,37 +15,45 @@
  * limitations under the License.
  */
 
-package org.keycloak.tests.conformance.vci;
+package org.keycloak.tests.conformance.vp;
 
 import org.keycloak.tests.conformance.ConformanceSigningKey;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/**
- * The attester key, generated at runtime so no private key material is committed to the repository. It is signed
- * by a CA so it serves both client attestation (verified against the trusted public JWKS) and key attestation
- * (which validates the x5c chain against the CA). The private JWKS is handed to the conformance suite to sign
- * attestations, while Keycloak trusts only the public JWKS and the CA certificate.
- */
-final class VciAttesterKey {
-
-    static final String KID = "ct_client_attester_key";
+final class VpVerifierKey {
 
     private static final ConformanceSigningKey KEY = ConformanceSigningKey.generate(
-            VciConformanceRealmConfig.REALM, KID, "OID4VCI Conformance Attester");
+            VpConformanceRealmConfig.REALM, "vp_verifier_key", "OID4VP Conformance Verifier");
 
-    private VciAttesterKey() {
+    private VpVerifierKey() {
     }
 
-    static JsonNode privateJwks() {
-        return KEY.privateJwks();
+    static String keyStorePath() {
+        return KEY.keyStorePath();
+    }
+
+    static String keyStorePassword() {
+        return ConformanceSigningKey.KEYSTORE_PASSWORD;
+    }
+
+    static String keyAlias() {
+        return KEY.keyAlias();
+    }
+
+    static String caCertificatePem() {
+        return KEY.caCertificatePem();
+    }
+
+    static JsonNode privateJwk() {
+        return KEY.privateJwk();
     }
 
     static JsonNode publicJwks() {
         return KEY.publicJwks();
     }
 
-    static String caCertificatePem() {
-        return KEY.caCertificatePem();
+    static String clientId() {
+        return "x509_hash:" + KEY.x509Hash();
     }
 }

--- a/themes/src/main/resources/theme/base/login/login-oid4vp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-oid4vp.ftl
@@ -1,0 +1,16 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=false; section>
+    <#if section = "header">
+        ${msg("oid4vpLoginTitle")}
+    <#elseif section = "form">
+        <#if (sameDeviceWalletUrl!'')?has_content>
+            <div class="${properties.kcFormGroupClass!}">
+                <a id="oid4vp-open-wallet"
+                   href="${sameDeviceWalletUrl}"
+                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}">
+                    ${msg("oid4vpOpenWalletApp")}
+                </a>
+            </div>
+        </#if>
+    </#if>
+</@layout.registrationLayout>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -574,3 +574,6 @@ orgDisabledMessage=The organization is not available at this time and cannot acc
 staleInviteOrgLink=The link you clicked is no longer valid. It may have expired or already been used.
 
 traceIdSupportMessage=If you contact support, please provide the following trace identifier: {0}
+
+oid4vpLoginTitle=Sign in with your wallet
+oid4vpOpenWalletApp=Open wallet app


### PR DESCRIPTION
Initial implementation for #49415 that passes almost all modules of the OID4VP conformance test plan, for the SD-JWT, direct_post, x509_hash variant. The negative testcases are all passed by previous work already present to verify SD-JWTs and KB-JWTs.

Some shortcuts are still made to keep the scope relatively small, while still having a working slice. Thats why there are a lot of TODO comments.

@rmartinc @tdiesler @mposolda could you please review?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
