### PR TITLE
[26.7] WebAuthn authenticator attachment policy is bypassed when the client omits the attachment field

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -525,9 +525,8 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                 return;
             }
 
-            // Browser may not provide authenticatorAttachment (not required by WebAuthn spec)
             if (StringUtil.isBlank(authenticatorAttachment)) {
-                return;
+                throw new WebAuthnException("Authenticator attachment is required by the policy but was not provided by the client.");
             }
 
             if (!WebAuthnConstants.SUPPORTED_AUTHENTICATOR_ATTACHMENTS.contains(authenticatorAttachment)) {

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
@@ -47,6 +47,16 @@ public class WebAuthnPolicyComplianceTest extends AbstractWebAuthnVirtualTest {
     }
 
     @Test
+    public void omittedAuthenticatorAttachment() {
+        managedRealm.updateWithCleanup(r -> r
+                .webAuthnPolicyAuthenticatorAttachment(AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM));
+
+        registerAndExpectError("attach-omit",
+                tamperFormField("authenticatorAttachment", ""),
+                "Authenticator attachment is required by the policy but was not provided by the client.");
+    }
+
+    @Test
     public void tamperedSignatureAlgorithm() {
         // Policy: ES512 only. Tamper pubKeyCredParams to ES256.
         managedRealm.updateWithCleanup(r -> r


### PR DESCRIPTION
- Closes #50719

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit be8d1dafb4d4c1ac247286e7d0f9f40e418e3322)
