### PR TITLE
Honor configured admin realm in ClientManager.isInternalClient

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/ClientManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ClientManager.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.keycloak.Config;
 import org.keycloak.authentication.ClientAuthenticator;
 import org.keycloak.authentication.ClientAuthenticatorFactory;
 import org.keycloak.common.Profile;
@@ -415,7 +416,7 @@ public class ClientManager {
     private boolean isInternalClient(String realmName, String clientId) {
         if (defaultClients.contains(clientId)) return true;
 
-        if (!"master".equals(realmName)) {
+        if (!Config.getAdminRealm().equals(realmName)) {
             return false;
         }
 


### PR DESCRIPTION
## Description

`ClientManager.isInternalClient(realmName, clientId)` hardcoded the literal
`"master"` realm name when deciding whether a realm is the admin realm:

```java
if (!"master".equals(realmName)) {
    return false;
}
```

On servers configured with an alternative admin realm (via
`Config.getAdminRealm()` / the `keycloak.admin.realm` option), the per-realm
internal admin-container clients (`<realm>-realm`, which live in the admin
realm) are therefore not recognised as internal by `isInternalClient`, and
can be deleted through `removeClient`.

This aligns the check with the admin-realm idiom used consistently across the
codebase (e.g. `ApplianceBootstrap`, `MgmtPermissions`, `ModelToRepresentation`,
`AdminConsole`), which all reference `Config.getAdminRealm()` rather than a
literal `"master"`.

## Fix

Use `Config.getAdminRealm().equals(realmName)` instead of `"master".equals(realmName)`.

`Config.getAdminRealm()` returns a non-null value that defaults to `"master"`,
so behaviour is unchanged on default installations and there is no new NPE
surface (`realmName == null` still yields `false`, as before).

## Testing

- `./mvnw spotless:check -pl services` — passes.
- `./mvnw compile -pl services -am` — compiles cleanly.
- The internal-client protection path is covered by the existing integration
  test `InternalClientManagementTest` (default admin realm), whose behaviour
  is unchanged. Exercising the custom-admin-realm path requires booting a
  server with a non-default `keycloak.admin.realm`; happy to add a dedicated
  integration test if preferred.

Closes #50796

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.
