### PR TITLE
Pre-authentication username enumeration via username/delegation scope types

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -463,7 +463,7 @@ public class TokenManager {
         Set<ClientScopeModel> clientScopes;
 
         if (Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES)) {
-            clientScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, client, scopeParam)
+            clientScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, client, userSession.getUser(), scopeParam)
                     .collect(Collectors.toSet());
         } else {
             clientScopes = getRequestedClientScopes(session, scopeParam, client, userSession.getUser())
@@ -811,7 +811,7 @@ public class TokenManager {
 
         if (Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES)) {
             AuthorizationRequestContext ctx = AuthorizationContextUtil.getAuthorizationRequestContextFromScopesWithClient(
-                    session, client, scopeParam);
+                    session, client, user, scopeParam);
             return ctx.getAuthorizationDetailEntries().stream()
                     .noneMatch(authDetails -> !isGrantedConsent(client, user, grantedConsent, authDetails.getClientScope(),
                     authDetails.getParameterizedScopeParam(), alwaysConsent));

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
@@ -182,7 +182,8 @@ public class BackchannelAuthenticationEndpoint extends AbstractCibaEndpoint {
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "missing parameter : scope",
                     Response.Status.BAD_REQUEST);
         }
-        if (!TokenManager.isValidScope(session, scope, client, user)) {
+        // User is only identified (login_hint), not authenticated yet — validate without user to prevent username enumeration via scope parameters
+        if (!TokenManager.isValidScope(session, scope, client)) {
             throw new ErrorResponseException(OAuthErrorException.INVALID_SCOPE, "Invalid scopes: " + scope,
                     Response.Status.BAD_REQUEST);
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/scope/UsernameScopeType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/scope/UsernameScopeType.java
@@ -40,7 +40,6 @@ public class UsernameScopeType implements ParameterizedScopeTypeProvider {
         if (StringUtil.isBlank(parameter)) {
             throw new InvalidScopeParameterException("Username parameter must not be blank");
         }
-        resolveUser(scope, parameter);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1287,7 +1287,7 @@ public class AuthenticationManager {
         //if Parameterized Scopes are enabled, get the scopes from the AuthorizationRequestContext, passing the session and scopes as parameters
         // then concat a Stream with the ClientModel, as it's discarded in the getAuthorizationRequestContext method
         if (Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES)) {
-            return AuthorizationContextUtil.getAuthorizationRequestsStreamFromScopesWithClient(session, client, authSession.getClientNote(OAuth2Constants.SCOPE));
+            return AuthorizationContextUtil.getAuthorizationRequestsStreamFromScopesWithClient(session, client, authSession.getAuthenticatedUser(), authSession.getClientNote(OAuth2Constants.SCOPE));
         }
         // if parameterized scopes are not enabled, we retain the old behaviour, but the ClientScopes will be wrapped in
         // AuthorizationRequest objects to standardize the code handling these.

--- a/services/src/main/java/org/keycloak/services/util/AuthorizationContextUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/AuthorizationContextUtil.java
@@ -80,7 +80,11 @@ public class AuthorizationContextUtil {
      * @return an {@link AuthorizationRequestContext} with scope entries and a ClientModel
      */
     public static AuthorizationRequestContext getAuthorizationRequestContextFromScopesWithClient(KeycloakSession session, ClientModel client, String scope) {
-        AuthorizationRequestContext authorizationRequestContext = getAuthorizationRequestContextFromScopes(session, client, null, scope);
+        return getAuthorizationRequestContextFromScopesWithClient(session, client, null, scope);
+    }
+
+    public static AuthorizationRequestContext getAuthorizationRequestContextFromScopesWithClient(KeycloakSession session, ClientModel client, UserModel user, String scope) {
+        AuthorizationRequestContext authorizationRequestContext = getAuthorizationRequestContextFromScopes(session, client, user, scope);
         authorizationRequestContext.getAuthorizationDetailEntries().add(new AuthorizationDetails(client));
         return authorizationRequestContext;
     }
@@ -93,7 +97,11 @@ public class AuthorizationContextUtil {
      * @return a Stream of {@link AuthorizationDetails} containing a ClientModel
      */
     public static Stream<AuthorizationDetails> getAuthorizationRequestsStreamFromScopesWithClient(KeycloakSession session, ClientModel client, String scope) {
-        AuthorizationRequestContext authorizationRequestContext = getAuthorizationRequestContextFromScopesWithClient(session, client, scope);
+        return getAuthorizationRequestsStreamFromScopesWithClient(session, client, null, scope);
+    }
+
+    public static Stream<AuthorizationDetails> getAuthorizationRequestsStreamFromScopesWithClient(KeycloakSession session, ClientModel client, UserModel user, String scope) {
+        AuthorizationRequestContext authorizationRequestContext = getAuthorizationRequestContextFromScopesWithClient(session, client, user, scope);
         return authorizationRequestContext.getAuthorizationDetailEntries().stream();
     }
 
@@ -104,7 +112,11 @@ public class AuthorizationContextUtil {
      * @return see description
      */
     public static Stream<ClientScopeModel> getClientScopesStreamFromAuthorizationRequestContextWithClient(KeycloakSession session, ClientModel client, String scope) {
-        return getAuthorizationRequestContextFromScopesWithClient(session, client, scope).getAuthorizationDetailEntries().stream()
+        return getClientScopesStreamFromAuthorizationRequestContextWithClient(session, client, null, scope);
+    }
+
+    public static Stream<ClientScopeModel> getClientScopesStreamFromAuthorizationRequestContextWithClient(KeycloakSession session, ClientModel client, UserModel user, String scope) {
+        return getAuthorizationRequestContextFromScopesWithClient(session, client, user, scope).getAuthorizationDetailEntries().stream()
                 .filter(authorizationDetails -> authorizationDetails.getSource() == AuthorizationRequestSource.SCOPE)
                 .map(AuthorizationDetails::getClientScope);
     }

--- a/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
+++ b/services/src/main/java/org/keycloak/services/util/DefaultClientSessionContext.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -37,6 +38,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.protocol.ProtocolMapperUtils;
@@ -96,11 +98,12 @@ public class DefaultClientSessionContext implements ClientSessionContext {
 
 
     public static DefaultClientSessionContext fromClientSessionAndScopeParameter(AuthenticatedClientSessionModel clientSession, String scopeParam, KeycloakSession session) {
+        UserModel user = Optional.ofNullable(clientSession.getUserSession()).map(UserSessionModel::getUser).orElse(null);
         Stream<ClientScopeModel> requestedScopes;
         if (Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES)) {
-            requestedScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, clientSession.getClient(), scopeParam);
+            requestedScopes = AuthorizationContextUtil.getClientScopesStreamFromAuthorizationRequestContextWithClient(session, clientSession.getClient(), user, scopeParam);
         } else {
-            requestedScopes = TokenManager.getRequestedClientScopes(session, scopeParam, clientSession.getClient(), clientSession.getUserSession().getUser());
+            requestedScopes = TokenManager.getRequestedClientScopes(session, scopeParam, clientSession.getClient(), user);
         }
         return new DefaultClientSessionContext(clientSession, requestedScopes.collect(Collectors.toSet()), null, scopeParam, session);
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesIsolationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesIsolationTest.java
@@ -4,10 +4,11 @@ import java.util.List;
 
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.OAuthErrorException;
 import org.keycloak.common.Profile;
+import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse;
 import org.keycloak.protocol.oidc.mappers.ParameterizedScopeMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
@@ -16,8 +17,10 @@ import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.InjectUser;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.CibaProvider;
 import org.keycloak.testframework.oauth.DefaultOAuthClientConfiguration;
 import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectCibaProvider;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ClientBuilder;
 import org.keycloak.testframework.realm.ManagedRealm;
@@ -33,6 +36,7 @@ import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.ciba.AuthenticationRequestAcknowledgement;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -69,6 +73,9 @@ public class ParameterizedScopesIsolationTest {
 
     @InjectOAuthClient(config = TestOAuthClientConfig.class)
     OAuthClient oauth;
+
+    @InjectCibaProvider
+    CibaProvider ciba;
 
     @Test
     public void isolationAcrossCodeExchangeAndRefresh() {
@@ -146,10 +153,55 @@ public class ParameterizedScopesIsolationTest {
         String requestedScope = scopeName + ":target@localhost";
         createAndAssignParameterizedScope(scopeName, "username");
 
+        AuthorizationEndpointResponse authResponse = oauth.loginForm()
+                .scope(requestedScope)
+                .doLogin(USERNAME, PASSWORD);
+        assertTrue(authResponse.isRedirected());
+
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(authResponse.getCode());
+        assertTrue(tokenResponse.isSuccess());
+        assertScopeNotContains(tokenResponse.getScope(), requestedScope);
+    }
+
+    @Test
+    public void usernameScopeTypeDoesNotLeakUserExistence() {
+        String scopeName = "user-check";
+        String requestedScope = scopeName + ":nonexistent-user";
+        createAndAssignParameterizedScope(scopeName, "username");
+
+        AuthorizationEndpointResponse authResponse = oauth.loginForm()
+                .scope(requestedScope)
+                .doLogin(USERNAME, PASSWORD);
+        assertTrue(authResponse.isRedirected());
+
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(authResponse.getCode());
+        assertTrue(tokenResponse.isSuccess());
+        assertScopeNotContains(tokenResponse.getScope(), requestedScope);
+    }
+
+    @Test
+    public void cibaUsernameScopeTypeDoesNotLeakUserExistence() throws Exception {
+        String scopeName = "ciba-user-check";
+        String requestedScope = scopeName + ":nonexistent-user";
+        createAndAssignParameterizedScope(scopeName, "username");
+
         oauth.scope(requestedScope);
-        oauth.openLoginForm();
-        AuthorizationEndpointResponse res = oauth.parseLoginResponse();
-        assertEquals(OAuthErrorException.INVALID_SCOPE, res.getError());
+        AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(USERNAME)
+                .bindingMessage("ciba-binding-msg")
+                .clientNotificationToken("ciba-notification-token")
+                .send();
+        assertTrue(response.isSuccess());
+        assertNotNull(response.getAuthReqId());
+
+        CibaProvider.CibaAuthenticationChannelRequest authChannelReq = ciba.getAuthChannel("ciba-binding-msg");
+        assertEquals(Response.Status.OK.getStatusCode(),
+                oauth.ciba().doAuthenticationChannelCallback(authChannelReq.getBearerToken(), AuthenticationChannelResponse.Status.SUCCEED));
+
+        ciba.getPushedCibaClientNotification("ciba-notification-token");
+
+        AccessTokenResponse tokenResponse = oauth.ciba().doBackchannelAuthenticationTokenRequest(response.getAuthReqId());
+        assertTrue(tokenResponse.isSuccess());
+        assertScopeNotContains(tokenResponse.getScope(), requestedScope);
     }
 
     @Test
@@ -303,14 +355,20 @@ public class ParameterizedScopesIsolationTest {
     static class TestOAuthClientConfig extends DefaultOAuthClientConfiguration {
         @Override
         public ClientBuilder configure(ClientBuilder client) {
-            return super.configure(client).consentRequired(false);
+            return super.configure(client)
+                    .consentRequired(false)
+                    .attribute(CibaConfig.CIBA_BACKCHANNEL_TOKEN_DELIVERY_MODE_PER_CLIENT, "ping")
+                    .attribute(CibaConfig.CIBA_BACKCHANNEL_CLIENT_NOTIFICATION_ENDPOINT, "http://localhost:8500/ciba/push-ciba-client-notification")
+                    .attribute(CibaConfig.OIDC_CIBA_GRANT_ENABLED, Boolean.TRUE.toString());
         }
     }
 
     public static class ParameterizedScopesServerConfig implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.PARAMETERIZED_SCOPES);
+            return config.features(Profile.Feature.PARAMETERIZED_SCOPES)
+                    .option("spi-ciba-auth-channel-ciba-http-auth-channel-http-authentication-channel-uri",
+                            "http://localhost:8500/ciba/request-authentication-channel");
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesOAuthGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesOAuthGrantTest.java
@@ -561,6 +561,41 @@ public class ParameterizedScopesOAuthGrantTest {
     }
 
     @Test
+    public void consentPageExcludesInvalidUsernameScopeParam() {
+        realm.updateClientScope(PARAMETERIZED_SCOPE_ID, s -> s.attribute(ClientScopeModel.CONSENT_SCREEN_TEXT, ""));
+
+        ClientScopeRepresentation usernameScope = ParameterizedScopeBuilder.create("user-scope")
+                .parameterizedScopeType("username")
+                .displayOnConsentScreen(true)
+                .build();
+        String usernameScopeId = ApiUtil.getCreatedId(realm.admin().clientScopes().create(usernameScope));
+        thirdParty.admin().addOptionalClientScope(usernameScopeId);
+        realm.cleanup().add(r -> {
+            r.clients().get(thirdParty.getId()).removeOptionalClientScope(usernameScopeId);
+            r.clientScopes().get(usernameScopeId).remove();
+        });
+
+        oauth.client(THIRD_PARTY_APP, "password");
+        oauth.scope("foo-parameter-scope:param1 user-scope:nonexistent-user");
+        oauth.openLoginForm();
+        oauth.fillLoginForm(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        grantPage.assertCurrent();
+
+        List<String> grants = grantPage.getDisplayedGrants();
+        Assertions.assertTrue(grants.contains("foo-parameter-scope: param1"),
+                "Valid string scope should be on consent page");
+        Assertions.assertTrue(grants.stream().noneMatch(g -> g.contains("user-scope")),
+                "Invalid username scope should NOT be on consent page");
+        grantPage.accept();
+
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse res = oauth.doAccessTokenRequest(code);
+        Assertions.assertTrue(res.isSuccess());
+        MatcherAssert.assertThat(scopesOf(res), Matchers.hasItems("foo-parameter-scope:param1"));
+        MatcherAssert.assertThat(scopesOf(res), Matchers.not(Matchers.hasItems("user-scope:nonexistent-user")));
+    }
+
+    @Test
     public void oauthGrantCustomRegexScopeValidation() {
         ClientScopeRepresentation customScope = ParameterizedScopeBuilder.create("custom-regex-scope")
                 .parameterizedScopeType("custom")

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenExchangeDelegationTest.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
@@ -49,12 +48,14 @@ import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.OAuthGrantPage;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
+import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.LogoutResponse;
 import org.keycloak.testsuite.util.oauth.ciba.AuthenticationRequestAcknowledgement;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -92,15 +93,24 @@ public class TokenExchangeDelegationTest {
     @InjectPage
     protected OAuthGrantPage grantPage;
 
+    @AfterEach
+    public void afterEach() {
+        AccountHelper.logout(realm.admin(), USERNAME);
+        List<Map<String, Object>> consents = AccountHelper.getUserConsents(realm.admin(), USERNAME);
+        if (consents.stream().anyMatch(m -> oauth.getClientId().equals(m.get("clientId")))) {
+            AccountHelper.revokeConsents(realm.admin(), USERNAME, oauth.getClientId());
+        }
+    }
+
     @Test
     public void delegationNoImpersonation() {
-        // request delegation with a user that cannot impersonate
+        // request delegation with a user that cannot impersonate — scope is silently dropped
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         oauth.scope(scope).openLoginForm();
         oauth.fillLoginForm(USERNAME, PASSWORD);
         grantPage.assertCurrent();
         List<String> grants = grantPage.getDisplayedGrants();
-        MatcherAssert.assertThat(grants, Matchers.hasItem("Delegate token to administrator administrator?"));
+        MatcherAssert.assertThat(grants, Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token"))));
         grantPage.accept();
 
         EventRepresentation loginEvent = events.poll();
@@ -110,7 +120,7 @@ public class TokenExchangeDelegationTest {
                 .details(Details.USERNAME, USERNAME)
                 .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
 
-        // get the code and obtain the scope, should not be present as cannot impersonate
+        // delegation scope should not be present as user cannot impersonate
         String code = oauth.parseLoginResponse().getCode();
         AccessTokenResponse res = oauth.doAccessTokenRequest(code);
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
@@ -231,8 +241,8 @@ public class TokenExchangeDelegationTest {
     }
 
     @Test
-    public void cibaDelegationNoImpersonation() {
-        // client Backchannel Authentication Request
+    public void cibaDelegationNoImpersonation() throws Exception {
+        // request delegation with a user that cannot impersonate — scope is silently dropped
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         oauth.scope(scope);
         AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(USERNAME)
@@ -240,8 +250,24 @@ public class TokenExchangeDelegationTest {
                 .clientNotificationToken("client-notification-token")
                 .additionalParams(Map.of("user_device", "mobile"))
                 .send();
-        Assertions.assertFalse(response.isSuccess());
-        Assertions.assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
+        Assertions.assertTrue(response.isSuccess());
+        Assertions.assertNotNull(response.getAuthReqId());
+
+        CibaProvider.CibaAuthenticationChannelRequest clientAuthenticationChannelReq = ciba.getAuthChannel("asdfghjkl");
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(),
+                oauth.ciba().doAuthenticationChannelCallback(clientAuthenticationChannelReq.getBearerToken(), AuthenticationChannelResponse.Status.SUCCEED));
+
+        ClientNotificationEndpointRequest pushedClientNotification = ciba.getPushedCibaClientNotification("client-notification-token");
+        Assertions.assertEquals(pushedClientNotification.getAuthReqId(), response.getAuthReqId());
+
+        // delegation scope should not be present as user cannot impersonate
+        AccessTokenResponse res = oauth.ciba().doBackchannelAuthenticationTokenRequest(response.getAuthReqId());
+        Assertions.assertTrue(res.isSuccess());
+        assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
+
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
     }
 
     @Test


### PR DESCRIPTION
- Closes #50468
- Removed user store lookup from pre-auth scope validation to prevent unauthenticated username enumeration via `username`/`delegation` scope types
- Fixed missing user propagation in post-auth scope resolution so scopes with non-existent or disabled users are properly dropped from tokens and the consent page
- Invalid parameterized scopes are silently dropped per RFC 6749 Section 3.3

**QUESTION:** However, for some cases like for the `delegate` scope, we may want to have hard-error when the scope contains invalid parameter instead of ignoring, right? 

EDIT: I was thinking about the hard error approach, but it's quite a complex topic to handle. We'd need to return an error `invalid_scope` after the user is authenticated (before the consent page), or maybe at the token endpoint as the scopes are obtained from the "code" attributes. The error would be just for DevEx, as the client would see the error explicitly (but we probably don't want to share the details about what's wrong with the scope to clients). Maybe it's just better to ignore the scope with the wrong parameter value, don't add it to the "scope" claim, and do not add the "may_act" claim either. Then, the client app knows the delegation was not successful and can make appropriate changes - probably no need to return the invalid_scope error for now?   

