### PR TITLE
WebAuthn authenticator attachment policy is bypassed when the client omits the attachment field

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -525,9 +525,8 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                 return;
             }
 
-            // Browser may not provide authenticatorAttachment (not required by WebAuthn spec)
             if (StringUtil.isBlank(authenticatorAttachment)) {
-                return;
+                throw new WebAuthnException("Authenticator attachment is required by the policy but was not provided by the client.");
             }
 
             if (!WebAuthnConstants.SUPPORTED_AUTHENTICATOR_ATTACHMENTS.contains(authenticatorAttachment)) {

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
@@ -47,6 +47,16 @@ public class WebAuthnPolicyComplianceTest extends AbstractWebAuthnVirtualTest {
     }
 
     @Test
+    public void omittedAuthenticatorAttachment() {
+        managedRealm.updateWithCleanup(r -> r
+                .webAuthnPolicyAuthenticatorAttachment(AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM));
+
+        registerAndExpectError("attach-omit",
+                tamperFormField("authenticatorAttachment", ""),
+                "Authenticator attachment is required by the policy but was not provided by the client.");
+    }
+
+    @Test
     public void tamperedSignatureAlgorithm() {
         // Policy: ES512 only. Tamper pubKeyCredParams to ES256.
         managedRealm.updateWithCleanup(r -> r


### PR DESCRIPTION
- Closes #50719
- The `authenticatorAttachment` should already be [widely adopted](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/authenticatorAttachment) by browsers
- We should change our notion of the webauthn policies - what we cannot enforce, we should have marked as "hints".

@keycloak/core-authn Could you please check it? Thanks!

## Considerations
- For ensuring the authenticator attachment (without the cryptographical proof), we would need to use the remote FIDO Metadata Service, which contains some more data about the authenticators based on the AAGUID, and it would be possible to recognize the device transports. However, it's something that is not planned on our side at this moment, and not [widely requested](https://github.com/keycloak/keycloak/issues/9509) by the community.
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
