### PR TITLE
Clarify key rotation priority guidance

### DIFF
--- a/docs/documentation/server_admin/topics/admin-cli.adoc
+++ b/docs/documentation/server_admin/topics/admin-cli.adoc
@@ -369,7 +369,7 @@ For example:
 ----
 $ kcadm.sh get realms/demorealm --fields id --format csv --noquotes
 ----
-. Add a new key provider with a higher priority than the existing providers as revealed by `kcadm.sh get keys -r demorealm`.
+. Add a new key provider with a lower priority than the existing providers as revealed by `kcadm.sh get keys -r demorealm`.
 +
 For example:
 +
@@ -377,17 +377,34 @@ For example:
 +
 [options="nowrap"]
 ----
-$ kcadm.sh create components -r demorealm -s name=rsa-generated -s providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=["101"]' -s 'config.enabled=["true"]' -s 'config.active=["true"]' -s 'config.keySize=["2048"]'
+$ kcadm.sh create components -r demorealm -s name=rsa-generated -s providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s 'config.priority=["99"]' -s 'config.enabled=["true"]' -s 'config.active=["true"]' -s 'config.keySize=["2048"]'
 ----
 * Windows:
 +
 [options="nowrap"]
 ----
-c:\> kcadm create components -r demorealm -s name=rsa-generated -s providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "config.priority=[\"101\"]" -s "config.enabled=[\"true\"]" -s "config.active=[\"true\"]" -s "config.keySize=[\"2048\"]"
+c:\> kcadm create components -r demorealm -s name=rsa-generated -s providerId=rsa-generated -s providerType=org.keycloak.keys.KeyProvider -s parentId=959844c1-d149-41d7-8359-6aa527fca0b0 -s "config.priority=[\"99\"]" -s "config.enabled=[\"true\"]" -s "config.active=[\"true\"]" -s "config.keySize=[\"2048\"]"
 ----
 . Set the `parentId` attribute to the value of the target realm's ID.
+. Wait until OpenID Connect clients have refreshed their cached public keys from `/realms/{realm-name}/protocol/openid-connect/certs`, and SAML service providers have refreshed `/realms/{realm-name}/protocol/saml/descriptor` or received the new certificate manually.
+. Use the new key's `providerId` to raise its priority above the existing providers.
 +
-The newly added key is now the active key, as revealed by `kcadm.sh get keys -r demorealm`.
+For example:
++
+* Linux:
++
+[options="nowrap"]
+----
+$ kcadm.sh update components/PROVIDER_ID -r demorealm -s 'config.priority=["101"]'
+----
+* Windows:
++
+[options="nowrap"]
+----
+c:\> kcadm update components/PROVIDER_ID -r demorealm -s "config.priority=[\"101\"]"
+----
++
+The newly added key is now the key used for signing, as revealed by `kcadm.sh get keys -r demorealm`.
 
 [discrete]
 ==== Adding new realm keys from a Java Key Store file

--- a/docs/documentation/server_admin/topics/realms/keys.adoc
+++ b/docs/documentation/server_admin/topics/realms/keys.adoc
@@ -22,10 +22,13 @@ that is able to provide an active key pair.
 
 ==== Rotating keys
 
-We recommend that you regularly rotate keys. Start by creating new keys with a higher priority than the existing active keys. You can instead create new keys with the same priority and making the previous keys passive.
+We recommend that you regularly rotate keys. Start by creating new keys with a lower priority than the keys currently
+used for signing. Wait until OpenID Connect clients have refreshed their cached public keys from the certificate
+endpoint and SAML service providers have refreshed the realm SAML descriptor or received the new certificate manually.
+Then increase the priority of the new keys above the keys previously used for signing.
 
-Once new keys are available, all new tokens and cookies will be signed with the new keys. When a user authenticates to an
-application, the SSO cookie is updated with the new signature. When OpenID Connect tokens are refreshed new tokens are
+Once the new keys have the highest priority, all new tokens and cookies will be signed with the new keys. When a user
+authenticates to an application, the SSO cookie is updated with the new signature. When OpenID Connect tokens are refreshed new tokens are
 signed with the new keys. Eventually, all cookies and tokens use the new keys and after a while the old keys can be removed.
 
 The frequency of deleting old keys is a tradeoff between security and making sure all cookies and tokens are updated. Consider creating new keys every three to six months and deleting old keys one to two months after you create the new keys. If a user was inactive in the period between the new keys being added and the old keys being removed, that user will have to re-authenticate.


### PR DESCRIPTION
## Summary
- Update the realm key rotation guidance to avoid activating newly generated keys before clients can refresh the public keys.
- Clarify that signing moves to the new keys after their priority is raised.

## Testing
- [x] `JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 ./mvnw -B -nsu clean install -am -pl docs/documentation/server_admin -Pdocumentation -DskipTests`
- [x] `git diff --check`

Closes #49658
