### PR TITLE
decouple ListOptions from Client fields

### DIFF
--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -37,7 +37,7 @@ public class ListOptions {
     @QueryParam("offset")
     protected Integer offset;
     
-    private transient List<SortOption> parsedSort;
+    private transient List<SortSegment> parsedSortSegments;
 
     public ListOptions fields(Set<String> fields) {
         this.setFields(fields);
@@ -54,7 +54,7 @@ public class ListOptions {
         return this;
     }
 
-    public ListOptions sort(List<SortOption> sort) {
+    public <F extends SortField> ListOptions sort(List<SortOption<F>> sort) {
         this.setSort(sort);
         return this;
     }
@@ -102,48 +102,79 @@ public class ListOptions {
         this.offset = offset;
     }
 
-    public List<SortOption> getSort() {
+    /**
+     * Parses the raw {@code sort} query parameter into an ordered list of segments
+     * (field name + direction), without resolving field names against any
+     * resource-specific field set. Use {@link #getSort(SortFieldResolver)} to resolve
+     * segments into typed {@link SortOption}s.
+     */
+    public List<SortSegment> getSortSegments() {
         if (sort == null) {
             return null;
         }
         if (sort.isEmpty()) {
             return List.of();
         }
-        if (parsedSort != null) {
-            return parsedSort;
+        if (parsedSortSegments != null) {
+            return parsedSortSegments;
         }
-        parsedSort = Arrays.stream(sort.split(","))
+        parsedSortSegments = Arrays.stream(sort.split(","))
                 .map(String::trim)
                 .filter(segment -> !segment.isEmpty())
                 .map(ListOptions::parseSortSegment)
                 .collect(Collectors.toUnmodifiableList());
-        if (parsedSort.isEmpty()) {
+        if (parsedSortSegments.isEmpty()) {
             throw new IllegalArgumentException("sort must specify at least one field");
         }
-        return parsedSort;
+        return parsedSortSegments;
     }
 
-    public void setSort(List<SortOption> sort) {
-        parsedSort = List.copyOf(sort);
+    /**
+     * Resolves the parsed {@code sort} segments against a resource-specific set of
+     * sortable fields.
+     *
+     * @throws IllegalArgumentException if a segment's field name cannot be resolved by {@code resolver}
+     */
+    public <F extends SortField> List<SortOption<F>> getSort(SortFieldResolver<F> resolver) {
+        List<SortSegment> segments = getSortSegments();
+        if (segments == null) {
+            return null;
+        }
+        if (segments.isEmpty()) {
+            return List.of();
+        }
+        return segments.stream()
+                .map(segment -> {
+                    F field = resolver.resolve(segment.fieldName()).orElseThrow(() ->
+                            new IllegalArgumentException(String.format("%s is not a sortable field", segment.fieldName())));
+                    return SortOption.of(field, segment.order());
+                })
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    public <F extends SortField> void setSort(List<SortOption<F>> sort) {
         if (sort == null) {
+            parsedSortSegments = null;
             this.sort = null;
         } else if (sort.isEmpty()) {
+            parsedSortSegments = List.of();
             this.sort = "";
         } else {
+            parsedSortSegments = sort.stream()
+                    .map(option -> new SortSegment(option.field().toQueryValue(), option.order()))
+                    .collect(Collectors.toUnmodifiableList());
             this.sort = sort.stream().map(SortOption::toQuerySegment).collect(Collectors.joining(","));
         }
     }
 
-    private static SortOption parseSortSegment(String segment) {
+    private static SortSegment parseSortSegment(String segment) {
         String[] parts = segment.split("\\|", 2);
         String fieldName = parts[0].trim();
         if (fieldName.isEmpty()) {
             throw new IllegalArgumentException("sort must specify at least one field");
         }
-        ClientField field = ClientField.fromApiName(fieldName).orElseThrow(() ->
-                new IllegalArgumentException(String.format("%s is not a sortable field", fieldName)));
         SortOrder order = parts.length == 1 ? SortOrder.ASC : parseSortOrder(parts[1].trim());
-        return SortOption.of(field, order);
+        return new SortSegment(fieldName, order);
     }
 
     private static SortOrder parseSortOrder(String value) {

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortField.java
@@ -1,0 +1,16 @@
+package org.keycloak.admin.api;
+
+/**
+ * A field that a resource's list query can sort by.
+ * <p>
+ * Implemented by resource-specific field enums (e.g. a {@code ClientField}) so that
+ * sort parsing in {@link ListOptions} stays resource-agnostic.
+ */
+public interface SortField {
+
+    String getApiName();
+
+    default String toQueryValue() {
+        return getApiName();
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortFieldResolver.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortFieldResolver.java
@@ -1,0 +1,14 @@
+package org.keycloak.admin.api;
+
+import java.util.Optional;
+
+/**
+ * Resolves a raw API field name (as used in the {@code sort} query parameter) to a
+ * resource-specific {@link SortField}. Allows {@link ListOptions} to parse sort
+ * expressions without depending on any concrete field enum.
+ */
+@FunctionalInterface
+public interface SortFieldResolver<F extends SortField> {
+
+    Optional<F> resolve(String apiName);
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOption.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOption.java
@@ -2,25 +2,25 @@ package org.keycloak.admin.api;
 
 import java.util.Objects;
 
-public final class SortOption {
+public final class SortOption<F extends SortField> {
 
-    private final ClientField field;
+    private final F field;
     private final SortOrder order;
 
-    private SortOption(ClientField field, SortOrder order) {
+    private SortOption(F field, SortOrder order) {
         this.field = Objects.requireNonNull(field, "field cannot be null");
         this.order = order == null ? SortOrder.ASC : order;
     }
 
-    public static SortOption of(ClientField field) {
-        return new SortOption(field, SortOrder.ASC);
+    public static <F extends SortField> SortOption<F> of(F field) {
+        return new SortOption<>(field, SortOrder.ASC);
     }
 
-    public static SortOption of(ClientField field, SortOrder order) {
-        return new SortOption(field, order);
+    public static <F extends SortField> SortOption<F> of(F field, SortOrder order) {
+        return new SortOption<>(field, order);
     }
 
-    public ClientField field() {
+    public F field() {
         return field;
     }
 
@@ -47,8 +47,8 @@ public final class SortOption {
         if (!(obj instanceof SortOption)) {
             return false;
         }
-        SortOption other = (SortOption) obj;
-        return field == other.field && order == other.order;
+        SortOption<?> other = (SortOption<?>) obj;
+        return Objects.equals(field, other.field) && order == other.order;
     }
 
     @Override

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortSegment.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortSegment.java
@@ -1,0 +1,43 @@
+package org.keycloak.admin.api;
+
+import java.util.Objects;
+
+/**
+ * A single parsed clause of a {@code sort} query expression, before the field name has
+ * been resolved to a resource-specific {@link SortField}.
+ */
+public final class SortSegment {
+
+    private final String fieldName;
+    private final SortOrder order;
+
+    public SortSegment(String fieldName, SortOrder order) {
+        this.fieldName = Objects.requireNonNull(fieldName, "fieldName cannot be null");
+        this.order = order == null ? SortOrder.ASC : order;
+    }
+
+    public String fieldName() {
+        return fieldName;
+    }
+
+    public SortOrder order() {
+        return order;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SortSegment)) {
+            return false;
+        }
+        SortSegment other = (SortSegment) obj;
+        return fieldName.equals(other.fieldName) && order == other.order;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName, order);
+    }
+}

--- a/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
+++ b/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
@@ -1,7 +1,9 @@
 package org.keycloak.admin.api;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +12,20 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ListOptionsTest {
+
+    private enum TestField implements SortField {
+        FOO,
+        BAR;
+
+        @Override
+        public String getApiName() {
+            return name().toLowerCase();
+        }
+
+        static Optional<TestField> fromApiName(String apiName) {
+            return Stream.of(values()).filter(field -> field.getApiName().equals(apiName)).findFirst();
+        }
+    }
 
     @Test
     void testGetFieldsEmpty() {
@@ -27,39 +43,55 @@ public class ListOptionsTest {
     }
 
     @Test
-    void testGetSortEmpty() {
+    void testGetSortSegmentsEmpty() {
         ListOptions options = new ListOptions();
-        options.setSort(List.of());
+        options.setSort(List.<SortOption<TestField>>of());
         assertEquals("", options.sort);
-        assertEquals(List.of(), options.getSort());
+        assertEquals(List.of(), options.getSortSegments());
     }
 
     @Test
-    void testGetSort() {
+    void testGetSortSegments() {
         ListOptions options = new ListOptions();
-        options.sort = "displayName|desc,clientId";
-        assertEquals(List.of(SortOption.of(ClientField.DISPLAY_NAME, SortOrder.DESC), SortOption.of(ClientField.CLIENT_ID)),
-                options.getSort());
+        options.sort = "bar|desc,foo";
+        assertEquals(List.of(new SortSegment("bar", SortOrder.DESC), new SortSegment("foo", SortOrder.ASC)),
+                options.getSortSegments());
     }
 
     @Test
-    void getSortCachesParsedResult() {
+    void getSortSegmentsCachesParsedResult() {
         ListOptions options = new ListOptions();
-        options.sort = "displayName|desc,clientId";
+        options.sort = "bar|desc,foo";
 
-        List<SortOption> first = options.getSort();
-        List<SortOption> second = options.getSort();
+        List<SortSegment> first = options.getSortSegments();
+        List<SortSegment> second = options.getSortSegments();
 
-        assertEquals(List.of(SortOption.of(ClientField.DISPLAY_NAME, SortOrder.DESC), SortOption.of(ClientField.CLIENT_ID)),
-                first);
+        assertEquals(List.of(new SortSegment("bar", SortOrder.DESC), new SortSegment("foo", SortOrder.ASC)), first);
         assertSame(first, second);
+    }
+
+    @Test
+    void testGetSortResolvesFields() {
+        ListOptions options = new ListOptions();
+        options.sort = "bar|desc,foo";
+        assertEquals(List.of(SortOption.of(TestField.BAR, SortOrder.DESC), SortOption.of(TestField.FOO)),
+                options.getSort(TestField::fromApiName));
     }
 
     @Test
     void testSetSort() {
         ListOptions options = new ListOptions();
-        options.setSort(List.of(SortOption.of(ClientField.CLIENT_ID, SortOrder.DESC)));
-        assertEquals("clientId|desc", options.sort);
+        options.setSort(List.of(SortOption.of(TestField.FOO, SortOrder.DESC)));
+        assertEquals("foo|desc", options.sort);
+    }
+
+    @Test
+    void invalidSortSegmentFormatThrowsBadRequest() {
+        ListOptions options = new ListOptions();
+        options.sort = "|desc";
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, options::getSortSegments);
+        assertEquals("sort must specify at least one field", exception.getMessage());
     }
 
     @Test
@@ -74,16 +106,17 @@ public class ListOptionsTest {
         ListOptions options = new ListOptions();
         options.sort = "unknown";
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, options::getSort);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> options.getSort(TestField::fromApiName));
         assertEquals("unknown is not a sortable field", exception.getMessage());
     }
 
     @Test
     void invalidSortDirectionThrowsBadRequest() {
         ListOptions options = new ListOptions();
-        options.sort = "clientId|what";
+        options.sort = "foo|what";
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, options::getSort);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, options::getSortSegments);
         assertEquals("sort direction must be asc or desc", exception.getMessage());
     }
 

--- a/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
+++ b/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
@@ -95,13 +95,6 @@ public class ListOptionsTest {
     }
 
     @Test
-    void testSortTime() {
-        ListOptions options = new ListOptions();
-        options.setSort(List.of(SortOption.of(ClientField.CREATED_TIMESTAMP, SortOrder.DESC)));
-        assertEquals("createdTimestamp|desc", options.sort);
-    }
-
-    @Test
     void invalidSortFieldThrowsBadRequest() {
         ListOptions options = new ListOptions();
         options.sort = "unknown";

--- a/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/OASModelFilter.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/OASModelFilter.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.keycloak.admin.api.ClientField;
+import org.keycloak.services.client.ClientField;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientField.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientField.java
@@ -1,4 +1,4 @@
-package org.keycloak.admin.api;
+package org.keycloak.services.client;
 
 import java.util.Comparator;
 import java.util.Optional;
@@ -6,13 +6,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.keycloak.admin.api.SortField;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 
 /**
  * Sortable fields for Client Admin API v2 list queries ({@code sort}).
  * API names map to scalar {@code CLIENT} table columns.
  */
-public enum ClientField {
+public enum ClientField implements SortField {
     CLIENT_ID("clientId", stringKey(BaseClientRepresentation::getClientId)),
     DISPLAY_NAME("displayName", stringKey(BaseClientRepresentation::getDisplayName)),
     DESCRIPTION("description", stringKey(BaseClientRepresentation::getDescription)),
@@ -30,10 +31,12 @@ public enum ClientField {
         this.comparatorFactory = comparatorFactory;
     }
 
+    @Override
     public String getApiName() {
         return apiName;
     }
 
+    @Override
     public String toQueryValue() {
         return apiName;
     }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientField.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientField.java
@@ -1,6 +1,8 @@
 package org.keycloak.services.client;
 
 import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -22,6 +24,9 @@ public enum ClientField implements SortField {
     APP_URL("appUrl", stringKey(BaseClientRepresentation::getAppUrl)),
     CREATED_TIMESTAMP("createdTimestamp", longKey(BaseClientRepresentation::getCreatedTimestamp)),
     UPDATED_TIMESTAMP("updatedTimestamp", longKey(BaseClientRepresentation::getUpdatedTimestamp));
+
+    private static final Map<String, ClientField> API_NAME_TO_CLIENT_FIELD = EnumSet.allOf(ClientField.class).stream()
+            .collect(Collectors.toMap(f -> f.apiName, Function.identity()));
 
     private final String apiName;
     private final ComparatorFactory comparatorFactory;
@@ -50,7 +55,7 @@ public enum ClientField implements SortField {
     }
 
     public static Optional<ClientField> fromApiName(String apiName) {
-        return Stream.of(values()).filter(field -> field.apiName.equals(apiName)).findFirst();
+        return Optional.ofNullable(API_NAME_TO_CLIENT_FIELD.get(apiName));
     }
 
     public static String allowedApiNames() {

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.SortOption;
 import org.keycloak.models.Constants;
@@ -40,11 +39,11 @@ public interface ClientService extends Service {
     }
 
     class ClientSortAndSliceOptions {
-        private List<SortOption> sortOptions;
+        private List<SortOption<ClientField>> sortOptions;
         private int offset;
         private int limit;
 
-        private ClientSortAndSliceOptions(List<SortOption> sortOptions, int offset, int limit) {
+        private ClientSortAndSliceOptions(List<SortOption<ClientField>> sortOptions, int offset, int limit) {
             this.offset = offset;
             this.limit = limit;
             this.sortOptions = List.copyOf(sortOptions);
@@ -59,11 +58,11 @@ public interface ClientService extends Service {
         }
 
         public static ClientSortAndSliceOptions fromQuery(ListOptions listOptions) {
-            List<SortOption> options;
+            List<SortOption<ClientField>> options;
             int normalizedOffset;
             int normalizedLimit;
             try {
-                var sort = listOptions.getSort();
+                var sort = listOptions.getSort(ClientField::fromApiName);
                 options = sort == null || sort.isEmpty()
                         ? List.of(SortOption.of(ClientField.defaultField()))
                         : sort;

--- a/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortParameterTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortParameterTest.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
-import org.keycloak.admin.api.ClientField;
+import org.keycloak.services.client.ClientField;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Field;
 import java.util.Comparator;
 import java.util.List;
 
-import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.SortOption;
 import org.keycloak.admin.api.SortOrder;

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -33,7 +33,6 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 
-import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.PatchTypeNames;
 import org.keycloak.admin.api.SortOption;
@@ -47,6 +46,7 @@ import org.keycloak.common.util.Time;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
 import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+import org.keycloak.services.client.ClientField;
 import org.keycloak.services.error.ViolationExceptionResponse;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectClient;


### PR DESCRIPTION
Introduce a resource-agnostic SortField marker interface + a
SortFieldResolver<F> functional interface, make SortOption generic over
F extends SortField, and split ListOptions sort parsing into two phases

fixes: #50558

