### PR TITLE
Fix ConcurrentModificationException updating organization attributes

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -149,7 +149,10 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
         }
 
         try {
-            Set<String> attrsToRemove = getAttributes().keySet();
+            // getAttributes() can expose the group's shared cached attribute map; work off a
+            // copy so we don't structurally modify its live keySet while concurrent requests
+            // read it, which throws ConcurrentModificationException.
+            Set<String> attrsToRemove = new HashSet<>(getAttributes().keySet());
             attrsToRemove.removeAll(attributes.keySet());
             attrsToRemove.forEach(group::removeAttribute);
             attributes.forEach(group::setAttribute);


### PR DESCRIPTION
Two concurrent `PUT /admin/realms/{realm}/organizations/{id}` calls can blow up with a `ConcurrentModificationException` and a 500, and the update gets rolled back.

`setAttributes` was calling `removeAll` straight on `getAttributes().keySet()`. That map can be the group's shared cached map (Infinispan `CachedGroup` hands out one `MultivaluedHashMap`), so one request mutates it while another iterates it. Copying the keys into a `HashSet` first fixes it.

I went with the contained fix. The alternative is to have the cache-layer `getAttributes()` return a copy so no caller can ever mutate the shared map, but that's a broader read-semantics change. The contained fix looks enough for the reported race (attribute updates invalidate and replace the cached entry, they don't mutate it), so once `removeAll` is gone the only access left is the copy. Happy to move the guard into `getAttributes()` if you'd prefer.

Regression test in `OrganizationTest` fails on `main`, passes with the fix. `spotless:check` clean.

Closes #50590
