### PR TITLE
SSF: Revise SSF event structure (#50792)

### DIFF
--- a/ssf/core/src/main/java/org/keycloak/ssf/event/GenericSsfEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/GenericSsfEvent.java
@@ -5,23 +5,19 @@ package org.keycloak.ssf.event;
  */
 public class GenericSsfEvent extends SsfEvent {
 
+    /**
+     * Required by Jackson: {@code SsfEventMapJsonDeserializer} materialises unknown
+     * event payloads via {@code treeToValue(eventData, GenericSsfEvent.class)} and
+     * sets the actual event type URI afterwards through {@link #setEventType}.
+     */
     public GenericSsfEvent() {
-        super(null);
+        this(null);
+    }
+
+    public GenericSsfEvent(String eventType) {
+        super(eventType);
 
         // Generic events don't have an alias by default
         setAlias(null);
-    }
-
-    @Override
-    public String toString() {
-        return "GenericSecurityEvent{" +
-               "subjectId=" + subjectId +
-               ", eventType='" + eventType + '\'' +
-               ", eventTimestamp=" + eventTimestamp +
-               ", initiatingEntity=" + initiatingEntity +
-               ", reasonAdmin=" + reasonAdmin +
-               ", reasonUser=" + reasonUser +
-               ", attributes=" + attributes +
-               '}';
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/SsfEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/SsfEvent.java
@@ -3,28 +3,28 @@ package org.keycloak.ssf.event;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import org.keycloak.ssf.subject.SubjectId;
-import org.keycloak.ssf.subject.SubjectIdJsonDeserializer;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Represents a generic SSF event.
- *
+ * <p>
  * See: https://datatracker.ietf.org/doc/html/rfc8417
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class SsfEvent {
+
+    private static final ConcurrentMap<Class<?>, Set<String>> DECLARED_JSON_PROPERTIES = new ConcurrentHashMap<>();
 
     /**
      * Internal (shorter) alias for the event type.
@@ -32,88 +32,26 @@ public abstract class SsfEvent {
     @JsonIgnore
     protected String alias;
 
-    @JsonProperty("subject")
-    @JsonDeserialize(using = SubjectIdJsonDeserializer.class)
-    protected SubjectId subjectId;
-
+    /**
+     * The event type URI
+     */
     @JsonIgnore
     protected String eventType;
 
     /**
-     * The time of the event (UNIX timestamp). Nullable so events that do
-     * not carry a timestamp — e.g. {@code ssf/event-type/verification}
-     * (SSF §8.1.4 carries only {@code state}) and other stream-management
-     * events — are omitted from the wire JSON instead of being serialized
-     * as {@code "event_timestamp": 0} (the default value of a primitive
-     * {@code long}, which Jackson always emits).
+     * Additional unmapped event-specific fields.
      */
-    @JsonProperty("event_timestamp")
-    protected Long eventTimestamp;
-
-    /**
-     * The entity that initiated the event
-     */
-    @JsonProperty("initiating_entity")
-    protected InitiatingEntity initiatingEntity;
-
-    /**
-     * A localized administrative message intended for logging and auditing.
-     * key is language code, value is message.
-     */
-    @JsonProperty("reason_admin")
-    protected Map<String, String> reasonAdmin;
-
-    /**
-     * A localized message intended for the end user.
-     * key is language code, value is message.
-     */
-    @JsonProperty("reason_user")
-    protected Map<String, String> reasonUser;
-
     @JsonIgnore
     protected Map<String, Object> attributes = new HashMap<>();
 
     public SsfEvent(String eventType) {
+        this(eventType, null);
+    }
+
+    public SsfEvent(String eventType, String alias) {
         this.eventType = eventType;
-
         // use the simple class name as the default alias
-        this.alias = getClass().getSimpleName();
-    }
-
-    public SubjectId getSubjectId() {
-        return subjectId;
-    }
-
-    public Long getEventTimestamp() {
-        return eventTimestamp;
-    }
-
-    public void setEventTimestamp(long eventTimestamp) {
-        this.eventTimestamp = eventTimestamp;
-    }
-
-    public InitiatingEntity getInitiatingEntity() {
-        return initiatingEntity;
-    }
-
-    public void setInitiatingEntity(InitiatingEntity initiatingEntity) {
-        this.initiatingEntity = initiatingEntity;
-    }
-
-    public Map<String, String> getReasonAdmin() {
-        return reasonAdmin;
-    }
-
-    public void setReasonAdmin(Map<String, String> reasonAdmin) {
-        this.reasonAdmin = reasonAdmin;
-    }
-
-    public Map<String, String> getReasonUser() {
-        return reasonUser;
-    }
-
-    public void setReasonUser(Map<String, String> reasonUser) {
-        this.reasonUser = reasonUser;
+        this.alias = alias == null ? getClass().getSimpleName() : alias;
     }
 
     public String getEventType() {
@@ -141,12 +79,10 @@ public abstract class SsfEvent {
         if (declaredJsonPropertyNames(getClass()).contains(key)) {
             throw new IllegalArgumentException(
                     "Custom attribute key '" + key + "' collides with a declared @JsonProperty on "
-                            + getClass().getName());
+                    + getClass().getName());
         }
         attributes.put(key, value);
     }
-
-    private static final ConcurrentMap<Class<?>, Set<String>> DECLARED_JSON_PROPERTIES = new ConcurrentHashMap<>();
 
     private static Set<String> declaredJsonPropertyNames(Class<?> type) {
         return DECLARED_JSON_PROPERTIES.computeIfAbsent(type, t -> {
@@ -165,10 +101,6 @@ public abstract class SsfEvent {
 
     public void setEventType(String eventType) {
         this.eventType = eventType;
-    }
-
-    public void setSubjectId(SubjectId subjectId) {
-        this.subjectId = subjectId;
     }
 
     public String getAlias() {
@@ -201,5 +133,37 @@ public abstract class SsfEvent {
      */
     public void validate() {
         // no-op — overridden by event subclasses that have spec-required fields
+    }
+
+    @Override
+    public String toString() {
+        Map<String, Object> fields = new LinkedHashMap<>();
+        appendFields(fields);
+        if (attributes != null && !attributes.isEmpty()) {
+            fields.putIfAbsent("attributes", attributes);
+        }
+        StringJoiner rendered = new StringJoiner(", ");
+        for (Map.Entry<String, Object> entry : fields.entrySet()) {
+            Object value = entry.getValue();
+            if (value == null) {
+                continue;
+            }
+            rendered.add(entry.getKey() + "=" + (value instanceof String ? "'" + value + '\'' : value));
+        }
+        String name = alias != null ? alias : getClass().getSimpleName();
+        return rendered.length() == 0 ? name : name + "::" + rendered;
+    }
+
+    /**
+     * Contributes the fields of this level of the event hierarchy to the
+     * {@link #toString()} output; insertion order is the render order.
+     * Subclasses override this (calling {@code super.appendFields(fields)} first)
+     * instead of {@code toString()} itself. Values may be put unconditionally —
+     * {@code null} entries are filtered and {@link String} values quoted centrally
+     * when rendering, and the extension {@link #attributes} map is appended
+     * automatically when non-empty.
+     */
+    protected void appendFields(Map<String, Object> fields) {
+        fields.put("eventType", eventType);
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/SsfEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/SsfEvent.java
@@ -140,7 +140,15 @@ public abstract class SsfEvent {
         Map<String, Object> fields = new LinkedHashMap<>();
         appendFields(fields);
         if (attributes != null && !attributes.isEmpty()) {
-            fields.putIfAbsent("attributes", attributes);
+            Map<String, Object> renderedAttributes = new LinkedHashMap<>();
+            for (var entry : attributes.entrySet()) {
+                if (entry.getValue() != null) {
+                    renderedAttributes.put(entry.getKey(), entry.getValue());
+                }
+            }
+            if (!renderedAttributes.isEmpty()) {
+                fields.putIfAbsent("attributes", renderedAttributes);
+            }
         }
         StringJoiner rendered = new StringJoiner(", ");
         for (Map.Entry<String, Object> entry : fields.entrySet()) {

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/SsfEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/SsfEvent.java
@@ -151,15 +151,43 @@ public abstract class SsfEvent {
             }
         }
         StringJoiner rendered = new StringJoiner(", ");
-        for (Map.Entry<String, Object> entry : fields.entrySet()) {
+        for (var entry : fields.entrySet()) {
             Object value = entry.getValue();
             if (value == null) {
                 continue;
             }
-            rendered.add(entry.getKey() + "=" + (value instanceof String ? "'" + value + '\'' : value));
+            rendered.add(entry.getKey() + "=" + render(value));
         }
         String name = alias != null ? alias : getClass().getSimpleName();
-        return rendered.length() == 0 ? name : name + "::" + rendered;
+        return rendered.length() == 0 ? name : name + "{" + rendered + "}";
+    }
+
+    /**
+     * Renders a field value for {@link #toString()}, quoting {@link String}
+     * values at every nesting level so entries inside maps (extension
+     * {@link #attributes}, {@code reason_admin} / {@code reason_user}) read the
+     * same as top-level fields. Values originate from JSON payloads, which
+     * cannot form cycles, so the recursion is bounded.
+     */
+    private static String render(Object value) {
+        if (value instanceof String) {
+            return "'" + value + '\'';
+        }
+        if (value instanceof Map<?, ?> map) {
+            StringJoiner joiner = new StringJoiner(", ", "{", "}");
+            for (var entry : map.entrySet()) {
+                joiner.add(entry.getKey() + "=" + render(entry.getValue()));
+            }
+            return joiner.toString();
+        }
+        if (value instanceof Iterable<?> iterable) {
+            StringJoiner joiner = new StringJoiner(", ", "[", "]");
+            for (var element : iterable) {
+                joiner.add(render(element));
+            }
+            return joiner.toString();
+        }
+        return String.valueOf(value);
     }
 
     /**
@@ -168,8 +196,8 @@ public abstract class SsfEvent {
      * Subclasses override this (calling {@code super.appendFields(fields)} first)
      * instead of {@code toString()} itself. Values may be put unconditionally —
      * {@code null} entries are filtered and {@link String} values quoted centrally
-     * when rendering, and the extension {@link #attributes} map is appended
-     * automatically when non-empty.
+     * at every nesting level when rendering, and the extension {@link #attributes}
+     * map is appended automatically when non-empty.
      */
     protected void appendFields(Map<String, Object> fields) {
         fields.put("eventType", eventType);

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepCredentialChange.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepCredentialChange.java
@@ -1,5 +1,7 @@
 package org.keycloak.ssf.event.caep;
 
+import java.util.Map;
+
 import org.keycloak.ssf.event.SsfEventValidationException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -15,8 +17,7 @@ public class CaepCredentialChange extends CaepEvent {
     /**
      * See: https://openid.github.io/sharedsignals/openid-caep-1_0.html#name-credential-change
      */
-    public static final String TYPE = "https://schemas.openid.net/secevent/caep/event-type/credential-change";
-
+    public static final String TYPE = CaepEvent.EVENT_TYPE_BASE_URI + "credential-change";
 
     /**
      * This MUST be one of the following strings, or any other credential type supported mutually by the Transmitter and the Receiver.
@@ -205,14 +206,13 @@ public class CaepCredentialChange extends CaepEvent {
     }
 
     @Override
-    public String toString() {
-        return "CredentialChange{" +
-               "credentialType=" + credentialType +
-               ", changeType=" + changeType +
-               ", friendlyName='" + friendlyName + '\'' +
-               ", x509Issuer='" + x509Issuer + '\'' +
-               ", x509Serial='" + x509Serial + '\'' +
-               ", fido2Aaguid='" + fido2Aaguid + '\'' +
-               '}';
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("credentialType", credentialType);
+        fields.put("changeType", changeType);
+        fields.put("friendlyName", friendlyName);
+        fields.put("x509Issuer", x509Issuer);
+        fields.put("x509Serial", x509Serial);
+        fields.put("fido2Aaguid", fido2Aaguid);
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
@@ -27,12 +27,9 @@ public abstract class CaepEvent extends SsfEvent {
     protected SubjectId subjectId;
 
     /**
-     * The time of the event (UNIX timestamp). Nullable so events that do
-     * not carry a timestamp — e.g. {@code ssf/event-type/verification}
-     * (SSF §8.1.4 carries only {@code state}) and other stream-management
-     * events — are omitted from the wire JSON instead of being serialized
-     * as {@code "event_timestamp": 0} (the default value of a primitive
-     * {@code long}, which Jackson always emits).
+     * The time of the event (UNIX timestamp). Nullable so an absent timestamp
+     * is omitted from wire JSON rather than serialized as
+     * {@code "event_timestamp": 0}.
      */
     @JsonProperty("event_timestamp")
     protected Long eventTimestamp;

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
@@ -1,6 +1,14 @@
 package org.keycloak.ssf.event.caep;
 
+import java.util.Map;
+
+import org.keycloak.ssf.event.InitiatingEntity;
 import org.keycloak.ssf.event.SsfEvent;
+import org.keycloak.ssf.subject.SubjectId;
+import org.keycloak.ssf.subject.SubjectIdJsonDeserializer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Generic CaepEvent.
@@ -9,7 +17,97 @@ import org.keycloak.ssf.event.SsfEvent;
  */
 public abstract class CaepEvent extends SsfEvent {
 
+    /**
+     * See: https://openid.net/specs/openid-caep-1_0-final.html#section-3
+     */
+    public static final String EVENT_TYPE_BASE_URI = "https://schemas.openid.net/secevent/caep/event-type/";
+
+    @JsonProperty("subject")
+    @JsonDeserialize(using = SubjectIdJsonDeserializer.class)
+    protected SubjectId subjectId;
+
+    /**
+     * The time of the event (UNIX timestamp). Nullable so events that do
+     * not carry a timestamp — e.g. {@code ssf/event-type/verification}
+     * (SSF §8.1.4 carries only {@code state}) and other stream-management
+     * events — are omitted from the wire JSON instead of being serialized
+     * as {@code "event_timestamp": 0} (the default value of a primitive
+     * {@code long}, which Jackson always emits).
+     */
+    @JsonProperty("event_timestamp")
+    protected Long eventTimestamp;
+
+    /**
+     * The entity that initiated the event
+     */
+    @JsonProperty("initiating_entity")
+    protected InitiatingEntity initiatingEntity;
+
+    /**
+     * A localized administrative message intended for logging and auditing.
+     * key is language code, value is message.
+     */
+    @JsonProperty("reason_admin")
+    protected Map<String, String> reasonAdmin;
+
+    /**
+     * A localized message intended for the end user.
+     * key is language code, value is message.
+     */
+    @JsonProperty("reason_user")
+    protected Map<String, String> reasonUser;
+
     public CaepEvent(String type) {
         super(type);
+    }
+
+    public SubjectId getSubjectId() {
+        return subjectId;
+    }
+
+    public void setSubjectId(SubjectId subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    public Long getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(long eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+
+    public InitiatingEntity getInitiatingEntity() {
+        return initiatingEntity;
+    }
+
+    public void setInitiatingEntity(InitiatingEntity initiatingEntity) {
+        this.initiatingEntity = initiatingEntity;
+    }
+
+    public Map<String, String> getReasonAdmin() {
+        return reasonAdmin;
+    }
+
+    public void setReasonAdmin(Map<String, String> reasonAdmin) {
+        this.reasonAdmin = reasonAdmin;
+    }
+
+    public Map<String, String> getReasonUser() {
+        return reasonUser;
+    }
+
+    public void setReasonUser(Map<String, String> reasonUser) {
+        this.reasonUser = reasonUser;
+    }
+
+    @Override
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("subjectId", subjectId);
+        fields.put("eventTimestamp", eventTimestamp);
+        fields.put("initiatingEntity", initiatingEntity);
+        fields.put("reasonAdmin", reasonAdmin);
+        fields.put("reasonUser", reasonUser);
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
@@ -22,6 +22,14 @@ public abstract class CaepEvent extends SsfEvent {
      */
     public static final String EVENT_TYPE_BASE_URI = "https://schemas.openid.net/secevent/caep/event-type/";
 
+    /**
+     * The legacy CAEP SSE subject attribute for backwards compatibility. In the OpenID Shared Signals and Events Framework Specification 1.0 - draft 01
+     * the subject attribute was used to identify the subject of the event.
+     * See: https://openid.net/specs/openid-sse-framework-1_0-ID1.html#rfc.section.3.3
+     *
+     * In SSF 1.0 the subject is encoded as the "sub_id" claim in the Security Event Token (SET).
+     * See: https://openid.github.io/sharedsignals/openid-sharedsignals-framework-1_0.html#section-3.1
+     */
     @JsonProperty("subject")
     @JsonDeserialize(using = SubjectIdJsonDeserializer.class)
     protected SubjectId subjectId;

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepSessionRevoked.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepSessionRevoked.java
@@ -8,14 +8,9 @@ public class CaepSessionRevoked extends CaepEvent {
     /**
      * See: https://openid.github.io/sharedsignals/openid-caep-1_0.html#name-session-revoked
      */
-    public static final String TYPE = "https://schemas.openid.net/secevent/caep/event-type/session-revoked";
+    public static final String TYPE = CaepEvent.EVENT_TYPE_BASE_URI + "session-revoked";
 
     public CaepSessionRevoked() {
         super(TYPE);
-    }
-
-    @Override
-    public String toString() {
-        return "SessionRevoked{}";
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/stream/SsfStreamEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/stream/SsfStreamEvent.java
@@ -7,6 +7,8 @@ import org.keycloak.ssf.event.SsfEvent;
  */
 public abstract class SsfStreamEvent extends SsfEvent {
 
+    public static final String EVENT_TYPE_BASE_URI = "https://schemas.openid.net/secevent/ssf/event-type/";
+
     public SsfStreamEvent(String eventType) {
         super(eventType);
     }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/stream/SsfStreamUpdatedEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/stream/SsfStreamUpdatedEvent.java
@@ -1,17 +1,19 @@
 package org.keycloak.ssf.event.stream;
 
+import java.util.Map;
+
 import org.keycloak.ssf.stream.StreamStatus;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * SSF Stream status updated event.
- *
+ * <p>
  * See: https://openid.net/specs/openid-sharedsignals-framework-1_0-final.html#name-stream-updated-event
  */
 public class SsfStreamUpdatedEvent extends SsfStreamEvent {
 
-    public static final String TYPE = "https://schemas.openid.net/secevent/ssf/event-type/stream-updated";
+    public static final String TYPE = SsfStreamEvent.EVENT_TYPE_BASE_URI + "stream-updated";
 
     /**
      * REQUIRED. Defines the new status of the stream.
@@ -43,5 +45,12 @@ public class SsfStreamUpdatedEvent extends SsfStreamEvent {
 
     public void setReason(String reason) {
         this.reason = reason;
+    }
+
+    @Override
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("status", status);
+        fields.put("reason", reason);
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/stream/SsfStreamVerificationEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/stream/SsfStreamVerificationEvent.java
@@ -1,15 +1,17 @@
 package org.keycloak.ssf.event.stream;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * SSF Verification event.
- *
+ * <p>
  * See: https://openid.net/specs/openid-sharedsignals-framework-1_0-final.html#name-verification
  */
 public class SsfStreamVerificationEvent extends SsfStreamEvent {
 
-    public static final String TYPE = "https://schemas.openid.net/secevent/ssf/event-type/verification";
+    public static final String TYPE = SsfStreamEvent.EVENT_TYPE_BASE_URI + "verification";
 
     @JsonProperty("state")
     protected String state;
@@ -27,12 +29,8 @@ public class SsfStreamVerificationEvent extends SsfStreamEvent {
     }
 
     @Override
-    public String toString() {
-        // Render absent state as an empty object rather than "state='null'"
-        // so the log representation matches what Jackson actually puts on
-        // the wire (omitted thanks to @JsonInclude(NON_NULL)).
-        return state == null
-                ? "VerificationEvent{}"
-                : "VerificationEvent{state='" + state + "'}";
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("state", state);
     }
 }

--- a/ssf/core/src/test/java/org/keycloak/ssf/event/SsfEventsTest.java
+++ b/ssf/core/src/test/java/org/keycloak/ssf/event/SsfEventsTest.java
@@ -1,0 +1,104 @@
+package org.keycloak.ssf.event;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.keycloak.ssf.event.caep.CaepCredentialChange;
+import org.keycloak.ssf.event.token.SsfSecurityEventToken;
+import org.keycloak.util.JsonSerialization;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SsfEventsTest {
+
+    @Test
+    void builtInEvents_toStringOnFreshInstanceDoesNotThrow() {
+        Map<String, Supplier<? extends SsfEvent>> factories =
+                new DefaultSsfEventProviderFactory().getContributedEventFactories();
+        assertFalse(factories.isEmpty(), "factory should contribute the built-in events");
+
+        for (Map.Entry<String, Supplier<? extends SsfEvent>> entry : factories.entrySet()) {
+            SsfEvent event = entry.getValue().get();
+            String rendered = assertDoesNotThrow(event::toString,
+                    () -> "toString() must not throw for fresh " + entry.getKey());
+            assertNotNull(rendered, () -> "toString() must not return null for " + entry.getKey());
+            assertFalse(rendered.isBlank(), () -> "toString() must not be blank for " + entry.getKey());
+            assertFalse(rendered.contains("null"),
+                    () -> "unset fields must be omitted, not rendered as null, for "
+                            + entry.getKey() + ": " + rendered);
+        }
+    }
+
+    @Test
+    void unknownEventType_isRepresentedAsGenericSsfEvent() throws Exception {
+        // A SET carrying an event type URI that is not in the registry:
+        // SsfEventMapJsonDeserializer falls back to GenericSsfEvent, so the
+        // full payload lands in the @JsonAnySetter extension attributes and
+        // the real type URI is set after materialisation.
+        String unknownType = "https://example.com/secevent/custom/unknown-event";
+        String setJson = """
+                {
+                  "jti": "jti-123",
+                  "iss": "https://issuer.example.test",
+                  "events": {
+                    "%s": {
+                      "foo": "bar",
+                      "count": 3,
+                      "nested": { "a": 1 }
+                    }
+                  }
+                }
+                """.formatted(unknownType);
+
+        SsfSecurityEventToken token = JsonSerialization.readValue(setJson, SsfSecurityEventToken.class);
+
+        Object event = token.getEvents().get(unknownType);
+        GenericSsfEvent generic = assertInstanceOf(GenericSsfEvent.class, event,
+                "unknown event types must degrade to GenericSsfEvent, not fail parsing");
+        assertEquals(unknownType, generic.getEventType(),
+                "the deserializer must preserve the original event type URI");
+        assertEquals("bar", generic.getAttributes().get("foo"),
+                "payload fields must be preserved in the extension attributes");
+        assertEquals(3, generic.getAttributes().get("count"));
+        assertEquals(Map.of("a", 1), generic.getAttributes().get("nested"),
+                "nested payload objects must be preserved as maps");
+
+        String rendered = assertDoesNotThrow(generic::toString);
+        assertTrue(rendered.contains(unknownType),
+                "toString should render the preserved event type URI: " + rendered);
+        assertTrue(rendered.contains("foo=bar"),
+                "toString should render the preserved attributes: " + rendered);
+    }
+
+    @Test
+    void genericEvent_toStringOnFreshInstanceDoesNotThrow() {
+        // GenericSsfEvent is the unknown-type fallback and is not part of the
+        // factory contributions, so it is covered explicitly.
+        GenericSsfEvent event = new GenericSsfEvent();
+        String rendered = assertDoesNotThrow(event::toString);
+        assertNotNull(rendered);
+        assertFalse(rendered.isBlank());
+    }
+
+    @Test
+    void caepEvent_toStringRendersOnlySetFields() {
+        CaepCredentialChange event = new CaepCredentialChange();
+        event.setCredentialType("password");
+        event.setChangeType(CaepCredentialChange.ChangeType.UPDATE);
+
+        String rendered = event.toString();
+        assertTrue(rendered.contains("credentialType='password'"),
+                "set String fields must be rendered quoted: " + rendered);
+        assertTrue(rendered.contains("changeType="),
+                "set fields must be rendered: " + rendered);
+        assertFalse(rendered.contains("null"),
+                "unset optional fields (friendlyName, x509*, …) must be omitted: " + rendered);
+    }
+}

--- a/ssf/core/src/test/java/org/keycloak/ssf/event/SsfEventsTest.java
+++ b/ssf/core/src/test/java/org/keycloak/ssf/event/SsfEventsTest.java
@@ -70,11 +70,15 @@ class SsfEventsTest {
         assertEquals(Map.of("a", 1), generic.getAttributes().get("nested"),
                 "nested payload objects must be preserved as maps");
 
+        generic.setAttributeValue("unset", null);
+
         String rendered = assertDoesNotThrow(generic::toString);
         assertTrue(rendered.contains(unknownType),
                 "toString should render the preserved event type URI: " + rendered);
         assertTrue(rendered.contains("foo=bar"),
                 "toString should render the preserved attributes: " + rendered);
+        assertFalse(rendered.contains("unset="),
+                "toString should omit null-valued attributes: " + rendered);
     }
 
     @Test

--- a/ssf/core/src/test/java/org/keycloak/ssf/event/SsfEventsTest.java
+++ b/ssf/core/src/test/java/org/keycloak/ssf/event/SsfEventsTest.java
@@ -1,12 +1,16 @@
 package org.keycloak.ssf.event;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 import org.keycloak.ssf.event.caep.CaepCredentialChange;
+import org.keycloak.ssf.event.token.SsfEventMapJsonDeserializer;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
 import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -30,18 +34,21 @@ class SsfEventsTest {
                     () -> "toString() must not throw for fresh " + entry.getKey());
             assertNotNull(rendered, () -> "toString() must not return null for " + entry.getKey());
             assertFalse(rendered.isBlank(), () -> "toString() must not be blank for " + entry.getKey());
-            assertFalse(rendered.contains("null"),
+            assertFalse(rendered.contains("=null"),
                     () -> "unset fields must be omitted, not rendered as null, for "
                             + entry.getKey() + ": " + rendered);
         }
     }
 
     @Test
-    void unknownEventType_isRepresentedAsGenericSsfEvent() throws Exception {
-        // A SET carrying an event type URI that is not in the registry:
-        // SsfEventMapJsonDeserializer falls back to GenericSsfEvent, so the
-        // full payload lands in the @JsonAnySetter extension attributes and
-        // the real type URI is set after materialisation.
+    void withoutBoundSession_setParsingDegradesToGenericSsfEvent() throws Exception {
+        // Outside a request scope no KeycloakSession is bound, so
+        // SsfEventMapJsonDeserializer.resolveRegistry() returns null and every
+        // event type degrades to GenericSsfEvent (documented contract of
+        // resolveRegistry): the full payload lands in the @JsonAnySetter
+        // extension attributes and the real type URI is set after
+        // materialisation. The registry-bound unknown-type fallback is covered
+        // separately below.
         String unknownType = "https://example.com/secevent/custom/unknown-event";
         String setJson = """
                 {
@@ -75,10 +82,51 @@ class SsfEventsTest {
         String rendered = assertDoesNotThrow(generic::toString);
         assertTrue(rendered.contains(unknownType),
                 "toString should render the preserved event type URI: " + rendered);
-        assertTrue(rendered.contains("foo=bar"),
-                "toString should render the preserved attributes: " + rendered);
+        assertTrue(rendered.contains("foo='bar'"),
+                "toString should render attribute Strings quoted like top-level fields: " + rendered);
+        assertTrue(rendered.contains("nested={a=1}"),
+                "toString should render nested maps recursively: " + rendered);
         assertFalse(rendered.contains("unset="),
                 "toString should omit null-valued attributes: " + rendered);
+    }
+
+    @Test
+    void registryBound_unknownTypeFallsBackToGenericWhileKnownTypeResolvesTyped() throws Exception {
+        // With a registry bound (stubbed resolveRegistry, same hook the
+        // per-session provider uses), a contributed type must resolve to its
+        // typed event class and only genuinely unknown types may fall back to
+        // GenericSsfEvent — the branch the no-session test above cannot cover.
+        SsfEventRegistry registry = SsfEventRegistry.from(List.of(new DefaultSsfEventProviderFactory()));
+        SsfEventMapJsonDeserializer deserializer = new SsfEventMapJsonDeserializer() {
+            @Override
+            protected SsfEventRegistry resolveRegistry() {
+                return registry;
+            }
+        };
+
+        String unknownType = "https://example.com/secevent/custom/unknown-event";
+        String eventsJson = """
+                {
+                  "%s": { "credential_type": "password" },
+                  "%s": { "foo": "bar" }
+                }
+                """.formatted(CaepCredentialChange.TYPE, unknownType);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, SsfEvent> events;
+        try (JsonParser parser = mapper.createParser(eventsJson)) {
+            events = deserializer.deserialize(parser, null);
+        }
+
+        CaepCredentialChange known = assertInstanceOf(CaepCredentialChange.class,
+                events.get(CaepCredentialChange.TYPE),
+                "registry-contributed types must resolve to their typed event class");
+        assertEquals("password", known.getCredentialType());
+
+        GenericSsfEvent generic = assertInstanceOf(GenericSsfEvent.class, events.get(unknownType),
+                "only unknown event types may fall back to GenericSsfEvent");
+        assertEquals(unknownType, generic.getEventType());
+        assertEquals("bar", generic.getAttributes().get("foo"));
     }
 
     @Test
@@ -102,7 +150,7 @@ class SsfEventsTest {
                 "set String fields must be rendered quoted: " + rendered);
         assertTrue(rendered.contains("changeType="),
                 "set fields must be rendered: " + rendered);
-        assertFalse(rendered.contains("null"),
+        assertFalse(rendered.contains("=null"),
                 "unset optional fields (friendlyName, x509*, …) must be omitted: " + rendered);
     }
 }


### PR DESCRIPTION
Move the CAEP-specific claims (subject, event_timestamp, initiating_entity, reason_admin, reason_user) from SsfEvent down to CaepEvent so the base event only carries the generic SET fields: event type, alias and the extension attributes map. Introduce shared EVENT_TYPE_BASE_URI constants for the CAEP and SSF stream event type URIs and an (eventType, alias) constructor on SsfEvent.

Rework toString across the event hierarchy: SsfEvent renders the fields subclasses contribute to a LinkedHashMap via the new appendFields hook, filtering null values, quoting String values uniformly and appending the extension attributes map only when non-empty. This replaces the per-class string concatenation, which rendered unset fields as null placeholders.

SsfEventsTest constructs every registry-contributed event type plus the GenericSsfEvent fallback and asserts toString neither throws nor renders unset fields.

Fixes #50792

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
