### PR TITLE
limit audience for OID4CI access tokens

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCITokenPostProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCITokenPostProcessor.java
@@ -1,6 +1,7 @@
 package org.keycloak.protocol.oid4vc.refresh;
 
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
 import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.protocol.oidc.token.TokenPostProcessor;
@@ -31,7 +32,9 @@ public class OID4VCITokenPostProcessor implements TokenPostProcessor {
             accessToken.setSessionId(null);
         }
 
-        // TODO: Should possibly update "aud" of the access token to Keycloak issuer URL. Other updates?
+        // Limit the audience to only the credential endpoint URL.
+        String credentialEndpoint = OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(session.getContext());
+        accessToken.audience(credentialEndpoint);
     }
 
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -42,6 +42,7 @@ import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.oauth.OAuthClient;
@@ -81,6 +82,7 @@ import static org.keycloak.tests.oid4vc.OID4VCTestContext.CREDENTIALS_OFFER_URI_
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CREDENTIALS_RESPONSE_ATTACHMENT_KEY;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.ISSUER_METADATA_ATTACHMENT_KEY;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -681,5 +683,18 @@ public class OID4VCBasicWallet {
             openLoginForm();
             return parseLoginResponse();
         }
+    }
+
+    public void assertAccessTokenAudience(String accessToken, String... expectedAudience) {
+        assertNotNull(accessToken);
+        assertNotNull(expectedAudience);
+
+        AccessToken token = oauth.verifyToken(accessToken);
+        assertNotNull(token);
+
+        String[] audience = token.getAudience();
+        assertNotNull(audience);
+        assertEquals(expectedAudience.length, audience.length);
+        assertArrayEquals(expectedAudience, audience, "Access token audience should be limited to credential endpoint");
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
@@ -374,6 +374,50 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         return tokenResponse;
     }
 
+    /**
+     * Test that both initial and refreshed access tokens have their audience limited to the credential endpoint.
+     * This verifies that the OID4VCITokenPostProcessor correctly sets the 'aud' claim.
+     */
+    @Test
+    public void testAccessTokenAudienceLimitedToCredentialEndpoint() throws Exception {
+        // Login
+        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
+        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+        assertTrue(tokenResponse.isSuccess());
+
+        // Get the expected credential endpoint URL from issuer metadata
+        String expectedAudience = issuer.getCredentialEndpoint();
+        assertNotNull(expectedAudience);
+
+        // Verify initial access token has correct audience
+        String accessToken1 = tokenResponse.getAccessToken();
+        wallet.assertAccessTokenAudience(accessToken1, expectedAudience);
+
+        // Obtain credential to ensure the token works
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken1)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+        assertSuccessfulCredentialResponse(credResponse);
+
+        // Move time forward a bit
+        timeOffSet.set(10);
+
+        // Refresh token
+        AccessTokenResponse refreshResponse = wallet.refreshRequest(ctx).send();
+        assertTrue(refreshResponse.isSuccess(), "Refresh token exchange should succeed");
+
+        // Verify refreshed access token also has correct audience
+        String accessToken2 = refreshResponse.getAccessToken();
+        wallet.assertAccessTokenAudience(accessToken2, expectedAudience);
+
+        // Verify the refreshed token still works for credential requests
+        credResponse = wallet.credentialRequest(ctx, accessToken2)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+        assertSuccessfulCredentialResponse(credResponse);
+    }
+
     protected void assertSuccessfulCredentialResponse(CredentialResponse credentialResponse) {
         CredentialResponse.Credential credentialObj = credentialResponse.getCredentials().get(0);
         assertNotNull(credentialObj, "The first credential in the array should not be null");


### PR DESCRIPTION
Closes #50338 

Set audience claim to credential endpoint URL in OID4VCITokenPostProcessor for initial access token and also refreshed access token.

I'm not validating the audience in `OID4VCIssuerEndpoint` when a credential is requested. There is already a validation that checks if the scope is a credential. Should we also validate the audience? We can discuss it and add  the validation as a follow-up if needed.


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
