### PR TITLE
[26.6] Documentation: clarify that running different operator versions on the same cluster is not supported

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -334,3 +334,13 @@ The previous `v2alpha1` version for these resources is deprecated but still serv
 There are currently no differences in the schema between the two versions,
 so you will just need to update the relevant `apiVersion` references.
 
+[WARNING]
+====
+If you are running multiple operator instances in different namespaces on the same cluster and using OLM, installing or upgrading to the 26.6 operator will prevent older operator versions (such as 26.4) from being installed or upgraded.
+Existing 26.4 operator installations will remain unaffected and will keep reconciling existing {project_name} 26.4 deployments.
+This is because CRDs are cluster-scoped and the introduction of the `v2beta1` version in the CRD will cause OLM to block any operator whose CRD does not include this version.
+If you have multiple operator instances, upgrade all of them to 26.6.
+Upgrading the operator does not require upgrading your Keycloak images at the same time — the 26.6 operator can manage instances running older images.
+See the <<truststore-initialization-moved-to-the-server, Truststore initialization moved to the server>> section for a configuration change that may be needed when running older images with the 26.6 operator.
+====
+

--- a/docs/guides/operator/installation.adoc
+++ b/docs/guides/operator/installation.adoc
@@ -140,6 +140,7 @@ If you do this please be aware:
 - CRD revisions from newer Operator versions won't introduce breaking changes except for the eventual removal of fields that have been well deprecated. Thus newer CRDs are generally backward compatible.
 - the CRDs installed last will be the ones in use. This applies to OLM installations as well where the Operator version, that is installed as the last, also installs and overrides the CRDs if they exists in the cluster already.
 - older CRDs may not be forwards compatible with new fields used by newer operators. When using OLM it will check if your custom resources are compatible with the CRDs being installed, so the usage of new fields can prevent the simultaneous installation of older operator versions.
+- when using OLM, newer CRDs containing new API versions (e.g. `v2beta1`) will prevent the installation or upgrade of older operators that do not include those versions.
 - fields introduced by newer CRDs will not be supported by older Operators. Older operators will fail to handle CRs that use such new fields with an error deserializing an unrecognized field.
 
 It is therefore recommended in a multiple Operator install scenario that you keep versions aligned as closely as possible to minimize the potential problems with different versions.


### PR DESCRIPTION
Backports https://github.com/keycloak/keycloak/pull/50264 which closed https://github.com/keycloak/keycloak/issues/50263 to 26.6.
