### PR TITLE
Skip user cache eviction when only lastSync timestamp changes

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -18,6 +18,7 @@
 package org.keycloak.models.cache.infinispan;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +32,7 @@ import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.enums.SslRequired;
+import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -63,6 +65,7 @@ import org.keycloak.models.cache.infinispan.entities.CachedRealm;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.UserStorageUtil;
 import org.keycloak.storage.client.ClientStorageProvider;
 
@@ -1722,9 +1725,72 @@ public class RealmAdapter implements CachedRealmModel {
     @Override
     public void updateComponent(ComponentModel component) {
         getDelegateForUpdate();
-        executeEvictions(component);
+        if (!isLastSyncOnlyUpdate(component)) {
+            executeEvictions(component);
+        }
         updated.updateComponent(component);
 
+    }
+
+    /**
+     * A user-storage sync ends by persisting the {@code lastSync} timestamp on the provider's
+     * component (see {@code UserStorageSyncTask#updateLastSyncInterval}). That update reloads the
+     * provider from the store and changes nothing but the {@code lastSync_*} config entries, yet it
+     * routes through {@link #updateComponent(ComponentModel)} which unconditionally evicts the whole
+     * realm's user cache via {@link #executeEvictions(ComponentModel)}. The {@code lastSync}
+     * timestamp is runtime bookkeeping and has no bearing on the staleness of cached users, so that
+     * eviction makes a long cache policy (e.g. {@code EVICT_DAILY}) ineffective in any realm that
+     * runs federation syncs.
+     * <p>
+     * Detect the case where a user-storage provider update only touches the {@code lastSync_*} keys
+     * so the eviction can be skipped; any user-affecting config change still evicts as before.
+     */
+    private boolean isLastSyncOnlyUpdate(ComponentModel updatedComponent) {
+        if (!UserStorageProvider.class.getName().equals(updatedComponent.getProviderType())) {
+            return false;
+        }
+
+        ComponentModel existing = getComponent(updatedComponent.getId());
+        if (existing == null) {
+            return false;
+        }
+
+        return onlyLastSyncChanged(existing.getConfig(), updatedComponent.getConfig());
+    }
+
+    /**
+     * Returns {@code true} only when every non-{@code lastSync} config entry is unchanged between the
+     * two configs and at least one {@code lastSync_*} entry actually differs — i.e. the update changes
+     * nothing but the {@code lastSync} bookkeeping. Returns {@code false} for any other config change,
+     * including a genuine no-op where the {@code lastSync} entries are identical.
+     */
+    private static boolean onlyLastSyncChanged(MultivaluedHashMap<String, String> existingConfig,
+                                               MultivaluedHashMap<String, String> updatedConfig) {
+        Set<String> keys = new HashSet<>(existingConfig.keySet());
+        keys.addAll(updatedConfig.keySet());
+
+        for (String key : keys) {
+            if (isLastSyncKey(key)) {
+                continue;
+            }
+            if (!Objects.equals(existingConfig.get(key), updatedConfig.get(key))) {
+                return false;
+            }
+        }
+
+        // The lastSync entries must actually differ, otherwise this is a genuine no-op update and we
+        // gain nothing by treating it specially.
+        for (String key : keys) {
+            if (isLastSyncKey(key) && !Objects.equals(existingConfig.get(key), updatedConfig.get(key))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isLastSyncKey(String key) {
+        return key != null && key.startsWith(UserStorageProviderModel.LAST_SYNC + "_");
     }
 
     @Override

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
@@ -23,6 +23,7 @@ import java.util.stream.IntStream;
 import javax.naming.directory.BasicAttribute;
 
 import org.keycloak.cluster.ClusterProvider;
+import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -31,6 +32,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.cache.CachedUserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.CacheableStorageProviderModel;
 import org.keycloak.storage.UserStoragePrivateUtil;
@@ -148,6 +150,73 @@ public class UserSyncTest extends KeycloakModelTest {
                 (float) (timeNeeded) / NUMBER_OF_USERS), timeNeeded, Matchers.lessThan((long) (18 * NUMBER_OF_USERS)));
         assertThat(res.getAdded(), is(NUMBER_OF_USERS));
         assertThat(withRealm(realmId, (session, realm) -> UserStoragePrivateUtil.userLocalStorage(session).getUsersCount(realm)), is(NUMBER_OF_USERS));
+    }
+
+    @Test
+    public void testUserCacheSurvivesLastSyncUpdate() {
+        // give the provider a caching policy so federated users are cached and the assertions below
+        // are meaningful regardless of the parameterized default (the assumeThat further down still
+        // covers configurations where the user cache is globally disabled)
+        withRealm(realmId, (session, realm) -> {
+            UserStorageProviderModel provider = new UserStorageProviderModel(realm.getComponent(userFederationId));
+            provider.setCachePolicy(CacheableStorageProviderModel.CachePolicy.EVICT_DAILY);
+            realm.updateComponent(provider);
+            return null;
+        });
+
+        // create a user in LDAP and read it so it gets cached
+        withRealm(realmId, (session, realm) -> {
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(realm);
+            LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, realm, "cacheuser", "CacheFN", "CacheLN", "cacheuser@email.org", "my-street 9", "1234");
+            return null;
+        });
+
+        Long firstCacheTimestamp = withRealm(realmId, (session, realm) -> {
+            UserModel user = session.users().getUserByUsername(realm, "cacheuser");
+            assertThat(user, is(notNullValue()));
+            return user instanceof CachedUserModel cached ? cached.getCacheTimestamp() : null;
+        });
+
+        // nothing to assert if this configuration does not cache federated users
+        assumeThat("Cannot run testUserCacheSurvivesLastSyncUpdate because federated users are not cached in this configuration",
+                firstCacheTimestamp, notNullValue());
+
+        // simulate the tail of a federation sync: persist only the lastSync timestamp on the provider
+        withRealm(realmId, (session, realm) -> {
+            UserStorageProviderModel provider = new UserStorageProviderModel(realm.getComponent(userFederationId));
+            provider.setLastSync(Time.currentTime(), UserStorageProviderModel.SyncMode.FULL);
+            realm.updateComponent(provider);
+            return null;
+        });
+
+        // the cached user must survive the lastSync bump (same cache timestamp => not evicted/reloaded)
+        withRealm(realmId, (session, realm) -> {
+            UserModel user = session.users().getUserByUsername(realm, "cacheuser");
+            assertThat(user, Matchers.instanceOf(CachedUserModel.class));
+            assertThat(((CachedUserModel) user).getCacheTimestamp(), is(firstCacheTimestamp));
+            return null;
+        });
+
+        // sanity check: a genuine (non-lastSync) config change still evicts the user cache
+        try {
+            Time.setOffset(10); // ensure a reload gets a strictly later cache timestamp
+            withRealm(realmId, (session, realm) -> {
+                UserStorageProviderModel provider = new UserStorageProviderModel(realm.getComponent(userFederationId));
+                provider.getConfig().putSingle("someUserAffectingSetting", "changed");
+                realm.updateComponent(provider);
+                return null;
+            });
+
+            withRealm(realmId, (session, realm) -> {
+                UserModel user = session.users().getUserByUsername(realm, "cacheuser");
+                assertThat(user, Matchers.instanceOf(CachedUserModel.class));
+                assertThat(((CachedUserModel) user).getCacheTimestamp(), is(not(firstCacheTimestamp)));
+                return null;
+            });
+        } finally {
+            Time.setOffset(0);
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #50596

## The problem

Every user-storage sync ends by persisting the `lastSync` timestamp on the
provider's component via `RealmModel.updateComponent`
(`UserStorageSyncTask#updateLastSyncInterval`).

In the infinispan cache adapter, `RealmAdapter.updateComponent` unconditionally
calls `executeEvictions`, which — for any `UserStorageProvider` component —
evicts the **entire realm's user cache**. So every periodic or manual sync,
even a no-op one, flushes all cached users. This makes a long cache policy such
as `EVICT_DAILY` effectively useless in any realm that runs federation syncs.

## The fix

The `lastSync` timestamp is runtime bookkeeping and has no bearing on the
staleness of cached users, so evicting for it is unnecessary.

`RealmAdapter.updateComponent` now skips the eviction when a user-storage
provider update changes **only** the `lastSync_*` config entries. This is
detected by comparing the incoming component against the currently stored one:
the eviction is skipped only when every non-`lastSync` config entry is
unchanged and at least one `lastSync_*` entry actually differs. Any
user-affecting config change still evicts the cache exactly as before.

This keeps the "when to invalidate" decision in a single place
(`RealmAdapter`), rather than special-casing the `lastSync` write in the sync
task.

## Testing

Added `UserSyncTest#testUserCacheSurvivesLastSyncUpdate`, which:
- caches a federated user, then persists a `lastSync`-only update and asserts
  the user survives in the cache (same cache timestamp) — this fails without
  the change;
- performs a genuine config change and asserts the user cache is still evicted.
