### PR TITLE
Fix: JpaSingleUseObjectProvider.putIfAbsent() missing lifespan valida…

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanSingleUseObjectProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanSingleUseObjectProvider.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.sessions.infinispan;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.keycloak.models.KeycloakSession;
@@ -51,6 +52,10 @@ public class InfinispanSingleUseObjectProvider implements SingleUseObjectProvide
 
     @Override
     public void put(String key, long lifespanSeconds, Map<String, String> notes) {
+        Objects.requireNonNull(key);
+        if (lifespanSeconds <= 0) {
+            throw new IllegalArgumentException("lifespanSeconds must be positive");
+        }
         SingleUseObjectValueEntity tokenValue = new SingleUseObjectValueEntity(notes);
         tx.put(singleUseObjectCache, key, tokenValue, lifespanSeconds, TimeUnit.SECONDS);
         if (persistRevokedTokens && key.endsWith(REVOKED_KEY)) {
@@ -63,6 +68,7 @@ public class InfinispanSingleUseObjectProvider implements SingleUseObjectProvide
 
     @Override
     public Map<String, String> get(String key) {
+        Objects.requireNonNull(key);
         if (persistRevokedTokens && key.endsWith(REVOKED_KEY)) {
             throw new ModelException("Revoked tokens can't be retrieved");
         }
@@ -73,6 +79,7 @@ public class InfinispanSingleUseObjectProvider implements SingleUseObjectProvide
 
     @Override
     public Map<String, String> remove(String key) {
+        Objects.requireNonNull(key);
         if (persistRevokedTokens && key.endsWith(REVOKED_KEY)) {
            throw new ModelException("Revoked tokens can't be removed");
         }
@@ -89,6 +96,7 @@ public class InfinispanSingleUseObjectProvider implements SingleUseObjectProvide
 
     @Override
     public boolean replace(String key, Map<String, String> notes) {
+        Objects.requireNonNull(key);
         if (persistRevokedTokens && key.endsWith(REVOKED_KEY)) {
             throw new ModelException("Revoked tokens can't be replaced");
         }
@@ -98,6 +106,10 @@ public class InfinispanSingleUseObjectProvider implements SingleUseObjectProvide
 
     @Override
     public boolean putIfAbsent(String key, long lifespanInSeconds) {
+        Objects.requireNonNull(key);
+        if (lifespanInSeconds <= 0) {
+            throw new IllegalArgumentException("lifespanInSeconds must be positive");
+        }
         SingleUseObjectValueEntity tokenValue = new SingleUseObjectValueEntity(null);
         SingleUseObjectValueEntity existing = singleUseObjectCache.putIfAbsent(key, tokenValue, lifespanInSeconds, TimeUnit.SECONDS);
         if (persistRevokedTokens && key.endsWith(REVOKED_KEY)) {
@@ -108,6 +120,7 @@ public class InfinispanSingleUseObjectProvider implements SingleUseObjectProvide
 
     @Override
     public boolean contains(String key) {
+        Objects.requireNonNull(key);
         return singleUseObjectCache.containsKey(key);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanSingleUseObjectProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanSingleUseObjectProvider.java
@@ -48,6 +48,10 @@ public class RemoteInfinispanSingleUseObjectProvider implements SingleUseObjectP
 
     @Override
     public void put(String key, long lifespanSeconds, Map<String, String> notes) {
+        Objects.requireNonNull(key);
+        if (lifespanSeconds <= 0) {
+            throw new IllegalArgumentException("lifespanSeconds must be positive");
+        }
         if (key.endsWith(REVOKED_KEY)) {
             revokeToken(key, lifespanSeconds);
             return;
@@ -57,11 +61,13 @@ public class RemoteInfinispanSingleUseObjectProvider implements SingleUseObjectP
 
     @Override
     public Map<String, String> get(String key) {
+        Objects.requireNonNull(key);
         return unwrap(transaction.get(key));
     }
 
     @Override
     public Map<String, String> remove(String key) {
+        Objects.requireNonNull(key);
         try {
             // Using a get-before-remove allows us to return the value even in cases when a state transfer happens in Infinispan
             // where it might not return the value in all cases.
@@ -83,11 +89,16 @@ public class RemoteInfinispanSingleUseObjectProvider implements SingleUseObjectP
 
     @Override
     public boolean replace(String key, Map<String, String> notes) {
+        Objects.requireNonNull(key);
         return withReturnValue().replace(key, wrap(notes)) != null;
     }
 
     @Override
     public boolean putIfAbsent(String key, long lifespanInSeconds) {
+        Objects.requireNonNull(key);
+        if (lifespanInSeconds <= 0) {
+            throw new IllegalArgumentException("lifespanInSeconds must be positive");
+        }
         try {
             boolean result = withReturnValue().putIfAbsent(key, wrap(null), lifespanInSeconds, TimeUnit.SECONDS) == null;
             if (key.endsWith(REVOKED_KEY)) {
@@ -104,6 +115,7 @@ public class RemoteInfinispanSingleUseObjectProvider implements SingleUseObjectP
 
     @Override
     public boolean contains(String key) {
+        Objects.requireNonNull(key);
         return transaction.getCache().containsKey(key);
     }
 

--- a/model/jpa/src/main/java/org/keycloak/singleobject/jpa/JpaSingleUseObjectProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/singleobject/jpa/JpaSingleUseObjectProvider.java
@@ -18,6 +18,7 @@
 package org.keycloak.singleobject.jpa;
 
 import java.util.Map;
+import java.util.Objects;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
@@ -43,21 +44,23 @@ public class JpaSingleUseObjectProvider implements SingleUseObjectProvider {
 
     @Override
     public void put(String key, long lifespanSeconds, Map<String, String> notes) {
+        Objects.requireNonNull(key);
         if (lifespanSeconds <= 0) {
             throw new IllegalArgumentException("lifespanSeconds must be positive");
         }
         getEntityManager().createNamedQuery("insertOrOverwriteSingleUseObject")
                 .setParameter("id", key)
                 .setParameter("notes", SingleUseObjectSerialization.notesToString(key, notes))
-                .setParameter("expire", Time.currentTime() + lifespanSeconds)
+                .setParameter("expire", Time.currentTimeSeconds() + lifespanSeconds)
                 .executeUpdate();
     }
 
     @Override
     public Map<String, String> get(String key) {
+        Objects.requireNonNull(key);
         var notes = getEntityManager().createNamedQuery("findSingleUseObjectNotes", String.class)
                 .setParameter("id", key)
-                .setParameter("currentTime", Time.currentTime())
+                .setParameter("currentTime", Time.currentTimeSeconds())
                 .getSingleResultOrNull();
         if (notes == null) {
             return null;
@@ -67,6 +70,7 @@ public class JpaSingleUseObjectProvider implements SingleUseObjectProvider {
 
     @Override
     public Map<String, String> remove(String key) {
+        Objects.requireNonNull(key);
         var em = getEntityManager();
         var entity = em.find(SingleUseObjectEntity.class, key, LockModeType.PESSIMISTIC_WRITE);
         if (entity == null) {
@@ -81,17 +85,22 @@ public class JpaSingleUseObjectProvider implements SingleUseObjectProvider {
 
     @Override
     public boolean replace(String key, Map<String, String> notes) {
+        Objects.requireNonNull(key);
         var rows = getEntityManager().createNamedQuery("updateIfNotExpiredSingleUseObject")
                 .setParameter("id", key)
                 .setParameter("notes", SingleUseObjectSerialization.notesToString(key, notes))
-                .setParameter("currentTime", Time.currentTime())
+                .setParameter("currentTime", Time.currentTimeSeconds())
                 .executeUpdate();
         return rows == 1;
     }
 
     @Override
     public boolean putIfAbsent(String key, long lifespanInSeconds) {
-        var currentTime = Time.currentTime();
+        Objects.requireNonNull(key);
+        if (lifespanInSeconds <= 0) {
+            throw new IllegalArgumentException("lifespanInSeconds must be positive");
+        }
+        var currentTime = Time.currentTimeSeconds();
         var rows = getEntityManager().createNamedQuery("insertIfAbsentOrExpiredSingleUseObject")
                 .setParameter("id", key)
                 .setParameter("notes", SingleUseObjectSerialization.notesToString(key, Map.of()))
@@ -103,6 +112,7 @@ public class JpaSingleUseObjectProvider implements SingleUseObjectProvider {
 
     @Override
     public boolean contains(String key) {
+        Objects.requireNonNull(key);
         var expireTime = getEntityManager().createNamedQuery("findSingleUseObjectExpireTime", Long.class)
                 .setParameter("id", key)
                 .getSingleResultOrNull();
@@ -119,6 +129,6 @@ public class JpaSingleUseObjectProvider implements SingleUseObjectProvider {
     }
 
     private static boolean isExpired(long expire) {
-        return expire <= Time.currentTime();
+        return expire <= Time.currentTimeSeconds();
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/SingleUseObjectProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/SingleUseObjectProvider.java
@@ -29,57 +29,71 @@ import org.keycloak.provider.Provider;
 public interface SingleUseObjectProvider extends Provider {
 
     /**
-     * Suffix to a key to indicate that token is considered revoked.
-     * For revoked tokens, only the methods {@link #put} and {@link #contains} must be used.
+     * Suffix appended to a key to indicate that a token is considered revoked. For revoked tokens, only the methods
+     * {@link #put} and {@link #contains} must be used.
      */
     String REVOKED_KEY = ".revoked";
 
     /**
-     * Stores the given data and guarantees that data should be available in the store for at least the time specified by {@param lifespanSeconds} parameter
-     * @param key String
-     * @param lifespanSeconds Minimum lifespan for which successfully added key will be kept in the cache.
-     * @param notes For revoked tokens, this must be an empty Map.
+     * Stores the given data and guarantees that data should be available in the store for at least the time specified
+     * by {@code lifespanSeconds} parameter.
+     *
+     * @param key             identifier for the single-use object. Must not be {@code null}.
+     * @param lifespanSeconds minimum lifespan for which the key will be kept in the store. Must be positive.
+     * @param notes           data to associate with the key. For revoked tokens, this must be an empty Map.
+     * @throws NullPointerException     if {@code key} is {@code null}.
+     * @throws IllegalArgumentException if {@code lifespanSeconds} is not positive.
      */
     void put(String key, long lifespanSeconds, Map<String, String> notes);
 
     /**
      * Gets data associated with the given key.
-     * @param key String
-     * @return Map<String, String> Data associated with the given key or {@code null} if there is no associated data.
+     *
+     * @param key identifier for the single-use object. Must not be {@code null}.
+     * @return data associated with the given key, or {@code null} if there is no associated data.
+     * @throws NullPointerException if {@code key} is {@code null}.
      */
     Map<String, String> get(String key);
 
     /**
-     * This method returns data just if removal was successful. Implementation should guarantee that "remove" is single-use. So if
-     * 2 threads (even on different cluster nodes or on different multi-site nodes) calls "remove(123)" concurrently, then just one of them
-     * is allowed to succeed and return data back. It can't happen that both will succeed.
+     * Returns data only if the removal was successful. Implementations must guarantee that removal is single-use: if
+     * two threads (even on different cluster nodes or different multi-site nodes) call {@code remove(key)}
+     * concurrently, only one of them is allowed to succeed and return data. It must not happen that both succeed.
      *
-     * @param key String
-     * @return context data associated to the key. It returns {@code null} if there are no context data available.
+     * @param key identifier for the single-use object. Must not be {@code null}.
+     * @return context data associated with the key, or {@code null} if there is no context data available.
+     * @throws NullPointerException if {@code key} is {@code null}.
      */
     Map<String, String> remove(String key);
 
     /**
      * Replaces data associated with the given key in the store if the store contains the key.
-     * @param key String
-     * @param notes Map<String, String> New data to be stored
+     *
+     * @param key   identifier for the single-use object. Must not be {@code null}.
+     * @param notes new data to be stored.
      * @return {@code true} if the store contains the key and data was replaced, otherwise {@code false}.
+     * @throws NullPointerException if {@code key} is {@code null}.
      */
     boolean replace(String key, Map<String, String> notes);
 
     /**
-     * Will try to put the key into the cache. It will succeed just if key is not already there.
+     * Tries to put the key into the store. It will succeed only if the key is not already present.
      *
-     * @param key
-     * @param lifespanInSeconds Minimum lifespan for which successfully added key will be kept in the cache.
-     * @return true if the key was successfully put into the cache. This means that same key wasn't in the cache before
+     * @param key               identifier for the single-use object. Must not be {@code null}.
+     * @param lifespanInSeconds minimum lifespan for which the key will be kept in the store. Must be positive.
+     * @return {@code true} if the key was successfully put into the store, meaning the same key wasn't in the store
+     * before.
+     * @throws NullPointerException     if {@code key} is {@code null}.
+     * @throws IllegalArgumentException if {@code lifespanInSeconds} is not positive.
      */
     boolean putIfAbsent(String key, long lifespanInSeconds);
 
     /**
      * Checks if there is a record in the store for the given key.
-     * @param key String
+     *
+     * @param key identifier for the single-use object. Must not be {@code null}.
      * @return {@code true} if the record is present in the store, {@code false} otherwise.
+     * @throws NullPointerException if {@code key} is {@code null}.
      */
     boolean contains(String key);
 }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/singleUseObject/SingleUseObjectModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/singleUseObject/SingleUseObjectModelTest.java
@@ -45,6 +45,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 @RequireProvider(SingleUseObjectProvider.class)
 public class SingleUseObjectModelTest extends KeycloakModelTest {
@@ -215,6 +216,31 @@ public class SingleUseObjectModelTest extends KeycloakModelTest {
             assertThat(session.revokedTokens().contains(revokedKey), Matchers.is(false));
         });
 
+    }
+
+    @Test
+    public void testNullKey() {
+        inComittedTransaction(session -> {
+            var singleUseStore = session.singleUseObjects();
+            assertThrows(NullPointerException.class, () -> singleUseStore.put(null, 60, Map.of()));
+            assertThrows(NullPointerException.class, () -> singleUseStore.get(null));
+            assertThrows(NullPointerException.class, () -> singleUseStore.remove(null));
+            assertThrows(NullPointerException.class, () -> singleUseStore.replace(null, Map.of()));
+            assertThrows(NullPointerException.class, () -> singleUseStore.putIfAbsent(null, 60));
+            assertThrows(NullPointerException.class, () -> singleUseStore.contains(null));
+        });
+    }
+
+    @Test
+    public void testNonPositiveLifespan() {
+        inComittedTransaction(session -> {
+            var singleUseStore = session.singleUseObjects();
+            var key = UUID.randomUUID().toString();
+            assertThrows(IllegalArgumentException.class, () -> singleUseStore.put(key, 0, Map.of()));
+            assertThrows(IllegalArgumentException.class, () -> singleUseStore.put(key, -1, Map.of()));
+            assertThrows(IllegalArgumentException.class, () -> singleUseStore.putIfAbsent(key, 0));
+            assertThrows(IllegalArgumentException.class, () -> singleUseStore.putIfAbsent(key, -1));
+        });
     }
 
     @Test


### PR DESCRIPTION
…tion present in put()

The key validation (not null) and the lifespan validation (positive value) added to all implementations

Closes #50481

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
