### PR TITLE
Prevent unnecessary user cache eviction after user federation sync

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -31,6 +31,7 @@ import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.enums.SslRequired;
+import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -63,6 +64,7 @@ import org.keycloak.models.cache.infinispan.entities.CachedRealm;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.UserStorageUtil;
 import org.keycloak.storage.client.ClientStorageProvider;
 
@@ -1708,7 +1710,10 @@ public class RealmAdapter implements CachedRealmModel {
 
           // invalidate entire user cache if we're dealing with user storage SPI
           if (UserStorageProvider.class.getName().equals(model.getProviderType())) {
-            userCache.evict(this);
+              ComponentModel existing = getComponent(model.getId());
+              if (existing == null || !isOnlyLastSyncUpdate(existing, model)) {
+                  userCache.evict(this);
+              }
           }
         }
 
@@ -1717,6 +1722,34 @@ public class RealmAdapter implements CachedRealmModel {
         if (ClientStorageProvider.class.getName().equals(model.getProviderType())) {
             cacheSession.evictRealmOnRemoval(this);
         }
+    }
+
+    /**
+     * Returns {@code true} if the only differences between the existing and incoming
+     * {@link ComponentModel} are the runtime sync-timestamp keys ({@code lastSync_FULL},
+     * {@code lastSync_CHANGED}). When that is the case the caller can safely skip
+     * a full user-cache eviction because no provider configuration has actually changed.
+     */
+    private boolean isOnlyLastSyncUpdate(ComponentModel existing, ComponentModel incoming) {
+        if (!Objects.equals(existing.getId(), incoming.getId())) return false;
+        if (!Objects.equals(existing.getName(), incoming.getName())) return false;
+        if (!Objects.equals(existing.getProviderId(), incoming.getProviderId())) return false;
+        if (!Objects.equals(existing.getProviderType(), incoming.getProviderType())) return false;
+        if (!Objects.equals(existing.getParentId(), incoming.getParentId())) return false;
+        if (!Objects.equals(existing.getSubType(), incoming.getSubType())) return false;
+
+        MultivaluedHashMap<String, String> existingConfig = new MultivaluedHashMap<>(existing.getConfig());
+        MultivaluedHashMap<String, String> incomingConfig = new MultivaluedHashMap<>(incoming.getConfig());
+
+        removeLastSyncKeys(existingConfig);
+        removeLastSyncKeys(incomingConfig);
+
+        return existingConfig.equals(incomingConfig);
+    }
+
+    private void removeLastSyncKeys(MultivaluedHashMap<String, String> config) {
+        config.remove(UserStorageProviderModel.LAST_SYNC + "_" + UserStorageProviderModel.SyncMode.FULL.name());
+        config.remove(UserStorageProviderModel.LAST_SYNC + "_" + UserStorageProviderModel.SyncMode.CHANGED.name());
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR prevents unnecessary user cache eviction when only the runtime synchronization metadata of a `UserStorageProvider` is updated.

## Root Cause

`UserStorageSyncTask` updates the `lastSync_FULL` or `lastSync_CHANGED` metadata by calling `realm.updateComponent()`. This eventually reaches `RealmAdapter.executeEvictions()`, which currently evicts the entire user cache for every `UserStorageProvider` update, regardless of whether any actual provider configuration changed.

## Solution

Before evicting the user cache, `RealmAdapter` now compares the existing and incoming `ComponentModel`.

If the only differences are the runtime synchronization metadata keys:

- `lastSync_FULL`
- `lastSync_CHANGED`

the cache eviction is skipped.

For all other configuration changes, the existing eviction behavior remains unchanged.

The implementation:
- compares the core `ComponentModel` fields
- creates defensive copies of the configuration maps
- removes only the runtime sync metadata keys
- compares the remaining configuration for equality

## Testing

- Reviewed the affected execution path and cache eviction logic.
- Validated the implementation against existing Keycloak code patterns.
- Full integration test execution could not be completed due to local build environment dependency issues.

## Notes

This change does **not** modify the behavior for:

- `ClientStorageProvider`
- User storage child components (such as LDAP mappers)
- Component creation
- Component removal
- Component import