### PR TITLE
Initial implementation for Token Exchange Delegation provider

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -91,7 +91,7 @@ public class Profile {
 
         TOKEN_EXCHANGE("Token Exchange Service", Type.PREVIEW, 1, true, null, null),
         TOKEN_EXCHANGE_STANDARD_V2("Standard Token Exchange version 2", Type.DEFAULT, 2),
-        TOKEN_EXCHANGE_DELEGATION("Token Exchange Delegation", Type.EXPERIMENTAL, Feature.PARAMETERIZED_SCOPES),
+        TOKEN_EXCHANGE_DELEGATION("Token Exchange Delegation", Type.EXPERIMENTAL, Feature.PARAMETERIZED_SCOPES, Feature.TOKEN_EXCHANGE_STANDARD_V2),
 
         JWT_AUTHORIZATION_GRANT("JWT Profile for Oauth 2.0 Authorization Grant", Type.DEFAULT),
 

--- a/core/src/main/java/org/keycloak/representations/IDToken.java
+++ b/core/src/main/java/org/keycloak/representations/IDToken.java
@@ -64,6 +64,7 @@ public class IDToken extends JsonWebToken {
 
     // RFC 8693 - OAuth 2.0 Token Exchange
     public static final String MAY_ACT = "may_act";
+    public static final String ACT = "act";
 
     // NOTE!!!  WE used to use @JsonUnwrapped on a UserClaimSet object.  This screws up otherClaims and the won't work
     // anymore.  So don't have any @JsonUnwrapped!

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -46,6 +46,7 @@ public interface Details {
     String REGISTER_METHOD = "register_method";
     String USERNAME = "username";
     String ACTOR = "actor";
+    String ACTOR_ID = "actor_id";
     String ACTOR_SESSION_ID = "actor_session_id";
     String FIRST_NAME = "first_name";
     String LAST_NAME = "last_name";

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -45,6 +45,8 @@ public interface Details {
     String IDENTITY_PROVIDER_BROKER_SESSION_ID = "identity_provider_broker_session_id";
     String REGISTER_METHOD = "register_method";
     String USERNAME = "username";
+    String ACTOR = "actor";
+    String ACTOR_SESSION_ID = "actor_session_id";
     String FIRST_NAME = "first_name";
     String LAST_NAME = "last_name";
     String PREVIOUS_FIRST_NAME = PREF_PREVIOUS + "first_name";

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -121,6 +121,12 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
     }
 
     protected AuthenticationManager.AuthResult processSubjectToken() {
+        if (!OAuth2Constants.ACCESS_TOKEN_TYPE.equals(context.getParams().getSubjectTokenType())) {
+            event.detail(Details.REASON, "subject_token_type invalid");
+            event.error(Errors.INVALID_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid subject token type", Response.Status.BAD_REQUEST);
+        }
+
         String subjectToken = context.getParams().getSubjectToken();
 
         event.detail(Details.REQUESTED_TOKEN_TYPE, context.getParams().getRequestedTokenType());

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -116,7 +116,11 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
 
     @Override
     protected Response tokenExchange() {
+        AuthenticationManager.AuthResult authResult = processSubjectToken();
+        return exchangeClientToClient(authResult.user(), authResult.session(), authResult.token(), true);
+    }
 
+    protected AuthenticationManager.AuthResult processSubjectToken() {
         String subjectToken = context.getParams().getSubjectToken();
 
         event.detail(Details.REQUESTED_TOKEN_TYPE, context.getParams().getRequestedTokenType());
@@ -133,6 +137,19 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
         UserSessionModel tokenSession = authResult.session();
         AccessToken token = authResult.token();
 
+        validateSenderConstrainedToken(token);
+
+        event.user(tokenUser);
+        event.detail(Details.USERNAME, tokenUser.getUsername());
+        if (token.getSessionId() != null) {
+            event.session(tokenSession);
+        }
+        event.detail(Details.SUBJECT_TOKEN_CLIENT_ID, token.getIssuedFor());
+
+        return authResult;
+    }
+
+    protected void validateSenderConstrainedToken(AccessToken token) {
         if (isSenderConstrainedToken(token)) {
             // Reject sender-constrained tokens (RFC 7800) as subject_token if client does not match the authorized parties claim
             if (!token.getIssuedFor().equals(client.getClientId())) {
@@ -169,15 +186,6 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
                 }
             }
         }
-
-        event.user(tokenUser);
-        event.detail(Details.USERNAME, tokenUser.getUsername());
-        if (token.getSessionId() != null) {
-            event.session(tokenSession);
-        }
-        event.detail(Details.SUBJECT_TOKEN_CLIENT_ID, token.getIssuedFor());
-
-        return exchangeClientToClient(tokenUser, tokenSession, token, true);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
  *  and other contributors as indicated by the @author tags.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,7 +81,7 @@ public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvid
         String actorTokenType = context.getParams().getActorTokenType();
         if (!OAuth2Constants.ACCESS_TOKEN_TYPE.equals(actorTokenType)) {
             event.detail(Details.REASON, "actor_token_type invalid");
-            event.error(Errors.INVALID_TOKEN);
+            event.error(Errors.INVALID_REQUEST);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid actor token type", Response.Status.BAD_REQUEST);
         }
 
@@ -96,6 +96,7 @@ public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvid
         UserSessionModel actorSession = actorAuthResult.session();
         actorAccessToken = actorAuthResult.token();
 
+        event.detail(Details.ACTOR_ID, actorUser.getId());
         event.detail(Details.ACTOR, actorUser.getUsername());
         if (actorAccessToken.getSessionId() != null) {
             event.detail(Details.ACTOR_SESSION_ID, actorSession.getId());
@@ -142,37 +143,31 @@ public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvid
         }
 
         Object mayActObject = subjectAccessToken.getOtherClaims().get(IDToken.MAY_ACT);
-        if (!(mayActObject instanceof Map)) {
+        if (!(mayActObject instanceof Map mayActMap)) {
             event.detail(Details.REASON, "Invalid may_act claim in the subject_token");
             event.error(Errors.INVALID_TOKEN);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid may_act claim in the subject_token", Response.Status.BAD_REQUEST);
         }
 
-        Map mayActMap = (Map) mayActObject;
-
         Object issObject = mayActMap.get(OIDCLoginProtocol.ISSUER);
-        if (issObject instanceof String iss
-                && !iss.equals(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()))) {
+        if (issObject != null && !issObject.equals(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()))) {
             event.detail(Details.REASON, "Invalid issuer in the may_act claim of the subject_token");
             event.error(Errors.INVALID_TOKEN);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid issuer in the may_act claim of the subject_token", Response.Status.BAD_REQUEST);
         }
 
         Object subjectObject = mayActMap.get(JsonWebToken.SUBJECT);
-        if (!(subjectObject instanceof String)) {
+        if (!(subjectObject instanceof String subject)) {
             event.detail(Details.REASON, "Invalid may_act claim in the subject_token");
             event.error(Errors.INVALID_TOKEN);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid may_act claim in the subject_token", Response.Status.BAD_REQUEST);
         }
 
-        String subject = (String) subjectObject;
         if (!actorUser.getId().equals(subject)) {
             event.detail(Details.REASON, "Actor user is not allowed by the may_act claim inside the subject_token");
             event.error(Errors.INVALID_TOKEN);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Actor user is not allowed by the may_act claim inside the subject_token", Response.Status.BAD_REQUEST);
         }
-
-        // TODO: check more things???
     }
 
     @Override
@@ -180,7 +175,7 @@ public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvid
         super.checkRequestedAudiences(responseBuilder);
 
         // add the "act" claim using the "may_act" claim sent in the subjectToken, chain current actor if present
-        Map act = new HashMap((Map) subjectAccessToken.getOtherClaims().get(IDToken.MAY_ACT)); // shold be present at this point
+        Map act = new HashMap((Map) subjectAccessToken.getOtherClaims().get(IDToken.MAY_ACT)); // should be present at this point
         Object prevAct = actorAccessToken.getOtherClaims().get(IDToken.ACT);
         if (prevAct != null) {
             act.put(IDToken.ACT, prevAct);

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProvider.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.protocol.oidc.tokenexchange;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.TokenExchangeContext;
+import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.CorsErrorResponseException;
+import org.keycloak.services.Urls;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.UserSessionManager;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvider {
+
+    private AccessToken actorAccessToken;
+    private AccessToken subjectAccessToken;
+
+    @Override
+    public boolean supports(TokenExchangeContext context) {
+        if(!OIDCAdvancedConfigWrapper.fromClientModel(context.getClient()).isStandardTokenExchangeEnabled()) {
+            context.setUnsupportedReason("Standard token exchange is not enabled for the requested client");
+            return false;
+        }
+
+        // Subject delegation request needs the actor token
+        String actorToken = context.getParams().getActorToken();
+        if (actorToken != null) {
+            return true;
+        }
+
+        context.setUnsupportedReason("Token exchange delegation not used because no actor_token sent");
+        return false;
+    }
+
+    @Override
+    protected Response tokenExchange() {
+        // validate subject token
+        AuthenticationManager.AuthResult subjectAuthResult = processSubjectToken();
+        UserModel subjectUser = subjectAuthResult.user();
+        subjectAccessToken = subjectAuthResult.token();
+
+        // validate actor token
+        String actorToken = context.getParams().getActorToken();
+        String actorTokenType = context.getParams().getActorTokenType();
+        if (!OAuth2Constants.ACCESS_TOKEN_TYPE.equals(actorTokenType)) {
+            event.detail(Details.REASON, "actor_token_type invalid");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid actor token type", Response.Status.BAD_REQUEST);
+        }
+
+        AuthenticationManager.AuthResult actorAuthResult = AuthenticationManager.verifyIdentityToken(session, realm, session.getContext().getUri(), clientConnection, true, true, null,
+                false, actorToken, context.getHeaders(), verifier -> {});
+        if (actorAuthResult == null) {
+            event.detail(Details.REASON, "actor_token validation failure");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid actor token", Response.Status.BAD_REQUEST);
+        }
+        UserModel actorUser = actorAuthResult.user();
+        UserSessionModel actorSession = actorAuthResult.session();
+        actorAccessToken = actorAuthResult.token();
+
+        event.detail(Details.ACTOR, actorUser.getUsername());
+        if (actorAccessToken.getSessionId() != null) {
+            event.detail(Details.ACTOR_SESSION_ID, actorSession.getId());
+        }
+
+        validateSenderConstrainedToken(actorAccessToken);
+        if (!client.equals(realm.getClientByClientId(actorAccessToken.getIssuedFor()))) {
+            forbiddenIfClientIsNotWithinTokenAudience(actorAccessToken);
+        }
+
+        // validate the subject token allows the actor in the "may_act" claim
+        validateMayAct(subjectAccessToken, subjectUser, actorUser);
+
+        // always create a transient session for delegation (no refresh token allowed)
+        UserSessionModel tokenSession = new UserSessionManager(session).createUserSession(
+                KeycloakModelUtils.generateId(), realm, subjectUser, subjectUser.getUsername(), clientConnection.getRemoteHost(),
+                ServiceAccountConstants.CLIENT_AUTH, false, null, null, UserSessionModel.SessionPersistenceState.TRANSIENT);
+
+        return exchangeClientToClient(subjectUser, tokenSession, subjectAccessToken, true);
+    }
+
+    @Override
+    protected String getRequestedTokenType() {
+        // only access token type is supported for token exchange delegation
+        String requestedTokenType = params.getRequestedTokenType();
+        if (requestedTokenType == null) {
+            requestedTokenType = OAuth2Constants.ACCESS_TOKEN_TYPE;
+            return requestedTokenType;
+        }
+        if (requestedTokenType.equals(OAuth2Constants.ACCESS_TOKEN_TYPE)) {
+            return requestedTokenType;
+        }
+
+        event.detail(Details.REASON, "requested_token_type unsupported");
+        event.error(Errors.INVALID_REQUEST);
+        throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "requested_token_type unsupported", Response.Status.BAD_REQUEST);
+    }
+
+    protected void validateMayAct(AccessToken subjectAccessToken, UserModel subjectUser, UserModel actorUser) {
+        if (subjectUser.getId().equals(actorUser.getId())) {
+            event.detail(Details.REASON, "Actor and subject user cannot be the same user");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Actor and subject user cannot be the same user", Response.Status.BAD_REQUEST);
+        }
+
+        Object mayActObject = subjectAccessToken.getOtherClaims().get(IDToken.MAY_ACT);
+        if (!(mayActObject instanceof Map)) {
+            event.detail(Details.REASON, "Invalid may_act claim in the subject_token");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid may_act claim in the subject_token", Response.Status.BAD_REQUEST);
+        }
+
+        Map mayActMap = (Map) mayActObject;
+
+        Object issObject = mayActMap.get(OIDCLoginProtocol.ISSUER);
+        if (issObject instanceof String iss
+                && !iss.equals(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()))) {
+            event.detail(Details.REASON, "Invalid issuer in the may_act claim of the subject_token");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid issuer in the may_act claim of the subject_token", Response.Status.BAD_REQUEST);
+        }
+
+        Object subjectObject = mayActMap.get(JsonWebToken.SUBJECT);
+        if (!(subjectObject instanceof String)) {
+            event.detail(Details.REASON, "Invalid may_act claim in the subject_token");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid may_act claim in the subject_token", Response.Status.BAD_REQUEST);
+        }
+
+        String subject = (String) subjectObject;
+        if (!actorUser.getId().equals(subject)) {
+            event.detail(Details.REASON, "Actor user is not allowed by the may_act claim inside the subject_token");
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Actor user is not allowed by the may_act claim inside the subject_token", Response.Status.BAD_REQUEST);
+        }
+
+        // TODO: check more things???
+    }
+
+    @Override
+    protected void checkRequestedAudiences(TokenManager.AccessTokenResponseBuilder responseBuilder) {
+        super.checkRequestedAudiences(responseBuilder);
+
+        // add the "act" claim using the "may_act" claim sent in the subjectToken, chain current actor if present
+        Map act = new HashMap((Map) subjectAccessToken.getOtherClaims().get(IDToken.MAY_ACT)); // shold be present at this point
+        Object prevAct = actorAccessToken.getOtherClaims().get(IDToken.ACT);
+        if (prevAct != null) {
+            act.put(IDToken.ACT, prevAct);
+        }
+        responseBuilder.getAccessToken().getOtherClaims().put(IDToken.ACT, act);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProviderFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.protocol.oidc.tokenexchange;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.protocol.oidc.TokenExchangeProvider;
+import org.keycloak.protocol.oidc.TokenExchangeProviderFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class TokenExchangeDelegationProviderFactory implements TokenExchangeProviderFactory, EnvironmentDependentProviderFactory {
+    @Override
+    public TokenExchangeProvider create(KeycloakSession session) {
+        return new TokenExchangeDelegationProvider();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return "delegation";
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION);
+    }
+
+    @Override
+    public int order() {
+        // Bigger priority than standard, so it has preference over it
+        return 15;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.TokenExchangeProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.TokenExchangeProviderFactory
@@ -1,2 +1,3 @@
 org.keycloak.protocol.oidc.tokenexchange.V1TokenExchangeProviderFactory
 org.keycloak.protocol.oidc.tokenexchange.StandardTokenExchangeProviderFactory
+org.keycloak.protocol.oidc.tokenexchange.TokenExchangeDelegationProviderFactory

--- a/services/src/test/java/org/keycloak/compatibility/FeatureCompatibilityMetadataProviderTest.java
+++ b/services/src/test/java/org/keycloak/compatibility/FeatureCompatibilityMetadataProviderTest.java
@@ -197,19 +197,13 @@ public class FeatureCompatibilityMetadataProviderTest extends AbstractCompatibil
         public FeatureConfig getFeatureConfig(String featureName) {
             // No support for transitive dependencies but that should be fine for now
             if (enabled) {
-                if (DEPENDENT_FEATURES.containsKey(feature)) {
-                    for (Profile.Feature dep : DEPENDENT_FEATURES.get(feature)) {
-                        if (dep.getVersionedKey().equals(featureName))
-                            return FeatureConfig.ENABLED;
-                    }
-                }
                 for (Profile.Feature dep : feature.getDependencies()) { // Explicitly enable dependencies that might be disabled by default
                     if (dep.getVersionedKey().equals(featureName))
                         return FeatureConfig.ENABLED;
                 }
                 return feature.getVersionedKey().equals(featureName) ? FeatureConfig.ENABLED : FeatureConfig.UNCONFIGURED;
             } else {
-                if (DEPENDENT_FEATURES.containsKey(feature)) {
+                if (DEPENDENT_FEATURES.containsKey(feature)) { // Explicitly disable features that depend on the passed one
                     for (Profile.Feature dep : DEPENDENT_FEATURES.get(feature)) {
                         if (dep.getUnversionedKey().equals(featureName))
                             return FeatureConfig.DISABLED;

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenExchangeDelegationTest.java
@@ -1,14 +1,20 @@
 package org.keycloak.tests.oauth;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.CibaConfig;
@@ -16,15 +22,22 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.protocol.oidc.grants.ciba.CibaGrantTypeFactory;
 import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
+import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.InjectUser;
@@ -37,6 +50,8 @@ import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectCibaProvider;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedClient;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.ManagedUser;
 import org.keycloak.testframework.realm.RealmBuilder;
@@ -47,9 +62,11 @@ import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.OAuthGrantPage;
+import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
 import org.keycloak.testsuite.util.oauth.LogoutResponse;
 import org.keycloak.testsuite.util.oauth.ciba.AuthenticationRequestAcknowledgement;
 
@@ -59,11 +76,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.representations.IDToken.ACT;
 import static org.keycloak.representations.IDToken.MAY_ACT;
 import static org.keycloak.representations.IDToken.PREFERRED_USERNAME;
 import static org.keycloak.representations.JsonWebToken.SUBJECT;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *
@@ -83,6 +99,9 @@ public class TokenExchangeDelegationTest {
 
     @InjectUser(config = AdministratorUserConfig.class)
     ManagedUser administrator;
+
+    @InjectClient(config = AdminClientConfig.class)
+    ManagedClient adminApp;
 
     @InjectEvents
     protected Events events;
@@ -106,23 +125,10 @@ public class TokenExchangeDelegationTest {
     public void delegationNoImpersonation() {
         // request delegation with a user that cannot impersonate — scope is silently dropped
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
-        oauth.scope(scope).openLoginForm();
-        oauth.fillLoginForm(USERNAME, PASSWORD);
-        grantPage.assertCurrent();
-        List<String> grants = grantPage.getDisplayedGrants();
-        MatcherAssert.assertThat(grants, Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token"))));
-        grantPage.accept();
 
-        EventRepresentation loginEvent = events.poll();
-        EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN)
-                .clientId("test-app")
-                .details(Details.REDIRECT_URI, oauth.getRedirectUri())
-                .details(Details.USERNAME, USERNAME)
-                .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
-
-        // delegation scope should not be present as user cannot impersonate
-        String code = oauth.parseLoginResponse().getCode();
-        AccessTokenResponse res = oauth.doAccessTokenRequest(code);
+        // request delegation with a user that cannot impersonate
+        AccessTokenResponse res = loginWithDelegation(scope, grants -> MatcherAssert.assertThat(grants,
+                Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token")))));
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
         assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
@@ -141,23 +147,8 @@ public class TokenExchangeDelegationTest {
 
         // request the delegation to administrator and accept the delegation
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
-        oauth.scope(scope).openLoginForm();
-        oauth.fillLoginForm(USERNAME, PASSWORD);
-        grantPage.assertCurrent();
-        List<String> grants = grantPage.getDisplayedGrants();
-        MatcherAssert.assertThat(grants, Matchers.hasItem("Delegate token to administrator administrator?"));
-        grantPage.accept();
+        AccessTokenResponse res = loginWithDelegation(scope);
 
-        EventRepresentation loginEvent = events.poll();
-        EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN)
-                .clientId("test-app")
-                .details(Details.REDIRECT_URI, oauth.getRedirectUri())
-                .details(Details.USERNAME, USERNAME)
-                .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
-
-        // get the code and obtain the scope
-        String code = oauth.parseLoginResponse().getCode();
-        AccessTokenResponse res = oauth.doAccessTokenRequest(code);
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeContains(res.getScope(), scope);
         assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
@@ -168,12 +159,21 @@ public class TokenExchangeDelegationTest {
         assertScopeContains(res.getScope(), scope);
         assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
+        // perform the token exchange with delegation
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
+
         // remove the impersonation and refresh the token
         administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
         assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
+
+        // token exchange does not work without "may_act" claim
+        String actorToken = getActorToken();
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE).send();
+        assertExchangeError(tokenExchangeRes, Errors.INVALID_TOKEN, "Invalid may_act claim in the subject_token");
 
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
@@ -196,7 +196,7 @@ public class TokenExchangeDelegationTest {
 
         try (var response = realm.admin().clientScopes().get(delegationScopeId).getProtocolMappers()
                 .createMapper(ModelToRepresentation.toRepresentation(preferredUsernameMapper))) {
-            assertEquals(201, response.getStatus(), "Mapper creation should succeed");
+            Assertions.assertEquals(201, response.getStatus(), "Mapper creation should succeed");
         }
         realm.cleanup().add(r -> {
             r.clientScopes().get(delegationScopeId).getProtocolMappers()
@@ -207,34 +207,24 @@ public class TokenExchangeDelegationTest {
         });
 
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
-        oauth.scope(scope).openLoginForm();
-        oauth.fillLoginForm(USERNAME, PASSWORD);
-        grantPage.assertCurrent();
-        grantPage.accept();
+        AccessTokenResponse res = loginWithDelegation(scope);
 
-        EventRepresentation loginEvent = events.poll();
-        EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN)
-                .clientId("test-app")
-                .details(Details.REDIRECT_URI, oauth.getRedirectUri())
-                .details(Details.USERNAME, USERNAME)
-                .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
-
-        String code = oauth.parseLoginResponse().getCode();
-        AccessTokenResponse res = oauth.doAccessTokenRequest(code);
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeContains(res.getScope(), scope);
 
         AccessToken token = oauth.verifyToken(res.getAccessToken());
-        assertMayActPresent(token, administrator.getId());
-        assertMayActPreferredUsernamePresent(token, administrator.getUsername());
+        assertMayActPresent(token, administrator.getId(), null, administrator.getUsername());
 
         res = oauth.scope(null).doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeContains(res.getScope(), scope);
 
         AccessToken refreshedToken = oauth.verifyToken(res.getAccessToken());
-        assertMayActPresent(refreshedToken, administrator.getId());
-        assertMayActPreferredUsernamePresent(refreshedToken, administrator.getUsername());
+        assertMayActPresent(refreshedToken, administrator.getId(), null, administrator.getUsername());
+
+        // perform the token exchange with delegation
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken(),
+                teToken -> assertActPresent(teToken, administrator.getId(), null, administrator.getUsername()));
 
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
         Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
@@ -315,7 +305,7 @@ public class TokenExchangeDelegationTest {
                 .hasAccessTokenId(CibaGrantTypeFactory.GRANT_SHORTCUT)
                 .details(Details.USERNAME, USERNAME)
                 .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
-       assertScopeContains(res.getScope(), scope);
+        assertScopeContains(res.getScope(), scope);
         assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
         // refresh the token
@@ -324,6 +314,9 @@ public class TokenExchangeDelegationTest {
         assertScopeContains(res.getScope(), scope);
         assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
+        // perform the token exchange with delegation
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
+
         // remove the impersonation and refresh the token
         administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
@@ -331,28 +324,283 @@ public class TokenExchangeDelegationTest {
         assertScopeNotContains(res.getScope(), scope);
         assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
 
+        // token exchange does not work without "may_act" claim
+        String actorToken = getActorToken();
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE).send();
+        assertExchangeError(tokenExchangeRes, Errors.INVALID_TOKEN, "Invalid may_act claim in the subject_token");
+
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
         Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
     }
 
-    @SuppressWarnings("unchecked")
+    @Test
+    public void failIfDisabledActor() {
+        addImpersonationToAdministrator();
+
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+
+        ProtocolMapperRepresentation audienceMapper = adminApp.admin().getProtocolMappers().getMappers().iterator().next();
+        adminApp.admin().getProtocolMappers().delete(audienceMapper.getId());
+        adminApp.cleanup().add(c -> c.getProtocolMappers().createMapper(List.of(audienceMapper)));
+
+        String actorToken = getActorToken();
+        administrator.updateWithCleanup(user -> user.enabled(false));
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE).send();
+        assertExchangeError(tokenExchangeRes, null, Errors.INVALID_TOKEN, "actor_token validation failure");
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void failIfInvalidAudienceInActorToken() {
+        addImpersonationToAdministrator();
+
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+
+        ProtocolMapperRepresentation audienceMapper = adminApp.admin().getProtocolMappers().getMappers().iterator().next();
+        adminApp.admin().getProtocolMappers().delete(audienceMapper.getId());
+        adminApp.cleanup().add(c -> c.getProtocolMappers().createMapper(List.of(audienceMapper)));
+
+        String actorToken = getActorToken();
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE).send();
+        assertExchangeError(tokenExchangeRes, Errors.NOT_ALLOWED, "client is not within the token audience");
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void failIfNoAccessTokenRequested() {
+        addImpersonationToAdministrator();
+
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+
+        String actorToken = getActorToken();
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE)
+                .requestedTokenType(OAuth2Constants.REFRESH_TOKEN_TYPE) // request refresh which is not valid
+                .send();
+        assertExchangeError(tokenExchangeRes, Errors.INVALID_REQUEST, "requested_token_type unsupported");
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void failIfOtherAdminInMayAct() {
+        addImpersonationToAdministrator();
+
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+
+        String actorToken = getActorToken("otheruser", PASSWORD);
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE)
+                .send();
+        assertExchangeError(tokenExchangeRes, "otheruser", Errors.INVALID_TOKEN,
+                "Actor user is not allowed by the may_act claim inside the subject_token");
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void issuerInMayAct() {
+        addImpersonationToAdministrator();
+
+        // create a hardcoded claim to add the iss of the realm
+        ProtocolMapperRepresentation issMapper = new ProtocolMapperRepresentation();
+        issMapper.setName("iss-may-act-mapper");
+        issMapper.setProtocol("openid-connect");
+        issMapper.setProtocolMapper("oidc-hardcoded-claim-mapper");
+        Map<String, String> config = new HashMap<>();
+        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "may_act.iss");
+        config.put(HardcodedClaim.CLAIM_VALUE, realm.getBaseUrl());
+        config.put(OIDCAttributeMapperHelper.JSON_TYPE, "String");
+        config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, Boolean.TRUE.toString());
+        issMapper.setConfig(config);
+        ClientScopeResource delegationScope = AdminApiUtil.findClientScopeByName(realm.admin(), OIDCLoginProtocolFactory.DELEGATION_SCOPE);
+        String issMapperId = ApiUtil.getCreatedId(delegationScope.getProtocolMappers().createMapper(issMapper));
+        issMapper.setId(issMapperId);
+        realm.cleanup().add(r -> AdminApiUtil.findClientScopeByName(r, OIDCLoginProtocolFactory.DELEGATION_SCOPE)
+                .getProtocolMappers().delete(issMapperId));
+
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId(), realm.getBaseUrl(), null);
+
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken(),
+                token -> assertActPresent(token, administrator.getId(), realm.getBaseUrl(), null));
+
+        // change the iss to other url
+        issMapper.getConfig().put(HardcodedClaim.CLAIM_VALUE, "http://otheriss");
+        delegationScope.getProtocolMappers().update(issMapperId, issMapper);
+
+        // refresh the token
+        res = oauth.scope(null).doRefreshTokenRequest(res.getRefreshToken());
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertScopeContains(res.getScope(), scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId(), "http://otheriss", null);
+
+        // check iss is wrong now
+        String actorToken = getActorToken();
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE)
+                .send();
+        assertExchangeError(tokenExchangeRes, Errors.INVALID_TOKEN, "Invalid issuer in the may_act claim of the subject_token");
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    private void addImpersonationToAdministrator() {
+        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
+        final String clientUUID = realmManagement.toRepresentation().getId();
+        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
+        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
+        administrator.cleanup().add(user -> user.roles().clientLevel(clientUUID).remove(List.of(impersonation)));
+    }
+
+    private void assertExchangeError(AccessTokenResponse tokenExchangeRes, String error, String reason) {
+        assertExchangeError(tokenExchangeRes, administrator.getUsername(), error, reason);
+    }
+
+    private void assertExchangeError(AccessTokenResponse tokenExchangeRes, String actor, String error, String reason) {
+        Assertions.assertFalse(tokenExchangeRes.isSuccess());
+        EventAssertion.assertError(events.poll())
+                .type(EventType.TOKEN_EXCHANGE_ERROR)
+                .clientId("test-app")
+                .hasUserId()
+                .details(Details.USERNAME, USERNAME)
+                .details(Details.ACTOR, actor)
+                .error(error)
+                .details(Details.REASON, reason)
+                .details(Details.SUBJECT_TOKEN_CLIENT_ID, "test-app");
+    }
+
+    private void tokenExchangeDelegationSuccess(String subjectToken, String actorToken) {
+        tokenExchangeDelegationSuccess(subjectToken, actorToken,
+                token -> assertActPresent(token, administrator.getId(), null, null));
+    }
+
+    private void tokenExchangeDelegationSuccess(String subjectToken, String actorToken, Consumer<AccessToken> actValidator) {
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(subjectToken)
+                .actorToken(actorToken)
+                .actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE)
+                .send();
+        Assertions.assertTrue(tokenExchangeRes.isSuccess());
+        EventAssertion.assertSuccess(events.poll())
+                .type(EventType.TOKEN_EXCHANGE)
+                .clientId("test-app")
+                .details(Details.USERNAME, USERNAME)
+                .details(Details.ACTOR, administrator.getUsername())
+                .details(Details.REQUESTED_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE)
+                .details(Details.SUBJECT_TOKEN_CLIENT_ID, "test-app");
+
+        AccessToken teToken = oauth.verifyToken(tokenExchangeRes.getAccessToken());
+        Assertions.assertEquals(USERNAME, teToken.getPreferredUsername());
+        actValidator.accept(teToken);
+        Assertions.assertNull(teToken.getSessionId(), "Session is not transient");
+
+        IntrospectionResponse introspectRes = oauth.doIntrospectionAccessTokenRequest(tokenExchangeRes.getAccessToken());
+        Assertions.assertTrue(introspectRes.isSuccess());
+        try {
+            TokenMetadataRepresentation rep = introspectRes.asTokenMetadata();
+            Assertions.assertEquals(USERNAME, rep.getUserName());
+        } catch (IOException e) {
+            Assertions.fail(e);
+        }
+    }
+
+    private AccessTokenResponse loginWithDelegation(String scope) {
+        return loginWithDelegation(scope, grants -> MatcherAssert.assertThat(grants,
+                Matchers.hasItem("Delegate token to administrator administrator?")));
+    }
+
+    private AccessTokenResponse loginWithDelegation(String scope, Consumer<List<String>> grantsValidator) {
+        oauth.scope(scope).openLoginForm();
+        oauth.fillLoginForm(USERNAME, PASSWORD);
+        grantPage.assertCurrent();
+        List<String> grants = grantPage.getDisplayedGrants();
+        grantsValidator.accept(grants);
+        grantPage.accept();
+
+        EventRepresentation loginEvent = events.poll();
+        EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN)
+                .clientId("test-app")
+                .details(Details.REDIRECT_URI, oauth.getRedirectUri())
+                .details(Details.USERNAME, USERNAME)
+                .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
+
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse res = oauth.doAccessTokenRequest(code);
+        EventAssertion.assertSuccess(events.poll()).type(EventType.CODE_TO_TOKEN);
+        return res;
+    }
+
+    private String getActorToken() {
+        return getActorToken(administrator.getUsername(), administrator.getPassword());
+    }
+
+    private String getActorToken(String username, String password) {
+        String actorToken = oauth.client(adminApp.getClientId(), adminApp.getSecret()).scope(null)
+                .doPasswordGrantRequest(username, password).getAccessToken();
+        EventAssertion.assertSuccess(events.poll()).type(EventType.LOGIN).details(Details.USERNAME, username);
+        return actorToken;
+    }
+
     private static void assertMayActPresent(AccessToken token, String expectedActorId) {
+        assertMayActPresent(token, expectedActorId, null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertMayActPresent(AccessToken token, String expectedActorId, String expectedIss, String expectedUsername) {
         Map<String, Object> mayAct = (Map<String, Object>) token.getOtherClaims().get(MAY_ACT);
         Assertions.assertNotNull(mayAct, "may_act claim should be present");
         Assertions.assertEquals(expectedActorId, mayAct.get(SUBJECT), "may_act.sub should contain the actor user ID");
+        if (expectedIss != null) {
+            Assertions.assertEquals(expectedIss, mayAct.get(OIDCLoginProtocol.ISSUER), "may_act.iss is not correct");
+        } else {
+            Assertions.assertNull(mayAct.get(OIDCLoginProtocol.ISSUER), "may_act.iss is not null");
+        }
+        if (expectedUsername != null) {
+            Assertions.assertEquals(expectedUsername, mayAct.get(PREFERRED_USERNAME), "may_act.preferred_username is not correct");
+        } else {
+            Assertions.assertNull(mayAct.get(PREFERRED_USERNAME), "may_act.preferred_username is not null");
+        }
+    }
+
+    private static void assertActPresent(AccessToken token, String expectedActorId, String expectedIss, String expectedUsername) {
+        Map<String, Object> act = (Map<String, Object>) token.getOtherClaims().get(ACT);
+        Assertions.assertNotNull(act, "act claim should be present");
+        Assertions.assertEquals(expectedActorId, act.get(SUBJECT), "act.sub should contain the actor user ID");
+        if (expectedIss != null) {
+            Assertions.assertEquals(expectedIss, act.get(OIDCLoginProtocol.ISSUER), "act.iss is not correct");
+        } else {
+            Assertions.assertNull(act.get(OIDCLoginProtocol.ISSUER), "act.iss is not null");
+        }
+        if (expectedUsername != null) {
+            Assertions.assertEquals(expectedUsername, act.get(PREFERRED_USERNAME), "act.preferred_username is not correct");
+        } else {
+            Assertions.assertNull(act.get(PREFERRED_USERNAME), "act.preferred_username is not null");
+        }
     }
 
     private static void assertMayActNotPresent(AccessToken token) {
         Assertions.assertNull(token.getOtherClaims().get(MAY_ACT), "may_act claim should not be present");
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void assertMayActPreferredUsernamePresent(AccessToken token, String expectedUsername) {
-        Map<String, Object> mayAct = (Map<String, Object>) token.getOtherClaims().get(MAY_ACT);
-        Assertions.assertNotNull(mayAct, "may_act claim should be present");
-        Assertions.assertEquals(expectedUsername, mayAct.get(PREFERRED_USERNAME),
-                "may_act.preferred_username should contain the actor username");
     }
 
     private String findDelegationScopeId() {
@@ -387,8 +635,11 @@ public class TokenExchangeDelegationTest {
 
         @Override
         public RealmBuilder configure(RealmBuilder realm) {
-            return realm.users(UserBuilder.create(USERNAME).password(PASSWORD)
-                    .email("test@localhost").firstName("Test").lastName("User"));
+            return realm.users(
+                    UserBuilder.create(USERNAME).password(PASSWORD)
+                            .email("test@localhost").firstName("Test").lastName("User"),
+                    UserBuilder.create("otheruser").password(PASSWORD)
+                            .email("otheruser@localhost").firstName("Other").lastName("User"));
         }
     }
 
@@ -400,6 +651,7 @@ public class TokenExchangeDelegationTest {
                     .defaultClientScopes("acr", "basic", "email", "profile")
                     .optionalClientScopes(OIDCLoginProtocolFactory.DELEGATION_SCOPE)
                     .consentRequired(true)
+                    .attribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
                     .attribute(CibaConfig.CIBA_BACKCHANNEL_TOKEN_DELIVERY_MODE_PER_CLIENT, "ping")
                     .attribute(CibaConfig.CIBA_BACKCHANNEL_CLIENT_NOTIFICATION_ENDPOINT, "http://localhost:8500/ciba/push-ciba-client-notification")
                     .attribute(CibaConfig.OIDC_CIBA_GRANT_ENABLED, Boolean.TRUE.toString());
@@ -412,6 +664,28 @@ public class TokenExchangeDelegationTest {
         public UserBuilder configure(UserBuilder user) {
             return user.username("administrator").password(PASSWORD)
                     .email("administrator@localhost").firstName("Administrator").lastName("User");
+        }
+    }
+
+    static class AdminClientConfig implements ClientConfig {
+
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            ProtocolMapperRepresentation audienceMapper = new ProtocolMapperRepresentation();
+            audienceMapper.setName("audience-mapper");
+            audienceMapper.setProtocol("openid-connect");
+            audienceMapper.setProtocolMapper("oidc-audience-mapper");
+            Map<String, String> config = new HashMap<>();
+            config.put("included.client.audience", "test-app");
+            config.put("id.token.claim", "false");
+            config.put("lightweight.claim", "false");
+            config.put("access.token.claim", "true");
+            config.put("introspection.token.claim", "true");
+            audienceMapper.setConfig(config);
+
+            return client.clientId("admin-app").name("admin-app").secret("secret")
+                    .directAccessGrantsEnabled()
+                    .protocolMappers(audienceMapper);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/StandardBaseTokenExchangeWithParameterizedScopesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/StandardBaseTokenExchangeWithParameterizedScopesTest.java
@@ -33,7 +33,7 @@ public class StandardBaseTokenExchangeWithParameterizedScopesTest extends Standa
 
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.PARAMETERIZED_SCOPES);
+            return config.features(Profile.Feature.PARAMETERIZED_SCOPES, Profile.Feature.TOKEN_EXCHANGE_DELEGATION);
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
@@ -505,8 +505,10 @@ public class TokenExchangeDelegationTest {
         EventAssertion.assertSuccess(events.poll())
                 .type(EventType.TOKEN_EXCHANGE)
                 .clientId("test-app")
+                .hasUserId()
                 .details(Details.USERNAME, USERNAME)
                 .details(Details.ACTOR, administrator.getUsername())
+                .details(Details.ACTOR_ID, administrator.getId())
                 .details(Details.REQUESTED_TOKEN_TYPE, OAuth2Constants.ACCESS_TOKEN_TYPE)
                 .details(Details.SUBJECT_TOKEN_CLIENT_ID, "test-app");
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
@@ -1,4 +1,4 @@
-package org.keycloak.tests.oauth;
+package org.keycloak.tests.oauth.tokenexchange;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
@@ -13,6 +13,8 @@ public class TokenExchangeRequest extends AbstractHttpPostRequest<TokenExchangeR
 
     private final String subjectToken;
     private final String subjectTokenType;
+    private String actorToken;
+    private String actorTokenType;
     private String requestedTokenType;
     private String requestedSubject;
     private List<String> audience;
@@ -53,6 +55,16 @@ public class TokenExchangeRequest extends AbstractHttpPostRequest<TokenExchangeR
         return this;
     }
 
+    public TokenExchangeRequest actorToken(String actorToken) {
+        this.actorToken = actorToken;
+        return this;
+    }
+
+    public TokenExchangeRequest actorTokenType(String actorTokenType) {
+        this.actorTokenType = actorTokenType;
+        return this;
+    }
+
     protected void initRequest() {
         parameter(OAuth2Constants.GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
 
@@ -65,6 +77,14 @@ public class TokenExchangeRequest extends AbstractHttpPostRequest<TokenExchangeR
 
         if (requestedSubject != null) {
             parameter(OAuth2Constants.REQUESTED_SUBJECT, requestedSubject);
+        }
+
+        if (actorToken != null) {
+            parameter(OAuth2Constants.ACTOR_TOKEN, actorToken);
+        }
+
+        if (actorTokenType != null) {
+            parameter(OAuth2Constants.ACTOR_TOKEN_TYPE, actorTokenType);
         }
 
         if (audience != null) {


### PR DESCRIPTION
Closes #50204

The initial implementation for the Token Exchange Delegation. For the moment it just accepts access token response type and only creates transient sessions (no refresh tokens allowed). Don't know if later we will need to create real sessions, but, I prefer to continue like this for now. Moving the test to the `tokenexchange` package where the other TE tests are present (second commit for better review). Draft for the moment.

Things to consider:

* Do we need another switch to allow the client to do a delegation exchange? Or is adding the `may_act` claim to the subject token enough?
* The `may_act` just checks the `sub` and the `iss` if present. Is this OK or we should check all the cliams there? (I would say that for the moment it's OK.)
* Only access token type allowed (transient sessions). Do we need refresh tokens?

My idea is presenting this in a demo, and then create follow-up issues for suggestions.
