### PR TITLE
contain x509 CRL distribution point file path to config dir

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
@@ -389,7 +390,11 @@ public class CertificateValidator {
             try {
                 String configDir = System.getProperty("jboss.server.config.dir");
                 if (configDir != null) {
-                    File f = new File(configDir + File.separator + relativePath);
+                    File f = resolveCRLPath(configDir, relativePath);
+                    if (f == null) {
+                        logger.warnf("CRL path \"%s\" resolves outside of the configuration directory and will not be loaded", relativePath);
+                        return null;
+                    }
                     if (f.isFile()) {
                         logger.debugf("Loading CRL from %s", f.getAbsolutePath());
 
@@ -406,6 +411,20 @@ public class CertificateValidator {
                 logger.errorf(ex.getMessage());
             }
             return null;
+        }
+
+        /**
+         * Resolves a CRL file path against the configuration directory, returning {@code null} when the
+         * resolved path escapes that directory. CRL distribution point values are taken verbatim from the
+         * presented client certificate, so the untrusted path segment must stay contained in the base dir.
+         */
+        static File resolveCRLPath(String baseDir, String relativePath) {
+            Path basePath = Path.of(baseDir).toAbsolutePath().normalize();
+            Path resolved = Path.of(baseDir, relativePath).toAbsolutePath().normalize();
+            if (!resolved.startsWith(basePath)) {
+                return null;
+            }
+            return resolved.toFile();
         }
 
         private X509CRL loadFromStream(CertificateFactory cf, InputStream is) throws IOException, CRLException {

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/CertificateValidatorTest.java
@@ -1,5 +1,7 @@
 package org.keycloak.authentication.authenticators.x509;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -325,6 +327,44 @@ public class CertificateValidatorTest {
     @Test
     public void testCertificatePolicyModeAnyTwoRequestedAndTwoPresent() throws GeneralSecurityException {
         testCertificatePolicyValidation("1.3.76.16.2.1,1.2.3.4.5.6", CERTIFICATE_POLICY_MODE_ANY, "1.3.76.16.2.1", "1.2.3.4.5.6");
+    }
+
+    /**
+     * A CRL distribution point is taken verbatim from the presented client certificate. When it is loaded
+     * as a local file it must stay within the configuration directory; a value containing parent references
+     * must not resolve to a file outside of it.
+     */
+    @Test
+    public void testCRLDistributionPointFilePathTraversalIsRejected() {
+        String baseDir = new File("target", "crl-base").getAbsolutePath();
+
+        Assert.assertNull(CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, "../../../../etc/passwd"));
+        Assert.assertNull(CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, "crls/../../../../../etc/passwd"));
+        Assert.assertNull(CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, ".."));
+        Assert.assertNull(CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, "../crl-base-sibling/x.crl"));
+    }
+
+    /**
+     * A CRL path that stays inside the configuration directory keeps resolving as before, including a value
+     * with a leading slash (which was already treated as relative to the base dir) and an internal parent
+     * reference that does not escape.
+     */
+    @Test
+    public void testCRLDistributionPointFilePathWithinBaseIsResolved() {
+        String baseDir = new File("target", "crl-base").getAbsolutePath();
+        Path basePath = Path.of(baseDir).toAbsolutePath().normalize();
+
+        File direct = CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, "my.crl");
+        Assert.assertNotNull(direct);
+        MatcherAssert.assertThat(direct.toPath().normalize().startsWith(basePath), Matchers.is(true));
+
+        File internalParent = CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, "sub/../my.crl");
+        Assert.assertNotNull(internalParent);
+        Assert.assertEquals(direct.getPath(), internalParent.getPath());
+
+        File leadingSlash = CertificateValidator.CRLFileLoader.resolveCRLPath(baseDir, "/nested/my.crl");
+        Assert.assertNotNull(leadingSlash);
+        MatcherAssert.assertThat(leadingSlash.toPath().normalize().startsWith(basePath), Matchers.is(true));
     }
 
     // Helper to test various certificate policy validation combinations


### PR DESCRIPTION
Closes #50600

Repro: enable CRL/DP checking on the x509 authenticator and present a client cert whose CRL distribution point has no http/ldap scheme and contains `../` (e.g. `../../../../etc/passwd`).
Cause: `CRLFileLoader.loadCRLFromFile` joins the distribution point read verbatim from the certificate onto `jboss.server.config.dir` with no containment, so `..` escapes the config dir and an arbitrary local file is opened during authentication.
Fix: resolve the path through a normalize + base-dir containment check (same shape as the theme `ResourceLoader`) and skip loading when it escapes. Configured relative paths, internal `..` that stays inside, and leading-slash values resolve as before.
