### PR TITLE
Review existing tests in tests/base for database matrix - Core IAM

### DIFF
--- a/.github/actions/conditional/conditional.sh
+++ b/.github/actions/conditional/conditional.sh
@@ -39,10 +39,6 @@ for C in "${CONDITIONS[@]}"; do
   if [ "$IS_PR" == true ]; then
     PATTERN="${CONDITION[0]}"
 
-    if [[ "$PATTERN" =~ testsuite::* ]]; then
-      PATTERN=$(cat testsuite/integration-arquillian/tests/base/testsuites/database-suite | grep -v -e '^[[:space:]]*$' | sed -z 's/\n$//g' | sed -z 's/\n/|/g' | sed 's/\./\//g' | sed 's/\*\*/*/g')
-    fi
-
     # Convert pattern to regex
     REGEX="$PATTERN"
 

--- a/.github/actions/conditional/conditions
+++ b/.github/actions/conditional/conditions
@@ -60,6 +60,4 @@ js/libs/ui-shared/                          ci ci-webauthn
 *.ts                                        codeql-typescript
 *.tsx                                       codeql-typescript
 
-testsuite::database-suite                   ci-store
-
 rest/admin-v2/                              admin-v2

--- a/.github/actions/run-store-tests/action.yml
+++ b/.github/actions/run-store-tests/action.yml
@@ -29,21 +29,6 @@ runs:
         DATABASE_PORT=$(docker ps -l --format '{{ .ID }}' | xargs docker port | cut -d ':' -f 2)
         echo "DATABASE_PORT=$DATABASE_PORT" >> $GITHUB_ENV 
 
-    - name: Run base tests
-      shell: bash
-      run: |
-        TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh database`
-        echo "Tests: $TESTS"
-        ./mvnw test ${{ env.SUREFIRE_RETRY }} \
-          -Pauth-server-quarkus -Pdb-${{ inputs.db }} \
-          "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" \
-          -Dtest=$TESTS \
-          -Ddocker.database.skip=true \
-          -Ddocker.database.port=$DATABASE_PORT \
-          -Ddocker.container.testdb.ip=localhost \
-          -Dkeycloak.distribution.start.timeout=360 \
-          -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
-
     - name: Run cluster JDBC_PING2 UDP smoke test
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,39 +602,6 @@ jobs:
           name: auroraDB-migration-tests-mvn-logs
           path: .github/scripts/ansible/files
 
-      - name: Run Aurora integration tests on EC2
-        id: aurora-integration-tests
-        run: |
-          EC2_CLUSTER_NAME=${{ steps.ec2-create.outputs.ec2_cluster }}
-          AWS_REGION=${{ steps.aurora-init.outputs.region }}
-          PROPS="-Dkeycloak.connectionsJpa.jdbcParameters=\"${{ steps.aurora-init.outputs.jdbc_params }}\""
-          PROPS+=" -Dauth.server.db.host=${{ steps.aurora-create.outputs.endpoint }} -Dkeycloak.connectionsJpa.password=${{ steps.aurora-init.outputs.aurora-cluster-password }}"
-          
-          TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh database`
-          echo "Tests: $TESTS"
-          
-          cd .github/scripts/ansible
-          ./mvn_remote_runner.sh ${AWS_REGION} ${EC2_CLUSTER_NAME} "test -B ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Pdb-aurora-postgres $PROPS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh"
-          
-          # Copy returned surefire-report directories to workspace root to ensure they're discovered
-          results=(files/keycloak/results/*)
-          rsync -a $results/* ../../../
-          rm -rf $results
-
-      - uses: ./.github/actions/upload-flaky-tests
-        name: Upload flaky tests
-        env:
-          GH_TOKEN: ${{ github.token }}
-        with:
-          job-name: AuroraDB IT
-
-      - name: EC2 Maven Logs
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: aurora-integration-tests-mvn-logs
-          path: .github/scripts/ansible/files
-
       - name: Clear Aurora DB schema
         id: aurora-clear-db-schema
         run: |
@@ -821,39 +788,6 @@ jobs:
 
           cd .github/scripts/ansible
           ./mvn_remote_runner.sh ${AZURE_REGION} ${AZ_VM_CLUSTER_NAME} 'clean install -B -DskipTests -pl testsuite/integration-arquillian/servers/migration -Pauth-server-migration -Dmigrated.auth.server.version=${{ env.old-version }} -Dmaven.build.cache.enabled=true -Pdb-mssql-azure -Dkeycloak.connectionsJpa.user=${{ steps.azure-create.outputs.username }} -Dkeycloak.connectionsJpa.password="${{ env.AZURE_DB_PASSWORD }}" -Dkeycloak.connectionsJpa.database=${{ steps.azure-create.outputs.db }} -Dkeycloak.connectionsJpa.url="jdbc:sqlserver://${{ steps.azure-create.outputs.endpoint }}:1433;databaseName=${{ steps.azure-create.outputs.db }};encrypt=true;trustServerCertificate=false;sendStringParametersAsUnicode=false" -Djdbc.driver.tmp.dir=target/unpacked/keycloak-${{ env.old-version }}/providers'
-
-      - name: Run Azure integration tests on VM
-        id: azure-integration-tests
-        env:
-          old-version: 24.0.4
-        run: |
-          AZ_VM_CLUSTER_NAME=${{ steps.vm-create.outputs.az_vm_cluster }}
-          AZURE_REGION=${{ steps.azure-init.outputs.region }}
-
-          TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh database`
-          echo "Tests: $TESTS"
-
-          cd .github/scripts/ansible
-          ./mvn_remote_runner.sh ${AZURE_REGION} ${AZ_VM_CLUSTER_NAME} "test -B ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Pdb-mssql-azure -DskipQuarkus=true -Dkeycloak.connectionsJpa.user=${{ steps.azure-create.outputs.username }} -Dkeycloak.connectionsJpa.database=${{ steps.azure-create.outputs.db }} -Dkeycloak.connectionsJpa.password=\"${{ env.AZURE_DB_PASSWORD }}\" -Dkeycloak.connectionsJpa.url=\"jdbc:sqlserver://${{ steps.azure-create.outputs.endpoint }}:1433;databaseName=${{ steps.azure-create.outputs.db }};encrypt=true;trustServerCertificate=false;sendStringParametersAsUnicode=false\" -Dkeycloak.connectionsJpa.jdbcParameters=\"?encrypt=true&trustServerCertificate=false\" -Djdbc.driver.tmp.dir=target/unpacked/keycloak-${{ env.old-version }}/providers -Dtest=$TESTS -Dmaven.build.cache.enabled=true -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh"
-
-          # Copy returned surefire-report directories to workspace root to ensure they're discovered
-          results=(files/keycloak/results/*)
-          rsync -a $results/* ../../../
-          rm -rf $results
-
-      - uses: ./.github/actions/upload-flaky-tests
-        name: Upload flaky tests
-        env:
-          GH_TOKEN: ${{ github.token }}
-        with:
-          job-name: AzureDB IT
-
-      - name: Azure VM Maven Logs
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: azure-integration-tests-mvn-logs
-          path: .github/scripts/ansible/files
 
       - name: Clear Azure DB schema
         id: azure-clear-db-schema

--- a/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
@@ -124,7 +124,6 @@ public class RoleByIdResourceTest {
     }
 
     @Test
-    @DatabaseTest
     public void updateRole() {
         RoleRepresentation role = resource.getRole(roleIds.get(roleNameA));
 
@@ -143,7 +142,6 @@ public class RoleByIdResourceTest {
     }
 
     @Test
-    @DatabaseTest
     public void deleteRole() {
         assertNotNull(resource.getRole(roleIds.get(roleNameA)));
         resource.deleteRole(roleIds.get(roleNameA));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/UsersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/UsersTest.java
@@ -31,6 +31,7 @@ import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +54,7 @@ public class UsersTest {
     RunOnServerClient runOnServer;
 
     @Test
+    @DatabaseTest
     public void searchUserWithWildcards() {
         createUser("User", "firstName", "lastName", "user@example.com");
 
@@ -79,6 +81,7 @@ public class UsersTest {
     }
 
     @Test
+    @DatabaseTest
     public void searchUserDefaultSettings() throws Exception {
         createUser("User", "firstName", "lastName", "user@example.com");
 
@@ -86,6 +89,7 @@ public class UsersTest {
     }
 
     @Test
+    @DatabaseTest
     public void searchUserMatchUsersCount() {
         createUser("john.doe", "John", "Doe Smith", "john.doe@keycloak.org");
         String search = "jo do";
@@ -100,6 +104,7 @@ public class UsersTest {
      * https://issues.redhat.com/browse/KEYCLOAK-15146
      */
     @Test
+    @DatabaseTest
     public void findUsersByEmailVerifiedStatus() {
         createUser(UserBuilder.create()
                 .username("user1")
@@ -160,6 +165,7 @@ public class UsersTest {
     }
 
     @Test
+    @DatabaseTest
     public void testCountUsersByEnabledStatus() {
         createUser(UserBuilder.create()
                 .username("user1")
@@ -183,6 +189,7 @@ public class UsersTest {
     }
 
     @Test
+    @DatabaseTest
     public void testCountUsersByFederatedIdentity() {
         createUser(UserBuilder.create()
                 .username("user1")
@@ -264,6 +271,7 @@ public class UsersTest {
     }
 
     @Test
+    @DatabaseTest
     public void countUsersBySearchWithViewPermission() {
         createUser(UserBuilder.create()
                 .username("user1")
@@ -322,6 +330,7 @@ public class UsersTest {
     }
 
     @Test
+    @DatabaseTest
     public void countUsersByFiltersWithViewPermission() {
         createUser("user1", "user1FirstName", "user1LastName", "user1@example.com");
         createUser("user2", "user2FirstName", "user2LastName", "user2@example.com");

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeFilteringTest.java
@@ -29,6 +29,7 @@ import org.keycloak.representations.idm.authorization.Logic;
 import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,6 +65,7 @@ public class ClientResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testViewAllClientsUsingUserPolicy() {
         List<ClientRepresentation> search = realmAdminClient.realm(realm.getName()).clients().findAll();
         assertTrue(search.isEmpty());
@@ -77,6 +79,7 @@ public class ClientResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testViewSpecificClientsUsingUserPolicy() {
         List<ClientRepresentation> search = realmAdminClient.realm(realm.getName()).clients().findAll();
         assertTrue(search.isEmpty());
@@ -90,6 +93,7 @@ public class ClientResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testViewClientsByAttributeUsingUserPolicy() {
         List<ClientRepresentation> search = realmAdminClient.realm(realm.getName()).clients().findAll();
         assertTrue(search.isEmpty());
@@ -103,6 +107,7 @@ public class ClientResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testDeniedResourcesPrecedenceOverGrantedResources() {
         UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
         createAllPermission(adminPermissionsClient, CLIENTS_RESOURCE_TYPE, policy, Set.of(VIEW));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeFilteringTest.java
@@ -38,6 +38,7 @@ import org.keycloak.testframework.realm.GroupBuilder;
 import org.keycloak.testframework.realm.ManagedUser;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,7 @@ public class GroupResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testViewAllGroupsUsingUserPolicy() {
         List<GroupRepresentation> search = realmAdminClient.realm(realm.getName()).groups().groups();
         assertTrue(search.isEmpty());
@@ -102,6 +104,7 @@ public class GroupResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testDeniedResourcesPrecedenceOverGrantedResources() {
         UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
         createAllPermission(adminPermissionsClient, GROUPS_RESOURCE_TYPE, policy, Set.of(VIEW));
@@ -123,6 +126,7 @@ public class GroupResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testFilterSubGroups() {
         UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
         createAllPermission(adminPermissionsClient, GROUPS_RESOURCE_TYPE, policy, Set.of(VIEW));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
@@ -57,6 +57,7 @@ import org.keycloak.testframework.realm.RoleBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.server.KeycloakUrls;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.suites.DatabaseTest;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,6 +102,7 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testViewAllUsersUsingUserPolicy() {
         UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
         createAllPermission(adminPermissionsClient, usersType, policy, Set.of(VIEW));
@@ -111,6 +113,7 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testDeniedResourcesPrecedenceOverGrantedResources() {
         UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
         createAllPermission(adminPermissionsClient, usersType, policy, Set.of(VIEW));
@@ -128,6 +131,7 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    @DatabaseTest
     public void testCountWithFilters() {
         assertThat(realmAdminClient.realm(realm.getName()).users().count("user-"), is(0));
         assertThat(realmAdminClient.realm(realm.getName()).users().count(null, null, null, "user-15"), is(0));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminSearchTest.java
@@ -25,6 +25,7 @@ import org.keycloak.services.resources.admin.fgap.AdminPermissions;
 import org.keycloak.services.resources.admin.fgap.ClientPermissionManagement;
 import org.keycloak.services.resources.admin.fgap.GroupPermissionManagement;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.tests.suites.DatabaseTest;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -35,6 +36,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
 @KeycloakIntegrationTest(config = AbstractFineGrainedAdminTest.FineGrainedAdminServerConf.class)
+@DatabaseTest
 public class FineGrainedAdminSearchTest extends AbstractFineGrainedAdminTest {
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminSearchTest.java
@@ -25,7 +25,6 @@ import org.keycloak.services.resources.admin.fgap.AdminPermissions;
 import org.keycloak.services.resources.admin.fgap.ClientPermissionManagement;
 import org.keycloak.services.resources.admin.fgap.GroupPermissionManagement;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
-import org.keycloak.tests.suites.DatabaseTest;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -36,7 +35,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
 @KeycloakIntegrationTest(config = AbstractFineGrainedAdminTest.FineGrainedAdminServerConf.class)
-@DatabaseTest
 public class FineGrainedAdminSearchTest extends AbstractFineGrainedAdminTest {
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupMappersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupMappersTest.java
@@ -47,7 +47,6 @@ import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.util.ApiUtil;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.ProtocolMapperUtil;
 
@@ -60,7 +59,6 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
 @KeycloakIntegrationTest
-@DatabaseTest
 public class GroupMappersTest extends AbstractGroupTest {
 
     @InjectRealm(config = GroupMappersTestRealmConfig.class)

--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
@@ -108,7 +108,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
 @KeycloakIntegrationTest
-@DatabaseTest
 public class GroupTest extends AbstractGroupTest {
 
     @InjectRealm(config = GroupTestRealmConfig.class)
@@ -125,6 +124,7 @@ public class GroupTest extends AbstractGroupTest {
 
     
     @Test
+    @DatabaseTest
     @DisabledForDatabases("mssql")
     public void createMultiDeleteMultiReadMulti() {
         // create multiple groups
@@ -214,6 +214,7 @@ public class GroupTest extends AbstractGroupTest {
     }
 
     @Test
+    @DatabaseTest
     // KEYCLOAK-16888 Error messages for groups with same name in the same level
     public void doNotAllowSameGroupNameAtSameLevel() {
         RealmResource realm = managedRealm.admin();
@@ -252,6 +253,7 @@ public class GroupTest extends AbstractGroupTest {
     }
 
     @Test
+    @DatabaseTest
     // KEYCLOAK-11412 Unintended Groups with same names
     public void doNotAllowSameGroupNameAtSameLevelWhenUpdatingName() {
         RealmResource realm = managedRealm.admin();
@@ -305,6 +307,7 @@ public class GroupTest extends AbstractGroupTest {
     }
 
     @Test
+    @DatabaseTest
     public void doNotAllowSameGroupNameAtTopLevel() {
         // creating "/test-group"
         GroupRepresentation topGroup = new GroupRepresentation();
@@ -319,6 +322,7 @@ public class GroupTest extends AbstractGroupTest {
     }
 
     @Test
+    @DatabaseTest
     public void doNotAllowSameGroupNameAtTopLevelInDatabase() {
         String realmName = managedRealm.getName();
         final String id = runOnServer.fetch(session -> {
@@ -654,6 +658,7 @@ public class GroupTest extends AbstractGroupTest {
 
 
     @Test
+    @DatabaseTest
     //KEYCLOAK-6300 List of group members is not sorted alphabetically
     public void groupMembershipUsersOrder() {
         RealmResource realm = managedRealm.admin();
@@ -842,6 +847,7 @@ public class GroupTest extends AbstractGroupTest {
     }
 
     @Test
+    @DatabaseTest
     public void defaultMaxResults() {
         GroupsResource groups = managedRealm.admin().groups();
         Response response = groups.add(GroupBuilder.create().name("test").build());

--- a/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderIssuerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderIssuerTest.java
@@ -29,7 +29,6 @@ import org.keycloak.representations.idm.ErrorRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.social.google.GoogleIdentityProviderFactory;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
-import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @KeycloakIntegrationTest
-@DatabaseTest
 public class IdentityProviderIssuerTest extends AbstractIdentityProviderTest {
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderOidcTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderOidcTest.java
@@ -52,7 +52,6 @@ import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.LoginPage;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
 import org.keycloak.testsuite.util.broker.OIDCIdentityProviderConfigRep;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
@@ -101,7 +100,6 @@ public class IdentityProviderOidcTest extends AbstractIdentityProviderTest {
     }
 
     @Test
-    @DatabaseTest
     public void testCreate() {
         IdentityProviderRepresentation newIdentityProvider = createRep("new-identity-provider", "oidc");
 
@@ -323,7 +321,6 @@ public class IdentityProviderOidcTest extends AbstractIdentityProviderTest {
     }
 
     @Test
-    @DatabaseTest
     public void testUpdate() {
         IdentityProviderRepresentation newIdentityProvider = createRep("update-identity-provider", "oidc");
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserAttributesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserAttributesTest.java
@@ -68,7 +68,6 @@ public class UserAttributesTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void attributes() {
         UserRepresentation user1 = new UserRepresentation();
         user1.setUsername("user1");

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCreateTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCreateTest.java
@@ -43,7 +43,6 @@ import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.providers.federation.DummyUserFederationProviderFactory;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.Assert;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
 import org.keycloak.util.JsonSerialization;
@@ -69,7 +68,6 @@ public class UserCreateTest extends AbstractUserTest {
     AdminClientFactory clientFactory;
 
     @Test
-    @DatabaseTest
     public void verifyCreateUser() {
         createUser();
     }
@@ -102,7 +100,6 @@ public class UserCreateTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void createDuplicatedUser1() {
         createUser();
 
@@ -391,7 +388,6 @@ public class UserCreateTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void createUserWithFederationLink() {
 
         // add a dummy federation provider

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCredentialTest.java
@@ -29,7 +29,6 @@ import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ManagedUser;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.realm.UserConfig;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
 import org.keycloak.testsuite.util.AccountHelper;
@@ -61,7 +60,6 @@ public class UserCredentialTest extends AbstractUserTest {
     ManagedUser testUser;
 
     @Test
-    @DatabaseTest
     public void resetUserPassword() {
         UserRepresentation userRep = UserBuilder.create()
                 .username("user1").name("User", "One").email("user1@localhost").build();
@@ -136,7 +134,6 @@ public class UserCredentialTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void testUpdateCredentials() {
         // both credentials have a null priority - stable ordering is not guaranteed between calls
         // Get user user-with-one-configured-otp and assert he has no label linked to its OTP credential
@@ -197,7 +194,6 @@ public class UserCredentialTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void testDeleteCredentials() {
         UserResource user = johnDoh.admin();
         List<CredentialRepresentation> creds = user.credentials();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserDeleteTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserDeleteTest.java
@@ -6,7 +6,6 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.events.AdminEventAssertion;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.util.ApiUtil;
-import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UserDeleteTest extends AbstractUserTest {
 
     @Test
-    @DatabaseTest
     public void delete() {
         String userId = ApiUtil.getCreatedId(managedRealm.admin().users().create(UserBuilder.create().username("user1").email("user1@localhost.com").build()));
         AdminEventAssertion.assertSuccess(adminEvents.poll());

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserFedarationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserFedarationTest.java
@@ -24,7 +24,6 @@ import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.providers.federation.UserMapStorageFactory;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.Assert;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
@@ -40,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UserFedarationTest extends AbstractUserTest {
 
     @Test
-    @DatabaseTest
     public void getFederatedIdentities() {
         // Add sample identity provider
         addSampleIdentityProvider();
@@ -122,7 +120,6 @@ public class UserFedarationTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void createFederatedIdentities() {
         String identityProviderAlias = "social-provider-id";
         String username = "federated-identities";

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserGroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserGroupTest.java
@@ -61,6 +61,7 @@ public class UserGroupTest extends AbstractUserTest {
     }
 
     @Test
+    @DatabaseTest
     public void testGetSearchedGroupsForUserFullRepresentation() {
         String userName = "averagejoe";
         String groupName1 = "group1WithAttribute";
@@ -147,7 +148,6 @@ public class UserGroupTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void createUserWithGroups() {
         String username = "user-with-groups";
         String groupToBeAdded = "test-group";

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserProfileTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserProfileTest.java
@@ -167,6 +167,7 @@ public class UserProfileTest extends AbstractUserTest {
     }
 
     @Test
+    @DatabaseTest
     public void defaultMaxResults() {
         UserProfileResource upResource = managedRealm.admin().users().userProfile();
         UPConfig upConfig = upResource.getConfiguration();
@@ -198,6 +199,7 @@ public class UserProfileTest extends AbstractUserTest {
     }
 
     @Test
+    @DatabaseTest
     public void defaultMaxResultsBrief() {
         UserProfileResource upResource = managedRealm.admin().users().userProfile();
         UPConfig upConfig = upResource.getConfiguration();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserRequiredActionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserRequiredActionsTest.java
@@ -8,7 +8,6 @@ import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.events.AdminEventAssertion;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
 
 import org.junit.jupiter.api.Assertions;
@@ -21,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class UserRequiredActionsTest extends AbstractUserTest {
 
     @Test
-    @DatabaseTest
     public void addRequiredAction() {
         String id = createUser();
 
@@ -37,7 +35,6 @@ public class UserRequiredActionsTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void removeRequiredAction() {
         String id = createUser();
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest
+@DatabaseTest
 public class UserSearchTest extends AbstractUserTest {
 
     @Test
@@ -81,7 +82,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByEmail() {
         createUsers();
 
@@ -103,7 +103,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByUsername() {
         createUsers();
 
@@ -115,7 +114,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByAttribute() {
         createUsers();
 
@@ -137,7 +135,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByMultipleAttributes() {
         createUsers();
 
@@ -158,7 +155,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByAttributesWithPagination() {
         createUsers();
 
@@ -172,7 +168,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void storeAndReadUserWithLongAttributeValue() {
         String longValue = RandomStringUtils.random(Integer.parseInt(DefaultAttributes.DEFAULT_MAX_LENGTH_ATTRIBUTES), true, true);
 
@@ -196,7 +191,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByLongAttributes() {
         // random string with suffix that makes it case-sensitive and distinct
         String longValue = RandomStringUtils.random(Integer.parseInt(DefaultAttributes.DEFAULT_MAX_LENGTH_ATTRIBUTES) - 1, true, true) + "u";
@@ -322,7 +316,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchWithFilters() {
         createUser();
 
@@ -376,7 +369,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByIdp() {
         // Add user without IDP
         createUser();
@@ -492,7 +484,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchById() {
         List<String> userIds = createUsers();
         String expectedUserId = userIds.get(0);
@@ -521,7 +512,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByUsernameSearch() {
         List<String> userIds = createUsers();
         String expectedUserId = userIds.get(0);
@@ -564,7 +554,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void searchByEmailSearch() {
         List<String> userIds = createUsers();
         String expectedUserId = userIds.get(0);
@@ -607,7 +596,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void infixSearch() {
         List<String> userIds = createUsers();
 
@@ -643,7 +631,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void prefixSearch() {
         List<String> userIds = createUsers();
 
@@ -711,7 +698,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void wildcardSearch() {
         UserProfileResource upResource = managedRealm.admin().users().userProfile();
         UPConfig upConfig = upResource.getConfiguration();
@@ -737,7 +723,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void sqlWildcardEscaping() {
         // Test underscore character doesn't act as SQL wildcard
         createUser("john_doe", "john_doe@test.com");
@@ -775,7 +760,6 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void exactSearch() {
         List<String> userIds = createUsers();
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserUpdateTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserUpdateTest.java
@@ -27,7 +27,6 @@ import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.util.ApiUtil;
-import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
 import org.keycloak.testsuite.util.AccountHelper;
 
@@ -52,7 +51,6 @@ public class UserUpdateTest extends AbstractUserTest {
     OAuthClient oauth;
 
     @Test
-    @DatabaseTest
     public void updateUserWithHashedCredentials() {
         UserRepresentation userRep = UserBuilder.create()
                 .username("user_hashed_creds").name("Hashed", "User").email("user_hashed_creds@localhost").build();
@@ -164,7 +162,6 @@ public class UserUpdateTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void updateUserWithExistingEmail() {
         final String userId = createUser();
         assertNotNull(userId);
@@ -260,7 +257,6 @@ public class UserUpdateTest extends AbstractUserTest {
     }
 
     @Test
-    @DatabaseTest
     public void updateUserWithRawCredentials() {
         UserRepresentation user = new UserRepresentation();
         user.setUsername("user_rawpw");

--- a/tests/base/src/test/java/org/keycloak/tests/organization/admin/OrganizationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/admin/OrganizationTest.java
@@ -61,6 +61,7 @@ import org.keycloak.testframework.ui.annotations.InjectWebDriver;
 import org.keycloak.testframework.ui.page.LoginUsernamePage;
 import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,6 +187,7 @@ public class OrganizationTest extends AbstractOrganizationTest {
     }
 
     @Test
+    @DatabaseTest
     public void testSearch() {
         // create some organizations with different names and domains.
         createOrganization("acme", "acme.org", "acme.net");
@@ -285,6 +287,7 @@ public class OrganizationTest extends AbstractOrganizationTest {
     }
 
     @Test
+    @DatabaseTest
     public void testSearchByAttributes() {
         List<OrganizationRepresentation> expected = new ArrayList<>();
         for (int i = 0; i < 4; i++) {

--- a/testsuite/integration-arquillian/HOW-TO-RUN.md
+++ b/testsuite/integration-arquillian/HOW-TO-RUN.md
@@ -662,25 +662,3 @@ The log should contain `KeycloakFipsSecurityProvider` mentioning "Approved mode"
 ```
 KC(BCFIPS version 1.000203 Approved Mode, FIPS-JVM: enabled) version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider,
 ```
-
-## Aurora DB Tests
-To run the Aurora DB tests on a local machine, do the following:
-
-1. Provision an Aurora DB:
-```bash
-AURORA_CLUSTER="example-cluster"
-AURORA_REGION=eu-west-1
-AURORA_PASSWORD=TODO
-source ./.github/scripts/aws/rds/aurora_create.sh
-```
-
-2. Execute the store integration tests:
-```bash
-TESTS=`testsuite/integration-arquillian/tests/base/testsuites/suite.sh database`
-mvn test -Pauth-server-quarkus -Pdb-aurora-postgres -Dtest=$TESTS  -Dauth.server.db.host=$AURORA_ENDPOINT -Dkeycloak.connectionsJpa.password=$AURORA_PASSWORD -pl testsuite/integration-arquillian/tests/base
-```
-
-3. Teardown Aurora DB instance:
-```bash
-./.github/scripts/aws/rds/aurora_delete.sh
-```

--- a/testsuite/integration-arquillian/tests/base/testsuites/database-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/database-suite
@@ -1,8 +1,0 @@
-AuthorizationTest
-KcOidcBrokerTest
-LDAPUserLoginTest
-UserProfileTest
-OidcAdvancedClaimToGroupMapperTest
-OidcAdvancedClaimToRoleMapperTest
-org.keycloak.testsuite.authz.**ManagementTest
-org.keycloak.testsuite.organization.admin.**


### PR DESCRIPTION
Closes #47808

No tests from legacy DB matrix that are listed in #47808 were identified as required to be migrated into the new DB testsuite. Either because they don't contain any special SQL constructs, or because those SQL constructs are already tested by other tests in the new DB testsuite. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
