### PR TITLE
PR #50341:Revoke credential when OID4VCI refresh token is revoked

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
@@ -166,6 +166,49 @@ public class OID4VCIRefreshTokenProvider extends AbstractRefreshTokenProvider im
         // Nothing needed for OID4VCI refresh tokens
     }
 
+    @Override
+    public void revokeToken(AccessToken token, UserModel user, ClientModel client, EventBuilder event) {
+        // Revoke the issued verifiable credential associated with this refresh token
+        List<AuthorizationDetailsJSONRepresentation> authorizationDetails = token.getAuthorizationDetails();
+        if (authorizationDetails == null || authorizationDetails.isEmpty()) {
+            logger.warnf("OID4VCI refresh token revoked but authorization_details is missing. " +
+                            "Realm: %s, client: %s, user: %s",
+                    session.getContext().getRealm().getName(), client.getClientId(), user.getUsername());
+            return;
+        }
+
+        for (AuthorizationDetailsJSONRepresentation detail : authorizationDetails) {
+            if (!OPENID_CREDENTIAL.equals(detail.getType())) {
+                continue;
+            }
+            OID4VCAuthorizationDetail oid4VCDetail = detail.asSubtype(OID4VCAuthorizationDetail.class);
+            String issuedCredentialId = oid4VCDetail.getIssuedCredentialId();
+            if (issuedCredentialId == null) {
+                continue;
+            }
+            boolean ownedByUserAndClient = session.users().getIssuedVerifiableCredentialsStreamByUser(user.getId())
+                    .anyMatch(issued -> issuedCredentialId.equals(issued.getId()) && client.getId().equals(issued.getClientId()));
+
+            if (!ownedByUserAndClient) {
+                logger.warnf("Issued verifiable credential '%s' referenced by revoked refresh token is not associated with current user/client. Realm: %s, client: %s, user: %s",
+                        issuedCredentialId, session.getContext().getRealm().getName(), client.getClientId(), user.getUsername());
+                continue;
+            }
+
+            boolean removed = session.users().removeIssuedVerifiableCredential(issuedCredentialId);
+
+            if (!removed) {
+                logger.warnf("Failed to remove issued verifiable credential '%s' on refresh token revocation. Realm: %s, client: %s, user: %s",
+                        issuedCredentialId, session.getContext().getRealm().getName(), client.getClientId(), user.getUsername());
+                continue;
+            }
+
+            logger.debugf("Removed issued verifiable credential '%s' on refresh token revocation. " +
+                            "Realm: %s, client: %s, user: %s",
+                    issuedCredentialId, session.getContext().getRealm().getName(),
+                    client.getClientId(), user.getUsername());
+        }
+    }
 
     // Might eventually be overridden for scenarios where a user is not available in the Keycloak DB
     protected UserModel getUser(RealmModel realm, RefreshToken oldToken) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -498,7 +498,6 @@ public class TokenManager {
         clientSession.detachFromUserSession();
     }
 
-
     public static Set<RoleModel> getAccess(UserModel user, ClientModel client, Stream<ClientScopeModel> clientScopes) {
         Set<RoleModel> roleMappings = RoleUtils.getDeepUserRoleMappings(user);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -46,14 +46,16 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.refresh.DefaultRefreshTokenProviderFactory;
+import org.keycloak.protocol.oidc.refresh.RefreshTokenProvider;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.RefreshToken;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenRevokeContext;
 import org.keycloak.services.clientpolicy.context.TokenRevokeResponseContext;
 import org.keycloak.services.cors.Cors;
-import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.util.TokenUtil;
 
@@ -116,7 +118,17 @@ public class TokenRevocationEndpoint {
         checkUser();
 
         if (TokenUtil.TOKEN_TYPE_REFRESH.equals(token.getType()) || TokenUtil.TOKEN_TYPE_OFFLINE.equals(token.getType())) {
-            revokeClientSession();
+            String providerClaim = (String)token.getOtherClaims().get(RefreshToken.PROVIDER);
+            String providerId = (providerClaim != null) ? providerClaim : DefaultRefreshTokenProviderFactory.PROVIDER_ID;
+            RefreshTokenProvider refreshTokenProvider = session.getProvider(RefreshTokenProvider.class, providerId);
+
+            if (refreshTokenProvider == null) {
+                // Fallback for unknown provider ID
+                refreshTokenProvider = session.getProvider(RefreshTokenProvider.class, DefaultRefreshTokenProviderFactory.PROVIDER_ID);
+            }
+
+            refreshTokenProvider.revokeToken(token, user, client, event);
+
             event.detail(Details.REVOKED_CLIENT, client.getClientId());
             event.session(token.getSessionId());
             event.detail(Details.REFRESH_TOKEN_ID, token.getId());
@@ -239,30 +251,6 @@ public class TokenRevocationEndpoint {
         for (List<String> strings : formParams.values()) {
             if (strings.size() != 1) {
                 throw new CorsErrorResponseException(cors, Errors.INVALID_REQUEST, "duplicated parameter", Response.Status.BAD_REQUEST);
-            }
-        }
-    }
-
-    private void revokeClientSession() {
-        if (TokenUtil.TOKEN_TYPE_OFFLINE.equals(token.getType())) {
-            UserSessionModel userSession = session.sessions().getOfflineUserSession(realm, token.getSessionId());
-            if (userSession != null) {
-                new UserSessionManager(session).removeClientFromOfflineUserSession(realm, userSession, client, user);
-            }
-        }
-        // Always remove "online" session as well if exists to make sure that issued access-tokens are revoked as well
-        UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
-        if (userSession != null) {
-            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
-            if (clientSession != null) {
-                TokenManager.detachClientSession(clientSession);
-
-                revokeTokenExchangeSession(userSession);
-
-                // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
-                if (userSession.getAuthenticatedClientSessions().isEmpty()) {
-                    session.sessions().removeUserSession(realm, userSession);
-                }
             }
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/refresh/DefaultRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/refresh/DefaultRefreshTokenProvider.java
@@ -111,9 +111,9 @@ public class DefaultRefreshTokenProvider extends AbstractRefreshTokenProvider im
         if (userSession != null) {
             AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
             if (clientSession != null) {
-                TokenManager.detachClientSession(clientSession);
-
                 revokeTokenExchangeSession(userSession, token, event);
+
+                TokenManager.detachClientSession(clientSession);
 
                 // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
                 if (userSession.getAuthenticatedClientSessions().isEmpty()) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/refresh/DefaultRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/refresh/DefaultRefreshTokenProvider.java
@@ -1,6 +1,9 @@
 package org.keycloak.protocol.oidc.refresh;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -9,6 +12,7 @@ import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.OAuthErrorException;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
@@ -16,11 +20,13 @@ import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.SessionExpirationUtils;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
+import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.util.TokenUtil;
 
 
@@ -88,6 +94,47 @@ public class DefaultRefreshTokenProvider extends AbstractRefreshTokenProvider im
         UserSessionModel userSession = clientSession.getUserSession();
         ctx.grant().updateClientSession(clientSession);
         ctx.grant().updateUserSessionFromClientAuth(userSession);
+    }
+
+    @Override
+    public void revokeToken(AccessToken token, UserModel user, ClientModel client, EventBuilder event) {
+        RealmModel realm = session.getContext().getRealm();
+
+        if (TokenUtil.TOKEN_TYPE_OFFLINE.equals(token.getType())) {
+            UserSessionModel userSession = session.sessions().getOfflineUserSession(realm, token.getSessionId());
+            if (userSession != null) {
+                new UserSessionManager(session).removeClientFromOfflineUserSession(realm, userSession, client, user);
+            }
+        }
+        // Always remove "online" session as well if exists to make sure that issued access-tokens are revoked as well
+        UserSessionModel userSession = session.sessions().getUserSession(realm, token.getSessionId());
+        if (userSession != null) {
+            AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+            if (clientSession != null) {
+                TokenManager.detachClientSession(clientSession);
+
+                revokeTokenExchangeSession(userSession, token, event);
+
+                // TODO: Might need optimization to prevent loading client sessions from cache in getAuthenticatedClientSessions()
+                if (userSession.getAuthenticatedClientSessions().isEmpty()) {
+                    session.sessions().removeUserSession(realm, userSession);
+                }
+            }
+        }
+    }
+
+    private void revokeTokenExchangeSession(UserSessionModel userSession, AccessToken token, EventBuilder event) {
+        Map<String, AuthenticatedClientSessionModel> clientSessionModelMap = userSession.getAuthenticatedClientSessions();
+        List<String> revokedClients = new ArrayList<>();
+        clientSessionModelMap.forEach((key, clientSessionModel) -> {
+            if (clientSessionModel.getNote(Constants.TOKEN_EXCHANGE_SUBJECT_CLIENT + token.getIssuedFor()) != null) {
+                revokedClients.add(clientSessionModel.getClient().getClientId());
+                TokenManager.detachClientSession(clientSessionModel);
+            }
+        });
+        if (!revokedClients.isEmpty()) {
+            event.detail(Details.TOKEN_EXCHANGE_REVOKED_CLIENTS, String.join(",", revokedClients));
+        }
     }
 
     private Long getExpiration(ClientSessionContext clientSessionCtx, UserSessionModel userSession, boolean offline) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/refresh/RefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/refresh/RefreshTokenProvider.java
@@ -1,8 +1,12 @@
 package org.keycloak.protocol.oidc.refresh;
 
 import org.keycloak.OAuthErrorException;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.provider.Provider;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
 
 /**
@@ -46,6 +50,21 @@ public interface RefreshTokenProvider extends Provider {
      * @throws OAuthErrorException In case that validation failed or some other issue happened during token refresh
      */
     TokenManager.AccessTokenResponseBuilder refreshAccessToken(RefreshTokenContext ctx) throws OAuthErrorException;
+
+    /**
+     * Invoked when the revocation endpoint receives a request to revoke a refresh token
+     * issued by this provider. The default implementation is a no-op; override to perform
+     * provider-specific cleanup (e.g., revoking associated credentials).
+     *
+     * @param token  the decoded token (refresh/offline) represented as an {@link AccessToken}
+     * @param user   the token subject
+     * @param client the client for which the token was issued
+     * @param event  the event builder for recording revocation events
+     *
+     */
+    default void revokeToken(AccessToken token, UserModel user, ClientModel client, EventBuilder event) {
+        // no-op by default
+    }
 
     @Override
     default void close() {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshTokenRevocationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshTokenRevocationTest.java
@@ -1,0 +1,219 @@
+package org.keycloak.tests.oid4vc;
+
+import java.util.List;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.events.EventType;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.ErrorType;
+import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.TokenRevocationResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialIssuerMetadataResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+public class OID4VCRefreshTokenRevocationTest extends OID4VCIssuerTestBase {
+
+    @InjectUser(config = OID4VCActionTest.OID4VCTestUserConfig.class)
+    ManagedUser user;
+
+    OID4VCTestContext ctx;
+
+    @TestSetup
+    public void configureTestRealm() {
+        super.configureTestRealm();
+        var realmRep = testRealm.admin().toRepresentation();
+        realmRep.setEnabledEventTypes(List.of(
+                EventType.REVOKE_GRANT.toString(),
+                EventType.REFRESH_TOKEN.toString()));
+        testRealm.admin().update(realmRep);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        ctx = new OID4VCTestContext(client, minimalJwtTypeCredentialScope);
+        user.admin().logout();
+        user.admin().verifiableCredentials().getIssuedCredentials()
+                .forEach(issuedCred -> user.admin().verifiableCredentials().revokeIssuedCredential(issuedCred.getId()));
+    }
+
+    /**
+     *    Test for revoking an OID4VCI refresh token, which MUST delete the linked IssuedVerifiableCredentialEntity row
+     */
+    @Test
+    public void testRevokeRefreshTokenRemovesIssuedCredential() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
+
+        // Obtain credential
+        String accessToken = tokenResponse.getAccessToken();
+        String refreshToken = tokenResponse.getRefreshToken();
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        List<IssuedVerifiableCredentialRepresentation> before = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, before.size(), "Single issued credential should be stored");
+
+        TokenRevocationResponse response = oauth.doTokenRevoke(refreshToken);
+        assertEquals(200, response.getStatusCode(), "Expected 200 OK response");
+
+        List<IssuedVerifiableCredentialRepresentation> after = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(0, after.size(), "IssuedVerifiableCredential row must be deleted when OID4VCI refresh token is revoked");
+    }
+
+    /**
+     *   Revoking an OID4VCI access token MUST block subsequent credential endpoint requests
+     *   that carry that same access token.
+     */
+    @Test
+    public void testRevokeAccessTokenBlocksCredentialEndpoint() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
+
+        // Obtain credential
+        String accessToken = tokenResponse.getAccessToken();
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        //Revoke the access token
+        TokenRevocationResponse response = oauth.doTokenRevoke(accessToken);
+        assertEquals(200, response.getStatusCode(), "Expected 200 OK response");
+
+        //Second credential request with revoked access token must fail
+        String cNonce = oauth.oid4vc().nonceRequest().send().getNonce();
+        Proofs proofs = OID4VCProofTestUtils.jwtProofs(
+                getCredentialIssuerMetadata().getCredentialIssuer(), cNonce);
+        Oid4vcCredentialResponse credentialResponse = oauth.oid4vc()
+                .credentialRequest()
+                .bearerToken(accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .proofs(proofs)
+                .send();
+
+        assertEquals(400, credentialResponse.getStatusCode(), "Credential request with revoked access token must be rejected");
+        assertEquals(ErrorType.INVALID_TOKEN.getValue(), credentialResponse.getError(), "Error must be invalid_token");
+    }
+
+    /**
+     *  Test checks idempotency of token revocation according to RFC 7009 (OAuth 2.0 Token Revocation)
+     */
+    @Test
+    public void testRevokeRefreshTokenIsIdempotent() {
+        AccessTokenResponse tokenResponse = authzCodeFlow();
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
+
+        // Obtain credential
+        String accessToken = tokenResponse.getAccessToken();
+        String refreshToken = tokenResponse.getRefreshToken();
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        //first invocation
+        TokenRevocationResponse revocationResponse = oauth.doTokenRevoke(refreshToken);
+        assertEquals(200, revocationResponse.getStatusCode(), "Expected 200 OK response");
+
+        //second invocation
+        TokenRevocationResponse response = oauth.doTokenRevoke(refreshToken);
+        assertEquals(200, response.getStatusCode(), "Expected 200 OK response");
+    }
+
+    /**
+     *   OIDC Regression, Revoking a standard OIDC refresh token MUST
+     *   still invalidate the user session
+     */
+    @Test
+    public void testRevokeStandardOIDCRefreshTokenRevokesSession() {
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(user.getUsername(), user.getPassword());
+        assertTrue(response.isSuccess(), "Access token exchange should succeed");
+        String oidcRefreshToken = response.getRefreshToken();
+
+        TokenRevocationResponse revocationResponse = oauth.doTokenRevoke(oidcRefreshToken);
+        assertEquals(200, revocationResponse.getStatusCode(), "Expected 200 OK response");
+
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(oidcRefreshToken);
+
+        assertTrue(OAuthErrorException.INVALID_GRANT.equals(refreshResponse.getError())
+                        || OAuthErrorException.INVALID_TOKEN.equals(refreshResponse.getError()),
+                "Refresh with revoked token must fail: " + refreshResponse.getError());
+    }
+
+    /**
+     *  Test for revoking OID4VCI refresh token, which MUST perform BOTH effects:
+     *      (a) OID4VCI-specific: the Issued Verifiable Credential row is deleted
+     *      (b) OIDC baseline: the refresh token is no longer usable
+     */
+    @Test
+    public void testAdditiveRevocationSemantics() {
+        // Test for Part a
+        AccessTokenResponse tokenResponse = authzCodeFlow();
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
+
+        // Obtain credential
+        String accessToken = tokenResponse.getAccessToken();
+        String refreshToken = tokenResponse.getRefreshToken();
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        List<IssuedVerifiableCredentialRepresentation> before = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, before.size(), "Single issued credential should be stored");
+
+        TokenRevocationResponse response = oauth.doTokenRevoke(refreshToken);
+        assertEquals(200, response.getStatusCode(), "Expected 200 OK response");
+
+        List<IssuedVerifiableCredentialRepresentation> after = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(0, after.size(), "IssuedVerifiableCredential row must be deleted when OID4VCI refresh token is revoked");
+
+        // Test for part B
+        AccessTokenResponse refreshTokenResponse = oauth.doRefreshTokenRequest(refreshToken);
+        assertTrue(OAuthErrorException.INVALID_GRANT.equals(refreshTokenResponse.getError())
+                        || OAuthErrorException.INVALID_TOKEN.equals(refreshTokenResponse.getError())
+                        || OAuthErrorException.INVALID_REQUEST.equals(refreshTokenResponse.getError()),
+                "Refresh with revoked token must fail: " + refreshTokenResponse.getError());
+    }
+
+    private AccessTokenResponse authzCodeFlow() {
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(user.getUsername(), TEST_PASSWORD);
+        String code = authResponse.getCode();
+        assertNotNull(code, "Authorization code should not be null");
+
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, code).send();
+        assertNotNull(tokenResponse, "Token response should not be null");
+
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken, "No accessToken");
+        return tokenResponse;
+    }
+
+    protected CredentialIssuer getCredentialIssuerMetadata() {
+        CredentialIssuerMetadataResponse metadataResponse = oauth.oid4vc().doIssuerMetadataRequest();
+        return metadataResponse.getMetadata();
+    }
+}


### PR DESCRIPTION
Ensure IssuedVerifiableCredentialEntity records are removed when an OID4VCI refresh token is revoked via the OIDC revocation endpoint.

- Add revokeToken() to RefreshTokenProvider SPI as a default no-op.
- Implement session teardown in DefaultRefreshTokenProvider.
- Implement credential removal in OID4VCIRefreshTokenProvider.
- Update TokenRevocationEndpoint to delegate to the correct provider based on the "prov" token claim.

Closes #50341

