### PR TITLE
Fixed the missing reference bug in haproxy reencrypt doc in keycloak repo

### DIFF
--- a/docs/guides/server/haproxy-reencrypt.adoc
+++ b/docs/guides/server/haproxy-reencrypt.adoc
@@ -47,6 +47,12 @@ frontend https_front
     http-request del-header x-original-.* -m reg
     http-request del-header x-real-ip
 
+    # Prevent external spoofing of client certificate headers
+    # These must be deleted unconditionally, because the set-header directives below
+    # are conditional
+    http-request del-header Client-Cert
+    http-request del-header Client-Cert-Chain
+
     # Prevent external tracing context injection (W3C Trace Context / Baggage)
     http-request del-header traceparent
     http-request del-header tracestate

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -488,6 +488,8 @@ Example HAProxy configuration:
 
 [source]
 ----
+http-request del-header Client-Cert
+http-request del-header Client-Cert-Chain
 http-request set-header Client-Cert %[ssl_c_der,base64] if { ssl_c_used } { ssl_c_verify 0 }
 http-request set-header Client-Cert-Chain %[ssl_c_chain_der,base64] if { ssl_c_used } { ssl_c_verify 0 }
 ----


### PR DESCRIPTION
This PR fixes the doc missing reference for the del-header for Client-Cert before conditional set-header in the keycloak repo.


Closes #50488

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
