### PR TITLE
fix: using the 26.6 release of the admin client with 26.6

### DIFF
--- a/operator/src/test/resources/example-realm.yaml
+++ b/operator/src/test/resources/example-realm.yaml
@@ -51,6 +51,7 @@ spec:
     quickLoginCheckMilliSeconds: 1000
     maxDeltaTimeSeconds: 43200
     failureFactor: 30
+    maxSecondaryAuthFailures: 100
     roles:
       realm:
       - id: c118f6c0-db44-4b29-a439-573b0d828e61

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
         <freemarker.version>2.3.32</freemarker.version>
         <sundrio.version>0.200.0</sundrio.version>
         <antlr4.version>4.13.2</antlr4.version>
+        <keycloak.admin.client.version>26.0.9</keycloak.admin.client.version>
 
         <!-- json-ld processing for oid4vci ld-proofs -->
         <com.apicatalog.titanium-json-ld.version>1.3.3</com.apicatalog.titanium-json-ld.version>
@@ -1352,6 +1353,19 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-scim-model</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <!-- overriding to a later keycloak-admin-client than quarkus is using
+                 so that the operator has up-to-date core classes  -->
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-admin-client</artifactId>
+                <version>${keycloak.admin.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-client-common-synced</artifactId>
+                <version>${keycloak.admin.client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
closes: #50582

Specialized backport of the main fix to just us a more up-to-date admin-client dependency. This however may still have problems later if additional fields are added to core classes in 26.6 backports without a corresponding update to the admin client version.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
