### PR TITLE
User Attribute mapper clears the value when custom attribute is selected

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/user-profile/attribute/KeySelect.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/attribute/KeySelect.tsx
@@ -34,8 +34,8 @@ export const KeySelect = ({ selectItems, ...rest }: KeySelectProp) => {
           onSelect={(value) => {
             if (value) {
               setCustom(false);
+              field.onChange(value);
             }
-            field.onChange(value);
             toggle();
           }}
           selections={!custom ? [field.value] : ""}


### PR DESCRIPTION
- Closes #50500
- The same bug for the User Profile attribute annotations
- @edewit Could you please check this small PR? 

New behavior: 
https://github.com/user-attachments/assets/380bbb86-764e-45d7-bbc5-47bcf51c0570


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
