### PR TITLE
fix: excluding synced-common dependency, and adding enforcement

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -122,8 +122,8 @@
             <artifactId>keycloak-admin-client</artifactId>
             <exclusions>
                 <exclusion>
-                	<groupId>org.keycloak</groupId>
-                	<artifactId>keycloak-client-common-synced</artifactId>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-client-common-synced</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -120,6 +120,16 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
+            <exclusions>
+                <exclusion>
+                	<groupId>org.keycloak</groupId>
+                	<artifactId>keycloak-client-common-synced</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -197,6 +207,40 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${version.enforcer.plugin}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-duplicate-classes</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- ensure that runtime isn't pulling in older common / core classes via
+                                     the admin client -->
+                                <banDuplicateClasses>
+                                    <findAllDuplicates>false</findAllDuplicates>
+                                    <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                                    <ignoredScopes>test</ignoredScopes>
+                                    <ignoreClasses>
+                                        <ignoreClass>module-info</ignoreClass>
+                                    </ignoreClasses>
+                                </banDuplicateClasses>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>extra-enforcer-rules</artifactId>
+                        <version>${extra.enforcer.rules.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>

--- a/operator/src/test/resources/example-realm.yaml
+++ b/operator/src/test/resources/example-realm.yaml
@@ -51,6 +51,7 @@ spec:
     quickLoginCheckMilliSeconds: 1000
     maxDeltaTimeSeconds: 43200
     failureFactor: 30
+    maxSecondaryAuthFailures: 100
     roles:
       realm:
       - id: c118f6c0-db44-4b29-a439-573b0d828e61

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,7 @@
         <!-- Maven Plugins -->
         <maven.plugins.version>3.15.2</maven.plugins.version>
         <version.enforcer.plugin>3.6.2</version.enforcer.plugin>
+        <extra.enforcer.rules.version>1.12.0</extra.enforcer.rules.version>
         <replacer.plugin.version>1.4.1</replacer.plugin.version>
         <jboss.as.plugin.version>7.5.Final</jboss.as.plugin.version>
         <jmeter.plugin.version>1.9.0</jmeter.plugin.version>


### PR DESCRIPTION
closes: #50582

This has a risk in that the particular version of the admin client we're using may actually be dependent on the older common/core classes in a subtle way.

The other way to take this is to instead depend directly on the Keycloak repo's version of the admin client (which is currently for testing only and is probably not currently available as a production artifact) so that we're using a cleaner set of dependencies - without any copied / older code.

WDYT @mposolda @vmuzikar @michalvavrik 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
