### PR TITLE
Add idp alias to store federated tokens in user session notes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/AbstractIdentityProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/AbstractIdentityProvider.java
@@ -72,6 +72,10 @@ public abstract class AbstractIdentityProvider<C extends IdentityProviderModel> 
         return this.config;
     }
 
+    protected String getFederatedAccessTokenKey() {
+        return FEDERATED_ACCESS_TOKEN + ":" + getConfig().getAlias();
+    }
+
     @Override
     public void close() {
         // no-op
@@ -231,11 +235,28 @@ public abstract class AbstractIdentityProvider<C extends IdentityProviderModel> 
     }
 
     protected String getFederatedAccessToken(UserSessionModel userSession) {
-        // return the FEDERATED_ACCESS_TOKEN but just if logged in using this identity provider
-        if (getConfig().getAlias().equals(userSession.getNote(Details.IDENTITY_PROVIDER))) {
-             return userSession.getNote(FEDERATED_ACCESS_TOKEN);
+        // First try alias-namespaced key (supports multiple linked IdPs)
+        String token = userSession.getNote(getFederatedAccessTokenKey());
+        if (token != null) {
+            return token;
+        }
+        // Fallback to un-namespaced key for backward compatibility
+        String brokerId = userSession.getNote(Details.IDENTITY_PROVIDER);
+        if (brokerId == null) {
+            brokerId = userSession.getNote(EXTERNAL_IDENTITY_PROVIDER);
+        }
+        if (getConfig().getAlias().equals(brokerId)) {
+            return userSession.getNote(FEDERATED_ACCESS_TOKEN);
         }
         return null;
+    }
+
+    protected void setFederatedAccessToken(UserSessionModel userSession, String token) {
+        userSession.setNote(getFederatedAccessTokenKey(), token);
+    }
+
+    protected void setFederatedAccessToken(AuthenticationSessionModel authSession, String token) {
+        authSession.setUserSessionNote(getFederatedAccessTokenKey(), token);
     }
 
     protected Response buildTokenResponse(UriInfo uriInfo, EventBuilder event, ClientModel authorizedClient,

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/AbstractIdentityProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/AbstractIdentityProvider.java
@@ -234,11 +234,10 @@ public abstract class AbstractIdentityProvider<C extends IdentityProviderModel> 
         return new DefaultDataMarshaller();
     }
 
-    protected String getFederatedAccessToken(UserSessionModel userSession) {
-        // First try alias-namespaced key (supports multiple linked IdPs)
-        String token = userSession.getNote(getFederatedAccessTokenKey());
-        if (token != null) {
-            return token;
+    protected String getFederatedTokenNote(UserSessionModel userSession, String namespacedKey, String legacyKey) {
+        String value = userSession.getNote(namespacedKey);
+        if (value != null) {
+            return value;
         }
         // Fallback to un-namespaced key for backward compatibility
         String brokerId = userSession.getNote(Details.IDENTITY_PROVIDER);
@@ -246,9 +245,13 @@ public abstract class AbstractIdentityProvider<C extends IdentityProviderModel> 
             brokerId = userSession.getNote(EXTERNAL_IDENTITY_PROVIDER);
         }
         if (getConfig().getAlias().equals(brokerId)) {
-            return userSession.getNote(FEDERATED_ACCESS_TOKEN);
+            return userSession.getNote(legacyKey);
         }
         return null;
+    }
+
+    protected String getFederatedAccessToken(UserSessionModel userSession) {
+        return getFederatedTokenNote(userSession, getFederatedAccessTokenKey(), FEDERATED_ACCESS_TOKEN);
     }
 
     protected void setFederatedAccessToken(UserSessionModel userSession, String token) {

--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -139,27 +139,15 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     }
 
     protected String getFederatedRefreshToken(UserSessionModel userSession) {
-        String token = userSession.getNote(getFederatedRefreshTokenKey());
-        if (token != null) {
-            return token;
-        }
-        return userSession.getNote(FEDERATED_REFRESH_TOKEN);
+        return getFederatedTokenNote(userSession, getFederatedRefreshTokenKey(), FEDERATED_REFRESH_TOKEN);
     }
 
     protected String getFederatedTokenExpiration(UserSessionModel userSession) {
-        String value = userSession.getNote(getFederatedTokenExpirationKey());
-        if (value != null) {
-            return value;
-        }
-        return userSession.getNote(FEDERATED_TOKEN_EXPIRATION);
+        return getFederatedTokenNote(userSession, getFederatedTokenExpirationKey(), FEDERATED_TOKEN_EXPIRATION);
     }
 
     protected String getFederatedIdToken(UserSessionModel userSession) {
-        String token = userSession.getNote(getFederatedIdTokenKey());
-        if (token != null) {
-            return token;
-        }
-        return userSession.getNote(OIDCIdentityProvider.FEDERATED_ID_TOKEN);
+        return getFederatedTokenNote(userSession, getFederatedIdTokenKey(), OIDCIdentityProvider.FEDERATED_ID_TOKEN);
     }
 
     protected void setFederatedRefreshToken(UserSessionModel userSession, String token) {

--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -125,6 +125,67 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
 
     public static final String FEDERATED_REFRESH_TOKEN = "FEDERATED_REFRESH_TOKEN";
     public static final String FEDERATED_TOKEN_EXPIRATION = "FEDERATED_TOKEN_EXPIRATION";
+
+    protected String getFederatedRefreshTokenKey() {
+        return FEDERATED_REFRESH_TOKEN + ":" + getConfig().getAlias();
+    }
+
+    protected String getFederatedTokenExpirationKey() {
+        return FEDERATED_TOKEN_EXPIRATION + ":" + getConfig().getAlias();
+    }
+
+    protected String getFederatedIdTokenKey() {
+        return OIDCIdentityProvider.FEDERATED_ID_TOKEN + ":" + getConfig().getAlias();
+    }
+
+    protected String getFederatedRefreshToken(UserSessionModel userSession) {
+        String token = userSession.getNote(getFederatedRefreshTokenKey());
+        if (token != null) {
+            return token;
+        }
+        return userSession.getNote(FEDERATED_REFRESH_TOKEN);
+    }
+
+    protected String getFederatedTokenExpiration(UserSessionModel userSession) {
+        String value = userSession.getNote(getFederatedTokenExpirationKey());
+        if (value != null) {
+            return value;
+        }
+        return userSession.getNote(FEDERATED_TOKEN_EXPIRATION);
+    }
+
+    protected String getFederatedIdToken(UserSessionModel userSession) {
+        String token = userSession.getNote(getFederatedIdTokenKey());
+        if (token != null) {
+            return token;
+        }
+        return userSession.getNote(OIDCIdentityProvider.FEDERATED_ID_TOKEN);
+    }
+
+    protected void setFederatedRefreshToken(UserSessionModel userSession, String token) {
+        userSession.setNote(getFederatedRefreshTokenKey(), token);
+    }
+
+    protected void setFederatedRefreshToken(AuthenticationSessionModel authSession, String token) {
+        authSession.setUserSessionNote(getFederatedRefreshTokenKey(), token);
+    }
+
+    protected void setFederatedTokenExpiration(UserSessionModel userSession, String value) {
+        userSession.setNote(getFederatedTokenExpirationKey(), value);
+    }
+
+    protected void setFederatedTokenExpiration(AuthenticationSessionModel authSession, String value) {
+        authSession.setUserSessionNote(getFederatedTokenExpirationKey(), value);
+    }
+
+    protected void setFederatedIdToken(UserSessionModel userSession, String token) {
+        userSession.setNote(getFederatedIdTokenKey(), token);
+    }
+
+    protected void setFederatedIdToken(AuthenticationSessionModel authSession, String token) {
+        authSession.setUserSessionNote(getFederatedIdTokenKey(), token);
+    }
+
     public static final String ACCESS_DENIED = "access_denied";
     protected static ObjectMapper mapper = new ObjectMapper();
 
@@ -312,10 +373,8 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
         Response response = null;
         if (userSession != null && getConfig().isStoreTokenInSession()) {
             // use the session if present and configured to be used, only in V2
-            String brokerId = userSession.getNote(Details.IDENTITY_PROVIDER);
-            brokerId = brokerId == null ? userSession.getNote(UserAuthenticationIdentityProvider.EXTERNAL_IDENTITY_PROVIDER) : brokerId;
-            String federatedAccessToken = userSession.getNote(FEDERATED_ACCESS_TOKEN);
-            if (getConfig().getAlias().equals(brokerId) && federatedAccessToken != null) {
+            String federatedAccessToken = getFederatedAccessToken(userSession);
+            if (federatedAccessToken != null) {
                 response = exchangeSessionToken(uriInfo, null, null, userSession, user);
                 if (Response.Status.Family.familyOf(response.getStatus()) == Response.Status.Family.SUCCESSFUL) {
                     return response;
@@ -413,17 +472,16 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
      */
     protected Response hasExternalExchangeToken(EventBuilder event, UserSessionModel tokenUserSession, MultivaluedMap<String, String> params) {
         if (getConfig().getAlias().equals(tokenUserSession.getNote(OIDCIdentityProvider.EXCHANGE_PROVIDER))) {
-
             String requestedType = params.getFirst(OAuth2Constants.REQUESTED_TOKEN_TYPE);
             if ((requestedType == null || requestedType.equals(OAuth2Constants.ACCESS_TOKEN_TYPE))) {
-                String accessToken = tokenUserSession.getNote(FEDERATED_ACCESS_TOKEN);
+                String accessToken = getFederatedAccessToken(tokenUserSession);
                 if (accessToken != null) {
                     AccessTokenResponse tokenResponse = new AccessTokenResponse();
                     tokenResponse.setToken(accessToken);
                     return buildTokenResponse(session.getContext().getUri(), event, null, tokenUserSession, tokenResponse, OAuth2Constants.ACCESS_TOKEN_TYPE);
                 }
             } else if (OAuth2Constants.ID_TOKEN_TYPE.equals(requestedType)) {
-                String idToken = tokenUserSession.getNote(OIDCIdentityProvider.FEDERATED_ID_TOKEN);
+                String idToken = getFederatedIdToken(tokenUserSession);
                 if (idToken != null) {
                     AccessTokenResponse tokenResponse = new AccessTokenResponse();
                     tokenResponse.setToken(null);
@@ -472,7 +530,7 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     }
 
     protected Response exchangeSessionToken(UriInfo uriInfo, EventBuilder event, ClientModel authorizedClient, UserSessionModel tokenUserSession, UserModel tokenSubject) {
-        String accessToken = tokenUserSession.getNote(FEDERATED_ACCESS_TOKEN);
+        String accessToken = getFederatedAccessToken(tokenUserSession);
 
         if (accessToken == null) {
             if (event != null) {
@@ -620,7 +678,9 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     @Override
     public void authenticationFinished(AuthenticationSessionModel authSession, BrokeredIdentityContext context) {
         String token = (String) context.getContextData().get(FEDERATED_ACCESS_TOKEN);
-        if (token != null) authSession.setUserSessionNote(FEDERATED_ACCESS_TOKEN, token);
+        if (token != null) {
+            setFederatedAccessToken(authSession, token);
+        }
     }
 
     public SimpleHttpRequest authenticateTokenRequest(final SimpleHttpRequest tokenRequest) {
@@ -1076,10 +1136,12 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     public void exchangeExternalComplete(UserSessionModel userSession, BrokeredIdentityContext context, MultivaluedMap<String, String> params) {
         if (getConfig().isStoreTokenInSession()) {
             if (context.getContextData().containsKey(OIDCIdentityProvider.VALIDATED_ACCESS_TOKEN)) {
-                userSession.setNote(FEDERATED_ACCESS_TOKEN, params.getFirst(OAuth2Constants.SUBJECT_TOKEN));
+                String subjectToken = params.getFirst(OAuth2Constants.SUBJECT_TOKEN);
+                setFederatedAccessToken(userSession, subjectToken);
             }
             if (context.getContextData().containsKey(OIDCIdentityProvider.VALIDATED_ID_TOKEN)) {
-                userSession.setNote(OIDCIdentityProvider.FEDERATED_ID_TOKEN, params.getFirst(OAuth2Constants.SUBJECT_TOKEN));
+                String subjectToken = params.getFirst(OAuth2Constants.SUBJECT_TOKEN);
+                setFederatedIdToken(userSession, subjectToken);
             }
             userSession.setNote(OIDCIdentityProvider.EXCHANGE_PROVIDER, getConfig().getAlias());
         }

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -152,7 +152,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
      * @return
      */
     public String refreshTokenForLogout(KeycloakSession session, UserSessionModel userSession) {
-        String refreshToken = userSession.getNote(FEDERATED_REFRESH_TOKEN);
+        String refreshToken = getFederatedRefreshToken(userSession);
         try (VaultStringSecret vaultStringSecret = session.vault().getStringSecret(getConfig().getClientSecret())) {
             return getRefreshTokenRequest(session, refreshToken, getConfig().getClientId(), vaultStringSecret.get().orElse(getConfig().getClientSecret())).asString();
         } catch (IOException e) {
@@ -164,7 +164,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     public void backchannelLogout(KeycloakSession session, UserSessionModel userSession, UriInfo uriInfo, RealmModel realm) {
         if (getConfig().getLogoutUrl() == null || getConfig().getLogoutUrl().trim().equals("") || !getConfig().isBackchannelSupported())
             return;
-        String idToken = userSession.getNote(FEDERATED_ID_TOKEN);
+        String idToken = getFederatedIdToken(userSession);
         if (idToken == null) return;
         backchannelLogout(userSession, idToken);
     }
@@ -195,7 +195,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     @Override
     public Response keycloakInitiatedBrowserLogout(KeycloakSession session, UserSessionModel userSession, UriInfo uriInfo, RealmModel realm) {
         if (getConfig().getLogoutUrl() == null || getConfig().getLogoutUrl().trim().equals("")) return null;
-        String idToken = userSession.getNote(FEDERATED_ID_TOKEN);
+        String idToken = getFederatedIdToken(userSession);
         if (getConfig().isBackchannelSupported()) {
             backchannelLogout(userSession, idToken);
             return null;
@@ -257,7 +257,7 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
                 updateStoredTokenModel(realm, tokenSubject, model, currentTime, newResponse, tokenResponse);
 
                 if (tokenUserSession != null) {
-                    String oldToken = tokenUserSession.getNote(FEDERATED_ACCESS_TOKEN);
+                    String oldToken = getFederatedAccessToken(tokenUserSession);
                     if (oldToken != null && oldToken.equals(tokenResponse.getToken())) {
                         updateUserSessionFromRefresh(tokenUserSession, newResponse, currentTime);
                     }
@@ -277,8 +277,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     @Override
     protected Response exchangeSessionToken(UriInfo uriInfo, EventBuilder event, ClientModel authorizedClient, UserSessionModel tokenUserSession, UserModel tokenSubject) {
         RealmModel realm = authorizedClient != null ? authorizedClient.getRealm() : session.getContext().getRealm();
-        String refreshToken = tokenUserSession.getNote(FEDERATED_REFRESH_TOKEN);
-        String accessToken = tokenUserSession.getNote(FEDERATED_ACCESS_TOKEN);
+        String refreshToken = getFederatedRefreshToken(tokenUserSession);
+        String accessToken = getFederatedAccessToken(tokenUserSession);
 
         if (accessToken == null) {
             if (event != null) {
@@ -289,7 +289,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         }
 
         try {
-            long expiration = Long.parseLong(tokenUserSession.getNote(FEDERATED_TOKEN_EXPIRATION));
+            String expirationNote = getFederatedTokenExpiration(tokenUserSession);
+            long expiration = Long.parseLong(expirationNote);
             final int currentTime = Time.currentTime();
 
             if (expiration == 0 || expiration > currentTime + getConfig().getMinValidityToken()) {
@@ -360,12 +361,13 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         final boolean isStoreTokenInSession = getConfig().isStoreTokenInSession();
         if (isStoreTokenInSession) {
             long accessTokenExpiration = newResponse.getExpiresIn() > 0 ? currentTime + newResponse.getExpiresIn() : 0;
-            tokenUserSession.setNote(FEDERATED_TOKEN_EXPIRATION, Long.toString(accessTokenExpiration));
-            tokenUserSession.setNote(FEDERATED_REFRESH_TOKEN, newResponse.getRefreshToken());
-            tokenUserSession.setNote(FEDERATED_ACCESS_TOKEN, newResponse.getToken());
+            String expirationStr = Long.toString(accessTokenExpiration);
+            setFederatedTokenExpiration(tokenUserSession, expirationStr);
+            setFederatedRefreshToken(tokenUserSession, newResponse.getRefreshToken());
+            setFederatedAccessToken(tokenUserSession, newResponse.getToken());
         }
         if (newResponse.getIdToken() != null && (isStoreTokenInSession || getConfig().isSendIdTokenOnLogout())) {
-            tokenUserSession.setNote(FEDERATED_ID_TOKEN, newResponse.getIdToken());
+            setFederatedIdToken(tokenUserSession, newResponse.getIdToken());
         }
     }
 
@@ -843,12 +845,13 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         if (isStoreTokenInSession) {
             int currentTime = Time.currentTime();
             long expiration = tokenResponse.getExpiresIn() > 0 ? tokenResponse.getExpiresIn() + currentTime : 0;
-            authSession.setUserSessionNote(FEDERATED_TOKEN_EXPIRATION, Long.toString(expiration));
-            authSession.setUserSessionNote(FEDERATED_REFRESH_TOKEN, tokenResponse.getRefreshToken());
-            authSession.setUserSessionNote(FEDERATED_ACCESS_TOKEN, tokenResponse.getToken());
+            String expirationStr = Long.toString(expiration);
+            setFederatedTokenExpiration(authSession, expirationStr);
+            setFederatedRefreshToken(authSession, tokenResponse.getRefreshToken());
+            setFederatedAccessToken(authSession, tokenResponse.getToken());
         }
         if (isStoreTokenInSession || getConfig().isSendIdTokenOnLogout()) {
-            authSession.setUserSessionNote(FEDERATED_ID_TOKEN, tokenResponse.getIdToken());
+            setFederatedIdToken(authSession, tokenResponse.getIdToken());
         }
     }
 

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -273,7 +273,8 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
 
         }
         if (context.getContextData().containsKey(FEDERATED_ACCESS_TOKEN)) {
-            authSession.setUserSessionNote(FEDERATED_ACCESS_TOKEN, (String) context.getContextData().get(FEDERATED_ACCESS_TOKEN));
+            String token = (String) context.getContextData().get(FEDERATED_ACCESS_TOKEN);
+            setFederatedAccessToken(authSession, token);
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -305,8 +305,9 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         externalExchangeContext.provider().exchangeExternalComplete(userSession, context, formParams);
 
         // this must exist so that we can obtain access token from user session if idp's store tokens is off
-        userSession.setNote(UserAuthenticationIdentityProvider.EXTERNAL_IDENTITY_PROVIDER, externalExchangeContext.idpModel().getAlias());
-        userSession.setNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN, subjectToken);
+        String idpAlias = externalExchangeContext.idpModel().getAlias();
+        userSession.setNote(UserAuthenticationIdentityProvider.EXTERNAL_IDENTITY_PROVIDER, idpAlias);
+        setFederatedAccessTokenNotes(userSession, idpAlias, subjectToken);
 
         context.addSessionNotesToUserSession(userSession);
 
@@ -431,6 +432,10 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         }
 
         return user;
+    }
+
+    private void setFederatedAccessTokenNotes(UserSessionModel userSession, String idpAlias, String token) {
+        userSession.setNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN + ":" + idpAlias, token);
     }
 
     // TODO: move to utility class

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/AbstractTokenExchangeProvider.java
@@ -307,7 +307,7 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         // this must exist so that we can obtain access token from user session if idp's store tokens is off
         String idpAlias = externalExchangeContext.idpModel().getAlias();
         userSession.setNote(UserAuthenticationIdentityProvider.EXTERNAL_IDENTITY_PROVIDER, idpAlias);
-        setFederatedAccessTokenNotes(userSession, idpAlias, subjectToken);
+        setFederatedAccessTokenNote(userSession, idpAlias, subjectToken);
 
         context.addSessionNotesToUserSession(userSession);
 
@@ -434,7 +434,7 @@ public abstract class AbstractTokenExchangeProvider implements TokenExchangeProv
         return user;
     }
 
-    private void setFederatedAccessTokenNotes(UserSessionModel userSession, String idpAlias, String token) {
+    private void setFederatedAccessTokenNote(UserSessionModel userSession, String idpAlias, String token) {
         userSession.setNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN + ":" + idpAlias, token);
     }
 

--- a/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
@@ -169,7 +169,7 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
     }
 
     protected Response exchangeSessionToken(UriInfo uriInfo, ClientModel authorizedClient, UserSessionModel tokenUserSession, UserModel tokenSubject) {
-        String accessToken = tokenUserSession.getNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN);
+        String accessToken = getFederatedAccessToken(tokenUserSession);
         if (accessToken == null) {
             return exchangeTokenExpired(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
         }
@@ -296,8 +296,8 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
 
     @Override
     public void authenticationFinished(AuthenticationSessionModel authSession, BrokeredIdentityContext context) {
-        authSession.setUserSessionNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN, (String) context.getContextData().get(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN));
-
+        String token = (String) context.getContextData().get(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN);
+        setFederatedAccessToken(authSession, token);
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenV2Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenV2Test.java
@@ -330,7 +330,12 @@ public interface InterfaceIdentityProviderStoreTokenV2Test extends InterfaceIden
         return getRunOnServer().fetch(session -> {
             RealmModel r = session.realms().getRealmByName(realmName);
             UserSessionModel userSession = session.sessions().getUserSession(r, sessionId);
-            return userSession.getNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN);
+            // Try alias-namespaced key first, then fall back to legacy un-namespaced key
+            String token = userSession.getNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN + ":" + IDP_ALIAS);
+            if (token == null) {
+                token = userSession.getNote(UserAuthenticationIdentityProvider.FEDERATED_ACCESS_TOKEN);
+            }
+            return token;
         }, String.class);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNonceParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerNonceParameterTest.java
@@ -46,7 +46,7 @@ public class KcOidcBrokerNonceParameterTest extends AbstractBrokerTest {
                 consumerSessionNoteToClaimMapper.setName(OIDCIdentityProvider.FEDERATED_ID_TOKEN);
                 consumerSessionNoteToClaimMapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
                 consumerSessionNoteToClaimMapper.setProtocolMapper(UserSessionNoteMapper.PROVIDER_ID);
-                consumerSessionNoteToClaimMapper.setConfig(Map.of(ProtocolMapperUtils.USER_SESSION_NOTE, OIDCIdentityProvider.FEDERATED_ID_TOKEN,
+                consumerSessionNoteToClaimMapper.setConfig(Map.of(ProtocolMapperUtils.USER_SESSION_NOTE, OIDCIdentityProvider.FEDERATED_ID_TOKEN + ":" + BrokerTestConstants.IDP_OIDC_ALIAS,
                         OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, OIDCIdentityProvider.FEDERATED_ID_TOKEN,
                         OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, Boolean.TRUE.toString()));
                 client.setProtocolMappers(Arrays.asList(consumerSessionNoteToClaimMapper));


### PR DESCRIPTION
Closes #50533

Fixed an issue where linking multiple identity providers would cause tokens to get mixed up, asking for IdP A's token could return IdP B's token instead.
  
All federated token notes now use colon-separated keys (FEDERATED_ACCESS_TOKEN:{alias}). Fallback reads to old noted for backward compatibility.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
