### PR TITLE
(docs) Fix incorrect permission name in Server Admin doc

### DIFF
--- a/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
@@ -423,7 +423,7 @@ Create user permission permission, allowing to view and manage all users in the 
 
 * Navigate to the *Permissions* tab in the administration console.
 * Click *Create permission* and choose *Users* resource type.
-* Fill in the name, such as `Disallow managing test-admins`.
+* Fill in the name, such as `Allow managing test-admins`.
 * Choose *view* and *manage* authorization scopes, keep checked *All Users*.
 * Create a condition, which needs to be met to get an access by clicking *Create new policy*.
 * Fill in the name `Allow test-admins`, select *Group* as *Policy type*.


### PR DESCRIPTION
The permission name here is incorrect.
Should be "Allow managing test-admins"

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
