### PR TITLE
Use realm Default Signature Algorithm for internal cookies and tokens

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -200,6 +200,18 @@ This parameter is sent by clients during token refresh and is used when the `${a
 It was primarily used by legacy adapters that have been removed.
 This improves security by ensuring that only trusted, pre-registered hosts can be used in backchannel logout URLs.
 
+=== Internal cookies and tokens now use the realm Default Signature Algorithm
+
+Internal cookies (such as `KC_RESTART`, `KEYCLOAK_IDENTITY` and `AUTH_SESSION_ID`) and internal tokens (refresh tokens, offline tokens, client registration / initial access tokens, the CIBA `auth_req_id` and OID4VC pre-authorized codes) are now signed with the realm's *Default Signature Algorithm* (`RS256` by default) instead of the previously hard-coded `HS512`.
+
+Previously these were always signed with a symmetric `HS512` key regardless of the realm configuration. Now they follow the same *Default Signature Algorithm* realm setting that already governed other tokens, so a single realm setting controls the signature algorithm of all tokens.
+
+No action is required on upgrade:
+
+* Existing refresh and offline tokens carry their algorithm in the token header and continue to be verified using the existing `HS512` key, which is retained.
+* Existing `AUTH_SESSION_ID` cookies are verified with a fallback to `HS512` so logins in progress are not interrupted.
+
+New tokens and cookies are signed with the realm Default Signature Algorithm. Because the default (`RS256`) is asymmetric, signing and verification are more expensive than `HS512` and signatures are larger. Realms that prefer the previous behavior can set the *Default Signature Algorithm* to an `HS*` algorithm (for example `HS512`) in the realm keys settings.
 === Default AES key size increased to 256 bits
 
 The default key size for newly generated AES key providers (aes-generated) has been increased from 128 bits to 256 bits for improved security.

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -198,7 +198,6 @@ public class DefaultTokenManager implements TokenManager {
     public String signatureAlgorithm(TokenCategory category) {
         switch (category) {
             case INTERNAL:
-                return Constants.INTERNAL_SIGNATURE_ALGORITHM;
             case ADMIN:
                 return getSignatureAlgorithm(null);
             case ACCESS:

--- a/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
+++ b/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
@@ -26,6 +26,7 @@ import org.keycloak.Token;
 import org.keycloak.TokenCategory;
 import org.keycloak.cookie.CookieProvider;
 import org.keycloak.cookie.CookieType;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwe.JWE;
@@ -191,11 +192,11 @@ public class RestartLoginCookie implements Token {
                 String jwt = new String(contentBytes, StandardCharsets.UTF_8);
                 return session.tokens().decode(jwt, RestartLoginCookie.class);
             } else {
-                // decoding as before
-                String sigAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
+                // legacy format (before the realm default algorithm applied to internal cookies):
+                // AES-CBC encryption with a separate HMAC key
                 String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
                 SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm).getSecretKey();
-                SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
+                SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, Algorithm.HS512).getSecretKey();
                 byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(encKey, signKey, encodedToken);
                 String jwt = new String(contentBytes, StandardCharsets.UTF_8);
                 return session.tokens().decode(jwt, RestartLoginCookie.class);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/channel/CIBAAuthenticationRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/channel/CIBAAuthenticationRequest.java
@@ -21,14 +21,13 @@ import java.nio.charset.StandardCharsets;
 import javax.crypto.SecretKey;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.TokenCategory;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyUse;
-import org.keycloak.crypto.SignatureProvider;
-import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwe.JWE;
 import org.keycloak.jose.jwe.JWEException;
-import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -61,17 +60,31 @@ public class CIBAAuthenticationRequest extends JsonWebToken {
      * @throws Exception
      */
     public static CIBAAuthenticationRequest deserialize(KeycloakSession session, String jwe) {
-        SecretKey aesKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, Algorithm.AES).getSecretKey();
-        SecretKey hmacKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, Constants.INTERNAL_SIGNATURE_ALGORITHM).getSecretKey();
-
         try {
-            byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(aesKey, hmacKey, jwe);
-            jwe = new String(contentBytes, StandardCharsets.UTF_8);
+            String kid = new JWE(jwe).getHeader().getKeyId();
+            if (kid != null) {
+                // new way using kid: signed with the realm default algorithm, encrypted with the AES key
+                String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
+                RealmModel realm = session.getContext().getRealm();
+                KeyWrapper encKey = session.keys().getKey(realm, kid, KeyUse.ENC, algAlgorithm);
+                if (encKey == null) {
+                    throw new RuntimeException("Cannot find encryption key '" + kid + "' for auth_req_id.");
+                }
+                byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(encKey.getSecretKey(), null, jwe);
+                String jwt = new String(contentBytes, StandardCharsets.UTF_8);
+                return session.tokens().decode(jwt, CIBAAuthenticationRequest.class);
+            } else {
+                // legacy format (before the realm default algorithm applied to internal tokens):
+                // AES-CBC encryption with a separate HMAC key
+                SecretKey aesKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, Algorithm.AES).getSecretKey();
+                SecretKey hmacKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, Algorithm.HS512).getSecretKey();
+                byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(aesKey, hmacKey, jwe);
+                String jwt = new String(contentBytes, StandardCharsets.UTF_8);
+                return session.tokens().decode(jwt, CIBAAuthenticationRequest.class);
+            }
         } catch (JWEException e) {
             throw new RuntimeException("Error decoding auth_req_id.", e);
         }
-
-        return session.tokens().decode(jwe, CIBAAuthenticationRequest.class);
     }
 
     public static final String SESSION_STATE = IDToken.SESSION_STATE;
@@ -155,13 +168,11 @@ public class CIBAAuthenticationRequest extends JsonWebToken {
      */
     public String serialize(KeycloakSession session) {
         try {
-            SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, Constants.INTERNAL_SIGNATURE_ALGORITHM);
-            SignatureSignerContext signer = signatureProvider.signer();
-            String encodedJwt = new JWSBuilder().type("JWT").jsonContent(this).sign(signer);
-            SecretKey aesKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, Algorithm.AES).getSecretKey();
-            SecretKey hmacKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, Constants.INTERNAL_SIGNATURE_ALGORITHM).getSecretKey();
+            String algAlgorithm = session.tokens().cekManagementAlgorithm(getCategory());
+            KeyWrapper encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm);
 
-            return TokenUtil.jweDirectEncode(aesKey, hmacKey, encodedJwt.getBytes(StandardCharsets.UTF_8));
+            String encodedJwt = session.tokens().encode(this);
+            return TokenUtil.jweDirectEncode(encKey.getKid(), encKey.getSecretKey(), null, encodedJwt.getBytes(StandardCharsets.UTF_8));
         } catch (JWEException e) {
             throw new RuntimeException("Error encoding auth_req_id.", e);
         }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -20,17 +20,18 @@ package org.keycloak.services.managers;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import org.keycloak.TokenCategory;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Time;
 import org.keycloak.cookie.CookieProvider;
 import org.keycloak.cookie.CookieType;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
@@ -155,24 +156,38 @@ public class AuthenticationSessionManager {
             return authSessionId;
         }
 
-        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, Constants.INTERNAL_SIGNATURE_ALGORITHM);
-        SignatureSignerContext signer = signatureProvider.signer();
-        try {
-            boolean valid = signatureProvider.verifier(signer.getKid()).verify(authSessionId.getBytes(StandardCharsets.UTF_8), Base64Url.decode(signature));
-            if (!valid) {
-                return null;
-            }
-            //Save the signature to avoid re-verification for the same request
-            session.setAttribute(authSessionId, signature);
-            return authSessionId;
-        } catch (Exception e) {
-            log.errorf("Signature validation failed for auth session id: %s", authSessionId, e);
+        String algorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
+        boolean valid = verifyAuthSessionIdSignature(authSessionId, signature, algorithm);
+        if (!valid && !Algorithm.HS512.equals(algorithm)) {
+            // Backwards compatibility: before the realm default signature algorithm was applied to
+            // internal cookies, AUTH_SESSION_ID was always signed with HS512. Validate such cookies
+            // against the legacy algorithm so logins in progress survive an upgrade.
+            valid = verifyAuthSessionIdSignature(authSessionId, signature, Algorithm.HS512);
         }
-        return null;
+        if (!valid) {
+            return null;
+        }
+        //Save the signature to avoid re-verification for the same request
+        session.setAttribute(authSessionId, signature);
+        return authSessionId;
+    }
+
+    private boolean verifyAuthSessionIdSignature(String authSessionId, String signature, String algorithm) {
+        try {
+            SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, algorithm);
+            if (signatureProvider == null) {
+                return false;
+            }
+            SignatureSignerContext signer = signatureProvider.signer();
+            return signatureProvider.verifier(signer.getKid()).verify(authSessionId.getBytes(StandardCharsets.UTF_8), Base64Url.decode(signature));
+        } catch (Exception e) {
+            log.debugf(e, "Signature validation with algorithm %s failed for auth session id: %s", algorithm, authSessionId);
+            return false;
+        }
     }
 
     public String signAndEncodeToBase64AuthSessionId(String authSessionId) {
-        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, Constants.INTERNAL_SIGNATURE_ALGORITHM);
+        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, session.tokens().signatureAlgorithm(TokenCategory.INTERNAL));
         SignatureSignerContext signer = signatureProvider.signer();
         StringBuilder buffer = new StringBuilder();
         byte[] signature =  signer.sign(authSessionId.getBytes(StandardCharsets.UTF_8));

--- a/tests/base/src/test/java/org/keycloak/tests/forms/LoginSSLTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/forms/LoginSSLTest.java
@@ -88,9 +88,9 @@ public class LoginSSLTest {
         driver.driver().navigate().to(keycloakUrls.getBase() + "/realms/" + managedRealm.getName() + "/");
         String keycloakIdentity = Objects.requireNonNull(driver.driver().manage().getCookieNamed("KEYCLOAK_IDENTITY")).getValue();
 
-        // Check identity cookie is signed with HS256
+        // Check identity cookie is signed with the realm default signature algorithm
         String algorithm = new JWSInput(keycloakIdentity).getHeader().getAlgorithm().name();
-        assertEquals(Constants.INTERNAL_SIGNATURE_ALGORITHM, algorithm);
+        assertEquals(Constants.DEFAULT_SIGNATURE_ALGORITHM, algorithm);
 
         // Change realm signature algorithm
         managedRealm.updateWithCleanup(realm -> realm.defaultSignatureAlgorithm(Algorithm.ES256));
@@ -100,9 +100,9 @@ public class LoginSSLTest {
         driver.driver().navigate().to(keycloakUrls.getBase() + "/realms/" + managedRealm.getName() + "/");
         keycloakIdentity = Objects.requireNonNull(driver.driver().manage().getCookieNamed("KEYCLOAK_IDENTITY")).getValue();
 
-        // Check identity cookie is still signed with HS256
+        // Check identity cookie now follows the changed realm default signature algorithm
         algorithm = new JWSInput(keycloakIdentity).getHeader().getAlgorithm().name();
-        assertEquals(Constants.INTERNAL_SIGNATURE_ALGORITHM, algorithm);
+        assertEquals(Algorithm.ES256, algorithm);
 
         // Check identity cookie still works
         oauth.openLoginForm();

--- a/tests/base/src/test/java/org/keycloak/tests/keys/FallbackKeyProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/keys/FallbackKeyProviderTest.java
@@ -21,7 +21,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.keycloak.crypto.Algorithm;
-import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -69,7 +68,9 @@ public class FallbackKeyProviderTest {
         Assertions.assertTrue(response.isSuccess());
 
         providers = realm.admin().components().query(realmId, "org.keycloak.keys.KeyProvider");
-        Assert.assertNames(providers, "fallback-RS256", "fallback-AES", "fallback-" + Constants.INTERNAL_SIGNATURE_ALGORITHM);
+        // Internal cookies/tokens now use the realm default signature algorithm (RS256), so no HS512
+        // fallback key is generated during a basic login + token flow.
+        Assert.assertNames(providers, "fallback-RS256", "fallback-AES");
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/keys/KeyRotationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/keys/KeyRotationTest.java
@@ -37,7 +37,6 @@ import org.keycloak.keys.Attributes;
 import org.keycloak.keys.GeneratedHmacKeyProviderFactory;
 import org.keycloak.keys.ImportedRsaKeyProviderFactory;
 import org.keycloak.keys.KeyProvider;
-import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
 import org.keycloak.representations.idm.ClientInitialAccessPresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -125,7 +124,7 @@ public class KeyRotationTest {
         AccessTokenResponse response = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
         assertEquals(200, response.getStatusCode());
         assertTokenKid(keys1.get(Algorithm.RS256), response.getAccessToken());
-        assertTokenKid(keys1.get(Constants.INTERNAL_SIGNATURE_ALGORITHM), response.getRefreshToken());
+        assertTokenKid(keys1.get(Algorithm.RS256), response.getRefreshToken());
 
         // Create client with keys #1
         ClientInitialAccessCreatePresentation initialToken = new ClientInitialAccessCreatePresentation();
@@ -152,13 +151,13 @@ public class KeyRotationTest {
         Map<String, String> keys2 = createKeys2();
 
         assertNotEquals(keys1.get(Algorithm.RS256), keys2.get(Algorithm.RS256));
-        assertNotEquals(keys1.get(Constants.INTERNAL_SIGNATURE_ALGORITHM), keys2.get(Algorithm.HS512));
+        assertNotEquals(keys1.get(Algorithm.HS512), keys2.get(Algorithm.HS512));
 
                 // Refresh token with keys #2
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
         assertEquals(200, response.getStatusCode());
         assertTokenKid(keys2.get(Algorithm.RS256), response.getAccessToken());
-        assertTokenKid(keys2.get(Constants.INTERNAL_SIGNATURE_ALGORITHM), response.getRefreshToken());
+        assertTokenKid(keys2.get(Algorithm.RS256), response.getRefreshToken());
 
         // Userinfo with keys #2
         assertUserInfo(response.getAccessToken(), 200);
@@ -177,7 +176,7 @@ public class KeyRotationTest {
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
 
         assertTokenKid(keys2.get(Algorithm.RS256), response.getAccessToken());
-        assertTokenKid(keys2.get(Constants.INTERNAL_SIGNATURE_ALGORITHM), response.getRefreshToken());
+        assertTokenKid(keys2.get(Algorithm.RS256), response.getRefreshToken());
 
         // Userinfo with keys #1 dropped
         assertUserInfo(response.getAccessToken(), 200);
@@ -289,7 +288,7 @@ public class KeyRotationTest {
 
         config = new org.keycloak.common.util.MultivaluedHashMap<>();
         config.addFirst(Attributes.PRIORITY_KEY, priority);
-        config.addFirst(Attributes.ALGORITHM_KEY, Constants.INTERNAL_SIGNATURE_ALGORITHM);
+        config.addFirst(Attributes.ALGORITHM_KEY, Algorithm.HS512);
         rep.setConfig(config);
 
         response = realm.admin().components().add(rep);

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenBasicFlowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenBasicFlowTest.java
@@ -676,12 +676,12 @@ public class OfflineTokenBasicFlowTest {
 
     @Test
     public void offlineTokenRequest_ClientES256_RealmPS256() throws Exception {
-        conductOfflineTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES256, Algorithm.PS256);
+        conductOfflineTokenRequest(Algorithm.PS256, Algorithm.ES256, Algorithm.PS256);
     }
 
     @Test
     public void offlineTokenRequest_ClientPS256_RealmES256() throws Exception {
-        conductOfflineTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS256, Algorithm.ES256);
+        conductOfflineTokenRequest(Algorithm.ES256, Algorithm.PS256, Algorithm.ES256);
     }
 
     private void setupCustomerUserRoles() {

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenTest.java
@@ -1005,42 +1005,42 @@ public class RefreshTokenTest {
 
     @Test
     public void tokenRefreshRequest_ClientRS384_RealmRS384() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.RS384, Algorithm.RS384);
+        conductTokenRefreshRequest(Algorithm.RS384, Algorithm.RS384, Algorithm.RS384);
     }
 
     @Test
     public void tokenRefreshRequest_ClientRS512_RealmRS256() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.RS512, Algorithm.RS256);
+        conductTokenRefreshRequest(Algorithm.RS256, Algorithm.RS512, Algorithm.RS256);
     }
 
     @Test
     public void tokenRefreshRequest_ClientES256_RealmRS256() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES256, Algorithm.RS256);
+        conductTokenRefreshRequest(Algorithm.RS256, Algorithm.ES256, Algorithm.RS256);
     }
 
     @Test
     public void tokenRefreshRequest_ClientES384_RealmES384() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES384, Algorithm.ES384);
+        conductTokenRefreshRequest(Algorithm.ES384, Algorithm.ES384, Algorithm.ES384);
     }
 
     @Test
     public void tokenRefreshRequest_ClientES512_RealmRS256() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES512, Algorithm.RS256);
+        conductTokenRefreshRequest(Algorithm.RS256, Algorithm.ES512, Algorithm.RS256);
     }
 
     @Test
     public void tokenRefreshRequest_ClientPS256_RealmRS256() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS256, Algorithm.RS256);
+        conductTokenRefreshRequest(Algorithm.RS256, Algorithm.PS256, Algorithm.RS256);
     }
 
     @Test
     public void tokenRefreshRequest_ClientPS384_RealmES384() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS384, Algorithm.ES384);
+        conductTokenRefreshRequest(Algorithm.ES384, Algorithm.PS384, Algorithm.ES384);
     }
 
     @Test
     public void tokenRefreshRequest_ClientPS512_RealmPS256() throws Exception {
-        conductTokenRefreshRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS512, Algorithm.PS256);
+        conductTokenRefreshRequest(Algorithm.PS256, Algorithm.PS512, Algorithm.PS256);
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -191,7 +191,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
             throw new RuntimeException(e);
         }
 
-        assertEquals(Algorithm.HS512, jws.getHeader().getAlgorithm().toString(),
+        assertEquals(Algorithm.RS256, jws.getHeader().getAlgorithm().toString(),
                 "Must use expected signing algorithm");
 
         assertNotNull(payload.getContext(), "Must embed an associated context");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/InitialAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/InitialAccessTokenTest.java
@@ -25,7 +25,6 @@ import org.keycloak.crypto.Algorithm;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
-import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
 import org.keycloak.representations.idm.ClientInitialAccessPresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -83,7 +82,7 @@ public class InitialAccessTokenTest extends AbstractClientRegistrationTest {
             String token = response.getToken();
 
             JWSHeader header = new JWSInput(token).getHeader();
-            assertEquals(Constants.INTERNAL_SIGNATURE_ALGORITHM, header.getAlgorithm().name());
+            assertEquals(Algorithm.ES256, header.getAlgorithm().name());
 
             ClientRepresentation rep = new ClientRepresentation();
             ClientRepresentation created = reg.create(rep);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
@@ -37,6 +37,8 @@ import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEHeader;
 import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.keys.Attributes;
 import org.keycloak.keys.GeneratedHmacKeyProviderFactory;
@@ -156,12 +158,19 @@ public class RestartCookieTest extends AbstractTestRealmKeycloakTest {
         getTestingClient().server(TEST_REALM_NAME).run(session -> {
             try {
                 RestartLoginCookie restartLoginCookie = RestartLoginCookie.decryptAndDecode(session, restartCookie);
-                String sigAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
+                // Reconstruct the legacy AES-CBC+HMAC (A*CBC_HS*) format, which used an HS512 HMAC key for content integrity
                 String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
                 SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm).getSecretKey();
-                SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
+                SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, Algorithm.HS512).getSecretKey();
                 String encodedJwt = session.tokens().encode(restartLoginCookie);
                 String oldRestartCookie = TokenUtil.jweDirectEncode(encKey, signKey, encodedJwt.getBytes(StandardCharsets.UTF_8));
+                // The legacy format is AES-CBC with a separate HMAC (enc is A128/A192/A256CBC-HS*
+                // depending on the AES key size), as opposed to the current AES-GCM format. Assert the
+                // reconstructed cookie really is the CBC+HMAC legacy format so the test can't silently
+                // stop exercising it.
+                JWEHeader oldHeader = (JWEHeader) new JWE(oldRestartCookie).getHeader();
+                Assertions.assertTrue(oldHeader.getEncryptionAlgorithm().contains("CBC"),
+                        "Expected a legacy AES-CBC+HMAC enc but was " + oldHeader.getEncryptionAlgorithm());
                 Assertions.assertNotNull(RestartLoginCookie.decryptAndDecode(session, oldRestartCookie));
             } catch (Exception e) {
                 Assertions.fail();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -59,7 +59,6 @@ import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.keys.GeneratedEddsaKeyProviderFactory;
 import org.keycloak.keys.KeyProvider;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserModel;
@@ -272,7 +271,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         assertNull(header.getContentType());
 
         header = new JWSInput(response.getRefreshToken()).getHeader();
-        assertEquals(Constants.INTERNAL_SIGNATURE_ALGORITHM, header.getAlgorithm().name());
+        assertEquals(Algorithm.RS256, header.getAlgorithm().name());
         assertEquals("JWT", header.getType());
         assertNull(header.getContentType());
 
@@ -1394,52 +1393,52 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
     @Test
     public void accessTokenRequest_ClientPS384_RealmRS256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS384, Algorithm.RS256);
+        conductAccessTokenRequest(Algorithm.RS256, Algorithm.PS384, Algorithm.RS256);
     }
 
     @Test
     public void accessTokenRequest_ClientPS256_RealmPS256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS256, Algorithm.PS256);
+        conductAccessTokenRequest(Algorithm.PS256, Algorithm.PS256, Algorithm.PS256);
     }
 
     @Test
     public void accessTokenRequest_ClientPS512_RealmPS256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS512, Algorithm.PS256);
+        conductAccessTokenRequest(Algorithm.PS256, Algorithm.PS512, Algorithm.PS256);
     }
 
     @Test
     public void accessTokenRequest_ClientRS384_RealmRS256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.RS384, Algorithm.RS256);
+        conductAccessTokenRequest(Algorithm.RS256, Algorithm.RS384, Algorithm.RS256);
     }
 
     @Test
     public void accessTokenRequest_ClientRS512_RealmRS512() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.RS512, Algorithm.RS512);
+        conductAccessTokenRequest(Algorithm.RS512, Algorithm.RS512, Algorithm.RS512);
     }
 
     @Test
     public void accessTokenRequest_ClientES256_RealmPS256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES256, Algorithm.PS256);
+        conductAccessTokenRequest(Algorithm.PS256, Algorithm.ES256, Algorithm.PS256);
     }
 
     @Test
     public void accessTokenRequest_ClientES384_RealmES384() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES384, Algorithm.ES384);
+        conductAccessTokenRequest(Algorithm.ES384, Algorithm.ES384, Algorithm.ES384);
     }
 
     @Test
     public void accessTokenRequest_ClientES512_RealmRS256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES512, Algorithm.RS256);
+        conductAccessTokenRequest(Algorithm.RS256, Algorithm.ES512, Algorithm.RS256);
     }
 
     @Test
     public void accessTokenRequest_ClientEdDSA_RealmES256() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.EdDSA, Algorithm.ES256);
+        conductAccessTokenRequest(Algorithm.ES256, Algorithm.EdDSA, Algorithm.ES256);
     }
 
     @Test
     public void accessTokenRequest_ClientEdDSA_RealmEdDSA() throws Exception {
-        conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.EdDSA, Algorithm.EdDSA);
+        conductAccessTokenRequest(Algorithm.EdDSA, Algorithm.EdDSA, Algorithm.EdDSA);
     }
 
     @Test
@@ -1458,7 +1457,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         try (Response response = realm.components().add(comp)) {
             assertEquals(201, response.getStatus());
             compId = ApiUtil.getCreatedId(response);
-            conductAccessTokenRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.EdDSA, Algorithm.EdDSA, JavaAlgorithm.Ed448);
+            conductAccessTokenRequest(Algorithm.EdDSA, Algorithm.EdDSA, Algorithm.EdDSA, JavaAlgorithm.Ed448);
         } finally {
             if (compId != null) {
                 realm.components().removeComponent(compId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -35,7 +35,6 @@ import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.Details;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AccessToken;
@@ -342,7 +341,7 @@ public class LogoutTest extends AbstractKeycloakTest {
         try {
             TokenSignatureUtil.changeRealmTokenSignatureProvider(adminClient, "RS384");
             TokenSignatureUtil.changeClientAccessTokenSignatureProvider(AdminApiUtil.findClientByClientId(adminClient.realm("test"), "test-app"), "RS512");
-            backchannelLogoutRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, "RS512", "RS384");
+            backchannelLogoutRequest("RS384", "RS512", "RS384");
         } finally {
             TokenSignatureUtil.changeRealmTokenSignatureProvider(adminClient, "RS256");
             TokenSignatureUtil.changeClientAccessTokenSignatureProvider(AdminApiUtil.findClientByClientId(adminClient.realm("test"), "test-app"), "RS256");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -9,6 +9,7 @@ import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -16,7 +17,6 @@ import org.keycloak.events.EventType;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.Constants;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.AccessToken;
@@ -433,7 +433,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
         assertNull(header.getContentType());
 
         header = new JWSInput(response.getRefreshToken()).getHeader();
-        assertEquals(Constants.INTERNAL_SIGNATURE_ALGORITHM, header.getAlgorithm().name());
+        assertEquals(Algorithm.RS256, header.getAlgorithm().name());
         assertEquals("JWT", header.getType());
         assertNull(header.getContentType());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ResourceOwnerPasswordCredentialsGrantTest.java
@@ -40,7 +40,6 @@ import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.ClientScopeModel;
-import org.keycloak.models.Constants;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.TimeBasedOTP;
@@ -365,12 +364,12 @@ public class ResourceOwnerPasswordCredentialsGrantTest extends AbstractKeycloakT
 
     @Test
     public void grantRequest_ClientES256_RealmPS256() throws Exception {
-        conductGrantRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES256, Algorithm.PS256);
+        conductGrantRequest(Algorithm.PS256, Algorithm.ES256, Algorithm.PS256);
     }
 
     @Test
     public void grantRequest_ClientPS256_RealmES256() throws Exception {
-        conductGrantRequest(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.PS256, Algorithm.ES256);
+        conductGrantRequest(Algorithm.ES256, Algorithm.PS256, Algorithm.ES256);
     }
 
     private void conductGrantRequest(String expectedRefreshAlg, String expectedAccessAlg, String realmTokenAlg) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ServiceAccountTest.java
@@ -34,7 +34,6 @@ import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.Constants;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
@@ -378,7 +377,7 @@ public class ServiceAccountTest extends AbstractKeycloakTest {
 
     @Test
     public void clientCredentialsAuthRequest_ClientES256_RealmPS256() throws Exception {
-        conductClientCredentialsAuthRequestWithRefreshToken(Constants.INTERNAL_SIGNATURE_ALGORITHM, Algorithm.ES256, Algorithm.PS256);
+        conductClientCredentialsAuthRequestWithRefreshToken(Algorithm.PS256, Algorithm.ES256, Algorithm.PS256);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
@@ -30,7 +30,6 @@ import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.jose.jws.crypto.HashUtils;
-import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.representations.AccessToken;
@@ -259,7 +258,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         assertNull(header.getContentType());
 
         header = new JWSInput(response.getRefreshToken()).getHeader();
-        assertEquals(Constants.INTERNAL_SIGNATURE_ALGORITHM, header.getAlgorithm().name());
+        assertEquals(Algorithm.RS256, header.getAlgorithm().name());
         assertEquals("JWT", header.getType());
         assertNull(header.getContentType());
 


### PR DESCRIPTION
Closes #50502

## What
Internal cookies (KC_RESTART, KEYCLOAK_IDENTITY, AUTH_SESSION_ID) and internal tokens (refresh/offline tokens, client registration tokens, CIBA auth_req_id, OID4VC pre-auth code) were always signed with a hard-coded HS512 key regardless of realm configuration. They now follow the realm's Default Signature Algorithm (RS256 by default), removing the hard-coded HS256/HS512 usage.

## Backward compatibility
- Refresh/offline and other header-carrying tokens verify via the JWS header; the HS512 key provider is retained so existing tokens keep verifying.
- AUTH_SESSION_ID uses a dual-verify fallback to the legacy HS512 algorithm.
- KC_RESTART and CIBA legacy formats decode via an HS512-pinned branch.

## AI disclosure
Written with assistance from Claude Code (see the Co-Authored-By trailer on the commit).