### PR TITLE
Documentation addition after the quickstart repo imp of isolating the master realm from public internet.

### DIFF
--- a/docs/guides/server/haproxy-reencrypt.adoc
+++ b/docs/guides/server/haproxy-reencrypt.adoc
@@ -230,6 +230,27 @@ These rules route by destination port:
 With this setup, any request to an admin path on the public port is denied with an HTTP 403 response.
 ====
 
+[[isolating-master-realm-haproxy-reencrypt]]
+== Isolating the master realm from the public internet
+
+As a security best practice, restrict access to the administrative `master` realm endpoints from public IP addresses.
+Use the following steps to allow access to these URLs only from allowed internal IP addresses.
+
+=== HAProxy configuration
+
+[source,haproxy]
+----
+# Config for isolating the master realm from public internet.
+acl is_master_realm path /realms/master
+acl is_master_realm path_beg /realms/master/
+http-request deny if is_master_realm !is_allowed_src
+----
+
+This configuration targets requests matching the administrative paths `/realms/master` or starting with `/realms/master/`.
+This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
+
+The explicit use of `priority: 100` on the master router and `priority: 50` on the public router defines a strict evaluation pipeline.
+
 [[graceful-shutdown-considerations-haproxy-reencrypt]]
 == Graceful shutdown considerations
 

--- a/docs/guides/server/haproxy-reencrypt.adoc
+++ b/docs/guides/server/haproxy-reencrypt.adoc
@@ -249,7 +249,7 @@ http-request deny if is_master_realm !is_allowed_src
 This configuration targets requests matching the administrative paths `/realms/master` or starting with `/realms/master/`.
 This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
 
-The explicit use of `priority: 100` on the master router and `priority: 50` on the public router defines a strict evaluation pipeline.
+HAProxy evaluates `http-request` rules from top to bottom, so place this deny rule before any broader allow/deny rules that would otherwise permit `/realms/` traffic from external clients.
 
 [[graceful-shutdown-considerations-haproxy-reencrypt]]
 == Graceful shutdown considerations

--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -304,7 +304,7 @@ The `keycloak-master` router isolates the default management realm from custom a
 This router targets requests matching the regular expression `^/realms/master(/|$)`.
 This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
 
-The explicit use of `priority: 100` on the master router and `priority: 50` on the public router defines a strict evaluation pipeline.
+The explicit use of `priority: 100` on the master router ensures it is evaluated before the `keycloak-public` router.
 
 [[graceful-shutdown-considerations-traefik-reencrypt]]
 == Graceful shutdown considerations

--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -275,6 +275,37 @@ With this setup, any request to an admin path on the public port (8443 in our ex
 Admin paths on this port will return a 404.
 ====
 
+[[isolating-master-realm-traefik-reencrypt]]
+== Isolating the master realm from the public internet
+
+As a security best practice, prevent logins to the administrative `master` realm from public IP addresses.
+Use the following steps to allow access to these URLs only from allowed internal IP addresses.
+
+=== Traefik configuration
+
+The `keycloak-master` router isolates the default management realm from custom application realms.
+
+[source,yaml]
+----
+  routers:
+    keycloak-master:
+      entryPoints:
+        - keycloak
+      rule: "PathRegexp(`^/realms/master(/|$)`)"
+      priority: 100
+      middlewares:
+        - filter-headers
+        - pass-client-cert
+        - ip-allowlist
+      tls: { }
+      service: keycloak
+----
+
+This router targets requests matching the regular expression `^/realms/master(/|$)`.
+This rule matches core management traffic (such as token requests, logins, or console lookups inside the master realm) while letting other user realm paths pass through unhindered.
+
+The explicit use of `priority: 100` on the master router and `priority: 50` on the public router defines a strict evaluation pipeline.
+
 [[graceful-shutdown-considerations-traefik-reencrypt]]
 == Graceful shutdown considerations
 


### PR DESCRIPTION
This PR is a documentation addition for isolating the master realm from the public internet to minimize the attack surface
The quick-starts repo links are : 

https://github.com/keycloak/keycloak-quickstarts/pull/783
https://github.com/keycloak/keycloak-quickstarts/pull/782


Closes #50258

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
