### PR TITLE
Avoid timeouts for Base2 testsuite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1263,7 +1263,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        suite: [Base1TestSuite, Base2TestSuite]
+        suite: [Base1TestSuite, Base2TestSuite, Base3TestSuite]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1262,6 +1262,7 @@ jobs:
       - build
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         suite: [Base1TestSuite, Base2TestSuite, Base3TestSuite]
     steps:

--- a/tests/base/src/test/java/org/keycloak/tests/suites/Base2TestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/Base2TestSuite.java
@@ -20,7 +20,8 @@ import org.junit.platform.suite.api.Suite;
         "org.keycloak.tests.i18n",
         "org.keycloak.tests.infinispan",
         "org.keycloak.tests.keys",
-        "org.keycloak.tests.login"
+        "org.keycloak.tests.login",
+        "org.keycloak.tests.loginfailures"
 })
 public class Base2TestSuite {
 }

--- a/tests/base/src/test/java/org/keycloak/tests/suites/Base2TestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/Base2TestSuite.java
@@ -20,24 +20,7 @@ import org.junit.platform.suite.api.Suite;
         "org.keycloak.tests.i18n",
         "org.keycloak.tests.infinispan",
         "org.keycloak.tests.keys",
-        "org.keycloak.tests.login",
-        "org.keycloak.tests.loginfailures",
-        "org.keycloak.tests.model",
-        "org.keycloak.tests.oauth",
-        "org.keycloak.tests.organization",
-        "org.keycloak.tests.oid4vc",
-        "org.keycloak.tests.policy",
-        "org.keycloak.tests.saml",
-        "org.keycloak.tests.securityprofile",
-        "org.keycloak.tests.session",
-        "org.keycloak.tests.sessionlimits",
-        "org.keycloak.tests.ssl",
-        "org.keycloak.tests.tracing",
-        "org.keycloak.tests.transactions",
-        "org.keycloak.tests.url",
-        "org.keycloak.tests.vault",
-        "org.keycloak.tests.welcomepage",
-        "org.keycloak.tests.workflow"
+        "org.keycloak.tests.login"
 })
 public class Base2TestSuite {
 }

--- a/tests/base/src/test/java/org/keycloak/tests/suites/Base3TestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/Base3TestSuite.java
@@ -1,0 +1,26 @@
+package org.keycloak.tests.suites;
+
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectPackages({
+        "org.keycloak.tests.model",
+        "org.keycloak.tests.oauth",
+        "org.keycloak.tests.organization",
+        "org.keycloak.tests.oid4vc",
+        "org.keycloak.tests.policy",
+        "org.keycloak.tests.saml",
+        "org.keycloak.tests.securityprofile",
+        "org.keycloak.tests.session",
+        "org.keycloak.tests.sessionlimits",
+        "org.keycloak.tests.ssl",
+        "org.keycloak.tests.tracing",
+        "org.keycloak.tests.transactions",
+        "org.keycloak.tests.url",
+        "org.keycloak.tests.vault",
+        "org.keycloak.tests.welcomepage",
+        "org.keycloak.tests.workflow"
+})
+public class Base3TestSuite {
+}


### PR DESCRIPTION
closes #50439

- Creating `Base3TestSuite` and add some packages from `Base2TestSuite` to it
- Did not increased any timeout (as I suppose preferred way is to make sure that CI is able to finish in smaller amount of time instead of increasing timeout to longer value)