### PR TITLE
Fix: Root authentication session lookup uses assert-only realm check

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
@@ -19,6 +19,7 @@ package org.keycloak.models.sessions.infinispan;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.util.Time;
@@ -135,6 +136,9 @@ public class InfinispanAuthenticationSessionProvider implements AuthenticationSe
     @Override
     public RootAuthenticationSessionModel getRootAuthenticationSession(RealmModel realm, String authenticationSessionId) {
         RootAuthenticationSessionEntity entity = getRootAuthenticationSessionEntity(authenticationSessionId);
+        if (entity != null && !Objects.equals(realm.getId(), entity.getRealmId())) {
+            return null;
+        }
         return wrap(realm, entity);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
@@ -68,9 +68,10 @@ public class RemoteInfinispanAuthenticationSessionProvider implements Authentica
     @Override
     public RootAuthenticationSessionModel getRootAuthenticationSession(RealmModel realm, String authenticationSessionId) {
         var updater = transaction.get(authenticationSessionId);
-        if(updater != null) {
-            updater.initialize(session, realm, authSessionsLimit);
+        if (updater == null || !Objects.equals(realm.getId(), updater.getValue().getRealmId())) {
+            return null;
         }
+        updater.initialize(session, realm, authSessionsLimit);
         return updater;
     }
 

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticateSessionAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticateSessionAdapter.java
@@ -60,11 +60,23 @@ class AuthenticateSessionAdapter implements AuthenticationSessionModel {
         this.session = Objects.requireNonNull(session);
     }
 
-    public static AuthenticateSessionAdapter create(RootAuthenticationSessionAdapter parentSession, KeycloakSession session, String tabId, String clientUUID, int timestamp) {
+    /**
+     * Creates a new {@link AuthenticateSessionAdapter} backed by a fresh {@link AuthenticationSessionEntity}.
+     *
+     * @param parentSession the parent root authentication session adapter.
+     * @param session       the current Keycloak session.
+     * @param tabId         the tab identifier for this authentication session.
+     * @param clientUUID    the UUID of the client initiating the authentication.
+     * @param timestamp     the creation timestamp.
+     * @return a new adapter instance. The underlying entity is not persisted; the caller must persist it.
+     * @throws NullPointerException if {@code parentSession}, {@code session}, {@code tabId}, or {@code clientUUID} is
+     *                              {@code null}.
+     */
+    public static AuthenticateSessionAdapter create(RootAuthenticationSessionAdapter parentSession, KeycloakSession session, String tabId, String clientUUID, long timestamp) {
         var authEntity = new AuthenticationSessionEntity();
-        authEntity.setTabId(tabId);
+        authEntity.setTabId(Objects.requireNonNull(tabId));
         authEntity.setRootAuthenticationSession(parentSession.getEntity());
-        authEntity.setClientUUID(clientUUID);
+        authEntity.setClientUUID(Objects.requireNonNull(clientUUID));
         authEntity.setTimestamp(timestamp);
         AuthenticationSessionSerialization.setClientScopes(authEntity, Set.of());
         AuthenticationSessionSerialization.setExecutionStatus(authEntity, Map.of());

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -92,6 +92,8 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
             logger.debugf("Root authentication session with id '%s' is expired.", id);
             // let's restart it
             entity.setTimestamp(Time.currentTimeSeconds());
+            entity.getAuthenticationSessions().forEach((s, authenticationSessionEntity) -> authenticationSessionEntity.setRootAuthenticationSession(null));
+            entity.getAuthenticationSessions().clear();
         }
         return RootAuthenticationSessionAdapter.wrapEntity(session, realm,  entity, authSessionsLimit);
     }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -92,7 +92,6 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
             logger.debugf("Root authentication session with id '%s' is expired.", id);
             // let's restart it
             entity.setTimestamp(Time.currentTimeSeconds());
-            entity.getAuthenticationSessions().forEach((s, authenticationSessionEntity) -> authenticationSessionEntity.setRootAuthenticationSession(null));
             entity.getAuthenticationSessions().clear();
         }
         return RootAuthenticationSessionAdapter.wrapEntity(session, realm,  entity, authSessionsLimit);

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -84,10 +84,14 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
         if (entity == null) {
             throw new ModelException("Unable to create or find root authentication session with id '" + id + "'");
         }
+        if (!Objects.equals(realm.getId(), entity.getRealmId())) {
+            throw new ModelException("Another root authentication session with id '" + id + "' already exists in other realm");
+        }
         var lifespan = SessionExpiration.getAuthSessionLifespan(realm);
         if (entity.getTimestamp() + lifespan < Time.currentTimeSeconds()) {
             logger.debugf("Root authentication session with id '%s' is expired.", id);
-            return null;
+            // let's restart it
+            entity.setTimestamp(Time.currentTimeSeconds());
         }
         return RootAuthenticationSessionAdapter.wrapEntity(session, realm,  entity, authSessionsLimit);
     }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -30,7 +30,6 @@ import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.KeycloakTransaction;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.SessionExpiration;
@@ -46,7 +45,6 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
     private final KeycloakSession session;
     private final int authSessionsLimit;
     private final Map<String, RootAuthenticationSessionAdapter> transientSessions = new HashMap<>();
-    private KeycloakTransaction transaction;
     private boolean enlisted;
 
     public JpaAuthenticationSessionProvider(KeycloakSession session, int authSessionsLimit) {
@@ -56,7 +54,7 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
 
     @Override
     public RootAuthenticationSessionModel createRootAuthenticationSession(RealmModel realm) {
-        var model = RootAuthenticationSessionAdapter.create(session, realm, SecretGenerator.SECURE_ID_GENERATOR.get(), Time.currentTime(), authSessionsLimit);
+        var model = RootAuthenticationSessionAdapter.create(session, realm, SecretGenerator.SECURE_ID_GENERATOR.get(), Time.currentTimeSeconds(), authSessionsLimit);
         // Those newly created authentication sessions with a random ID do not exist in the database, so there can not be any conflict.
         // For resource owner password grants, those sessions are created temporarily, so we only insert them if they are not removed within the same session.
         transientSessions.put(model.getEntity().getId(), model);
@@ -80,14 +78,14 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
         em.createNamedQuery("insertRootAuthSessionIfAbsent")
                 .setParameter("id", id)
                 .setParameter("realmId", realm.getId())
-                .setParameter("timestamp", Time.currentTime())
+                .setParameter("timestamp", Time.currentTimeSeconds())
                 .executeUpdate();
         var entity = em.find(RootAuthenticationSessionEntity.class, id, LockModeType.PESSIMISTIC_WRITE);
         if (entity == null) {
             throw new ModelException("Unable to create or find root authentication session with id '" + id + "'");
         }
         var lifespan = SessionExpiration.getAuthSessionLifespan(realm);
-        if (entity.getTimestamp() + lifespan < Time.currentTime()) {
+        if (entity.getTimestamp() + lifespan < Time.currentTimeSeconds()) {
             logger.debugf("Root authentication session with id '%s' is expired.", id);
             return null;
         }
@@ -108,11 +106,11 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
 
         var em = getEntityManager();
         var entity = em.find(RootAuthenticationSessionEntity.class, id, LockModeType.PESSIMISTIC_WRITE);
-        if (entity == null) {
+        if (entity == null || !Objects.equals(realm.getId(), entity.getRealmId())) {
             return null;
         }
         var lifespan = SessionExpiration.getAuthSessionLifespan(realm);
-        if (entity.getTimestamp() + lifespan < Time.currentTime()) {
+        if (entity.getTimestamp() + lifespan < Time.currentTimeSeconds()) {
             logger.debugf("Root authentication session with id '%s' is expired.", id);
             em.remove(entity);
             return null;

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
@@ -45,22 +45,49 @@ class RootAuthenticationSessionAdapter implements RootAuthenticationSessionModel
     private final int authSessionsLimit;
     private Map<String, AuthenticateSessionAdapter> adapters;
 
-    public static RootAuthenticationSessionAdapter create(KeycloakSession session, RealmModel realm, String id, int timestamp, int authSessionsLimit) {
+    /**
+     * Creates a new {@link RootAuthenticationSessionAdapter} backed by a fresh
+     * {@link RootAuthenticationSessionEntity}.
+     *
+     * @param session           the current Keycloak session.
+     * @param realm             the realm this authentication session belongs to.
+     * @param id                the unique identifier for the root authentication session.
+     * @param timestamp         the creation timestamp.
+     * @param authSessionsLimit the maximum number of concurrent authentication sessions.
+     * @return a new adapter instance. The underlying entity is not persisted; the caller must persist it.
+     * @throws NullPointerException if {@code session}, {@code id}, or {@code realm} is {@code null}.
+     */
+    public static RootAuthenticationSessionAdapter create(KeycloakSession session, RealmModel realm, String id, long timestamp, int authSessionsLimit) {
         assert session != null;
         assert realm != null;
+        assert id != null;
+
         var entity = new RootAuthenticationSessionEntity();
-        entity.setId(id);
+        entity.setId(Objects.requireNonNull(id));
         entity.setTimestamp(timestamp);
         entity.setAuthenticationSessions(new HashMap<>());
         entity.setRealmId(realm.getId());
         return new RootAuthenticationSessionAdapter(entity, realm, session, authSessionsLimit);
     }
 
+    /**
+     * Wraps an existing {@link RootAuthenticationSessionEntity} in an adapter.
+     *
+     * @param session           the current Keycloak session.
+     * @param realm             the realm this authentication session belongs to.
+     * @param entity            the JPA entity to wrap.
+     * @param authSessionsLimit the maximum number of concurrent authentication sessions.
+     * @return a new adapter instance, or {@code null} if the entity's realm does not match {@code realm}.
+     * @throws NullPointerException if {@code session}, {@code realm}, or {@code entity} is {@code null}.
+     */
     public static RootAuthenticationSessionAdapter wrapEntity(KeycloakSession session, RealmModel realm, RootAuthenticationSessionEntity entity, int authSessionsLimit) {
         assert session != null;
         assert realm != null;
         assert entity != null;
-        assert Objects.equals(realm.getId(), entity.getRealmId());
+
+        if (!Objects.equals(realm.getId(), entity.getRealmId())) {
+            return null;
+        }
 
         return new RootAuthenticationSessionAdapter(entity, realm, session, authSessionsLimit);
     }
@@ -113,7 +140,7 @@ class RootAuthenticationSessionAdapter implements RootAuthenticationSessionModel
     @Override
     public AuthenticationSessionModel createAuthenticationSession(ClientModel client) {
         var tabId = Base64Url.encode(SecretGenerator.getInstance().randomBytes(8));
-        var timestamp = Time.currentTime();
+        var timestamp = Time.currentTimeSeconds();
 
         if (entity.getAuthenticationSessions().size() >= authSessionsLimit) {
             entity.getAuthenticationSessions().values().stream()
@@ -146,7 +173,7 @@ class RootAuthenticationSessionAdapter implements RootAuthenticationSessionModel
     @Override
     public void restartSession(RealmModel realm) {
         entity.getAuthenticationSessions().clear();
-        entity.setTimestamp(Time.currentTime());
+        entity.setTimestamp(Time.currentTimeSeconds());
         if (adapters != null) {
             adapters.clear();
         }

--- a/tests/base/src/test/java/org/keycloak/tests/forms/LoginTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/forms/LoginTest.java
@@ -1129,7 +1129,11 @@ public class LoginTest {
         assertTrue(authSessionId.length() >= 24);
         assertNotNull(signature);
 
-        runOnServer.run(session-> assertNotNull(session.authenticationSessions().getRootAuthenticationSession(session.getContext().getRealm(), authSessionId)));
+        var managedRealmId = managedRealm.getId();
+        runOnServer.run(session-> {
+            RealmModel realm = session.realms().getRealm(managedRealmId);
+            assertNotNull(session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId));
+        });
     }
 
     @Test

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -209,6 +209,29 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
             assertNull(rootAuthSession);
 
+            setTimeOffset(0);
+
+            return null;
+        });
+
+
+        withRealm(realmId, (session, realm) -> {
+            RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm, "test");
+            ClientModel client = realm.getClientByClientId("test-app");
+            rootAuthSession.createAuthenticationSession(client);
+            rootAuthSessionId.set(rootAuthSession.getId());
+
+            return null;
+        });
+
+        withRealm(realmId, (session, realm) -> {
+            setTimeOffset(1900);
+
+            RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm, "test");
+            ClientModel client = realm.getClientByClientId("test-app");
+            rootAuthSession.createAuthenticationSession(client);
+            rootAuthSessionId.set(rootAuthSession.getId());
+
             return null;
         });
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -232,6 +232,8 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             rootAuthSession.createAuthenticationSession(client);
             rootAuthSessionId.set(rootAuthSession.getId());
 
+            setTimeOffset(0);
+
             return null;
         });
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 import static org.keycloak.testsuite.model.session.UserSessionPersisterProviderTest.createClients;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author <a href="mailto:mkanis@redhat.com">Martin Kanis</a>
@@ -111,7 +112,7 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             Assert.assertEquals(tabId, ras.getAuthenticationSession(client, tabId).getTabId());
 
             // assert the first authentication session was deleted
-            Assert.assertNull(ras.getAuthenticationSession(client, tabIds.get(0)));
+            assertNull(ras.getAuthenticationSession(client, tabIds.get(0)));
 
             return null;
         });
@@ -166,8 +167,8 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
 
             assertThat(rootAuthSession.getAuthenticationSessions(), Matchers.aMapWithSize(3));
 
-            Assert.assertNull(rootAuthSession.getAuthenticationSessions().get(tabIds.get(0)));
-            Assert.assertNull(rootAuthSession.getAuthenticationSessions().get(tabIds.get(1)));
+            assertNull(rootAuthSession.getAuthenticationSessions().get(tabIds.get(0)));
+            assertNull(rootAuthSession.getAuthenticationSessions().get(tabIds.get(1)));
             IntStream.range(2,4).mapToObj(i -> rootAuthSession.getAuthenticationSessions().get(tabIds.get(i))).forEach(Assert::assertNotNull);
 
             session.authenticationSessions().removeRootAuthenticationSession(realm, rootAuthSession);
@@ -177,7 +178,7 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
 
         withRealm(realmId, (session, realm) -> {
             RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
-            Assert.assertNull(rootAuthSession);
+            assertNull(rootAuthSession);
 
             return null;
         });
@@ -206,7 +207,7 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
 
         withRealm(realmId, (session, realm) -> {
             RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
-            Assert.assertNull(rootAuthSession);
+            assertNull(rootAuthSession);
 
             return null;
         });
@@ -260,9 +261,52 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
 
         withRealm(realmId, (session, realm) -> {
             RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootId);
-            Assert.assertNull(rootAuthSession);
+            assertNull(rootAuthSession);
             return null;
         });
+    }
+
+    @Test
+    public void testCrossRealmIsolation() {
+        // Create a second realm
+        var realmBId = inComittedTransaction(s -> {
+            var realmB = createRealm(s, "test-realm-b");
+            s.getContext().setRealm(realmB);
+            realmB.setDefaultRole(s.roles().addRealmRole(realmB, Constants.DEFAULT_ROLES_ROLE_PREFIX + "-" + realmB.getName()));
+            realmB.setAccessCodeLifespanLogin(1800);
+            createClients(s, realmB);
+            return realmB.getId();
+        });
+
+        try {
+            AtomicReference<String> rootAuthSessionId = new AtomicReference<>();
+            withRealm(realmId, (session, realm) -> {
+                var rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm);
+                rootAuthSessionId.set(rootAuthSession.getId());
+                ClientModel client = realm.getClientByClientId("test-app");
+                rootAuthSession.createAuthenticationSession(client);
+                return null;
+            });
+
+            // Lookup using realmB must return null
+            withRealm(realmBId, (session, realmB) -> {
+                var rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realmB, rootAuthSessionId.get());
+                assertNull("Authentication session from realmA must not be visible in realmB", rootAuthSession);
+                return null;
+            });
+
+            // Lookup using the original realm must still work
+            withRealm(realmId, (session, realm) -> {
+                var rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
+                Assert.assertNotNull(rootAuthSession);
+                session.authenticationSessions().removeRootAuthenticationSession(realm, rootAuthSession);
+                return null;
+            });
+        } finally {
+            inComittedTransaction(s -> {
+                s.realms().removeRealm(realmBId);
+            });
+        }
     }
 
     @Test

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -304,6 +304,7 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             });
         } finally {
             inComittedTransaction(s -> {
+                s.getContext().setRealm(s.realms().getRealm(realmBId));
                 s.realms().removeRealm(realmBId);
             });
         }


### PR DESCRIPTION
Closes #50482

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
