### PR TITLE
[26.4] Defer the joinGroup, grantRole and addRequiredAction calls to the LDA…

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -329,23 +329,32 @@ public class LDAPStorageProvider implements UserStorageProvider,
             user = new InMemoryUserAdapter(session, realm, new StorageId(model.getId(), username).getId());
             user.setUsername(username);
         }
+        List<Runnable> onCreatedActions = new ArrayList<>();
+
         LDAPObject ldapUser = LDAPUtils.addUserToLDAP(this, realm, user, ldapObject -> {
             LDAPUtils.checkUuid(ldapObject, ldapIdentityStore.getConfig());
             user.setSingleAttribute(LDAPConstants.LDAP_ID, ldapObject.getUuid());
             user.setSingleAttribute(LDAPConstants.LDAP_ENTRY_DN, ldapObject.getDn().toString());
+            onCreatedActions.forEach(Runnable::run);
         });
 
-        // Add the user to the default groups and add default required actions
         UserModel proxy = proxy(realm, user, ldapUser, true);
-        proxy.grantRole(realm.getDefaultRole());
 
-        realm.getDefaultGroupsStream().forEach(proxy::joinGroup);
+        Runnable assignDefaults = () -> {
+            proxy.grantRole(realm.getDefaultRole());
+            realm.getDefaultGroupsStream().forEach(proxy::joinGroup);
+            realm.getRequiredActionProvidersStream()
+                    .filter(RequiredActionProviderModel::isEnabled)
+                    .filter(RequiredActionProviderModel::isDefaultAction)
+                    .map(RequiredActionProviderModel::getAlias)
+                    .forEachOrdered(proxy::addRequiredAction);
+        };
 
-        realm.getRequiredActionProvidersStream()
-                .filter(RequiredActionProviderModel::isEnabled)
-                .filter(RequiredActionProviderModel::isDefaultAction)
-                .map(RequiredActionProviderModel::getAlias)
-                .forEachOrdered(proxy::addRequiredAction);
+        if (ldapUser.isWaitingForExecutionOnMandatoryAttributesComplete()) {
+            onCreatedActions.add(assignDefaults);
+        } else {
+            assignDefaults.run();
+        }
 
         return proxy;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperTest.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.testsuite.federation.ldap;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
@@ -39,11 +38,13 @@ import org.keycloak.storage.ldap.LDAPUtils;
 import org.keycloak.storage.ldap.idm.model.LDAPDn;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
+import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.LDAPGroupMapperMode;
 import org.keycloak.storage.ldap.mappers.membership.MembershipType;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupLDAPStorageMapperFactory;
 import org.keycloak.storage.ldap.mappers.membership.group.GroupMapperConfig;
+import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.util.LDAPRule;
 import org.keycloak.testsuite.util.LDAPTestUtils;
 
@@ -56,6 +57,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.keycloak.testsuite.util.LDAPTestUtils.getGroupDescriptionLDAPAttrName;
 
 /**
@@ -1069,5 +1071,75 @@ public class LDAPGroupMapperTest extends AbstractLDAPTest {
             appRealm.updateComponent(mapperModel);
         });
     }
-}
 
+
+    @Test
+    public void test13_registrationWithDefaultGroupsAndDeferredLdapCreation() {
+        // GH issue #44832: when LDAP user creation is deferred (mandatory attribute not yet
+        // available) and default groups use LDAP_ONLY mode, joinGroup must not NPE on null DN.
+        configureGroupMapperAndRegistration(LDAPGroupMapperMode.LDAP_ONLY, "true", "false");
+        registerAndVerifyDefaultGroups("newuser@test.com", "newuserkeycloak");
+        revertEmailMapperAndRegistration();
+    }
+
+    @Test
+    public void test14_registrationWithDefaultGroupsAndImmediateLdapCreation() {
+        // Verifies the immediate LDAP creation path (email mandatory + Force Default Value ON)
+        // still works correctly with LDAP_ONLY mode after the deferred-creation fix.
+        configureGroupMapperAndRegistration(LDAPGroupMapperMode.LDAP_ONLY, "true", "true");
+        registerAndVerifyDefaultGroups("immediateuser@test.com", "immediateuserkeycloak");
+        revertEmailMapperAndRegistration();
+    }
+
+    private void configureGroupMapperAndRegistration(LDAPGroupMapperMode groupMode,
+                                                     String emailMandatory, String emailForceDefault) {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ComponentModel mapperModel = LDAPTestUtils.getSubcomponentByName(appRealm, ctx.getLdapModel(), "groupsMapper");
+            LDAPTestUtils.updateConfigOptions(mapperModel, GroupMapperConfig.MODE, groupMode.toString());
+            appRealm.updateComponent(mapperModel);
+            if (emailMandatory != null) {
+                ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(appRealm, ctx.getLdapModel(), "email");
+                LDAPTestUtils.updateConfigOptions(emailMapper,
+                        UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP, emailMandatory,
+                        UserAttributeLDAPStorageMapper.FORCE_DEFAULT_VALUE, emailForceDefault);
+                appRealm.updateComponent(emailMapper);
+            }
+            appRealm.setRegistrationAllowed(true);
+        });
+    }
+
+    private void revertEmailMapperAndRegistration() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(appRealm, ctx.getLdapModel(), "email");
+            LDAPTestUtils.updateConfigOptions(emailMapper,
+                    UserAttributeLDAPStorageMapper.IS_MANDATORY_IN_LDAP, "false",
+                    UserAttributeLDAPStorageMapper.FORCE_DEFAULT_VALUE, "true");
+            appRealm.updateComponent(emailMapper);
+            appRealm.setRegistrationAllowed(false);
+        });
+    }
+
+    private void registerAndVerifyDefaultGroups(String email, String username) {
+        oauth.openLoginForm();
+        loginPage.clickRegister();
+        registerPage.assertCurrent();
+        registerPage.register("Test", "User", email, username, "Password1", "Password1");
+        Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            UserModel user = session.users().getUserByUsername(appRealm, username);
+            assertThat(user, notNullValue());
+            GroupModel defaultGroup11 = KeycloakModelUtils.findGroupByPath(session, appRealm, "/defaultGroup1/defaultGroup11");
+            GroupModel defaultGroup12 = KeycloakModelUtils.findGroupByPath(session, appRealm, "/defaultGroup1/defaultGroup12");
+            Set<GroupModel> groups = user.getGroupsStream().collect(Collectors.toSet());
+            assertThat("User should be in default group 11", groups.contains(defaultGroup11), equalTo(true));
+            assertThat("User should be in default group 12", groups.contains(defaultGroup12), equalTo(true));
+        });
+    }
+}


### PR DESCRIPTION
…P entry creation callback

Closes #44832



(cherry picked from commit e7bd51c6c74a6ffad266dbfdaed21abf31e7357b)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
