### PR TITLE
Fix device version displaying wrong one on Safari

### DIFF
--- a/services/src/main/java/org/keycloak/device/DeviceRepresentationProviderImpl.java
+++ b/services/src/main/java/org/keycloak/device/DeviceRepresentationProviderImpl.java
@@ -82,13 +82,39 @@ public class DeviceRepresentationProviderImpl implements DeviceRepresentationPro
                 osVersion += "." + client.os.patchMinor;
             }
 
-            current.setOsVersion(osVersion);
+            current.setOsVersion(resolveOsVersion(client, osVersion, browserVersion));
             current.setIpAddress(context.getConnection().getRemoteHost());
             current.setMobile(userAgent.toLowerCase().contains("mobile"));
             return current;
         } catch (Exception cause) {
             logger.error("Failed to create device info from user agent header", cause);
             return null;
+        }
+    }
+
+    static String resolveOsVersion(Client client, String osVersion, String browserVersion) {
+        if (!"iOS".equalsIgnoreCase(client.os.family)) {
+            return osVersion;
+        }
+
+        String browserFamily = client.userAgent.family;
+
+        if (browserFamily == null || !browserFamily.toLowerCase().contains("safari")) {
+            return osVersion;
+        }
+
+        if (toInt(client.userAgent.major) > toInt(client.os.major)) {
+            return browserVersion;
+        }
+
+        return osVersion;
+    }
+
+    private static int toInt(String major) {
+        try {
+            return major == null ? -1 : Integer.parseInt(major.trim());
+        } catch (NumberFormatException e) {
+            return -1;
         }
     }
 }


### PR DESCRIPTION
The root cause is on apple side. Every browser sends a "user-agent" string describing the device. Keycloak reads the iOS version from it to show in Device Activity. Starting with iOS 26, Apple made Safari report the old version "18.7" in the part of that string where the OS version normally goes. link: https://webkit.org/blog/17333/webkit-features-in-safari-26-0/  They do this so old websites don't break.
The real version (26.x) is still in the string , but in a different spot (Safari's own version number).
Keycloak was only looking at the first spot, so it showed 18.7 instead of 26.x.

<img width="590" height="1278" alt="IMG_1570" src="https://github.com/user-attachments/assets/b0b6a592-6ea2-426d-aa80-bc956de85ff0" />


The UI part seems need another ticket to fix, right now the responsive design doesn't work well


Closes #44741

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
