### PR TITLE
Clear visual distinction for parameterized scope settings

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2516,6 +2516,7 @@ eventTypes.EXECUTE_ACTIONS.description=Execute actions
 userModelAttributeName=User model attribute name
 importResourceError=Could not import the resource due to {{error}}
 parameterizedScope=Parameterized scope
+parameterizedScopeSettings=Parameterized scope settings
 validateName=You must enter a name
 flowDetails=Flow details
 never=Never

--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -4,9 +4,11 @@ import {
   ActionGroup,
   Alert,
   Button,
+  Divider,
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Title,
 } from "@patternfly/react-core";
 import { useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
@@ -380,6 +382,9 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
             />
             {parameterizedScope === "true" && (
               <>
+                <Title headingLevel="h2" size="lg">
+                  {t("parameterizedScopeSettings")}
+                </Title>
                 <SelectControl
                   id="kc-parameter-type"
                   name={parameterTypeFieldName}
@@ -417,6 +422,7 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
                   labelIcon={t("repeatableScopeHelp")}
                   stringify
                 />
+                <Divider className="pf-v5-u-mb-sm" />
               </>
             )}
           </>


### PR DESCRIPTION
- Closes #50685
- Just minor visual improvement for better UX

### Old

https://github.com/user-attachments/assets/3dc4a253-f181-4fff-8dcd-85e28aac1860



### New


https://github.com/user-attachments/assets/4f304a72-c976-4767-bc59-6987d5164c6d

@edewit @keycloak/core-authn Could you please check it? Thanks!

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
