### PR TITLE
Lowercase email read directly from LDAP

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -455,7 +455,11 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                 @Override
                 public String getEmail() {
                     if (UserModel.EMAIL.equalsIgnoreCase(userModelAttrName)) {
-                        return ldapUser.getAttributeAsString(ldapAttrName);
+                        String email = ldapUser.getAttributeAsString(ldapAttrName);
+                        if (ldapProvider.getModel().isImportEnabled()) {
+                            return KeycloakModelUtils.toLowerCaseSafe(email);
+                        }
+                        return email;
                     } else {
                         return super.getEmail();
                     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/UserAttributeLDAPStorageMapper.java
@@ -453,19 +453,6 @@ public class UserAttributeLDAPStorageMapper extends AbstractLDAPStorageMapper {
                 }
 
                 @Override
-                public String getEmail() {
-                    if (UserModel.EMAIL.equalsIgnoreCase(userModelAttrName)) {
-                        String email = ldapUser.getAttributeAsString(ldapAttrName);
-                        if (ldapProvider.getModel().isImportEnabled()) {
-                            return KeycloakModelUtils.toLowerCaseSafe(email);
-                        }
-                        return email;
-                    } else {
-                        return super.getEmail();
-                    }
-                }
-
-                @Override
                 public boolean isEnabled() {
                     if (UserModel.ENABLED.equalsIgnoreCase(userModelAttrName)) {
                         return Boolean.parseBoolean(ldapUser.getAttributeAsString(ldapAttrName));

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/user/UserSyncTest.java
@@ -255,6 +255,64 @@ public class UserSyncTest extends KeycloakModelTest {
     }
 
     @Test
+    public void testEmailLowercasedWithAlwaysReadValueFromLDAP() {
+        withRealm(realmId, (session, realm) -> {
+            UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));
+            providerModel.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
+            realm.updateComponent(providerModel);
+
+            ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(realm, providerModel, "email");
+            emailMapper.put(UserAttributeLDAPStorageMapper.ALWAYS_READ_VALUE_FROM_LDAP, true);
+            realm.updateComponent(emailMapper);
+
+            return null;
+        });
+
+        withRealm(realmId, (session, realm) -> {
+            ComponentModel ldapModel = LDAPTestUtils.getLdapProviderModel(realm);
+            LDAPStorageProvider ldapFedProvider = LDAPTestUtils.getLdapProvider(session, ldapModel);
+            LDAPTestUtils.addLDAPUser(ldapFedProvider, realm, "mixedcaseuser", "Test", "User", "Mixed.Case@Email.ORG", null, "5678");
+            return null;
+        });
+
+        // Import enabled: email should be lowercased
+        withRealm(realmId, (session, realm) -> {
+            UserModel user = session.users().getUserByUsername(realm, "mixedcaseuser");
+            assertThat(user, is(notNullValue()));
+            assertThat(user.getEmail(), is(equalTo("mixed.case@email.org")));
+            return null;
+        });
+
+        // Toggle import to disabled
+        withRealm(realmId, (session, realm) -> {
+            UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));
+            providerModel.setImportEnabled(false);
+            realm.updateComponent(providerModel);
+            return null;
+        });
+
+        // Import disabled: original LDAP casing should be preserved
+        withRealm(realmId, (session, realm) -> {
+            UserModel user = session.users().getUserByUsername(realm, "mixedcaseuser");
+            assertThat(user, is(notNullValue()));
+            assertThat(user.getEmail(), is(equalTo("Mixed.Case@Email.ORG")));
+            return null;
+        });
+
+        // Cleanup: re-enable import and reset always-read-from-LDAP
+        withRealm(realmId, (session, realm) -> {
+            UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));
+            providerModel.setImportEnabled(true);
+            realm.updateComponent(providerModel);
+
+            ComponentModel emailMapper = LDAPTestUtils.getSubcomponentByName(realm, providerModel, "email");
+            emailMapper.put(UserAttributeLDAPStorageMapper.ALWAYS_READ_VALUE_FROM_LDAP, false);
+            realm.updateComponent(emailMapper);
+            return null;
+        });
+    }
+
+    @Test
     public void testInvalidUsersAreDeleted() {
         withRealm(realmId, (session, realm) -> {
             UserStorageProviderModel providerModel = new UserStorageProviderModel(realm.getComponent(userFederationId));


### PR DESCRIPTION
Closes #50691

The "Always Read Value From LDAP" delegate in `UserAttributeLDAPStorageMapper.proxy()` returned raw email from LDAP without lowercasing. The writable delegate already applies `toLowerCaseIfImportEnabled`, but the always-read delegate was missed in #43261.

This applies the same conditional lowercasing to the always-read delegate's `getEmail()`.

The regression test covers both branches:
- Import enabled: email is lowercased
- Import disabled: original LDAP casing is preserved

AI disclosure: Claude Code and OpenAI Codex were used to assist code analysis and implementation. I understand every change and can revise the code