### PR TITLE
Apply X509 identity regex to SAN sources

### DIFF
--- a/common/src/main/java/org/keycloak/common/crypto/UserIdentityExtractorProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/UserIdentityExtractorProvider.java
@@ -21,7 +21,6 @@ package org.keycloak.common.crypto;
 
 import java.security.Principal;
 import java.security.cert.X509Certificate;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -80,7 +79,12 @@ public abstract class UserIdentityExtractorProvider {
 
         @Override
         public Object extractUserIdentity(X509Certificate[] certs) {
-            String value = Optional.ofNullable(_f.apply(certs)).orElseThrow(IllegalArgumentException::new);
+            String value = _f.apply(certs);
+
+            if (value == null) {
+                logger.debugf("[PatternMatcher:extract] No value was found for pattern=\"%s\"", _pattern);
+                return null;
+            }
 
             Pattern r = Pattern.compile(_pattern, Pattern.CASE_INSENSITIVE);
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
@@ -202,10 +202,10 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
                             .or(userIdExtractor.getX500NameExtractor("E", subject));
                     break;
                 case SUBJECTALTNAME_EMAIL:
-                    extractor = userIdExtractor.getSubjectAltNameExtractor(1);
+                    extractor = getPatternIdentityExtractor(userIdExtractor, pattern, userIdExtractor.getSubjectAltNameExtractor(1));
                     break;
                 case SUBJECTALTNAME_OTHERNAME:
-                    extractor = userIdExtractor.getSubjectAltNameExtractor(0);
+                    extractor = getPatternIdentityExtractor(userIdExtractor, pattern, userIdExtractor.getSubjectAltNameExtractor(0));
                     break;
                 case CERTIFICATE_PEM:
                     extractor = userIdExtractor.getCertificatePemIdentityExtractor();
@@ -215,6 +215,13 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
                     break;
             }
             return extractor;
+        }
+
+        private static UserIdentityExtractor getPatternIdentityExtractor(UserIdentityExtractorProvider userIdExtractor, String pattern, UserIdentityExtractor extractor) {
+            return userIdExtractor.getPatternIdentityExtractor(pattern, certs -> {
+                Object userIdentity = extractor.extractUserIdentity(certs);
+                return userIdentity == null ? null : userIdentity.toString();
+            });
         }
     }
 

--- a/services/src/test/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModelTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModelTest.java
@@ -1,7 +1,21 @@
 package org.keycloak.authentication.authenticators.x509;
 
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.security.cert.X509Certificate;
+
+import org.keycloak.common.crypto.UserIdentityExtractor;
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.common.util.StreamUtil;
+import org.keycloak.rule.CryptoInitRule;
+
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SERIALNUMBER;
+import static org.keycloak.authentication.authenticators.x509.X509AuthenticatorConfigModel.MappingSourceType.SUBJECTALTNAME_OTHERNAME;
 
 /**
  * author Pascal Knueppel <br>
@@ -10,6 +24,9 @@ import org.junit.Test;
  *
  */
 public class X509AuthenticatorConfigModelTest {
+
+    @ClassRule
+    public static CryptoInitRule cryptoInitRule = new CryptoInitRule();
 
     /**
      * this test will verify that no exception occurs if no settings are stored for the timestamp validation
@@ -39,5 +56,38 @@ public class X509AuthenticatorConfigModelTest {
         X509AuthenticatorConfigModel configModel = new X509AuthenticatorConfigModel();
         Assert.assertNull(configModel.getConfig().get(AbstractX509ClientCertificateAuthenticator.CERTIFICATE_POLICY_MODE));
         Assert.assertEquals(AbstractX509ClientCertificateAuthenticator.CERTIFICATE_POLICY_MODE_ALL, configModel.getCertificatePolicyMode().getMode());
+    }
+
+    @Test
+    public void testSubjectAltNameOtherNameUsesRegularExpression() throws Exception {
+        X509AuthenticatorConfigModel configModel = new X509AuthenticatorConfigModel()
+                .setMappingSourceType(SUBJECTALTNAME_OTHERNAME)
+                .setRegularExpression("(.*?)(?:@|$)");
+
+        UserIdentityExtractor extractor = AbstractX509ClientCertificateAuthenticator.UserIdentityExtractorBuilder.fromConfig(configModel);
+        String userIdentity = (String) extractor.extractUserIdentity(new X509Certificate[] { getCertificate("/certs/UPN-cert.pem") });
+
+        assertEquals("test-user", userIdentity);
+    }
+
+    @Test
+    public void testSerialNumberIgnoresRegularExpression() throws Exception {
+        X509Certificate certificate = getCertificate("/certs/UPN-cert.pem");
+        X509AuthenticatorConfigModel configModel = new X509AuthenticatorConfigModel()
+                .setMappingSourceType(SERIALNUMBER)
+                .setRegularExpression("(nomatch)");
+
+        UserIdentityExtractor extractor = AbstractX509ClientCertificateAuthenticator.UserIdentityExtractorBuilder.fromConfig(configModel);
+        String userIdentity = (String) extractor.extractUserIdentity(new X509Certificate[] { certificate });
+
+        assertEquals(certificate.getSerialNumber().toString(), userIdentity);
+    }
+
+    private X509Certificate getCertificate(String resourceFilename) throws Exception {
+        try (InputStream is = getClass().getResourceAsStream(resourceFilename)) {
+            Assert.assertNotNull("Test certificate resource not found: " + resourceFilename, is);
+            String certificate = StreamUtil.readString(is, Charset.defaultCharset());
+            return PemUtils.decodeCertificate(certificate);
+        }
     }
 }


### PR DESCRIPTION
Closes #41967

AI Code: This pull request includes code generated with AI assistance.

### Summary
- Apply the configured X.509 regular expression to SAN-based identity sources, including otherName UPN.
- Keep missing SAN values as a non-match instead of throwing from the pattern matcher.
- Add a unit test for extracting the username part from a SAN UPN.

### Testing
- Not run locally: JAVA_HOME/JDK is not configured in this environment.
- `git diff --check HEAD~1 HEAD`