### PR TITLE
26.6 Backport: Add kotlin exclusion to quarkus-server's quarkus-smallrye-openapi dependency

### DIFF
--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -43,6 +43,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlinx</groupId>
+                    <artifactId>kotlinx-metadata-jvm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
See #50515