### PR TITLE
fix: don't use our interceptors when the classloaders don't match

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigBuilderCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigBuilderCustomizer.java
@@ -1,0 +1,22 @@
+package org.keycloak.quarkus.runtime.configuration;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+public class ConfigBuilderCustomizer implements SmallRyeConfigBuilderCustomizer {
+
+    @Override
+    public void configBuilder(SmallRyeConfigBuilder builder) {
+        if (builder.getClassLoader() == Thread.currentThread().getContextClassLoader()) {
+            // the Keycloak interceptors shouldn't be used when the classloader doesn't match
+            // as our logic will implicitly create a config via Configuration.getConfig in effectively
+            // the wrong classloader
+            addInterceptors(builder); 
+        }
+    }
+
+    static SmallRyeConfigBuilder addInterceptors(SmallRyeConfigBuilder builder) {
+        return builder.withInterceptors(new PropertyMappingInterceptor(), new NestedPropertyMappingInterceptor());
+    }
+    
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -101,7 +101,7 @@ public final class Configuration {
 
     public static synchronized SmallRyeConfig getConfig() {
         if (config == null) {
-            config = ConfigUtils.emptyConfigBuilder().addDiscoveredSources().build();
+            config = ConfigUtils.emptyConfigBuilder().addDiscoveredSources().withCustomizers(new ConfigBuilderCustomizer()).build();
         }
         return config;
     }

--- a/quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/quarkus/runtime/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor
-org.keycloak.quarkus.runtime.configuration.NestedPropertyMappingInterceptor
+org.keycloak.quarkus.runtime.configuration.ConfigBuilderCustomizer

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -104,7 +104,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertTrue(Configuration.getConfig().isPropertyPresent("quarkus.log.category.\"io.k8s\".level"));
         putEnvVar("SOME_LOG_LEVEL", "debug");
         assertEquals("debug", createConfig().getRawValue("kc.log-level"));
-        SmallRyeConfig config = ConfigUtils.emptyConfigBuilder().setAddDefaultSources(false).addDiscoveredSources().build();
+        SmallRyeConfig config = ConfigBuilderCustomizer.addInterceptors(ConfigUtils.emptyConfigBuilder().setAddDefaultSources(false).addDiscoveredSources()).build();
         assertNull(Expressions.withoutExpansion(() -> config.getConfigValue("kc.log-level")).getValue());
     }
 


### PR DESCRIPTION
closes: #50484

@Pepo48 after looking more at the explicit config creation this seemed like the more focused change - to just check for the classloader mismatch in a ConfigBuilderCustomizer.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
