### PR TITLE
Invalidate in progress authentication sessions on credential reset

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/marshalling/KeycloakModelSchema.java
+++ b/model/infinispan/src/main/java/org/keycloak/marshalling/KeycloakModelSchema.java
@@ -89,6 +89,7 @@ import org.keycloak.models.sessions.infinispan.events.RealmRemovedSessionEvent;
 import org.keycloak.models.sessions.infinispan.events.RemoveAllUserLoginFailuresEvent;
 import org.keycloak.models.sessions.infinispan.events.RemoveUserSessionsEvent;
 import org.keycloak.models.sessions.infinispan.stream.AuthClientSessionSetMapper;
+import org.keycloak.models.sessions.infinispan.stream.AuthenticatedUserAuthSessionPredicate;
 import org.keycloak.models.sessions.infinispan.stream.ClientSessionFilterByUser;
 import org.keycloak.models.sessions.infinispan.stream.CollectionToStreamMapper;
 import org.keycloak.models.sessions.infinispan.stream.GroupAndCountCollectorSupplier;
@@ -174,6 +175,7 @@ import org.infinispan.protostream.types.java.CommonTypes;
                 RemoveUserSessionsEvent.class,
 
                 // models.sessions.infinispan.stream package
+                AuthenticatedUserAuthSessionPredicate.class,
                 SessionPredicate.class,
                 SessionWrapperPredicate.class,
                 UserSessionPredicate.class,

--- a/model/infinispan/src/main/java/org/keycloak/marshalling/Marshalling.java
+++ b/model/infinispan/src/main/java/org/keycloak/marshalling/Marshalling.java
@@ -193,6 +193,9 @@ public final class Marshalling {
     public static final int WORKFLOW_SCHEDULE_CLUSTER_EVENT = 65621;
     public static final int USER_VERIFIABLE_CREDENTIALS_UPDATED_EVENT = 65622;
 
+
+    public static final int AUTHENTICATED_USER_AUTH_SESSION_PREDICATE = 65623;
+
     public static void configure(GlobalConfigurationBuilder builder) {
         getSchemas().forEach(builder.serialization()::addContextInitializer);
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
@@ -20,6 +20,8 @@ package org.keycloak.models.sessions.infinispan;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.util.Time;
@@ -27,6 +29,7 @@ import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.cache.infinispan.events.AuthenticationSessionAuthNoteUpdateEvent;
 import org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction;
@@ -94,6 +97,16 @@ public class InfinispanAuthenticationSessionProvider implements AuthenticationSe
     private RootAuthenticationSessionEntity getRootAuthenticationSessionEntity(String authSessionId) {
         SessionEntityWrapper<RootAuthenticationSessionEntity> entityWrapper = sessionTx.get(authSessionId);
         return entityWrapper==null ? null : entityWrapper.getEntity();
+    }
+
+    @Override
+    public Stream<RootAuthenticationSessionModel> getRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user) {
+        return StreamSupport.stream(sessionTx.getCache().entrySet().stream()
+                        .filter(SessionWrapperPredicate.create(realm.getId()))
+                        .spliterator(), false)
+                .map(entry -> entry.getValue().getEntity())
+                .filter(entity -> entity.hasAuthenticationSessionForUser(user.getId()))
+                .map(entity -> (RootAuthenticationSessionModel) wrap(realm, entity));
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanAuthenticationSessionProvider.java
@@ -27,6 +27,7 @@ import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.cache.infinispan.events.AuthenticationSessionAuthNoteUpdateEvent;
 import org.keycloak.models.sessions.infinispan.changes.InfinispanChangelogBasedTransaction;
@@ -36,6 +37,7 @@ import org.keycloak.models.sessions.infinispan.changes.Tasks;
 import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
 import org.keycloak.models.sessions.infinispan.events.RealmRemovedSessionEvent;
 import org.keycloak.models.sessions.infinispan.events.SessionEventsSenderTransaction;
+import org.keycloak.models.sessions.infinispan.stream.AuthenticatedUserAuthSessionPredicate;
 import org.keycloak.models.sessions.infinispan.stream.SessionWrapperPredicate;
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionProvider;
@@ -94,6 +96,11 @@ public class InfinispanAuthenticationSessionProvider implements AuthenticationSe
     private RootAuthenticationSessionEntity getRootAuthenticationSessionEntity(String authSessionId) {
         SessionEntityWrapper<RootAuthenticationSessionEntity> entityWrapper = sessionTx.get(authSessionId);
         return entityWrapper==null ? null : entityWrapper.getEntity();
+    }
+
+    @Override
+    public void removeRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user, String rootAuthenticationSessionIdToKeep) {
+        sessionTx.getCache().values().removeIf(new AuthenticatedUserAuthSessionPredicate(realm.getId(), user.getId(), rootAuthenticationSessionIdToKeep));
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/RootAuthenticationSessionEntity.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/entities/RootAuthenticationSessionEntity.java
@@ -78,6 +78,11 @@ public class RootAuthenticationSessionEntity extends SessionEntity {
         this.authenticationSessions = authenticationSessions;
     }
 
+    public boolean hasAuthenticationSessionForUser(String userId) {
+        return authenticationSessions.values().stream()
+                .anyMatch(authSession -> Objects.equals(authSession.getAuthUserId(), userId));
+    }
+
     @Override
     public boolean shouldEvaluateRemoval() {
         return true;

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/query/AuthenticationSessionQueries.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/query/AuthenticationSessionQueries.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.query;
+
+import org.keycloak.marshalling.Marshalling;
+import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.api.query.Query;
+
+/**
+ * Util class with Infinispan Ickle Queries for {@link RootAuthenticationSessionEntity}.
+ */
+public final class AuthenticationSessionQueries {
+
+    private AuthenticationSessionQueries() {
+    }
+
+    public static final String AUTHENTICATION_SESSION = Marshalling.protoEntity(RootAuthenticationSessionEntity.class);
+
+    private static final String BY_REALM = "FROM %s as e WHERE e.realmId = :realmId".formatted(AUTHENTICATION_SESSION);
+
+    /**
+     * Returns all root authentication sessions belonging to the Realm.
+     */
+    public static Query<RootAuthenticationSessionEntity> searchByRealm(RemoteCache<String, RootAuthenticationSessionEntity> cache, String realmId) {
+        return cache.<RootAuthenticationSessionEntity>query(BY_REALM)
+                .setParameter("realmId", realmId);
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
@@ -19,6 +19,9 @@ package org.keycloak.models.sessions.infinispan.remote;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.util.SecretGenerator;
@@ -26,9 +29,11 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.infinispan.events.AuthenticationSessionAuthNoteUpdateEvent;
 import org.keycloak.models.sessions.infinispan.InfinispanAuthenticationSessionProviderFactory;
 import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
+import org.keycloak.models.sessions.infinispan.query.QueryHelper;
 import org.keycloak.models.sessions.infinispan.remote.transaction.AuthenticationSessionChangeLogTransaction;
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionProvider;
@@ -82,6 +87,22 @@ public class RemoteInfinispanAuthenticationSessionProvider implements Authentica
             throw new ModelException("Authentication session with id '" + authenticationSession.getId() + "' does not belong to realm '" + realm.getId() + "'");
         }
         transaction.remove(authenticationSession.getId());
+    }
+
+    @Override
+    public Stream<RootAuthenticationSessionModel> getRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user) {
+
+        var query = transaction.getCache()
+                .<RootAuthenticationSessionEntity>query("FROM " + RemoteInfinispanAuthenticationSessionProviderFactory.PROTO_ENTITY + " WHERE realmId = :realmId")
+                .setParameter("realmId", realm.getId());
+
+        return QueryHelper.streamAll(query, 100, Function.identity())
+                .filter(entity -> entity.hasAuthenticationSessionForUser(user.getId()))
+                .map(RootAuthenticationSessionEntity::getId)
+                .collect(Collectors.toList())
+                .stream()
+                .map(id -> getRootAuthenticationSession(realm, id))
+                .filter(Objects::nonNull);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/remote/RemoteInfinispanAuthenticationSessionProvider.java
@@ -19,6 +19,7 @@ package org.keycloak.models.sessions.infinispan.remote;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.util.SecretGenerator;
@@ -26,15 +27,20 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.infinispan.events.AuthenticationSessionAuthNoteUpdateEvent;
 import org.keycloak.models.sessions.infinispan.InfinispanAuthenticationSessionProviderFactory;
 import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
+import org.keycloak.models.sessions.infinispan.query.AuthenticationSessionQueries;
+import org.keycloak.models.sessions.infinispan.query.QueryHelper;
 import org.keycloak.models.sessions.infinispan.remote.transaction.AuthenticationSessionChangeLogTransaction;
 import org.keycloak.sessions.AuthenticationSessionCompoundId;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 public class RemoteInfinispanAuthenticationSessionProvider implements AuthenticationSessionProvider {
+
+    private static final int BATCH_SIZE = 100;
 
     private final KeycloakSession session;
     private final AuthenticationSessionChangeLogTransaction transaction;
@@ -82,6 +88,16 @@ public class RemoteInfinispanAuthenticationSessionProvider implements Authentica
             throw new ModelException("Authentication session with id '" + authenticationSession.getId() + "' does not belong to realm '" + realm.getId() + "'");
         }
         transaction.remove(authenticationSession.getId());
+    }
+
+    @Override
+    public void removeRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user, String rootAuthenticationSessionIdToKeep) {
+        var query = AuthenticationSessionQueries.searchByRealm(transaction.getCache(), realm.getId());
+        QueryHelper.streamAll(query, BATCH_SIZE, Function.identity())
+                .filter(entity -> entity.hasAuthenticationSessionForUser(user.getId()))
+                .map(RootAuthenticationSessionEntity::getId)
+                .filter(id -> !Objects.equals(id, rootAuthenticationSessionIdToKeep))
+                .forEach(transaction::remove);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/AuthenticatedUserAuthSessionPredicate.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/stream/AuthenticatedUserAuthSessionPredicate.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.sessions.infinispan.stream;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.keycloak.models.sessions.infinispan.changes.SessionEntityWrapper;
+import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
+
+import org.infinispan.protostream.annotations.Proto;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+
+import static org.keycloak.marshalling.Marshalling.AUTHENTICATED_USER_AUTH_SESSION_PREDICATE;
+
+/**
+ * A {@link Predicate} to match {@link RootAuthenticationSessionEntity} values that hold an in progress
+ * authentication session for the given user in the given realm, except for an optional root session id to keep.
+ *
+ * @param realmId                            The Realm ID.
+ * @param userId                             The authenticated User ID.
+ * @param rootAuthenticationSessionIdToKeep  Optional root authentication session id to keep; {@code null} keeps none.
+ */
+@ProtoTypeId(AUTHENTICATED_USER_AUTH_SESSION_PREDICATE)
+@Proto
+public record AuthenticatedUserAuthSessionPredicate(String realmId, String userId,
+                                                    String rootAuthenticationSessionIdToKeep)
+        implements Predicate<SessionEntityWrapper<RootAuthenticationSessionEntity>> {
+
+    @Override
+    public boolean test(SessionEntityWrapper<RootAuthenticationSessionEntity> wrapper) {
+        var entity = wrapper.getEntity();
+        return Objects.equals(realmId, entity.getRealmId())
+                && entity.hasAuthenticationSessionForUser(userId)
+                && !Objects.equals(rootAuthenticationSessionIdToKeep, entity.getId());
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -21,6 +21,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
@@ -32,6 +33,7 @@ import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.SessionExpiration;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -140,6 +142,18 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
         if (entity != null) {
             em.remove(entity);
         }
+    }
+
+    @Override
+    public Stream<RootAuthenticationSessionModel> getRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user) {
+        return getEntityManager()
+                .createNamedQuery("findRootAuthSessionIdsByUser", String.class)
+                .setParameter("realmId", realm.getId())
+                .setParameter("userId", user.getId())
+                .getResultList()
+                .stream()
+                .map(id -> getRootAuthenticationSession(realm, id))
+                .filter(Objects::nonNull);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -32,6 +32,7 @@ import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.SessionExpiration;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -140,6 +141,16 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
         if (entity != null) {
             em.remove(entity);
         }
+    }
+
+    @Override
+    public void removeRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user, String rootAuthenticationSessionIdToKeep) {
+        getEntityManager()
+                .createNamedQuery("deleteRootAuthSessionsByUser")
+                .setParameter("realmId", realm.getId())
+                .setParameter("userId", user.getId())
+                .setParameter("rootSessionIdToKeep", rootAuthenticationSessionIdToKeep)
+                .executeUpdate();
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
@@ -48,6 +48,12 @@ import org.hibernate.annotations.DynamicUpdate;
                         " WHERE sess.realmId = :realmId AND sess.timestamp < :timestamp"
         ),
         @NamedQuery(
+                name = "findRootAuthSessionIdsByUser",
+                query = "SELECT DISTINCT sess.id FROM RootAuthenticationSessionEntity sess" +
+                        " JOIN sess.authenticationSessions auth" +
+                        " WHERE sess.realmId = :realmId AND auth.authUserId = :userId"
+        ),
+        @NamedQuery(
                 name = "deleteExpiredRootAuthSessionByIds",
                 query = "DELETE FROM RootAuthenticationSessionEntity e WHERE e.id IN :ids AND e.timestamp < :timestamp"
         ),

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
@@ -48,6 +48,16 @@ import org.hibernate.annotations.DynamicUpdate;
                         " WHERE sess.realmId = :realmId AND sess.timestamp < :timestamp"
         ),
         @NamedQuery(
+            name = "deleteRootAuthSessionsByUser",
+            query = "DELETE FROM RootAuthenticationSessionEntity sess" +
+                " WHERE sess.realmId = :realmId" +
+                " AND (:rootSessionIdToKeep IS NULL OR sess.id <> :rootSessionIdToKeep)" +
+                " AND EXISTS (" +
+                " SELECT auth.tabId FROM AuthenticationSessionEntity auth" +
+                " WHERE auth.rootAuthenticationSession = sess AND auth.authUserId = :userId" +
+                " )"
+        ),
+        @NamedQuery(
                 name = "deleteExpiredRootAuthSessionByIds",
                 query = "DELETE FROM RootAuthenticationSessionEntity e WHERE e.id IN :ids AND e.timestamp < :timestamp"
         ),

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.8.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.8.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="26.8.0-auth-session-auth-user-id-index">
+        <!-- Index used when invalidating a user's in-progress authentication sessions on credential reset
+             with "sign out of other devices" (findRootAuthSessionIdsByUser filters on AUTH_USER_ID). -->
+        <createIndex tableName="AUTH_SESSION" indexName="IDX_AUTH_SESSION_AUTH_USER_ID">
+            <column name="AUTH_USER_ID"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -92,5 +92,6 @@
     <include file="META-INF/jpa-changelog-26.5.0.xml"/>
     <include file="META-INF/jpa-changelog-26.6.0.xml"/>
     <include file="META-INF/jpa-changelog-26.7.0.xml"/>
+    <include file="META-INF/jpa-changelog-26.8.0.xml"/>
 
 </databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/queries-mariadb.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-mariadb.properties
@@ -17,6 +17,10 @@ deleteClientSessionsByRealmSessionType[native]=delete c from OFFLINE_CLIENT_SESS
 deleteClientSessionsByUser[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
  where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = :userId
 
+deleteRootAuthSessionsByUser[native]=delete r from ROOT_AUTH_SESSION r join AUTH_SESSION a \
+ where r.ID = a.ROOT_AUTH_SESSION_ID and r.REALM_ID = :realmId and a.AUTH_USER_ID = :userId \
+ and (:rootSessionIdToKeep IS NULL or r.ID <> :rootSessionIdToKeep)
+
 deleteUserConsentClientScopesByRealm[native]=delete cc from USER_CONSENT_CLIENT_SCOPE cc join USER_CONSENT uc join USER_ENTITY u \
  where cc.USER_CONSENT_ID = uc.ID and uc.USER_ID = u.ID and u.REALM_ID=:realmId
 

--- a/model/jpa/src/main/resources/META-INF/queries-mysql.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-mysql.properties
@@ -17,6 +17,10 @@ deleteClientSessionsByRealmSessionType[native]=delete c from OFFLINE_CLIENT_SESS
 deleteClientSessionsByUser[native]=delete c from OFFLINE_CLIENT_SESSION c join OFFLINE_USER_SESSION u \
  where c.USER_SESSION_ID = u.USER_SESSION_ID and u.USER_ID = :userId
 
+deleteRootAuthSessionsByUser[native]=delete r from ROOT_AUTH_SESSION r join AUTH_SESSION a \
+ where r.ID = a.ROOT_AUTH_SESSION_ID and r.REALM_ID = :realmId and a.AUTH_USER_ID = :userId \
+ and (:rootSessionIdToKeep IS NULL or r.ID <> :rootSessionIdToKeep)
+
 deleteUserConsentClientScopesByRealm[native]=delete cc from USER_CONSENT_CLIENT_SCOPE cc join USER_CONSENT uc join USER_ENTITY u \
  where cc.USER_CONSENT_ID = uc.ID and uc.USER_ID = u.ID and u.REALM_ID=:realmId
 

--- a/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
@@ -18,10 +18,12 @@
 package org.keycloak.sessions;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.provider.Provider;
 
 /**
@@ -81,6 +83,18 @@ public interface AuthenticationSessionProvider extends Provider {
      */
     @Deprecated(since = "19.0", forRemoval = true)
     default void removeExpired(RealmModel realm) {}
+
+    /**
+     * Returns all root authentication sessions of the given realm that hold an in-progress authentication session for the given authenticated user.
+     * This is used to invalidate in-progress authentication sessions.
+     * 
+     * @param realm {@code RealmModel} Can't be {@code null}.
+     * @param user {@code UserModel} Can't be {@code null}.
+     * @return a stream of matching {@code RootAuthenticationSessionModel}s. Never returns {@code null}.
+     */
+    default Stream<RootAuthenticationSessionModel> getRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user) {
+        return Stream.empty();
+    }
 
     /**
      * Removes all associated root authentication sessions to the given realm which was removed.

--- a/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
+++ b/server-spi/src/main/java/org/keycloak/sessions/AuthenticationSessionProvider.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.provider.Provider;
 
 /**
@@ -81,6 +82,17 @@ public interface AuthenticationSessionProvider extends Provider {
      */
     @Deprecated(since = "19.0", forRemoval = true)
     default void removeExpired(RealmModel realm) {}
+
+    /**
+     * Removes all root authentication sessions of the given realm that hold an in-progress authentication session
+     * for the given authenticated user, except for the provided root authentication session id.
+     *
+     * @param realm {@code RealmModel} Can't be {@code null}.
+     * @param user {@code UserModel} Can't be {@code null}.
+     * @param rootAuthenticationSessionIdToKeep optional id of a root authentication session to keep.
+     */
+    default void removeRootAuthenticationSessionsByAuthenticatedUser(RealmModel realm, UserModel user, String rootAuthenticationSessionIdToKeep) {
+    }
 
     /**
      * Removes all associated root authentication sessions to the given realm which was removed.

--- a/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
@@ -215,6 +215,10 @@ public class AuthenticatorUtil {
                     });
         }
 
+        session.authenticationSessions().getRootAuthenticationSessionsByAuthenticatedUser(realm, user)
+                .filter(rootAuthSession -> !Objects.equals(rootAuthSession.getId(), authSession.getParentSession().getId()))
+                .collect(Collectors.toList())
+                .forEach(rootAuthSession -> session.authenticationSessions().removeRootAuthenticationSession(realm, rootAuthSession));
     }
 
     private static void backchannelLogout(KeycloakSession session, RealmModel realm, ClientConnection conn, HttpRequest req, EventBuilder event, UserSessionModel s) {

--- a/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
@@ -215,6 +215,8 @@ public class AuthenticatorUtil {
                     });
         }
 
+        session.authenticationSessions().removeRootAuthenticationSessionsByAuthenticatedUser(realm, user,
+                authSession.getParentSession().getId());
     }
 
     private static void backchannelLogout(KeycloakSession session, RealmModel realm, ClientConnection conn, HttpRequest req, EventBuilder event, UserSessionModel s) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
@@ -58,6 +58,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -139,6 +140,36 @@ public class RequiredActionResetPasswordTest extends AbstractTestRealmKeycloakTe
     @Test
     public void resetPasswordLogoutSessionsNotChecked() {
         resetPassword(false);
+    }
+
+    @Test
+    public void resetPasswordLogoutSessionsInvalidatesInProgressAuthSession() {
+        requireUpdatePassword();
+        UserResource testUser = managedRealm.admin().users().get(findUser("test-user@localhost").getId());
+
+        // Browser attacker: authenticate with the current password and stop on the update-password screen.
+        OAuthClient oauth2 = oauth.newConfig().driver(driver2);
+        oauth2.openLoginForm();
+        driver2.findElement(By.id("username")).sendKeys("test-user@localhost");
+        driver2.findElement(By.id("password")).sendKeys("password");
+        driver2.findElement(By.id("password")).submit();
+        MatcherAssert.assertThat("Browser 2 should be parked on the update-password page",
+                driver2.findElements(By.id("password-new")).isEmpty(), Matchers.is(false));
+
+        // Browser victim: reset the password and choose to sign out of other devices.
+        oauth.openLoginForm();
+        loginPage.login("test-user@localhost", "password");
+        changePasswordPage.assertCurrent();
+        changePasswordPage.checkLogoutSessions();
+        changePasswordPage.changePassword("new-password", "new-password");
+        Assertions.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        assertEquals(1, testUser.getUserSessions().size());
+
+        // Browser attacker: try to finish the parked flow. Its in-progress authentication session was deleted by the reset, so it must not be able to complete and must not create a user session.
+        driver2.findElement(By.id("password-new")).sendKeys("attacker-password");
+        driver2.findElement(By.id("password-confirm")).sendKeys("attacker-password");
+        driver2.findElement(By.id("password-confirm")).submit();
+        assertEquals(1, testUser.getUserSessions().size());
     }
 
     private void resetPassword(boolean logoutOtherSessions) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
@@ -44,6 +44,7 @@ import org.keycloak.testsuite.util.FlowUtil;
 import org.keycloak.testsuite.util.MailServer;
 import org.keycloak.testsuite.util.RealmManager;
 import org.keycloak.testsuite.util.SecondBrowser;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
@@ -56,6 +57,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -134,6 +136,38 @@ public class RequiredActionResetPasswordTest extends AbstractTestRealmKeycloakTe
     @Test
     public void resetPasswordLogoutSessionsNotChecked() {
         resetPassword(false);
+    }
+
+    @Test
+    public void resetPasswordLogoutSessionsInvalidatesInProgressAuthSession() {
+        requireUpdatePassword();
+        UserResource testUser = managedRealm.admin().users().get(findUser("test-user@localhost").getId());
+
+        // Browser attacker: authenticate with the current password and stop on the update-password screen.
+        OAuthClient oauth2 = oauth.newConfig().driver(driver2);
+        oauth2.openLoginForm();
+        driver2.findElement(By.id("username")).sendKeys("test-user@localhost");
+        driver2.findElement(By.id("password")).sendKeys("password");
+        driver2.findElement(By.id("password")).submit();
+        MatcherAssert.assertThat("Browser 2 should be parked on the update-password page",
+                driver2.findElements(By.id("password-new")).isEmpty(), Matchers.is(false));
+
+        // Browser victim: reset the password and choose to sign out of other devices.
+        oauth.openLoginForm();
+        loginPage.login("test-user@localhost", "password");
+        changePasswordPage.assertCurrent();
+        changePasswordPage.checkLogoutSessions();
+        changePasswordPage.changePassword("new-password", "new-password");
+        Assertions.assertTrue(oauth.parseLoginResponse().isSuccess());
+        assertEquals(1, testUser.getUserSessions().size());
+
+        // Browser attacker: try to finish the parked flow. Its in-progress authentication session was deleted by the reset, so the flow must restart with a login-timeout error and must not create a user session.
+        driver2.findElement(By.id("password-new")).sendKeys("attacker-password");
+        driver2.findElement(By.id("password-confirm")).sendKeys("attacker-password");
+        UIUtils.clickLink(driver2.findElement(By.cssSelector("[type=\"submit\"]")));
+        assertEquals(loginPage.getExpectedPageId(), driver2.findElement(By.xpath("//body")).getDomAttribute("data-page-id"));
+        assertEquals("Your login attempt timed out. Login will start from the beginning.", driver2.findElement(By.className("pf-m-danger")).getText());
+        assertEquals(1, testUser.getUserSessions().size());
     }
 
     private void resetPassword(boolean logoutOtherSessions) {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.model.session;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -31,6 +32,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -180,6 +182,78 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
             assertNull(rootAuthSession);
 
+            return null;
+        });
+    }
+
+    @Test
+    public void testGetRootAuthenticationSessionsByAuthenticatedUser() {
+        AtomicReference<String> user1Id = new AtomicReference<>();
+        AtomicReference<String> user2Id = new AtomicReference<>();
+        List<String> user1RootIds = new ArrayList<>();
+        AtomicReference<String> user2RootId = new AtomicReference<>();
+        AtomicReference<String> anonymousRootId = new AtomicReference<>();
+
+        withRealm(realmId, (session, realm) -> {
+            UserModel user1 = session.users().addUser(realm, "user1");
+            UserModel user2 = session.users().addUser(realm, "user2");
+            user1Id.set(user1.getId());
+            user2Id.set(user2.getId());
+            ClientModel client = realm.getClientByClientId("test-app");
+
+            // two separate in-progress authentication sessions authenticated as user1 (e.g. two devices)
+            for (int i = 0; i < 2; i++) {
+                RootAuthenticationSessionModel root = session.authenticationSessions().createRootAuthenticationSession(realm);
+                root.createAuthenticationSession(client).setAuthenticatedUser(user1);
+                user1RootIds.add(root.getId());
+            }
+            // one authenticated as user2
+            RootAuthenticationSessionModel root2 = session.authenticationSessions().createRootAuthenticationSession(realm);
+            root2.createAuthenticationSession(client).setAuthenticatedUser(user2);
+            user2RootId.set(root2.getId());
+
+            // one without an authenticated user (credentials not verified yet)
+            RootAuthenticationSessionModel anon = session.authenticationSessions().createRootAuthenticationSession(realm);
+            anon.createAuthenticationSession(client);
+            anonymousRootId.set(anon.getId());
+            return null;
+        });
+
+        // lookup returns exactly the root sessions of the requested authenticated user
+        withRealm(realmId, (session, realm) -> {
+            UserModel user1 = session.users().getUserById(realm, user1Id.get());
+            List<String> foundForUser1 = session.authenticationSessions()
+                    .getRootAuthenticationSessionsByAuthenticatedUser(realm, user1)
+                    .map(RootAuthenticationSessionModel::getId)
+                    .collect(Collectors.toList());
+            assertThat(foundForUser1, Matchers.containsInAnyOrder(user1RootIds.toArray(new String[0])));
+
+            UserModel user2 = session.users().getUserById(realm, user2Id.get());
+            List<String> foundForUser2 = session.authenticationSessions()
+                    .getRootAuthenticationSessionsByAuthenticatedUser(realm, user2)
+                    .map(RootAuthenticationSessionModel::getId)
+                    .collect(Collectors.toList());
+            assertThat(foundForUser2, Matchers.contains(user2RootId.get()));
+            return null;
+        });
+
+        // emulate "logout other sessions": remove all of user1's in-progress sessions except the current one
+        String currentRootId = user1RootIds.get(0);
+        withRealm(realmId, (session, realm) -> {
+            UserModel user1 = session.users().getUserById(realm, user1Id.get());
+            session.authenticationSessions().getRootAuthenticationSessionsByAuthenticatedUser(realm, user1)
+                    .filter(root -> !root.getId().equals(currentRootId))
+                    .collect(Collectors.toList())
+                    .forEach(root -> session.authenticationSessions().removeRootAuthenticationSession(realm, root));
+            return null;
+        });
+
+        // the current session survives; the other user1 session is gone; other users are untouched
+        withRealm(realmId, (session, realm) -> {
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, currentRootId), Matchers.notNullValue());
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, user1RootIds.get(1)), Matchers.nullValue());
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, user2RootId.get()), Matchers.notNullValue());
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, anonymousRootId.get()), Matchers.notNullValue());
             return null;
         });
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.model.session;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -31,6 +32,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -180,6 +182,55 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
             RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
             assertNull(rootAuthSession);
 
+            return null;
+        });
+    }
+
+    @Test
+    public void testRemoveRootAuthenticationSessionsByAuthenticatedUser() {
+        AtomicReference<String> user1Id = new AtomicReference<>();
+        List<String> user1RootIds = new ArrayList<>();
+        AtomicReference<String> user2RootId = new AtomicReference<>();
+        AtomicReference<String> anonymousRootId = new AtomicReference<>();
+
+        withRealm(realmId, (session, realm) -> {
+            UserModel user1 = session.users().addUser(realm, "user1");
+            UserModel user2 = session.users().addUser(realm, "user2");
+            user1Id.set(user1.getId());
+            ClientModel client = realm.getClientByClientId("test-app");
+
+            // two separate in-progress authentication sessions authenticated as user1 (e.g. two devices)
+            for (int i = 0; i < 2; i++) {
+                RootAuthenticationSessionModel root = session.authenticationSessions().createRootAuthenticationSession(realm);
+                root.createAuthenticationSession(client).setAuthenticatedUser(user1);
+                user1RootIds.add(root.getId());
+            }
+            // one authenticated as user2
+            RootAuthenticationSessionModel root2 = session.authenticationSessions().createRootAuthenticationSession(realm);
+            root2.createAuthenticationSession(client).setAuthenticatedUser(user2);
+            user2RootId.set(root2.getId());
+
+            // one without an authenticated user (credentials not verified yet)
+            RootAuthenticationSessionModel anon = session.authenticationSessions().createRootAuthenticationSession(realm);
+            anon.createAuthenticationSession(client);
+            anonymousRootId.set(anon.getId());
+            return null;
+        });
+
+        // emulate "logout other sessions": remove all of user1's in-progress sessions except the current one
+        String currentRootId = user1RootIds.get(0);
+        withRealm(realmId, (session, realm) -> {
+            UserModel user1 = session.users().getUserById(realm, user1Id.get());
+            session.authenticationSessions().removeRootAuthenticationSessionsByAuthenticatedUser(realm, user1, currentRootId);
+            return null;
+        });
+
+        // the current session survives; the other user1 session is gone; other users are untouched
+        withRealm(realmId, (session, realm) -> {
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, currentRootId), Matchers.notNullValue());
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, user1RootIds.get(1)), Matchers.nullValue());
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, user2RootId.get()), Matchers.notNullValue());
+            assertThat(session.authenticationSessions().getRootAuthenticationSession(realm, anonymousRootId.get()), Matchers.notNullValue());
             return null;
         });
     }


### PR DESCRIPTION
The problem right now is when user reset their credentials and picks "Sign out of other devices", keycloak logged out their finished sessions but not their half-finished ones. An attacker who authenticated with the old password on such stop could complete it after the reset and gain the access.

This PR's idea is to find a user's in-progress authentication sessions, and on the 'reset with sign out others' step, delete all of them except the one is doing the reset.



after fix:



https://github.com/user-attachments/assets/283ca240-ceae-44f5-8beb-0223c5c15837



Closes #50621

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
