### PR TITLE
Fix warning when loading pre-computed password denylist with duplicates

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProviderFactory.java
@@ -431,13 +431,8 @@ public class DenylistPasswordPolicyProviderFactory implements PasswordPolicyProv
                     filter = BloomFilter.readFrom(in, Funnels.stringFunnel(StandardCharsets.UTF_8));
                 }
                 long loadTimeMillis = System.currentTimeMillis() - loadStartMillis;
-                LOG.infof("Loading pre-computed denylist finished: name=%s path=%s expectedFpp=%s loadTime=%dms",
-                        name, path, filter.expectedFpp(), loadTimeMillis);
-                if (Math.abs(filter.expectedFpp() - falsePositiveProbability) > 1e-9) {
-                    LOG.warnf("Pre-computed denylist '%s' has fpp=%.6f but configured fpp=%.6f. "
-                            + "Regenerate the .bloom file with 'kc.sh tools build-password-denylist' if this is unintended.",
-                            name, filter.expectedFpp(), falsePositiveProbability);
-                }
+                LOG.infof("Loading pre-computed denylist finished: name=%s path=%s loadTime=%dms",
+                        name, path, loadTimeMillis);
                 return filter;
             } catch (IOException e) {
                 throw new RuntimeException("Loading pre-computed denylist failed: path=" + path, e);

--- a/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProviderFactory.java
@@ -416,7 +416,6 @@ public class DenylistPasswordPolicyProviderFactory implements PasswordPolicyProv
 
         /**
          * Fast path: deserialise a pre-computed Bloom filter binary (.bloom).
-         * Emits a warning when the stored false-positive probability differs from the configured value.
          *
          * @return the deserialised {@link BloomFilter}
          * @throws IOException if the binary file cannot be read

--- a/server-spi-private/src/test/java/org/keycloak/policy/DenylistPasswordPolicyProviderTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/policy/DenylistPasswordPolicyProviderTest.java
@@ -166,17 +166,27 @@ public class DenylistPasswordPolicyProviderTest {
     }
 
     @Test
-    public void testFppMismatchStillLoadsSuccessfully() throws Exception {
-        Path txtFile = tempFolder.newFile("denylist.txt").toPath();
-        Files.writeString(txtFile, "mismatchpw\n");
+    public void testBloomFileWorksCorrectlyWithDuplicateHeavyFile() throws Exception {
+        // 10-line file with only 2 unique passwords — 80% duplicates
+        String content = "password1\npassword2\n"
+                + "password1\npassword1\npassword1\n"
+                + "password1\npassword1\npassword1\n"
+                + "password1\npassword1\n";
 
-        double bloomFpp = 0.01;
-        double serverFpp = DenylistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY;
-        DenylistPasswordPolicyProviderFactory.buildBloomFile(txtFile, txtFile.resolveSibling("denylist.txt.bloom"), bloomFpp);
+        Path txtFile = tempFolder.newFile("dupes.txt").toPath();
+        Files.writeString(txtFile, content);
+
+        Path bloomFile = txtFile.resolveSibling("dupes.txt.bloom");
+        DenylistPasswordPolicyProviderFactory.buildBloomFile(
+                txtFile, bloomFile, DenylistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY);
 
         FileBasedPasswordDenylist denylist = new FileBasedPasswordDenylist(
-                tempFolder.getRoot().toPath(), "denylist.txt.bloom", serverFpp, 0);
-        Assert.assertTrue("password must still be found despite fpp mismatch", denylist.contains("mismatchpw"));
+                tempFolder.getRoot().toPath(), "dupes.txt.bloom",
+                DenylistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 0);
+
+        Assert.assertTrue(denylist.contains("password1"));
+        Assert.assertTrue(denylist.contains("password2"));
+        Assert.assertFalse(denylist.contains("notinlist"));
     }
 
     private static void writeBloomFile(Path baseDir, String name, double fpp) throws IOException {


### PR DESCRIPTION
Fixes #50751

Removes the fpp mismatch warning in `loadFromBloom()`. The warning was added
with the intent of alerting admins who configure a strict server fpp but use a
bloom file built with a looser fpp, assuming the server config would apply.
It does not, the server's fpp config only affects the plaintext loading path
where the filter is rebuilt from scratch; for a pre-computed `.bloom` file the
false positive rate is fixed at build time. The comparison was therefore
meaningless from the start.

On top of that, the wrong metric was used: Guava's `filter.expectedFpp()`
measures the filter's current fill ratio, not the originally requested fpp.
For any denylist file with duplicate entries (which all real-world password
lists have), it returns a value orders of magnitude smaller, producing a false
alarm on startup.

Adds a regression test covering duplicate-heavy files.