### PR TITLE
SSF: Confine authority-attached wildcards in SSF push URL allow-list (#50460)

### DIFF
--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidator.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidator.java
@@ -158,6 +158,14 @@ public final class SsfPushUrlValidator {
                 String r = idx == -1 ? pushUrl : pushUrl.substring(0, idx);
                 int length = validUrl.length() - 1;
                 String trimmed = validUrl.substring(0, length);
+                // When the '*' is attached directly to the authority (no path
+                // separator after scheme://), a bare prefix match would also
+                // accept hosts that merely start with the allow-listed host.
+                int schemeIdx = trimmed.indexOf("://");
+                if (schemeIdx >= 0 && trimmed.indexOf('/', schemeIdx + 3) == -1
+                        && !trimmed.equals(r) && !r.startsWith(trimmed + "/")) {
+                    continue;
+                }
                 if (r.startsWith(trimmed)) {
                     return trimmed;
                 }

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidatorTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidatorTest.java
@@ -187,6 +187,79 @@ class SsfPushUrlValidatorTest {
                 SsfPushUrlValidator.matchesAllowList(allow, "https://backup.example.com/feeds/x"));
     }
 
+    @Test
+    void match_authorityWildcardStaysConfinedToHost() {
+        // "https://example.com*" — the '*' sits on the authority with no path
+        // separator. It must behave like "https://example.com/*": match the
+        // host and anything under it, but never a different host that merely
+        // begins with the same characters. Mirrors RedirectUtils.
+        Set<String> allow = set("https://example.com*");
+
+        assertEquals("https://example.com",
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com"));
+        assertEquals("https://example.com",
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com/feeds/x"));
+
+        assertEquals(null,
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com.attacker.example/feeds/x"),
+                "an authority-attached wildcard must not match an extended host");
+    }
+
+    @Test
+    void validate_rejectsAuthorityWildcardHostExtension() {
+        // End-to-end: a wildcard that sits on the authority must not let the
+        // push target slip onto a different, attacker-controlled host outside
+        // the host the operator reviewed.
+        SsfPushUrlValidationException ex = assertThrows(SsfPushUrlValidationException.class,
+                () -> strict.validate(
+                        "https://example.com.attacker.example/feeds/x",
+                        set("https://example.com*")));
+
+        assertEquals(Reason.NOT_IN_ALLOWLIST, ex.getReason());
+    }
+
+    @Test
+    void match_authorityWildcardRejectsPrefixSiblingHost() {
+        // The classic prefix-match bug, distinct from the dotted-subdomain
+        // case above: a host that merely *continues* the allow-listed host
+        // with no separator (example.com -> example.community) must not match.
+        // Guards against a future fix that only special-cases the '.' boundary.
+        Set<String> allow = set("https://example.com*");
+
+        assertEquals(null,
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.community/feeds/x"),
+                "a host that extends the allow-listed host without a boundary must not match");
+    }
+
+    @Test
+    void match_authorityWildcardWithPort_staysConfinedToHostAndPort() {
+        // Same authority-attached guard, exercised through the ':port' branch
+        // (no path separator after the authority, but a port is present).
+        Set<String> allow = set("https://example.com:8443*");
+
+        // host:port itself and anything under it still match...
+        assertEquals("https://example.com:8443",
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com:8443/feeds/x"));
+        // ...but a longer port that merely shares the "8443" prefix must not
+        // (this is the realistic sibling for a port-attached wildcard; a host
+        // extension like "...:8443.evil" isn't a valid URL and never reaches here).
+        assertEquals(null,
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com:84430/feeds/x"),
+                "a port that merely shares the allow-listed port's prefix must not match");
+    }
+
+    @Test
+    void filterUsableEntries_keepsAuthorityAttachedWildcard() {
+        // Approach contract: the authority-attached wildcard is *kept* (and
+        // confined at match time), not dropped — so the entry survives
+        // filtering. This pins the chosen design against a regression that
+        // would silently remove it instead.
+        Set<String> usable = strict.filterUsableEntries(set("https://example.com*"));
+
+        assertEquals(set("https://example.com*"), usable,
+                "an authority-attached wildcard is honoured (confined at match time), not filtered out");
+    }
+
     // -- validate(): rejection codes ----------------------------------------
 
     @Test


### PR DESCRIPTION
A trailing-* wildcard glued directly onto the authority (e.g. "https://receiver.example*") was prefix-matched without a host boundary, so it also accepted unrelated hosts such as "https://receiver.example.attacker.example/sink".

Enforce the host boundary in SsfPushUrlValidator.matchesAllowList, treating "scheme://host*" like "scheme://host/*", mirroring RedirectUtils.checkValidRedirectWildcard. Add tests for the dotted-subdomain extension, the no-separator prefix sibling, and the port-attached branch.

Fixes #50460

Adapted from https://github.com/keycloak/keycloak/pull/50346

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
