### PR TITLE
PR for Support refresh token scenarios for the scenarios with credential offer  #50340

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -895,7 +895,7 @@ public class OID4VCIssuerEndpoint {
 
             offerState = offerStorage.getOfferStateById(credOfferId);
             if (offerState == null) {
-                if(tokenAuthDetail.getIssuedCredentialId() == null) {
+                if (tokenAuthDetail.getIssuedCredentialId() == null) {
                     var errorMessage = "No credential offer state for: " + credOfferId;
                     eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
                     throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -895,41 +895,42 @@ public class OID4VCIssuerEndpoint {
 
             offerState = offerStorage.getOfferStateById(credOfferId);
             if (offerState == null) {
-                var errorMessage = "No credential offer state for: " + credOfferId;
-                eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
-                throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
-            }
+                if(tokenAuthDetail.getIssuedCredentialId() == null) {
+                    var errorMessage = "No credential offer state for: " + credOfferId;
+                    eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
+                    throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+                }
+                LOGGER.debugf("Credential offer '%s' no longer present in storage — skipping offer validation for re-issuance (issuedCredentialId: %s)",
+                        credOfferId, tokenAuthDetail.getIssuedCredentialId());
+            } else {
 
-            // Verify not expired
-            // The cache should have evicted the expired CredentialOfferState - we check anyway
-            if (offerState.isExpired()) {
-                var errorMessage = "Credential offer has already expired";
-                LOGGER.errorf(errorMessage);
-                eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
-                throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
-            }
+                if (offerState.isExpired()) {
+                    var errorMessage = "Credential offer has already expired";
+                    LOGGER.errorf(errorMessage);
+                    eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
+                    throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+                }
 
-            // Verify the user login session
-            //
-            if (offerState.getTargetUserId() != null && !offerState.getTargetUserId().equals(userModel.getId())) {
-                var errorMessage = "Unexpected login user: " + userModel.getUsername();
-                LOGGER.errorf(errorMessage + " != %s", offerState.getTargetUserId());
-                eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
-                throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
-            }
+                if (offerState.getTargetUserId() != null && !offerState.getTargetUserId().equals(userModel.getId())) {
+                    var errorMessage = "Unexpected login user: " + userModel.getUsername();
+                    LOGGER.errorf(errorMessage + " != %s", offerState.getTargetUserId());
+                    eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
+                    throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+                }
 
-            // Verify the login client
-            //
-            if (offerState.getTargetClientId() != null && !offerState.getTargetClientId().equals(clientModel.getClientId())) {
-                var errorMessage = "Unexpected login client: " + clientModel.getClientId();
-                LOGGER.errorf(errorMessage + " != %s", offerState.getTargetClientId());
-                eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
-                throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+                if (offerState.getTargetClientId() != null && !offerState.getTargetClientId().equals(clientModel.getClientId())) {
+                    var errorMessage = "Unexpected login client: " + clientModel.getClientId();
+                    LOGGER.errorf(errorMessage + " != %s", offerState.getTargetClientId());
+                    eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
+                    throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+                }
             }
         }
 
         // Validate that authorization_details from the token matches the offer state
         // This ensures the correct access token is being used for the credential request
+        LOGGER.debugf("Validating authorization_details: offerState=%s, credOfferId=%s, issuedCredentialId=%s",
+                offerState != null ? "present" : "null", credOfferId, tokenAuthDetail.getIssuedCredentialId());
         if (offerState != null && !offerState.matchAuthorizationDetails(List.of(tokenAuthDetail))) {
             var errorMessage = "Authorization details in access token do not match the credential offer state. " +
                     "The access token may not be the one issued for this credential offer.";

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
@@ -183,7 +183,7 @@ public class OID4VCIRefreshTokenProvider extends AbstractRefreshTokenProvider im
         }
 
         responseBuilder.getAccessToken().setAuthorizationDetails(clearedDetails);
-          if (responseBuilder.getRefreshToken() != null) {
+        if (responseBuilder.getRefreshToken() != null) {
             responseBuilder.getRefreshToken().setAuthorizationDetails(clearedDetails);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
@@ -1,5 +1,6 @@
 package org.keycloak.protocol.oid4vc.refresh;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.ws.rs.core.HttpHeaders;
@@ -163,7 +164,30 @@ public class OID4VCIRefreshTokenProvider extends AbstractRefreshTokenProvider im
 
     @Override
     protected void afterRefreshTokenGenerated(RefreshTokenContext ctx, TokenManager.AccessTokenResponseBuilder responseBuilder) {
-        // Nothing needed for OID4VCI refresh tokens
+        ClientSessionContext clientSessionCtx = responseBuilder.getClientSessionCtx();
+        List<AuthorizationDetailsJSONRepresentation> authzDetails = clientSessionCtx.getAttribute(AUTHORIZATION_DETAILS_RESPONSE, List.class);
+
+        if (authzDetails == null) {
+            return;
+        }
+
+        List<AuthorizationDetailsJSONRepresentation> clearedDetails = new ArrayList<>(authzDetails.size());
+        for (AuthorizationDetailsJSONRepresentation d : authzDetails) {
+            if (OPENID_CREDENTIAL.equals(d.getType())) {
+                OID4VCAuthorizationDetail typed = d.asSubtype(OID4VCAuthorizationDetail.class);
+                typed.setCredentialsOfferId(null);
+                clearedDetails.add(typed);
+            } else {
+                clearedDetails.add(d);
+            }
+        }
+
+        responseBuilder.getAccessToken().setAuthorizationDetails(clearedDetails);
+          if (responseBuilder.getRefreshToken() != null) {
+            responseBuilder.getRefreshToken().setAuthorizationDetails(clearedDetails);
+        }
+
+        clientSessionCtx.setAttribute(AUTHORIZATION_DETAILS_RESPONSE, clearedDetails);
     }
 
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
@@ -17,6 +17,7 @@ import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
@@ -47,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -54,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-14.5">OID4VCI specification section about credential refresh</a>
  */
-@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithRestCredentialOfferEnabled.class)
 public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
 
     @InjectUser(config = OID4VCActionTest.OID4VCTestUserConfig.class)
@@ -110,10 +112,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
      *
      **/
     @Test
-    public void testRefreshTokenSingleCredentialIssued() throws Exception {
-        // Login
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+    public void testRefreshTokenSingleCredentialIssued() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         // Obtain credential
@@ -159,6 +159,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         // Assert issued-credential ID matches and has not changed
         OID4VCAuthorizationDetail authzDetailResponse2 = ctx.getAuthorizationDetailFromAccessToken();
         assertEquals(issuedCred1.getId(), authzDetailResponse2.getIssuedCredentialId());
+        assertNull(authzDetailResponse2.getCredentialsOfferId(),
+                "credentials_offer_id must not be present in refresh-token-derived access token");
 
         // Verify that authorization_details on the token endpoint response have only known properties
         //
@@ -194,10 +196,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
      * Then make sure that refresh token is successful even after user session is expired (EG. after 14 days)
      **/
     @Test
-    public void testRefreshSuccessAfterSessionExpired() throws Exception {
-        // Login
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+    public void testRefreshSuccessAfterSessionExpired() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         // Obtain credential
@@ -243,10 +243,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
      * Then remove issued verifiable credential and try to refresh token. Refresh should fail due the issued VC revoked
      **/
     @Test
-    public void testRefreshFailsWhenIssuedCredentialRemoved() throws Exception {
-        // Login
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+    public void testRefreshFailsWhenIssuedCredentialRemoved() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         // Obtain credential
@@ -286,10 +284,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
      * Then make sure that issued verifiable credential is expired and try to refresh token. Refresh should fail due the issued VC expired
      **/
     @Test
-    public void testRefreshFailsWhenIssuedCredentialExpired() throws Exception {
-        // Login
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+    public void testRefreshFailsWhenIssuedCredentialExpired() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         // Obtain credential
@@ -326,10 +322,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
      * parameter, the refresh should fail as it is OID4VCI refresh token, but without the OID4VCI scope requested inside "scope" parameter
      **/
     @Test
-    public void testRefreshWithScopeParameter() throws Exception {
-        // Login
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+    public void testRefreshWithScopeParameter() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         // Obtain credential
@@ -371,6 +365,113 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
     }
 
     /**
+     * Verify credential re-issuance succeeds with refresh token after the original
+     * credential offer has been removed.
+     */
+    @Test
+    public void testRefreshSucceedsAfterCredentialOfferRemoved() {
+        CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
+            req.targetUser(user.getUsername());
+            req.preAuthorized(false);
+        });
+
+        assertNotNull(credOffer, "Credential offer should be created");
+
+        AccessTokenResponse tokenResponse = authzCodeFlow(credOffer.getAuthorizationCodeGrant().getIssuerState());;
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
+
+        String accessToken1 = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken1, "access token must be present");
+
+        OID4VCAuthorizationDetail authzDetail1 = ctx.getAuthorizationDetailFromAccessToken();
+        assertNotNull(authzDetail1, "Authorization detail should be present in the first access token");
+
+        // Verify credentialsOfferId is present in first authorization detail/access token
+        assertNotNull(authzDetail1.getCredentialsOfferId(), "credentials_offer_id must be present in the first access token");
+
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        CredentialResponse credResponse1 = wallet.credentialRequest(ctx, accessToken1)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        assertSuccessfulCredentialResponse(credResponse1);
+
+        // Verify the issued credential was created and stored
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds1 = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, issuedCreds1.size(), "One issued credential should exist after first issuance");
+        String issuedCredId = issuedCreds1.get(0).getId();
+
+        // Verify issuedCredentialId is now present in the access token's authorization_details
+        assertEquals(issuedCredId, authzDetail1.getIssuedCredentialId(), "issuedCredentialId should be set after credential issuance");
+
+        //Time Delay
+        timeOffSet.set(10);
+
+        // Refresh the access token using the refresh token
+        AccessTokenResponse refreshTokenResponse = wallet.refreshRequest(ctx).send();
+        assertTrue(refreshTokenResponse.isSuccess(), "Refresh token exchange should succeed");
+        String accessToken2 = refreshTokenResponse.getAccessToken();
+
+        EventAssertion.assertSuccess(events.poll())
+                .details(CREDENTIAL_TYPE, ctx.getCredentialConfigurationId())
+                .type(EventType.REFRESH_TOKEN);
+
+        OID4VCAuthorizationDetail authzDetail2 = ctx.getAuthorizationDetailFromAccessToken();
+        assertNull(authzDetail2.getCredentialsOfferId(), "Refreshed access token should NOT contain credentialsOfferId");
+
+        assertEquals(authzDetail2.getIssuedCredentialId(), issuedCredId, "Refreshed access token should contain the correct issuedCredentialId");
+
+        CredentialResponse credResponse2 = wallet.credentialRequest(ctx, accessToken2)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        assertSuccessfulCredentialResponse(credResponse2);
+
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds2 = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, issuedCreds2.size(), "Should still have one issued credential (re-issuance, not duplication)");
+        assertEquals(issuedCredId, issuedCreds2.get(0).getId(), "Issued credential ID should remain the same after refresh and re-issuance");
+    }
+
+    /**
+     * Verify that attempting to request a credential after the credential offer has expired results in an exception being thrown.
+     */
+    @Test
+    public void testThrowExceptionWhenCredentialIsOfferExpiredBeforeIssuance() {
+
+        long offerExpiryTime = Time.currentTimeSeconds() + 3;
+        CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
+            req.targetUser(user.getUsername());
+            req.expireAt((int) offerExpiryTime);
+            req.preAuthorized(false);
+        });
+
+        assertNotNull(credOffer, "Credential offer should be created");
+
+        timeOffSet.set(8);
+
+        AccessTokenResponse tokenResponse = authzCodeFlow(credOffer.getAuthorizationCodeGrant().getIssuerState());;
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
+
+        String accessToken1 = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken1, "access token must be present");
+
+        OID4VCAuthorizationDetail authzDetail1 = ctx.getAuthorizationDetailFromAccessToken();
+        assertNotNull(authzDetail1, "Authorization detail should be present in the first access token");
+
+        // Verify credentialsOfferId is present in first authorization detail/access token
+        assertNotNull(authzDetail1.getCredentialsOfferId(), "credentials_offer_id must be present in the first access token");
+
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> wallet.credentialRequest(ctx, accessToken1)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse());
+
+        String expectedExceptionMessage = "Credential offer has already expired";
+        assertTrue(exception.getMessage().contains(expectedExceptionMessage), "Expected exception message for expired credential offer");
+    }
+
+    /**
      * Test that the VC expiration (exp claim) uses the refresh interval,
      * while the issued credential and refresh token use the credential lifetime.
      * To verify the core feature: separating VC expiration from refresh token expiration.
@@ -381,17 +482,16 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         int credentialLifetime = 31536000; // 365 days
         int refreshInterval = 604800; // 7 days
 
-       String scopeId = getCredentialScopeId(minimalJwtTypeCredentialScopeName);
+        String scopeId = getCredentialScopeId(minimalJwtTypeCredentialScopeName);
 
-       testRealm.updateClientScope(scopeId, clientScope -> {
+        testRealm.updateClientScope(scopeId, clientScope -> {
             CredentialScopeRepresentation credScopeRep = new CredentialScopeRepresentation(clientScope.build());
             credScopeRep.setExpiryInSeconds(credentialLifetime);
             credScopeRep.setRefreshIntervalInSeconds(refreshInterval);
             return ClientScopeBuilder.update(credScopeRep);
         });
 
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         String accessToken = tokenResponse.getAccessToken();
@@ -447,6 +547,50 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
     }
 
     /**
+     * Test that both initial and refreshed access tokens have their audience limited to the credential endpoint.
+     * This verifies that the OID4VCITokenPostProcessor correctly sets the 'aud' claim.
+     */
+    @Test
+    public void testAccessTokenAudienceLimitedToCredentialEndpoint() throws Exception {
+        // Login
+        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
+        AccessTokenResponse tokenResponse = authzCodeFlow();
+        assertTrue(tokenResponse.isSuccess());
+
+        // Get the expected credential endpoint URL from issuer metadata
+        String expectedAudience = issuer.getCredentialEndpoint();
+        assertNotNull(expectedAudience);
+
+        // Verify initial access token has correct audience
+        String accessToken1 = tokenResponse.getAccessToken();
+        wallet.assertAccessTokenAudience(accessToken1, expectedAudience);
+
+        // Obtain credential to ensure the token works
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken1)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+        assertSuccessfulCredentialResponse(credResponse);
+
+        // Move time forward a bit
+        timeOffSet.set(10);
+
+        // Refresh token
+        AccessTokenResponse refreshResponse = wallet.refreshRequest(ctx).send();
+        assertTrue(refreshResponse.isSuccess(), "Refresh token exchange should succeed");
+
+        // Verify refreshed access token also has correct audience
+        String accessToken2 = refreshResponse.getAccessToken();
+        wallet.assertAccessTokenAudience(accessToken2, expectedAudience);
+
+        // Verify the refreshed token still works for credential requests
+        credResponse = wallet.credentialRequest(ctx, accessToken2)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+        assertSuccessfulCredentialResponse(credResponse);
+    }
+
+    /**
      * Test that a custom refresh interval value is correctly applied to the VC.
      */
     @Test
@@ -462,8 +606,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         });
 
         // Obtain VC
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess());
 
         CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenResponse.getAccessToken())
@@ -481,8 +624,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
 
         long tolerance = 60;
         assertTrue(Math.abs(vcLifetimeSeconds - customRefreshInterval) <= tolerance,
-                                    String.format("VC lifetime should be ~%d seconds, but was %d seconds",
-                                    customRefreshInterval, vcLifetimeSeconds));
+                String.format("VC lifetime should be ~%d seconds, but was %d seconds",
+                        customRefreshInterval, vcLifetimeSeconds));
     }
 
     /**
@@ -505,8 +648,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         });
 
         // Obtain VC
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+        AccessTokenResponse tokenResponse = authzCodeFlow();
         assertTrue(tokenResponse.isSuccess());
 
         CredentialResponse credResponse_1 = wallet.credentialRequest(ctx, tokenResponse.getAccessToken())
@@ -554,14 +696,26 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
 
         // Both VCs should point to the same issued credential (same ID)
         List<IssuedVerifiableCredentialRepresentation> issuedCreds = testRealm.admin().users().get(user.getId())
-                                                                              .verifiableCredentials().getIssuedCredentials();
+                .verifiableCredentials().getIssuedCredentials();
         assertEquals(1, issuedCreds.size(), "Should still be only one issued credential");
     }
 
-    protected AccessTokenResponse authzCodeFlow(CredentialIssuer issuer) throws Exception {
+    protected AccessTokenResponse authzCodeFlow() {
         AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
                 .scope(ctx.getScope())
                 .send(user.getUsername(), TEST_PASSWORD);
+        return assertAndGetAccessTokenResponse(authResponse);
+    }
+
+    protected AccessTokenResponse authzCodeFlow(String issuerState) {
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .issuerState(issuerState)
+                .send(user.getUsername(), TEST_PASSWORD);
+        return assertAndGetAccessTokenResponse(authResponse);
+    }
+
+    private AccessTokenResponse assertAndGetAccessTokenResponse(AuthorizationEndpointResponse authResponse) {
         String code = authResponse.getCode();
         assertNotNull(code, "Authorization code should not be null");
 
@@ -569,50 +723,6 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
         assertNotNull(accessToken, "No accessToken");
         return tokenResponse;
-    }
-
-    /**
-     * Test that both initial and refreshed access tokens have their audience limited to the credential endpoint.
-     * This verifies that the OID4VCITokenPostProcessor correctly sets the 'aud' claim.
-     */
-    @Test
-    public void testAccessTokenAudienceLimitedToCredentialEndpoint() throws Exception {
-        // Login
-        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
-        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
-        assertTrue(tokenResponse.isSuccess());
-
-        // Get the expected credential endpoint URL from issuer metadata
-        String expectedAudience = issuer.getCredentialEndpoint();
-        assertNotNull(expectedAudience);
-
-        // Verify initial access token has correct audience
-        String accessToken1 = tokenResponse.getAccessToken();
-        wallet.assertAccessTokenAudience(accessToken1, expectedAudience);
-
-        // Obtain credential to ensure the token works
-        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
-        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken1)
-                .credentialIdentifier(credentialIdentifier)
-                .send().getCredentialResponse();
-        assertSuccessfulCredentialResponse(credResponse);
-
-        // Move time forward a bit
-        timeOffSet.set(10);
-
-        // Refresh token
-        AccessTokenResponse refreshResponse = wallet.refreshRequest(ctx).send();
-        assertTrue(refreshResponse.isSuccess(), "Refresh token exchange should succeed");
-
-        // Verify refreshed access token also has correct audience
-        String accessToken2 = refreshResponse.getAccessToken();
-        wallet.assertAccessTokenAudience(accessToken2, expectedAudience);
-
-        // Verify the refreshed token still works for credential requests
-        credResponse = wallet.credentialRequest(ctx, accessToken2)
-                .credentialIdentifier(credentialIdentifier)
-                .send().getCredentialResponse();
-        assertSuccessfulCredentialResponse(credResponse);
     }
 
     protected void assertSuccessfulCredentialResponse(CredentialResponse credentialResponse) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
@@ -377,7 +377,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
 
         assertNotNull(credOffer, "Credential offer should be created");
 
-        AccessTokenResponse tokenResponse = authzCodeFlow(credOffer.getAuthorizationCodeGrant().getIssuerState());;
+        AccessTokenResponse tokenResponse = authzCodeFlow(credOffer.getAuthorizationCodeGrant().getIssuerState());
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         String accessToken1 = wallet.validateHolderAccessToken(ctx, tokenResponse);
@@ -401,8 +401,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         assertEquals(1, issuedCreds1.size(), "One issued credential should exist after first issuance");
         String issuedCredId = issuedCreds1.get(0).getId();
 
-        // Verify issuedCredentialId is now present in the access token's authorization_details
-        assertEquals(issuedCredId, authzDetail1.getIssuedCredentialId(), "issuedCredentialId should be set after credential issuance");
+        // Verify issuedCredentialId from authorization_details matches the stored issued credential
+        assertEquals(issuedCredId, authzDetail1.getIssuedCredentialId(), "issued_credential_id in authorization_details should match the stored issued credential");
 
         //Time Delay
         timeOffSet.set(10);
@@ -419,7 +419,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         OID4VCAuthorizationDetail authzDetail2 = ctx.getAuthorizationDetailFromAccessToken();
         assertNull(authzDetail2.getCredentialsOfferId(), "Refreshed access token should NOT contain credentialsOfferId");
 
-        assertEquals(authzDetail2.getIssuedCredentialId(), issuedCredId, "Refreshed access token should contain the correct issuedCredentialId");
+        assertEquals(issuedCredId, authzDetail2.getIssuedCredentialId(), "Refreshed access token should contain the correct issuedCredentialId");
 
         CredentialResponse credResponse2 = wallet.credentialRequest(ctx, accessToken2)
                 .credentialIdentifier(credentialIdentifier)
@@ -436,7 +436,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
      * Verify that attempting to request a credential after the credential offer has expired results in an exception being thrown.
      */
     @Test
-    public void testThrowExceptionWhenCredentialIsOfferExpiredBeforeIssuance() {
+    public void testThrowsExceptionWhenCredentialOfferExpiredBeforeIssuance() {
 
         long offerExpiryTime = Time.currentTimeSeconds() + 3;
         CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
@@ -447,9 +447,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
 
         assertNotNull(credOffer, "Credential offer should be created");
 
-        timeOffSet.set(8);
-
-        AccessTokenResponse tokenResponse = authzCodeFlow(credOffer.getAuthorizationCodeGrant().getIssuerState());;
+        AccessTokenResponse tokenResponse = authzCodeFlow(credOffer.getAuthorizationCodeGrant().getIssuerState());
         assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         String accessToken1 = wallet.validateHolderAccessToken(ctx, tokenResponse);
@@ -462,6 +460,8 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         assertNotNull(authzDetail1.getCredentialsOfferId(), "credentials_offer_id must be present in the first access token");
 
         String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        timeOffSet.set(8);
 
         Exception exception = assertThrows(IllegalStateException.class, () -> wallet.credentialRequest(ctx, accessToken1)
                 .credentialIdentifier(credentialIdentifier)

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCAuthorizationDetailsFlowPreAuthTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCAuthorizationDetailsFlowPreAuthTestBase.java
@@ -706,11 +706,12 @@ public abstract class OID4VCAuthorizationDetailsFlowPreAuthTestBase extends OID4
     }
 
     @Test
-    public void testCompleteFlowWithConsumedCredentialOffer() throws Exception {
+    public void testCredentialReissuanceSucceedsAfterOfferConsumed() throws Exception {
         AccessTokenResponse tokenResponse = preAuthzCodeSuccessful();
         assertSuccessfulCredentialRequest(tokenResponse);
-        // Second credential request should fail as offer is already expired
-        assertFailedCredentialRequest(tokenResponse);
+        // After fix for #50340: Second request succeeds because authorization
+        // is now based on having a valid user verifiable credential, not the offer
+        assertSuccessfulCredentialRequest(tokenResponse);
     }
 
     private AccessTokenResponse preAuthzCodeSuccessful() throws Exception {


### PR DESCRIPTION
  Allow credential re-issuance after refresh when the original credential offer has been removed from storage.
  The endpoint now tolerates missing
  offers when issued_credential_id is present, and the refresh provider clears credentials_offer_id from refreshed tokens.

Closes #50340


