### PR TITLE
fix: removing the initial workaround of preferring http for operator admin connections

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakClientBaseController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakClientBaseController.java
@@ -418,9 +418,7 @@ public abstract class KeycloakClientBaseController<R extends CustomResource<? ex
     }
 
     private static String getAdminUrl(Keycloak keycloak, KubernetesClient client, String addressOverride) {
-        boolean httpEnabled = KeycloakServiceDependentResource.isHttpEnabled(keycloak);
-        // for now preferring to use http if available
-        boolean https = isTlsConfigured(keycloak) && !httpEnabled;
+        boolean https = isTlsConfigured(keycloak);
         String protocol = https?HTTPS:"http";
         String address = addressOverride;
 


### PR DESCRIPTION
closes: #50494

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
