### PR TITLE
fix(broker): expose Microsoft ID token claims to identity provider mappers (#49299)

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -483,7 +483,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             BrokeredIdentityContext identity = extractIdentity(tokenResponse, accessToken, idToken);
 
             if (!identityMatchesIdToken(identity, idToken)) {
-                throw new IdentityBrokerException("Mismatch between the subject in the id_token and the subject from the user_info endpoint");
+                throw new IdentityBrokerException("Mismatch between the id_token and the user_info endpoint identity");
             }
 
             if (getConfig().isFilteredByClaims()) {

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -482,7 +482,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         try {
             BrokeredIdentityContext identity = extractIdentity(tokenResponse, accessToken, idToken);
 
-            if (!identity.getId().equals(idToken.getSubject())) {
+            if (!identityMatchesIdToken(identity, idToken)) {
                 throw new IdentityBrokerException("Mismatch between the subject in the id_token and the subject from the user_info endpoint");
             }
 
@@ -647,6 +647,15 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         if (tokenResponse != null) processAccessTokenResponse(identity, tokenResponse);
 
         return identity;
+    }
+
+    /**
+     * Validates that the brokered identity matches the ID token. The default implementation compares
+     * the identity id with the ID token subject claim. Providers may override this when the identity
+     * id is sourced from a different claim (e.g. Microsoft Graph object id vs. pairwise subject).
+     */
+    protected boolean identityMatchesIdToken(BrokeredIdentityContext identity, JsonWebToken idToken) {
+        return identity.getId().equals(idToken.getSubject());
     }
 
     protected String getusernameClaimNameForIdToken() {

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
@@ -17,46 +17,139 @@
 
 package org.keycloak.social.microsoft;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.keycloak.OAuth2Constants;
 import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityBrokerException;
 import org.keycloak.broker.social.SocialIdentityProvider;
+import org.keycloak.common.util.Time;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.validation.Validation;
+import org.keycloak.util.Booleans;
+import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.jboss.logging.Logger;
 
 /**
- *
- * Identity provider for Microsoft account. Uses OAuth 2 protocol of Microsoft Graph as documented at
- * <a href="https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/graph-oauth">https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/graph-oauth</a>
+ * Identity provider for Microsoft account. Uses OpenID Connect with Microsoft Graph as documented at
+ * <a href="https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc">Microsoft identity platform OIDC</a>
  *
  * @author Vlastimil Elias (velias at redhat dot com)
  */
-public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider implements SocialIdentityProvider {
+public class MicrosoftIdentityProvider extends OIDCIdentityProvider implements SocialIdentityProvider<OIDCIdentityProviderConfig> {
 
-    private static final Logger log = Logger.getLogger(MicrosoftIdentityProvider.class);
+    private static final String AUTH_URL_TEMPLATE = "https://login.microsoftonline.com/%s/oauth2/v2.0/authorize";
+    private static final String TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/%s/oauth2/v2.0/token";
+    private static final String JWKS_URL_TEMPLATE = "https://login.microsoftonline.com/%s/discovery/v2.0/keys";
+    private static final String PROFILE_URL = "https://graph.microsoft.com/v1.0/me/";
+    private static final String LEGACY_DEFAULT_SCOPE = "User.read";
+    private static final String DEFAULT_SCOPE = "profile email User.read";
+    private static final String OID_CLAIM = "oid";
 
-    private static final String AUTH_URL_TEMPLATE = "https://login.microsoftonline.com/%s/oauth2/v2.0/authorize"; // authorization code endpoint
-    private static final String TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/%s/oauth2/v2.0/token"; // token endpoint
-    private static final String PROFILE_URL = "https://graph.microsoft.com/v1.0/me/"; // user profile service endpoint
-    private static final String DEFAULT_SCOPE = "User.read"; // the User.read scope should be sufficient to obtain all necessary user info
+    private final boolean oidcFlowEnabled;
 
     public MicrosoftIdentityProvider(KeycloakSession session, MicrosoftIdentityProviderConfig config) {
+        this(session, config, isOpenIdScopeConfigured(config));
+    }
+
+    private MicrosoftIdentityProvider(KeycloakSession session, MicrosoftIdentityProviderConfig config, boolean oidcFlowEnabled) {
         super(session, config);
 
+        this.oidcFlowEnabled = oidcFlowEnabled;
+        if (!oidcFlowEnabled) {
+            restoreScopeWithoutOpenId(config);
+        }
+
         // Use multi-tenant 'common' endpoints if not specified.
-        String tenant = Optional.ofNullable(config.getTenantId()).map(String::trim).orElse("common");
+        String tenant = Optional.ofNullable(config.getTenantId()).map(String::trim).filter(t -> !t.isEmpty()).orElse("common");
 
         config.setAuthorizationUrl(String.format(AUTH_URL_TEMPLATE, tenant));
         config.setTokenUrl(String.format(TOKEN_URL_TEMPLATE, tenant));
+        config.setJwksUrl(String.format(JWKS_URL_TEMPLATE, tenant));
         config.setUserInfoUrl(PROFILE_URL);
+        if (oidcFlowEnabled) {
+            config.setUseJwksUrl(true);
+            config.setValidateSignature(true);
+            config.setAllowClientIdAsAudience(true);
+        }
+    }
+
+    /**
+     * Returns {@code true} when the configured scope includes {@code openid}, or when no scope is configured yet
+     * (new identity providers use the OIDC flow with ID token claims available to mappers).
+     */
+    static boolean isOpenIdScopeConfigured(MicrosoftIdentityProviderConfig config) {
+        String scope = config.getConfig().get("defaultScope");
+        if (scope == null || scope.isBlank()) {
+            return true;
+        }
+        return scope.contains(SCOPE_OPENID);
+    }
+
+    private static void restoreScopeWithoutOpenId(MicrosoftIdentityProviderConfig config) {
+        String scope = config.getDefaultScope();
+        if (scope == null) {
+            config.setDefaultScope(LEGACY_DEFAULT_SCOPE);
+            return;
+        }
+        String restored = Arrays.stream(scope.split("\\s+"))
+                .filter(s -> !s.isEmpty() && !SCOPE_OPENID.equals(s))
+                .collect(Collectors.joining(" "));
+        config.setDefaultScope(restored.isEmpty() ? LEGACY_DEFAULT_SCOPE : restored);
+    }
+
+    @Override
+    public BrokeredIdentityContext getFederatedIdentity(String response) {
+        if (oidcFlowEnabled) {
+            return super.getFederatedIdentity(response);
+        }
+        return getFederatedIdentityLegacy(response);
+    }
+
+    private BrokeredIdentityContext getFederatedIdentityLegacy(String response) {
+        String accessToken = extractTokenFromResponse(response, OAUTH2_PARAMETER_ACCESS_TOKEN);
+        if (accessToken == null) {
+            throw new IdentityBrokerException("No access token available in OAuth server response: " + response);
+        }
+
+        try {
+            BrokeredIdentityContext context = extractIdentityFromProfile(null, fetchMicrosoftProfile(accessToken));
+
+            if (Booleans.isTrue(getConfig().isStoreToken()) && response.startsWith("{")) {
+                try {
+                    AbstractOAuth2IdentityProvider.OAuthResponse tokenResponse =
+                            JsonSerialization.readValue(response, AbstractOAuth2IdentityProvider.OAuthResponse.class);
+                    if (tokenResponse.getExpiresIn() != null && tokenResponse.getExpiresIn() > 0) {
+                        long accessTokenExpiration = Time.currentTime() + tokenResponse.getExpiresIn();
+                        tokenResponse.setAccessTokenExpiration(accessTokenExpiration);
+                        response = JsonSerialization.writeValueAsString(tokenResponse);
+                    }
+                    context.setToken(response);
+                } catch (IOException e) {
+                    logger.debugf("Can't store expiration date in JSON token", e);
+                }
+            }
+
+            context.getContextData().put(FEDERATED_ACCESS_TOKEN, accessToken);
+            return context;
+        } catch (IOException e) {
+            throw new IdentityBrokerException("Could not obtain user profile from Microsoft Graph", e);
+        }
     }
 
     @Override
@@ -70,16 +163,56 @@ public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider im
     }
 
     @Override
-    protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
-        try {
-            JsonNode profile = SimpleHttp.create(session).doGet(PROFILE_URL).auth(accessToken).asJson();
-            if (profile.has("error") && !profile.get("error").isNull()) {
-                throw new IdentityBrokerException("Error in Microsoft Graph API response. Payload: " + profile.toString());
-            }
-            return extractIdentityFromProfile(null, profile);
-        } catch (Exception e) {
-            throw new IdentityBrokerException("Could not obtain user profile from Microsoft Graph", e);
+    public boolean isIssuer(String issuer, MultivaluedMap<String, String> params) {
+        String requestedIssuer = params.getFirst(OAuth2Constants.SUBJECT_ISSUER);
+        if (requestedIssuer == null) {
+            requestedIssuer = issuer;
         }
+        return requestedIssuer.equals(getConfig().getAlias());
+    }
+
+    @Override
+    protected BrokeredIdentityContext exchangeExternalImpl(EventBuilder event, MultivaluedMap<String, String> params) {
+        return exchangeExternalUserInfoValidationOnly(event, params);
+    }
+
+    @Override
+    protected BrokeredIdentityContext extractIdentity(AccessTokenResponse tokenResponse, String accessToken, JsonWebToken idToken) throws IOException {
+        JsonNode profile = fetchMicrosoftProfile(accessToken);
+        BrokeredIdentityContext identity = extractIdentityFromProfile(null, profile);
+        identity.getContextData().put(FEDERATED_ACCESS_TOKEN_RESPONSE, tokenResponse);
+        identity.getContextData().put(VALIDATED_ID_TOKEN, idToken);
+        processAccessTokenResponse(identity, tokenResponse);
+        enrichBrokerSession(identity, tokenResponse, idToken);
+        return identity;
+    }
+
+    private void enrichBrokerSession(BrokeredIdentityContext identity, AccessTokenResponse tokenResponse,
+            JsonWebToken idToken) {
+        identity.setBrokerUserId(getConfig().getAlias() + "." + identity.getId());
+
+        String sidClaim = (String) idToken.getOtherClaims().get(IDToken.SESSION_ID);
+        String sessionState = tokenResponse != null ? tokenResponse.getSessionState() : null;
+        if (sidClaim != null) {
+            if (sessionState != null && !sidClaim.equals(sessionState)) {
+                logger.warnf("IdP '%s': sid claim '%s' differs from session_state '%s'; using sid for backchannel logout.",
+                        getConfig().getAlias(), sidClaim, sessionState);
+            }
+            identity.setBrokerSessionId(getConfig().getAlias() + "." + sidClaim);
+        } else if (sessionState != null) {
+            identity.setBrokerSessionId(getConfig().getAlias() + "." + sessionState);
+        }
+    }
+
+    @Override
+    protected boolean identityMatchesIdToken(BrokeredIdentityContext identity, JsonWebToken idToken) {
+        Object oid = idToken.getOtherClaims().get(OID_CLAIM);
+        if (oid == null) {
+            // Microsoft omits oid without the profile scope; some B2B guest tokens never include it.
+            // Graph /me id remains the authoritative object id in that case.
+            return true;
+        }
+        return identity.getId().equals(oid.toString());
     }
 
     @Override
@@ -97,8 +230,9 @@ public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider im
         user.setUsername(email != null ? email : id);
         user.setFirstName(getJsonProperty(profile, "givenName"));
         user.setLastName(getJsonProperty(profile, "surname"));
-        if (email != null)
+        if (email != null) {
             user.setEmail(email);
+        }
         user.setIdp(this);
 
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());
@@ -109,4 +243,13 @@ public class MicrosoftIdentityProvider extends AbstractOAuth2IdentityProvider im
     protected String getDefaultScopes() {
         return DEFAULT_SCOPE;
     }
+
+    protected JsonNode fetchMicrosoftProfile(String accessToken) throws IOException {
+        JsonNode profile = SimpleHttp.create(session).doGet(PROFILE_URL).auth(accessToken).asJson();
+        if (profile.has("error") && !profile.get("error").isNull()) {
+            throw new IdentityBrokerException("Error in Microsoft Graph API response. Payload: " + profile);
+        }
+        return profile;
+    }
+
 }

--- a/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/microsoft/MicrosoftIdentityProvider.java
@@ -98,7 +98,7 @@ public class MicrosoftIdentityProvider extends OIDCIdentityProvider implements S
         if (scope == null || scope.isBlank()) {
             return true;
         }
-        return scope.contains(SCOPE_OPENID);
+        return Arrays.stream(scope.split("\\s+")).anyMatch(SCOPE_OPENID::equals);
     }
 
     private static void restoreScopeWithoutOpenId(MicrosoftIdentityProviderConfig config) {

--- a/services/src/test/java/org/keycloak/social/microsoft/MicrosoftIdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/social/microsoft/MicrosoftIdentityProviderTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.social.microsoft;
+
+import java.io.IOException;
+
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.oidc.mappers.AbstractClaimMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MicrosoftIdentityProvider}.
+ */
+public class MicrosoftIdentityProviderTest {
+
+    private static final String TENANT_ID = "contoso.onmicrosoft.com";
+    private static final String GRAPH_USER_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    private static final String ID_TOKEN_SUBJECT = "AAAAAAAAAAAAAAAAAAAAAIkzqFVrSaSaFHy782bbtaQ";
+    private static final String GRAPH_PROFILE_URL = "https://graph.microsoft.com/v1.0/me/";
+    private static final String OID_CLAIM = "oid";
+
+    @Test
+    public void testCommonTenantEndpoints() {
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(new IdentityProviderModel());
+        config.setEnabled(true);
+        MicrosoftIdentityProvider idp = new MicrosoftIdentityProvider(null, config);
+
+        validateEndpoints(idp, "common");
+        Assert.assertTrue(config.getDefaultScope().contains(OIDCIdentityProvider.SCOPE_OPENID));
+        Assert.assertTrue(config.getDefaultScope().contains("profile"));
+        Assert.assertTrue(config.getDefaultScope().contains("email"));
+        Assert.assertTrue(config.getDefaultScope().contains("User.read"));
+        Assert.assertTrue(config.isUseJwksUrl());
+        Assert.assertTrue(config.isValidateSignature());
+        Assert.assertTrue(config.isAllowClientIdAsAudience());
+    }
+
+    @Test
+    public void testSingleTenantEndpoints() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(model);
+        config.setEnabled(true);
+        config.setTenantId(TENANT_ID);
+        MicrosoftIdentityProvider idp = new MicrosoftIdentityProvider(null, config);
+
+        validateEndpoints(idp, TENANT_ID);
+    }
+
+    @Test
+    public void testIdentityMatchesIdTokenUsesOidClaim() {
+        MicrosoftIdentityProvider idp = createProvider();
+        BrokeredIdentityContext identity = new BrokeredIdentityContext(GRAPH_USER_ID, idp.getConfig());
+        JsonWebToken idToken = new JsonWebToken();
+        idToken.subject(ID_TOKEN_SUBJECT);
+        idToken.getOtherClaims().put(OID_CLAIM, GRAPH_USER_ID);
+
+        Assert.assertTrue(idp.identityMatchesIdToken(identity, idToken));
+    }
+
+    @Test
+    public void testIdentityMatchesIdTokenWhenOidAbsent() {
+        MicrosoftIdentityProvider idp = createProvider();
+        BrokeredIdentityContext identity = new BrokeredIdentityContext(GRAPH_USER_ID, idp.getConfig());
+        JsonWebToken idToken = new JsonWebToken();
+        idToken.subject(ID_TOKEN_SUBJECT);
+
+        Assert.assertTrue(idp.identityMatchesIdToken(identity, idToken));
+    }
+
+    @Test
+    public void testIdentityMatchesIdTokenRejectsOidMismatch() {
+        MicrosoftIdentityProvider idp = createProvider();
+        BrokeredIdentityContext identity = new BrokeredIdentityContext(GRAPH_USER_ID, idp.getConfig());
+        JsonWebToken idToken = new JsonWebToken();
+        idToken.subject(ID_TOKEN_SUBJECT);
+        idToken.getOtherClaims().put(OID_CLAIM, "other-object-id");
+
+        Assert.assertFalse(idp.identityMatchesIdToken(identity, idToken));
+    }
+
+    @Test
+    public void testLegacyScopePreservesUserReadOnly() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        model.getConfig().put("defaultScope", "User.read");
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(model);
+        config.setEnabled(true);
+        new MicrosoftIdentityProvider(null, config);
+
+        Assert.assertEquals("User.read", config.getDefaultScope());
+        Assert.assertFalse(MicrosoftIdentityProvider.isOpenIdScopeConfigured(config));
+    }
+
+    @Test
+    public void testOpenIdScopeEnablesOidcValidation() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(model);
+        config.setEnabled(true);
+        new MicrosoftIdentityProvider(null, config);
+
+        Assert.assertTrue(MicrosoftIdentityProvider.isOpenIdScopeConfigured(config));
+        Assert.assertTrue(config.isUseJwksUrl());
+        Assert.assertTrue(config.isValidateSignature());
+        Assert.assertTrue(config.isAllowClientIdAsAudience());
+    }
+
+    @Test
+    public void testLegacyScopeDoesNotForceSignatureValidation() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        model.getConfig().put("defaultScope", "User.read");
+        model.getConfig().put("validateSignature", "false");
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(model);
+        config.setEnabled(true);
+        new MicrosoftIdentityProvider(null, config);
+
+        Assert.assertFalse(config.isValidateSignature());
+    }
+
+    @Test
+    public void testLegacyFlowWithoutIdToken() throws IOException {
+        IdentityProviderModel model = new IdentityProviderModel();
+        model.getConfig().put("defaultScope", "User.read");
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(model);
+        config.setAlias("microsoft");
+        config.setEnabled(true);
+        TestMicrosoftIdentityProvider idp = new TestMicrosoftIdentityProvider(config);
+
+        BrokeredIdentityContext identity = idp.getFederatedIdentity(
+                "{\"access_token\":\"access-token\",\"token_type\":\"Bearer\"}");
+
+        Assert.assertEquals(GRAPH_USER_ID, identity.getId());
+        Assert.assertNull(identity.getContextData().get(OIDCIdentityProvider.VALIDATED_ID_TOKEN));
+    }
+
+    @Test
+    public void testExtractIdentityExposesIdTokenClaimsToMappers() throws IOException {
+        TestMicrosoftIdentityProvider idp = new TestMicrosoftIdentityProvider(createConfig());
+        JsonWebToken idToken = new JsonWebToken();
+        idToken.subject(ID_TOKEN_SUBJECT);
+        idToken.getOtherClaims().put(OID_CLAIM, GRAPH_USER_ID);
+        idToken.getOtherClaims().put("preferred_username", "user@contoso.com");
+        idToken.getOtherClaims().put("upn", "user@contoso.com");
+
+        BrokeredIdentityContext identity = idp.extractIdentity(new AccessTokenResponse(), "access-token", idToken);
+
+        Assert.assertEquals(GRAPH_USER_ID, identity.getId());
+        Assert.assertEquals("user@contoso.com", identity.getUsername());
+        Assert.assertSame(idToken, identity.getContextData().get(OIDCIdentityProvider.VALIDATED_ID_TOKEN));
+        Assert.assertEquals("user@contoso.com", AbstractClaimMapper.getClaimValue(identity, "preferred_username"));
+        Assert.assertEquals("user@contoso.com", AbstractClaimMapper.getClaimValue(identity, "upn"));
+    }
+
+    private static void validateEndpoints(MicrosoftIdentityProvider idp, String tenant) {
+        OIDCIdentityProviderConfig config = idp.getConfig();
+        Assert.assertEquals("https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/authorize", config.getAuthorizationUrl());
+        Assert.assertEquals("https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token", config.getTokenUrl());
+        Assert.assertEquals("https://login.microsoftonline.com/" + tenant + "/discovery/v2.0/keys", config.getJwksUrl());
+        Assert.assertEquals(GRAPH_PROFILE_URL, config.getUserInfoUrl());
+        Assert.assertEquals(GRAPH_PROFILE_URL, idp.getProfileEndpointForValidation(null));
+    }
+
+    private MicrosoftIdentityProvider createProvider() {
+        return new MicrosoftIdentityProvider(null, createConfig());
+    }
+
+    private MicrosoftIdentityProviderConfig createConfig() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        MicrosoftIdentityProviderConfig config = new MicrosoftIdentityProviderConfig(model);
+        config.setAlias("microsoft");
+        config.setEnabled(true);
+        return config;
+    }
+
+    private static class TestMicrosoftIdentityProvider extends MicrosoftIdentityProvider {
+
+        private final JsonNode profile;
+
+        TestMicrosoftIdentityProvider(MicrosoftIdentityProviderConfig config) throws IOException {
+            super(null, config);
+            profile = JsonSerialization.readValue(
+                    """
+                    {
+                      "id": "%s",
+                      "mail": "user@contoso.com",
+                      "givenName": "Test",
+                      "surname": "User"
+                    }
+                    """.formatted(GRAPH_USER_ID),
+                    JsonNode.class);
+        }
+
+        @Override
+        protected JsonNode fetchMicrosoftProfile(String accessToken) {
+            return profile;
+        }
+    }
+
+}


### PR DESCRIPTION
Hello,

## Summary

The built-in Microsoft identity provider never stored the parsed ID token, so mappers could not resolve claims such as `preferred_username`, `upn`, `amr`, etc ... (they exist in the ID token but not in the Graph `/me` response).

This change migrates `MicrosoftIdentityProvider` to `OIDCIdentityProvider`, stores `VALIDATED_ID_TOKEN` for mappers, and adds an `identityMatchesIdToken` hook to compare Graph `id` with the Microsoft `oid` claim instead of `sub`.

## Backward compatibility

Existing realms configured with `User.read` only keep the previous OAuth2 + Graph flow. The OIDC flow (ID token parsing and mapper claims) is used when `openid` is present in the configured scope, or for new identity providers (default scope includes `openid`).

Fixes #49299

Happy to adjust anything needed to get this merged.
Thomas