### PR TITLE
fix: adding more context to deprecated yet default features

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,7 +46,15 @@ import org.jboss.logging.Logger;
  */
 public class Profile {
 
+    private static final String FEATURES_ENABLED = "{0} features enabled: {1}";
+
     private static volatile Map<String, TreeSet<Feature>> FEATURES;
+    
+    public static enum Enablement {
+        VERSIONED,
+        UNVERSIONED,
+        DEFAULT
+    }
 
     public enum Feature {
         AUTHORIZATION("Authorization Service", Type.DEFAULT),
@@ -349,6 +358,7 @@ public class Profile {
     private final ProfileName profileName;
 
     private final Map<Feature, Boolean> features;
+    private final Map<Feature, Enablement> enablements;
 
     public static Profile defaults() {
         return configure();
@@ -358,6 +368,8 @@ public class Profile {
         ProfileName profile = Arrays.stream(resolvers).map(ProfileConfigResolver::getProfileName).filter(Objects::nonNull).findFirst().orElse(ProfileName.DEFAULT);
 
         Map<Feature, Boolean> features = new LinkedHashMap<>();
+
+        Map<Feature, Enablement> enablements = new LinkedHashMap<Profile.Feature, Enablement>();
 
         for (Map.Entry<String, TreeSet<Feature>> entry : getOrderedFeatures().entrySet()) {
 
@@ -407,6 +419,10 @@ public class Profile {
                     break;
                 }
             }
+            if (enabledFeature != null) {
+                enablements.put(enabledFeature, isExplicitlyEnabledFeature ? Enablement.VERSIONED
+                        : unversionedConfig == FeatureConfig.ENABLED ? Enablement.UNVERSIONED : Enablement.DEFAULT);
+            }
             for (Feature f : entry.getValue()) {
                 features.put(f, f == enabledFeature);
             }
@@ -414,7 +430,7 @@ public class Profile {
 
         verifyConfig(features);
 
-        return init(profile, features);
+        return init(profile, features, enablements);
     }
 
     private static boolean isEnabledByDefault(ProfileName profile, Feature f) {
@@ -490,13 +506,18 @@ public class Profile {
     }
 
     public static Profile init(ProfileName profileName, Map<Feature, Boolean> features) {
-        CURRENT = new Profile(profileName, features);
+        return init(profileName, features, Collections.emptyMap());
+    }
+
+    public static Profile init(ProfileName profileName, Map<Feature, Boolean> features, Map<Feature, Enablement> enablements) {
+        CURRENT = new Profile(profileName, features, enablements);
         return CURRENT;
     }
 
-    private Profile(ProfileName profileName, Map<Feature, Boolean> features) {
+    private Profile(ProfileName profileName, Map<Feature, Boolean> features, Map<Feature, Enablement> enablements) {
         this.profileName = profileName;
         this.features = Collections.unmodifiableMap(features);
+        this.enablements = Collections.unmodifiableMap(enablements);
     }
 
     public static Profile getInstance() {
@@ -579,16 +600,25 @@ public class Profile {
     public void logUnsupportedFeatures() {
         logUnsupportedFeatures(Feature.Type.PREVIEW, getPreviewFeatures(), Logger.Level.INFO);
         logUnsupportedFeatures(Feature.Type.EXPERIMENTAL, getExperimentalFeatures(), Logger.Level.WARN);
-        logUnsupportedFeatures(Feature.Type.DEPRECATED, getDeprecatedFeatures(), Logger.Level.WARN);
+        Set<Feature> deprecatedFeatures = getDeprecatedFeatures();
+        logUnsupportedFeatures(Feature.Type.DEPRECATED, deprecatedFeatures, Logger.Level.WARN,
+                feature -> Enablement.VERSIONED.equals(enablements.get(feature)), FEATURES_ENABLED);
+        logUnsupportedFeatures(Feature.Type.DEPRECATED, deprecatedFeatures, Logger.Level.WARN,
+                feature -> !Enablement.VERSIONED.equals(enablements.get(feature)),
+                "Deprecated features {1} enabled by default. Check the upgrading guide for steps to use later versions if available.");
     }
 
     private void logUnsupportedFeatures(Feature.Type type, Set<Feature> checkedFeatures, Logger.Level level) {
-        String enabledFeaturesOfType = features.entrySet().stream()
-                .filter(e -> e.getValue() && checkedFeatures.contains(e.getKey()))
-                .map(e -> e.getKey().getVersionedKey()).sorted().collect(Collectors.joining(", "));
+        logUnsupportedFeatures(type, checkedFeatures, level, ignored -> true, FEATURES_ENABLED);
+    }
+
+    private void logUnsupportedFeatures(Feature.Type type, Set<Feature> checkedFeatures, Logger.Level level, Predicate<Feature> predicate, String message) {
+        String enabledFeaturesOfType = checkedFeatures.stream()
+                .filter(e -> Boolean.TRUE.equals(features.get(e)) && predicate.test(e))
+                .map(e -> e.getVersionedKey()).sorted().collect(Collectors.joining(", "));
 
         if (!enabledFeaturesOfType.isEmpty()) {
-            logger.logv(level, "{0} features enabled: {1}", type.getLabel(), enabledFeaturesOfType);
+            logger.logv(level, message, type.getLabel(), enabledFeaturesOfType);
         }
     }
 
@@ -599,5 +629,9 @@ public class Profile {
         ROLLING_NO_UPGRADE,
         // Always require a cluster shutdown when the Feature is enabled/disabled
         SHUTDOWN;
+    }
+
+    public Map<Feature, Enablement> getEnablements() {
+        return enablements;
     }
 }

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -269,9 +269,9 @@ class KeycloakProcessor {
     @Produce(ProfileBuildItem.class)
     void configureProfile(KeycloakRecorder recorder) {
         Profile profile = getCurrentOrCreateFeatureProfile();
-
+        Profile.getInstance().logUnsupportedFeatures();
         // record the features so that they are not calculated again at runtime
-        recorder.configureProfile(profile.getName(), profile.getFeatures());
+        recorder.configureProfile(profile.getName(), profile.getFeatures(), profile.getEnablements());
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -31,6 +31,8 @@ import org.keycloak.Config;
 import org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticatorMetadata;
 import org.keycloak.authentication.authenticators.browser.WebAuthnMetadataService;
 import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Enablement;
+import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.crypto.FipsMode;
@@ -87,8 +89,8 @@ public class KeycloakRecorder {
         }
     }
 
-    public void configureProfile(Profile.ProfileName profileName, Map<Profile.Feature, Boolean> features) {
-        Profile.init(profileName, features);
+    public void configureProfile(Profile.ProfileName profileName, Map<Profile.Feature, Boolean> features, Map<Feature, Enablement> enablements) {
+        Profile.init(profileName, features, enablements);
     }
 
     // default handler for redirecting to specific path

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -25,6 +25,7 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
+import org.keycloak.quarkus.runtime.cli.command.Build;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.NestedPropertyMappingInterceptor;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
@@ -317,7 +318,7 @@ public final class PropertyMappers {
                 PersistedConfigSource.getInstance().runWithDisabled(Environment::getCurrentOrCreateFeatureProfile);
             } else {
                 Environment.getCurrentOrCreateFeatureProfile();
-                if (!command.shouldStart()) {
+                if (!command.shouldStart() && !Build.NAME.equals(command.getName())) {
                     // this will use the deferred logger, which means it may not be seen in some circumstances
                     Profile.getInstance().logUnsupportedFeatures();
                 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -144,4 +144,21 @@ class BuildCommandDistTest {
     void multiSiteDoesNotRequireRuntimeOptions(CLIResult cliResult) {
         cliResult.assertBuild();
     }
+    
+    @Test
+    @RawDistOnly(reason = "Containers are immutable")
+    void deprecatedByDefaultWarning(KeycloakRunner runner) {
+        CLIResult cliResult = runner.run("build", "--db=dev-file");
+        cliResult.assertBuild();
+        cliResult.assertMessage("Deprecated features identity-brokering-api:v1, twitter-broker:v1 enabled by default. Check the upgrading guide for steps to use later versions if available.");
+        cliResult.assertNoMessage("Deprecated features enabled:");
+        
+        cliResult = runner.run("build", "--db=dev-file", "--features=identity-brokering-api:v2");
+        cliResult.assertBuild();
+        cliResult.assertMessage("Deprecated features twitter-broker:v1 enabled by default. Check the upgrading guide for steps to use later versions if available.");
+        
+        cliResult = runner.run("build", "--db=dev-file", "--features=identity-brokering-api");
+        cliResult.assertBuild();
+        cliResult.assertMessage("Deprecated features identity-brokering-api:v1, twitter-broker:v1 enabled by default. Check the upgrading guide for steps to use later versions if available.");
+    }
 }


### PR DESCRIPTION
closes: #50054

Adds more context to the warning about a deprecated, yet enabled by default feature.

There are two cases now for default deprecation:

twitter-broker:v1 - no replacement version available. For the admin to suppress this warning, they need to add it to features-disabled. Then remove that override for 27.0 as the feature key will no longer be valid.

identity-brokering-api:v1 - v2 is available, but may be a breaking change. For the admin to suppress this warning, they need to add it to features-disabled or switch to v2. If they use v2, then for KC 27.0 they can either leave that explicit version in place, or if we are still going to treat v2 as the default, remove it.

There are three cases for how these are enabled:
versioned: --features=feature:vX
unversioned: --features=feature
default

I had started down the path of differentiating the message for all three, but that probably isn't worth it. So what is here will use the standard warning if versioned. Otherwise it will use a warning with a bit more context on why this happening. However based upon the remediation from above, I struggled to come up with something succinct yet meaningful message to describe why this is happening and what to do about it.

If it turns out that the message in the pr doesn't seem to add much value, then we can simply show the simple warning message.

In general we should still have a conversation about how to avoid this situation in the future - possibly by being more stringent about what can be enabled by default.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
