### PR TITLE
Allow subclasses of DefaultEmailSenderProvider to customize the message before sending

### DIFF
--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -187,6 +187,7 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
             msg.setHeader("To", address);
             msg.setSubject(MimeUtility.encodeText(subject, StandardCharsets.UTF_8.name(), null));
             msg.setContent(multipart);
+            customizeMessage(msg, config);
             msg.saveChanges();
             msg.setSentDate(new Date());
 
@@ -198,6 +199,18 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
         } catch (MessagingException e) {
             throw new EmailException("MessagingException occurred", e);
         }
+    }
+
+    /**
+     * Extension point for subclasses to modify the message before it is sent, e.g. to add
+     * vendor-specific headers. Invoked after the standard headers and content have been set,
+     * just before the message is saved and handed to the transport. The default implementation
+     * does nothing.
+     *
+     * @param message the message about to be sent
+     * @param config the realm's SMTP configuration
+     */
+    protected void customizeMessage(Message message, Map<String, String> config) throws MessagingException {
     }
 
     private Multipart buildMultipartBody(String textBody, String htmlBody) throws EmailException {

--- a/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
@@ -114,7 +114,7 @@ class DefaultEmailSenderProviderTest {
             // then
             assertThat(greenMail.waitForIncomingEmail(1), is(true));
             MimeMessage received = greenMail.getReceivedMessages()[0];
-            assertThat(received.getHeader("X-Custom-Header")[0], is("custom-value"));
+            assertThat(received.getHeader("X-Custom-Header", null), is("custom-value"));
         } finally {
             greenMail.stop();
         }

--- a/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
@@ -4,6 +4,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -81,5 +87,36 @@ class DefaultEmailSenderProviderTest {
 
         // then
         assertThat(exception.getMessage(), containsString("Invalid reply-to address"));
+    }
+
+    @Test
+    void testCustomizeMessageCanAddHeaders() throws Exception {
+        // given
+        GreenMail greenMail = new GreenMail(ServerSetupTest.SMTP.dynamicPort());
+        greenMail.start();
+        try {
+            DefaultEmailSenderProvider provider = new DefaultEmailSenderProvider(null,
+                    Map.of(EmailAuthenticator.AuthenticatorType.NONE, new DefaultEmailAuthenticator())) {
+                @Override
+                protected void customizeMessage(Message message, Map<String, String> config) throws MessagingException {
+                    message.setHeader("X-Custom-Header", "custom-value");
+                }
+            };
+
+            Map<String, String> config = new HashMap<>();
+            config.put("from", "test@keycloak.com");
+            config.put("host", "localhost");
+            config.put("port", String.valueOf(greenMail.getSmtp().getPort()));
+
+            // when
+            provider.send(config, "user@keycloak.com", "subject", "text body", null);
+
+            // then
+            assertThat(greenMail.waitForIncomingEmail(1), is(true));
+            MimeMessage received = greenMail.getReceivedMessages()[0];
+            assertThat(received.getHeader("X-Custom-Header")[0], is("custom-value"));
+        } finally {
+            greenMail.stop();
+        }
     }
 }


### PR DESCRIPTION
Hi all, we stumbled upon a use case, when we need to add headers for email sender. We are using sendgrid and they allow to define custom "category", which can be used for filters, UI and webhooks.
This category can be defined by a header, which is sent together with an email request

We couldn't find any way on how to add such headers to existing keycloak classes. And we had to copypaste the whole default sender class, with several line modifications. It would cause problems for each update.
We would like to make the default sender class extendable and allow to customize a message before sending.
Let me know if this approach is fine, or you would prefer to have it in a different way.
