### PR TITLE
fix: removing temporary client creation in favor of a simple clientmodel

### DIFF
--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -326,6 +326,8 @@ public class DefaultClientService implements ClientService {
                             throw new ServiceException(r.getAllErrorsAsString(), Response.Status.BAD_REQUEST);
                         });
 
+                        model.updateClient();
+
                         session.clientPolicy().triggerOnEvent(new AdminClientUpdatedContext(proposedRepresentation, model, permissions.adminAuth()));
                     }
                 }
@@ -390,22 +392,18 @@ public class DefaultClientService implements ClientService {
     /**
      * Creates a temporary client to convert BaseClientRepresentation to ClientRepresentation.
      * Required because client policy contexts expect ClientRepresentation (v1), but there's no
-     * direct converter from BaseClientRepresentation (v2 API). The temp client is immediately removed.
+     * direct converter from BaseClientRepresentation (v2 API).
      * <p>
      * For more details, see the <a href="https://github.com/keycloak/keycloak/issues/47576">keycloak#47576</a>.
      */
     private ClientRepresentation getProposedOldRepresentation(RealmModel realm, BaseClientRepresentation client, ClientModelMapper mapper) {
-        String tempId = "__temp__" + client.getClientId() + "__" + System.nanoTime();
-        ClientModel tempModel = realm.addClient(tempId);
         String clientId = client.getClientId();
+        SimpleClientModel tempModel = new SimpleClientModel("", realm);
         mapper.toModel(client, tempModel);
-        try {
-            var proposedRepresentation = ModelToRepresentation.toRepresentation(tempModel, session);
-            proposedRepresentation.setClientId(clientId);
-            return proposedRepresentation;
-        } finally {
-            realm.removeClient(tempModel.getId());
-        }
+        var proposedRepresentation = ModelToRepresentation.toRepresentation(tempModel, session);
+        proposedRepresentation.setClientId(clientId);
+        proposedRepresentation.setId(null);
+        return proposedRepresentation;
     }
 
     private void generateClientSecretIfNeeded(BaseClientRepresentation client, ClientModel model, CreateOrUpdateStrategy strategy, boolean patchExplicitNullSecret) {

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/SimpleClientModel.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/SimpleClientModel.java
@@ -1,0 +1,311 @@
+package org.keycloak.services.client;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+
+public class SimpleClientModel implements ClientModel {
+
+    // ── Identity ──────────────────────────────────────────────────────────────
+    private String id;
+    private String clientId;
+    private String name;
+    private String description;
+    private RealmModel realm;
+
+    // ── Flags ─────────────────────────────────────────────────────────────────
+    private boolean enabled;
+    private boolean alwaysDisplayInConsole;
+    private boolean surrogateAuthRequired;
+    private boolean bearerOnly;
+    private boolean frontchannelLogout;
+    private boolean fullScopeAllowed;
+    private boolean publicClient;
+    private boolean consentRequired;
+    private boolean standardFlowEnabled;
+    private boolean implicitFlowEnabled;
+    private boolean directAccessGrantsEnabled;
+    private boolean serviceAccountsEnabled;
+
+    // ── URLs ──────────────────────────────────────────────────────────────────
+    private Set<String> webOrigins = new LinkedHashSet<>();
+    private Set<String> redirectUris = new LinkedHashSet<>();
+    private String managementUrl;
+    private String rootUrl;
+    private String baseUrl;
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+    private String clientAuthenticatorType;
+    private String secret;
+    private String registrationToken;
+    private String protocol;
+    private int nodeReRegistrationTimeout;
+    private int notBefore;
+
+    // ── Attributes & flow overrides ───────────────────────────────────────────
+    private final Map<String, String> attributes = new LinkedHashMap<>();
+    private final Map<String, String> authFlowBindingOverrides = new LinkedHashMap<>();
+
+    // ── Scopes ────────────────────────────────────────────────────────────────
+    /** key = scope name, value = scope model; true = default, false = optional */
+    private final Map<String, ClientScopeModel> defaultClientScopes = new LinkedHashMap<>();
+    private final Map<String, ClientScopeModel> optionalClientScopes = new LinkedHashMap<>();
+
+    // ── Protocol mappers ──────────────────────────────────────────────────────
+    private final Map<String, ProtocolMapperModel> protocolMappers = new LinkedHashMap<>();
+
+    // ── Registered nodes ──────────────────────────────────────────────────────
+    private final Map<String, Integer> registeredNodes = new LinkedHashMap<>();
+
+    // ── Timestamps ────────────────────────────────────────────────────────────
+    private Long createdTimestamp;
+    private Long lastModifiedTimestamp;
+
+    // =========================================================================
+    // ClientModel
+    // =========================================================================
+    
+    public SimpleClientModel(String id, RealmModel realm) {
+        this.id = id;
+        this.realm = realm;
+    }
+
+    @Override public void updateClient() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public String getId() { return id; }
+
+    @Override public String getClientId() { return clientId; }
+    @Override public void setClientId(String clientId) { this.clientId = clientId; }
+
+    @Override public String getName() { return name; }
+    @Override public void setName(String name) { this.name = name; }
+
+    @Override public String getDescription() { return description; }
+    @Override public void setDescription(String description) { this.description = description; }
+
+    @Override public boolean isEnabled() { return enabled; }
+    @Override public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    @Override public boolean isAlwaysDisplayInConsole() { return alwaysDisplayInConsole; }
+    @Override public void setAlwaysDisplayInConsole(boolean alwaysDisplayInConsole) { this.alwaysDisplayInConsole = alwaysDisplayInConsole; }
+
+    @Override public boolean isSurrogateAuthRequired() { return surrogateAuthRequired; }
+    @Override public void setSurrogateAuthRequired(boolean surrogateAuthRequired) { this.surrogateAuthRequired = surrogateAuthRequired; }
+
+    @Override public Set<String> getWebOrigins() { return webOrigins; }
+    @Override public void setWebOrigins(Set<String> webOrigins) { this.webOrigins = webOrigins; }
+    @Override public void addWebOrigin(String webOrigin) { webOrigins.add(webOrigin); }
+    @Override public void removeWebOrigin(String webOrigin) { webOrigins.remove(webOrigin); }
+
+    @Override public Set<String> getRedirectUris() { return redirectUris; }
+    @Override public void setRedirectUris(Set<String> redirectUris) { this.redirectUris = redirectUris; }
+    @Override public void addRedirectUri(String redirectUri) { redirectUris.add(redirectUri); }
+    @Override public void removeRedirectUri(String redirectUri) { redirectUris.remove(redirectUri); }
+
+    @Override public String getManagementUrl() { return managementUrl; }
+    @Override public void setManagementUrl(String url) { this.managementUrl = url; }
+
+    @Override public String getRootUrl() { return rootUrl; }
+    @Override public void setRootUrl(String url) { this.rootUrl = url; }
+
+    @Override public String getBaseUrl() { return baseUrl; }
+    @Override public void setBaseUrl(String url) { this.baseUrl = url; }
+
+    @Override public boolean isBearerOnly() { return bearerOnly; }
+    @Override public void setBearerOnly(boolean only) { this.bearerOnly = only; }
+
+    @Override public int getNodeReRegistrationTimeout() { return nodeReRegistrationTimeout; }
+    @Override public void setNodeReRegistrationTimeout(int timeout) { this.nodeReRegistrationTimeout = timeout; }
+
+    @Override public String getClientAuthenticatorType() { return clientAuthenticatorType; }
+    @Override public void setClientAuthenticatorType(String clientAuthenticatorType) { this.clientAuthenticatorType = clientAuthenticatorType; }
+
+    @Override public boolean validateSecret(String secret) { return Objects.equals(this.secret, secret); }
+    @Override public String getSecret() { return secret; }
+    @Override public void setSecret(String secret) { this.secret = secret; }
+
+    @Override public String getRegistrationToken() { return registrationToken; }
+    @Override public void setRegistrationToken(String registrationToken) { this.registrationToken = registrationToken; }
+
+    @Override public String getProtocol() { return protocol; }
+    @Override public void setProtocol(String protocol) { this.protocol = protocol; }
+
+    @Override public void setAttribute(String name, String value) { attributes.put(name, value); }
+    @Override public void removeAttribute(String name) { attributes.remove(name); }
+    @Override public String getAttribute(String name) { return attributes.get(name); }
+    @Override public Map<String, String> getAttributes() { return attributes; }
+
+    @Override public String getAuthenticationFlowBindingOverride(String binding) { return authFlowBindingOverrides.get(binding); }
+    @Override public Map<String, String> getAuthenticationFlowBindingOverrides() { return authFlowBindingOverrides; }
+    @Override public void removeAuthenticationFlowBindingOverride(String binding) { authFlowBindingOverrides.remove(binding); }
+    @Override public void setAuthenticationFlowBindingOverride(String binding, String flowId) { authFlowBindingOverrides.put(binding, flowId); }
+
+    @Override public boolean isFrontchannelLogout() { return frontchannelLogout; }
+    @Override public void setFrontchannelLogout(boolean flag) { this.frontchannelLogout = flag; }
+
+    @Override public boolean isFullScopeAllowed() { return fullScopeAllowed; }
+    @Override public void setFullScopeAllowed(boolean value) { this.fullScopeAllowed = value; }
+
+    @Override public boolean isPublicClient() { return publicClient; }
+    @Override public void setPublicClient(boolean flag) { this.publicClient = flag; }
+
+    @Override public boolean isConsentRequired() { return consentRequired; }
+    @Override public void setConsentRequired(boolean consentRequired) { this.consentRequired = consentRequired; }
+
+    @Override public boolean isStandardFlowEnabled() { return standardFlowEnabled; }
+    @Override public void setStandardFlowEnabled(boolean standardFlowEnabled) { this.standardFlowEnabled = standardFlowEnabled; }
+
+    @Override public boolean isImplicitFlowEnabled() { return implicitFlowEnabled; }
+    @Override public void setImplicitFlowEnabled(boolean implicitFlowEnabled) { this.implicitFlowEnabled = implicitFlowEnabled; }
+
+    @Override public boolean isDirectAccessGrantsEnabled() { return directAccessGrantsEnabled; }
+    @Override public void setDirectAccessGrantsEnabled(boolean directAccessGrantsEnabled) { this.directAccessGrantsEnabled = directAccessGrantsEnabled; }
+
+    @Override public boolean isServiceAccountsEnabled() { return serviceAccountsEnabled; }
+    @Override public void setServiceAccountsEnabled(boolean serviceAccountsEnabled) { this.serviceAccountsEnabled = serviceAccountsEnabled; }
+
+    @Override public RealmModel getRealm() { return realm; }
+
+    @Override
+    public void addClientScope(ClientScopeModel clientScope, boolean defaultScope) {
+        if (defaultScope) defaultClientScopes.put(clientScope.getName(), clientScope);
+        else optionalClientScopes.put(clientScope.getName(), clientScope);
+    }
+
+    @Override
+    public void addClientScopes(Set<ClientScopeModel> clientScopes, boolean defaultScope) {
+        clientScopes.forEach(cs -> addClientScope(cs, defaultScope));
+    }
+
+    @Override
+    public void removeClientScope(ClientScopeModel clientScope) {
+        defaultClientScopes.remove(clientScope.getName());
+        optionalClientScopes.remove(clientScope.getName());
+    }
+
+    @Override
+    public Map<String, ClientScopeModel> getClientScopes(boolean defaultScope) {
+        return defaultScope ? defaultClientScopes : optionalClientScopes;
+    }
+
+    @Override public int getNotBefore() { return notBefore; }
+    @Override public void setNotBefore(int notBefore) { this.notBefore = notBefore; }
+
+    @Override public Map<String, Integer> getRegisteredNodes() { return registeredNodes; }
+
+    @Override
+    public void registerNode(String nodeHost, int registrationTime) {
+        registeredNodes.put(nodeHost, registrationTime);
+    }
+
+    @Override
+    public void unregisterNode(String nodeHost) {
+        registeredNodes.remove(nodeHost);
+    }
+
+    @Override public Long getCreatedTimestamp() { return createdTimestamp; }
+
+    @Override public Long getLastModifiedTimestamp() { return lastModifiedTimestamp; }
+
+    // =========================================================================
+    // RoleContainerModel
+    // =========================================================================
+
+    @Override
+    public RoleModel getRole(String name) { throw new UnsupportedOperationException(); }
+
+    @Override
+    public RoleModel addRole(String name) { throw new UnsupportedOperationException(); }
+
+    @Override
+    public RoleModel addRole(String id, String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeRole(RoleModel role) { throw new UnsupportedOperationException(); }
+
+    @Override
+    public Stream<RoleModel> getRolesStream() { throw new UnsupportedOperationException(); }
+
+    @Override
+    public Stream<RoleModel> getRolesStream(Integer firstResult, Integer maxResults) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stream<RoleModel> searchForRolesStream(String search, Integer first, Integer max) {
+        throw new UnsupportedOperationException();
+    }
+
+    // =========================================================================
+    // ProtocolMapperContainerModel
+    // =========================================================================
+
+    @Override
+    public Stream<ProtocolMapperModel> getProtocolMappersStream() {
+        return protocolMappers.values().stream();
+    }
+
+    @Override
+    public ProtocolMapperModel addProtocolMapper(ProtocolMapperModel model) {
+        protocolMappers.put(model.getId(), model);
+        return model;
+    }
+
+    @Override
+    public void removeProtocolMapper(ProtocolMapperModel mapping) {
+        protocolMappers.remove(mapping.getId());
+    }
+
+    @Override
+    public void updateProtocolMapper(ProtocolMapperModel mapping) {
+        protocolMappers.put(mapping.getId(), mapping);
+    }
+
+    @Override
+    public ProtocolMapperModel getProtocolMapperById(String id) {
+        return protocolMappers.get(id);
+    }
+
+    @Override
+    public ProtocolMapperModel getProtocolMapperByName(String protocol, String name) {
+        return protocolMappers.values().stream()
+                .filter(m -> Objects.equals(m.getProtocolMapper(), protocol) && Objects.equals(m.getName(), name))
+                .findFirst().orElse(null);
+    }
+
+    // =========================================================================
+    // ScopeContainerModel
+    // =========================================================================
+
+    @Override
+    public Stream<RoleModel> getScopeMappingsStream() { throw new UnsupportedOperationException(); }
+
+    @Override
+    public Stream<RoleModel> getRealmScopeMappingsStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addScopeMapping(RoleModel role) { throw new UnsupportedOperationException(); }
+
+    @Override
+    public void deleteScopeMapping(RoleModel role) { throw new UnsupportedOperationException(); }
+
+    @Override
+    public boolean hasScope(RoleModel role) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.BadRequestException;
@@ -44,6 +45,9 @@ import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
 import org.keycloak.authentication.authenticators.client.JWTClientSecretAuthenticator;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
+import org.keycloak.models.ClientModel;
+import org.keycloak.provider.ProviderEvent;
+import org.keycloak.provider.ProviderEventListener;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
 import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
@@ -63,6 +67,8 @@ import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.tests.admin.client.v2.ClientApiV2Test.ClientProviderEventListener.ClientEvent;
+import org.keycloak.tests.admin.client.v2.ClientApiV2Test.ClientProviderEventListener.EventType;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.http.client.methods.HttpGet;
@@ -201,6 +207,32 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         }
     }
 
+    public static class ClientProviderEventListener implements ProviderEventListener {
+
+        public enum EventType {
+            CREATE,
+            UPDATE,
+            REMOVED
+        }
+        
+        public record ClientEvent(EventType type, String clientId) {};
+        
+        public static ClientProviderEventListener INSTANCE = new ClientProviderEventListener();
+        
+        public ConcurrentLinkedQueue<ClientEvent> events = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public void onEvent(ProviderEvent event) {
+            if (event instanceof ClientModel.ClientCreationEvent e) {
+                this.events.add(new ClientEvent(EventType.CREATE, e.getCreatedClient().getClientId()));
+            } else if (event instanceof ClientModel.ClientUpdatedEvent e) {
+                this.events.add(new ClientEvent(EventType.UPDATE, e.getUpdatedClient().getClientId()));
+            } else if (event instanceof ClientModel.ClientRemovedEvent e) {
+                this.events.add(new ClientEvent(EventType.REMOVED, e.getClient().getClientId()));
+            }
+        }
+    }
+
     @Test
     public void putCreateOrUpdates() {
         var clientId = "other";
@@ -209,19 +241,39 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         rep.setClientId(clientId);
         rep.setDescription("I'm new");
 
-        try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
-            assertEquals(201, response.getStatus());
-            OIDCClientRepresentation client = response.readEntity(OIDCClientRepresentation.class);
-            assertEquals("I'm new", client.getDescription());
-            assertClientUuid(client);
-        }
+        runOnServer.run(session -> {
 
-        rep.setDescription("I'm updated");
-        try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
-            assertEquals(200, response.getStatus());
-            OIDCClientRepresentation client = response.readEntity(OIDCClientRepresentation.class);
-            assertEquals("I'm updated", client.getDescription());
-            assertClientUuid(client);
+            session.getKeycloakSessionFactory().register(ClientProviderEventListener.INSTANCE);
+
+        });
+
+        try {
+
+            try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
+                assertEquals(201, response.getStatus());
+                OIDCClientRepresentation client = response.readEntity(OIDCClientRepresentation.class);
+                assertEquals("I'm new", client.getDescription());
+                assertClientUuid(client);
+            }
+
+            rep.setDescription("I'm updated");
+            try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
+                assertEquals(200, response.getStatus());
+                OIDCClientRepresentation client = response.readEntity(OIDCClientRepresentation.class);
+                assertEquals("I'm updated", client.getDescription());
+                assertClientUuid(client);
+            }
+
+            List<ClientEvent> events = List.of(runOnServer.fetch(session -> ClientProviderEventListener.INSTANCE.events, ClientEvent[].class));
+
+            assertEquals(List.of(new ClientEvent(EventType.CREATE, "other"), new ClientEvent(EventType.UPDATE, "other")), events);
+
+        } finally {
+            runOnServer.run(session -> {
+
+                session.getKeycloakSessionFactory().unregister(ClientProviderEventListener.INSTANCE);
+
+            });
         }
     }
 


### PR DESCRIPTION
closes: #50489 

rather than add mapping logic from v2 to v1, the direction here is to add a simple ClientModel implementation as an intermediate representation.

The changes also highlighted that we're missing the generation of the client updated provider event.

relates to #47576 as well - just switching the AdminClientUpdateContext to ClientModel won't yet work as we don't have a proper way of creating a detached ClientModel - the only current implementations have logic / notifications embedded in them.

Another direction for that issue is to create a "BaseClientModel" or similar interface containing a narrower set of methods, such that the value could be either one of the ClientAdapters or something like SimpleClientModel.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
