### PR TITLE
Use custom implementation instead of uuid for web-crypto-shim

### DIFF
--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -481,9 +481,6 @@ importers:
       rfc4648:
         specifier: ^1.5.4
         version: 1.5.4
-      uuid:
-        specifier: ^14.0.1
-        version: 14.0.1
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^29.0.0

--- a/js/themes-vendor/package.json
+++ b/js/themes-vendor/package.json
@@ -27,8 +27,7 @@
     "patternfly": "^3.59.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "rfc4648": "^1.5.4",
-    "uuid": "^14.0.1"
+    "rfc4648": "^1.5.4"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^29.0.0",

--- a/js/themes-vendor/src/main/js/web-crypto-shim.js
+++ b/js/themes-vendor/src/main/js/web-crypto-shim.js
@@ -1,5 +1,4 @@
 import { sha256, sha384 } from "@noble/hashes/sha2.js";
-import { v4 as uuidv4 } from "uuid";
 
 // Shim for Web Crypto API specifically for Keycloak JS, as this API can sometimes be missing, for example in an insecure context:
 // https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
@@ -41,7 +40,17 @@ if (typeof crypto.getRandomValues === "undefined") {
 if (typeof crypto.randomUUID === "undefined") {
   Object.defineProperty(crypto, "randomUUID", {
     value: () => {
-      return uuidv4();
+      const arr = new Uint8Array(16);
+      crypto.getRandomValues(arr);
+
+      // UUID version (4) and variant (1: 10xx)
+      arr[6] = (arr[6] & 0x0f) | 0x40; // bits 12-15 are 0100
+      arr[8] = (arr[8] & 0x3f) | 0x80; // bits 14-15 are 10
+
+      // Convert to hex string
+      return Array.from(arr, (v) => v.toString(16).padStart(2, "0"))
+        .join("")
+        .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, "$1-$2-$3-$4-$5");
     },
   });
 }


### PR DESCRIPTION
Closes #50633

Starting with `uuid` version 14.0.0, the implementation relies on the web crypto API. So we need to implement our own implementation for the non secure context (only for development).
