### PR TITLE
SSF: Reject mismatched user+tenant subjects in synthetic SSF emit (#50812)

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3333,6 +3333,10 @@ ssfEmitEvent=Emit event
 ssfEmitResult=Emitted — status={{status}}, jti={{jti}}
 ssfEmitResultLookupLink=Look up this event in Event Search
 ssfEmitErrorSubjectNotFound=Subject not found: {{type}} = {{value}}
+ssfEmitErrorUserSubjectMemberNotFound=Subject not found: the user member of the complex subject could not be resolved.
+ssfEmitErrorTenantSubjectMemberNotFound=Subject not found: the tenant member of the complex subject could not be resolved to an organization.
+ssfEmitErrorSubjectMismatch=Subject mismatch: user "{{user}}" is not a member of the tenant organization "{{tenant}}".
+ssfEmitErrorSubjectMismatchGeneric=Subject mismatch: the user subject is not a member of the tenant organization.
 ssfEmitErrorInvalidRequest=Invalid request: {{detail}}
 ssfEmitErrorNoDeliveryConfig=The stream has no delivery method configured, so the event cannot be delivered. Configure push or poll delivery for the stream first.
 ssfEmitErrorUnknown=Emit failed: {{detail}}

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3335,8 +3335,7 @@ ssfEmitResultLookupLink=Look up this event in Event Search
 ssfEmitErrorSubjectNotFound=Subject not found: {{type}} = {{value}}
 ssfEmitErrorUserSubjectMemberNotFound=Subject not found: the user member of the complex subject could not be resolved.
 ssfEmitErrorTenantSubjectMemberNotFound=Subject not found: the tenant member of the complex subject could not be resolved to an organization.
-ssfEmitErrorSubjectMismatch=Subject mismatch: user "{{user}}" is not a member of the tenant organization "{{tenant}}".
-ssfEmitErrorSubjectMismatchGeneric=Subject mismatch: the user subject is not a member of the tenant organization.
+ssfEmitErrorSubjectMismatch=Subject mismatch: the user subject is not a member of the tenant organization.
 ssfEmitErrorInvalidRequest=Invalid request: {{detail}}
 ssfEmitErrorNoDeliveryConfig=The stream has no delivery method configured, so the event cannot be delivered. Configure push or poll delivery for the stream first.
 ssfEmitErrorUnknown=Emit failed: {{detail}}

--- a/js/apps/admin-ui/src/clients/ssf/tabs/EmitEventsTab.tsx
+++ b/js/apps/admin-ui/src/clients/ssf/tabs/EmitEventsTab.tsx
@@ -247,13 +247,10 @@ export const EmitEventsTab = ({
         // the tenant organization. Not reachable from this form yet
         // (it only sends the single-member shorthand), but wired up so
         // complex-subject support added later inherits a translated
-        // message. params carries the resolved pairing that failed.
-        return body.params?.user && body.params.tenant
-          ? t("ssfEmitErrorSubjectMismatch", {
-              user: body.params.user,
-              tenant: body.params.tenant,
-            })
-          : t("ssfEmitErrorSubjectMismatchGeneric");
+        // message. Deliberately generic: the server omits the resolved
+        // user/tenant identifiers so the role-scoped emit endpoint
+        // cannot be used to disclose realm metadata.
+        return t("ssfEmitErrorSubjectMismatch");
       case "invalid_request":
         return t("ssfEmitErrorInvalidRequest", { detail });
       case "no_delivery_config":

--- a/js/apps/admin-ui/src/clients/ssf/tabs/EmitEventsTab.tsx
+++ b/js/apps/admin-ui/src/clients/ssf/tabs/EmitEventsTab.tsx
@@ -223,6 +223,18 @@ export const EmitEventsTab = ({
       (error instanceof Error ? error.message : String(error));
     switch (body?.error) {
       case "subject_not_found":
+        // A complex sub_id whose user or tenant subject member (SSF
+        // §3.3) failed to resolve ships a machine-readable
+        // params.subjectMember discriminator — render the
+        // member-specific message instead of the generic (type, value)
+        // one, which only fits the single-member shorthand this form
+        // sends today.
+        if (body.params?.subjectMember === "user") {
+          return t("ssfEmitErrorUserSubjectMemberNotFound");
+        }
+        if (body.params?.subjectMember === "tenant") {
+          return t("ssfEmitErrorTenantSubjectMemberNotFound");
+        }
         // Prefer server-supplied params so the message reflects the
         // values that actually failed validation, not whatever the user
         // may have typed into the form while the request was in flight.
@@ -230,6 +242,18 @@ export const EmitEventsTab = ({
           type: body.params?.subjectType ?? values.emitSubjectType,
           value: body.params?.subjectValue ?? values.emitSubjectValue.trim(),
         });
+      case "subject_mismatch":
+        // Complex user+tenant subject whose user is not a member of
+        // the tenant organization. Not reachable from this form yet
+        // (it only sends the single-member shorthand), but wired up so
+        // complex-subject support added later inherits a translated
+        // message. params carries the resolved pairing that failed.
+        return body.params?.user && body.params.tenant
+          ? t("ssfEmitErrorSubjectMismatch", {
+              user: body.params.user,
+              tenant: body.params.tenant,
+            })
+          : t("ssfEmitErrorSubjectMismatchGeneric");
       case "invalid_request":
         return t("ssfEmitErrorInvalidRequest", { detail });
       case "no_delivery_config":

--- a/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
@@ -71,7 +71,17 @@ public class SubjectResolver {
         return SubjectResolution.UNSUPPORTED_FORMAT;
     }
 
-    private static SubjectResolution resolveOrganization(KeycloakSession session, SubjectId tenantSubject) {
+    /**
+     * Resolves a tenant subject to an organization. This is the shared
+     * contract for tenant facets — {@code opaque} (org id or alias),
+     * {@code iss_sub} (sub as org id), {@code email} (org domain or
+     * alias) and {@code uri} ({@code urn:keycloak:org:<alias>} or last
+     * path segment) are all understood. Callers that gate on "the
+     * supplied tenant facet must resolve" (e.g. the synthetic event
+     * emitter) must use this rather than a narrower lookup so a tenant
+     * format accepted elsewhere is not rejected there.
+     */
+    public static SubjectResolution resolveOrganization(KeycloakSession session, SubjectId tenantSubject) {
         if (!Organizations.isEnabled(session)) {
             log.debugf("Organization feature is disabled — cannot resolve tenant subject");
             return SubjectResolution.UNSUPPORTED_FORMAT;

--- a/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
@@ -27,6 +27,14 @@ import org.jboss.logging.Logger;
  */
 public class SubjectResolver {
 
+    /**
+     * URI tenant scheme ({@code urn:keycloak:org:<alias>}) for Organizations: the only
+     * URI form {@link #resolveOrganization} resolves to a local
+     * organization — arbitrary URIs must not resolve, see the
+     * {@code uri} branch there.
+     */
+    public static final String ORG_URN_PREFIX = "urn:keycloak:org:";
+
     private static final Logger log = Logger.getLogger(SubjectResolver.class);
 
     /**
@@ -74,12 +82,13 @@ public class SubjectResolver {
     /**
      * Resolves a tenant subject to an organization. This is the shared
      * contract for tenant subject members — {@code opaque} (org id or alias),
-     * {@code iss_sub} (sub as org id), {@code email} (org domain or
-     * alias) and {@code uri} ({@code urn:keycloak:org:<alias>} or last
-     * path segment) are all understood. Callers that gate on "the
-     * supplied tenant subject member must resolve" (e.g. the synthetic event
-     * emitter) must use this rather than a narrower lookup so a tenant
-     * format accepted elsewhere is not rejected there.
+     * {@code iss_sub} (sub as org id, realm issuer only), {@code email}
+     * (org domain or alias) and {@code uri}
+     * ({@code urn:keycloak:org:<alias>} only) are all understood.
+     * Callers that gate on "the supplied tenant subject member must
+     * resolve" (e.g. the synthetic event emitter) must use this rather
+     * than a narrower lookup so a tenant format accepted elsewhere is
+     * not rejected there.
      */
     public static SubjectResolution resolveOrganization(KeycloakSession session, SubjectId tenantSubject) {
         if (!Organizations.isEnabled(session)) {
@@ -94,8 +103,19 @@ public class SubjectResolver {
             return resolveOrgById(orgProvider, opaque.getId());
         }
 
-        // iss_sub → sub as org id
+        // iss_sub → sub as org id, accepted only for this realm's own
+        // issuer. Unlike user iss_sub lookups there is no
+        // federated-identity analog for organizations, so a foreign iss
+        // cannot be mapped to anything this server has validated — and
+        // callers like the synthetic emitter forward the sub_id
+        // verbatim, so resolving the org regardless would let an
+        // emitter mint a signed SET whose tenant ties a local
+        // organization to an issuer Keycloak never checked.
         if (tenantSubject instanceof IssuerSubjectId issSub) {
+            if (!SubjectUserLookup.isRealmIssuer(session, issSub.getIss())) {
+                log.debugf("Tenant iss_sub subject carries a foreign issuer — not resolvable. iss=%s", issSub.getIss());
+                return SubjectResolution.NOT_FOUND;
+            }
             return resolveOrgById(orgProvider, issSub.getSub());
         }
 
@@ -114,9 +134,15 @@ public class SubjectResolver {
             return SubjectResolution.NOT_FOUND;
         }
 
-        // uri → extract the path/fragment as alias or domain
-        // e.g. "https://keycloak.example.com/orgs/acme" → "acme"
-        //   or "urn:keycloak:org:acme" → "acme"
+        // uri → only the Keycloak-scoped URN form
+        // ("urn:keycloak:org:<alias>") is accepted. An earlier revision
+        // also took arbitrary https URIs and resolved their last path
+        // segment as an alias, but — like the foreign-iss_sub case
+        // above — the sub_id travels verbatim in emitted SETs, so
+        // resolving "https://evil.example/orgs/acme" against the local
+        // org "acme" would let an emitter tie a local organization to
+        // a URI namespace Keycloak never validated. The URN scheme is
+        // the only URI form this server can authoritatively interpret.
         if (tenantSubject instanceof UriSubjectId uriSubject) {
             String alias = extractOrgAliasFromUri(uriSubject.getUri());
             if (alias != null) {
@@ -156,36 +182,17 @@ public class SubjectResolver {
         return SubjectResolution.NOT_FOUND;
     }
 
+    /**
+     * Extracts the org alias from a {@code urn:keycloak:org:<alias>}
+     * URN. Any other URI shape yields {@code null} — see the caller's
+     * comment for why arbitrary URIs must not resolve to local orgs.
+     */
     private static String extractOrgAliasFromUri(String uri) {
-        if (uri == null || uri.isBlank()) {
+        if (uri == null || !uri.startsWith(ORG_URN_PREFIX)) {
+            log.debugf("Tenant URI subject is not a urn:keycloak:org URN — not resolvable. uri=%s", uri);
             return null;
         }
-
-        // Validate that the string is a syntactically valid URI before
-        // attempting to extract an alias from it.
-        java.net.URI parsed;
-        try {
-            parsed = java.net.URI.create(uri);
-        } catch (IllegalArgumentException e) {
-            log.debugf("Tenant URI subject is not a valid URI: %s", uri);
-            return null;
-        }
-
-        // urn:keycloak:org:<alias>
-        if ("urn".equals(parsed.getScheme()) && uri.startsWith("urn:keycloak:org:")) {
-            String alias = uri.substring("urn:keycloak:org:".length());
-            return alias.isBlank() ? null : alias;
-        }
-
-        // https://example.com/orgs/acme → last path segment "acme"
-        String path = parsed.getPath();
-        if (path != null && !path.isBlank()) {
-            int lastSlash = path.lastIndexOf('/');
-            if (lastSlash >= 0 && lastSlash < path.length() - 1) {
-                return path.substring(lastSlash + 1);
-            }
-        }
-
-        return null;
+        String alias = uri.substring(ORG_URN_PREFIX.length());
+        return alias.isBlank() ? null : alias;
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
@@ -28,12 +28,22 @@ import org.jboss.logging.Logger;
 public class SubjectResolver {
 
     /**
-     * URI tenant scheme ({@code urn:keycloak:org:<alias>}) for Organizations: the only
-     * URI form {@link #resolveOrganization} resolves to a local
-     * organization — arbitrary URIs must not resolve, see the
+     * Base namespace of the URI tenant scheme for Organizations. Not
+     * resolvable on its own: an explicit identifier segment is
+     * required — {@link #ORG_URN_ALIAS_PREFIX} or
+     * {@link #ORG_URN_ID_PREFIX} — so a URN always states which lookup
+     * it wants instead of relying on alias/id heuristics. These URNs
+     * are the only URI forms {@link #resolveOrganization} resolves to
+     * a local organization — arbitrary URIs must not resolve, see the
      * {@code uri} branch there.
      */
     public static final String ORG_URN_PREFIX = "urn:keycloak:org:";
+
+    /** {@code urn:keycloak:org:alias:<alias>} — resolves strictly by organization alias. */
+    public static final String ORG_URN_ALIAS_PREFIX = ORG_URN_PREFIX + "alias:";
+
+    /** {@code urn:keycloak:org:id:<id>} — resolves strictly by internal organization id. */
+    public static final String ORG_URN_ID_PREFIX = ORG_URN_PREFIX + "id:";
 
     private static final Logger log = Logger.getLogger(SubjectResolver.class);
 
@@ -81,10 +91,13 @@ public class SubjectResolver {
 
     /**
      * Resolves a tenant subject to an organization. This is the shared
-     * contract for tenant subject members — {@code opaque} (org id or alias),
-     * {@code iss_sub} (sub as org id, realm issuer only), {@code email}
+     * contract for tenant subject members — {@code opaque} (internal
+     * org id only — aliases go through the {@code alias:} URN form),
+     * {@code iss_sub} (sub as internal org id, realm issuer only), {@code email}
      * (org domain or alias) and {@code uri}
-     * ({@code urn:keycloak:org:<alias>} only) are all understood.
+     * ({@code urn:keycloak:org:alias:<alias>} or
+     * {@code urn:keycloak:org:id:<id>}, each resolving strictly by the
+     * named identifier) are all understood.
      * Callers that gate on "the supplied tenant subject member must
      * resolve" (e.g. the synthetic event emitter) must use this rather
      * than a narrower lookup so a tenant format accepted elsewhere is
@@ -98,7 +111,10 @@ public class SubjectResolver {
 
         OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
 
-        // opaque id → getById
+        // opaque id → internal org id only. Aliases are addressed via
+        // the explicit urn:keycloak:org:alias: URN form instead, so an
+        // opaque value never needs a lookup heuristic — a UUID-shaped
+        // alias can't shadow another organization's id or vice versa.
         if (tenantSubject instanceof OpaqueSubjectId opaque) {
             return resolveOrgById(orgProvider, opaque.getId());
         }
@@ -134,26 +150,59 @@ public class SubjectResolver {
             return SubjectResolution.NOT_FOUND;
         }
 
-        // uri → only the Keycloak-scoped URN form
-        // ("urn:keycloak:org:<alias>") is accepted. An earlier revision
-        // also took arbitrary https URIs and resolved their last path
-        // segment as an alias, but — like the foreign-iss_sub case
-        // above — the sub_id travels verbatim in emitted SETs, so
-        // resolving "https://evil.example/orgs/acme" against the local
-        // org "acme" would let an emitter tie a local organization to
-        // a URI namespace Keycloak never validated. The URN scheme is
-        // the only URI form this server can authoritatively interpret.
+        // uri → only the Keycloak-scoped URN forms
+        // urn:keycloak:org:alias:<alias> and urn:keycloak:org:id:<id>
+        // are accepted, each resolving strictly by the identifier the
+        // URN names. Earlier revisions took arbitrary https URIs
+        // (resolving their last path segment as an alias) and a bare
+        // urn:keycloak:org:<value> shorthand with heuristic lookup —
+        // both are gone: the sub_id travels verbatim in emitted SETs,
+        // so resolving "https://evil.example/orgs/acme" against the
+        // local org "acme" would let an emitter tie a local
+        // organization to a URI namespace Keycloak never validated,
+        // and the explicit segment removes any alias/id ambiguity for
+        // the one URI scheme this server authoritatively owns.
         if (tenantSubject instanceof UriSubjectId uriSubject) {
-            String alias = extractOrgAliasFromUri(uriSubject.getUri());
-            if (alias != null) {
-                return resolveOrgByAliasOrDomain(orgProvider, alias);
-            }
-            return SubjectResolution.NOT_FOUND;
+            return resolveOrgByUrn(orgProvider, uriSubject.getUri());
         }
 
         return SubjectResolution.UNSUPPORTED_FORMAT;
     }
 
+    /**
+     * Resolves a {@code urn:keycloak:org:} tenant URN, strictly by the
+     * identifier kind its segment names ({@code alias:} / {@code id:},
+     * no cross-fallback). Any other URI shape — including the bare
+     * {@code urn:keycloak:org:<value>} form without a segment — yields
+     * {@link SubjectResolution#NOT_FOUND}; see the caller's comment
+     * for why arbitrary URIs must not resolve to local orgs.
+     */
+    private static SubjectResolution resolveOrgByUrn(OrganizationProvider orgProvider, String uri) {
+        if (uri == null) {
+            return SubjectResolution.NOT_FOUND;
+        }
+        if (uri.startsWith(ORG_URN_ALIAS_PREFIX)) {
+            String alias = uri.substring(ORG_URN_ALIAS_PREFIX.length());
+            var org = alias.isBlank() ? null : orgProvider.getByAlias(alias);
+            return org != null ? new SubjectResolution.Organization(org) : SubjectResolution.NOT_FOUND;
+        }
+        if (uri.startsWith(ORG_URN_ID_PREFIX)) {
+            String id = uri.substring(ORG_URN_ID_PREFIX.length());
+            var org = id.isBlank() ? null : orgProvider.getById(id);
+            return org != null ? new SubjectResolution.Organization(org) : SubjectResolution.NOT_FOUND;
+        }
+        log.debugf("Tenant URI subject is not a urn:keycloak:org:{alias|id} URN — not resolvable. uri=%s", uri);
+        return SubjectResolution.NOT_FOUND;
+    }
+
+    /**
+     * Strict internal-id lookup — deliberately no alias fallback.
+     * Every tenant identifier states its lookup kind now (opaque /
+     * iss_sub {@code sub} = internal id, URN segments = explicit), and
+     * Keycloak's own producers serialize the self-describing
+     * {@code urn:keycloak:org:alias:} form, so a heuristic here would
+     * only reintroduce the alias/id shadowing it exists to prevent.
+     */
     private static SubjectResolution resolveOrgById(OrganizationProvider orgProvider, String orgId) {
         if (orgId == null) {
             return SubjectResolution.UNSUPPORTED_FORMAT;
@@ -162,37 +211,7 @@ public class SubjectResolver {
         if (org != null) {
             return new SubjectResolution.Organization(org);
         }
-        // id didn't match — try as alias
-        org = orgProvider.getByAlias(orgId);
-        if (org != null) {
-            return new SubjectResolution.Organization(org);
-        }
         return SubjectResolution.NOT_FOUND;
     }
 
-    private static SubjectResolution resolveOrgByAliasOrDomain(OrganizationProvider orgProvider, String value) {
-        var org = orgProvider.getByAlias(value);
-        if (org != null) {
-            return new SubjectResolution.Organization(org);
-        }
-        org = orgProvider.getByDomainName(value);
-        if (org != null) {
-            return new SubjectResolution.Organization(org);
-        }
-        return SubjectResolution.NOT_FOUND;
-    }
-
-    /**
-     * Extracts the org alias from a {@code urn:keycloak:org:<alias>}
-     * URN. Any other URI shape yields {@code null} — see the caller's
-     * comment for why arbitrary URIs must not resolve to local orgs.
-     */
-    private static String extractOrgAliasFromUri(String uri) {
-        if (uri == null || !uri.startsWith(ORG_URN_PREFIX)) {
-            log.debugf("Tenant URI subject is not a urn:keycloak:org URN — not resolvable. uri=%s", uri);
-            return null;
-        }
-        String alias = uri.substring(ORG_URN_PREFIX.length());
-        return alias.isBlank() ? null : alias;
-    }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectResolver.java
@@ -73,11 +73,11 @@ public class SubjectResolver {
 
     /**
      * Resolves a tenant subject to an organization. This is the shared
-     * contract for tenant facets — {@code opaque} (org id or alias),
+     * contract for tenant subject members — {@code opaque} (org id or alias),
      * {@code iss_sub} (sub as org id), {@code email} (org domain or
      * alias) and {@code uri} ({@code urn:keycloak:org:<alias>} or last
      * path segment) are all understood. Callers that gate on "the
-     * supplied tenant facet must resolve" (e.g. the synthetic event
+     * supplied tenant subject member must resolve" (e.g. the synthetic event
      * emitter) must use this rather than a narrower lookup so a tenant
      * format accepted elsewhere is not rejected there.
      */

--- a/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectUserLookup.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/subject/SubjectUserLookup.java
@@ -36,12 +36,28 @@ public class SubjectUserLookup {
         return null;
     }
 
+    /**
+     * Returns {@code true} when {@code iss} is this realm's own issuer
+     * URL, computed from the frontend base URI — the same value the
+     * realm stamps into its tokens. Shared issuer gate for
+     * {@code iss_sub} subjects: user lookups fall back to configured
+     * identity-provider issuers, while tenant lookups
+     * ({@link SubjectResolver#resolveOrganization}) accept only the
+     * realm issuer because organizations have no federated analog.
+     */
+    public static boolean isRealmIssuer(KeycloakSession session, String iss) {
+        if (iss == null) {
+            return false;
+        }
+        UriInfo frontendUriInfo = session.getContext().getUri(UrlType.FRONTEND);
+        String realmIssuer = Urls.realmIssuer(frontendUriInfo.getBaseUri(), session.getContext().getRealm().getName());
+        return realmIssuer.equals(iss);
+    }
+
     private static UserModel getUserByIssuerSub(KeycloakSession session, RealmModel realm, String iss, String sub) {
 
         // iss = current realm issuer
-        UriInfo frontendUriInfo = session.getContext().getUri(UrlType.FRONTEND);
-        String realmIssuer = Urls.realmIssuer(frontendUriInfo.getBaseUri(), session.getContext().getRealm().getName());
-        if (realmIssuer.equals(iss)) {
+        if (isRealmIssuer(session, iss)) {
             // Find realm user
             return getUserById(session, realm, sub);
         }

--- a/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
+++ b/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
@@ -950,7 +950,12 @@ public class SsfAdminResource {
      * {@code default_subjects} / {@code ssf.notify.<clientId>}
      * configuration. The dispatch outcome (dispatched vs. drop reason)
      * is reported in the response so emitter integrations can debug
-     * their wiring without enabling verbose logging.
+     * their wiring without enabling verbose logging. Complex subjects
+     * that name both a user and a tenant are additionally required to
+     * be internally consistent — the user must be a member of the
+     * tenant organization — so a subscribed tenant facet cannot carry
+     * an unrelated, unsubscribed user subject past the subject filter
+     * (keycloak/keycloak#50812).
      *
      * <p>Console-only convenience: callers with {@code manage-clients}
      * on the receiver bypass the {@code allowEmitEvents} opt-in and
@@ -1148,6 +1153,9 @@ public class SsfAdminResource {
             case SUBJECT_NOT_FOUND:
                 return invalidRequest(emitErrorCode, emitMessage,
                         "Subject referenced by the request does not exist");
+            case SUBJECT_MISMATCH:
+                return invalidRequest(emitErrorCode, emitMessage,
+                        "User subject is not a member of the tenant organization");
             case STREAM_NOT_FOUND:
                 // Defensive — the early stream check above usually catches
                 // this before emit() runs, but emit() can also return it

--- a/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
+++ b/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
@@ -1138,9 +1138,8 @@ public class SsfAdminResource {
         // so callers can distinguish categories (unknown_event_type,
         // subject_not_found, ...) from the wire response without having
         // to parse a free-form description. Any structured params the
-        // emitter attached (e.g. the failing complex-subject member, or
-        // the user/tenant pairing behind a subject_mismatch) are
-        // forwarded verbatim so the admin UI can parameterize a
+        // emitter attached (e.g. the failing complex-subject member)
+        // are forwarded verbatim so the admin UI can parameterize a
         // translated message without parsing error_description.
         String emitMessage = emitResult.message();
         String emitErrorCode = emitResult.status().wireValue();

--- a/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
+++ b/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
@@ -951,7 +951,12 @@ public class SsfAdminResource {
      * {@code default_subjects} / {@code ssf.notify.<clientId>}
      * configuration. The dispatch outcome (dispatched vs. drop reason)
      * is reported in the response so emitter integrations can debug
-     * their wiring without enabling verbose logging.
+     * their wiring without enabling verbose logging. Complex subjects
+     * that name both a user and a tenant are additionally required to
+     * be internally consistent — the user must be a member of the
+     * tenant organization — so a subscribed tenant facet cannot carry
+     * an unrelated, unsubscribed user subject past the subject filter
+     * (keycloak/keycloak#50812).
      *
      * <p>Console-only convenience: callers with {@code manage-clients}
      * on the receiver bypass the {@code allowEmitEvents} opt-in and
@@ -1149,6 +1154,9 @@ public class SsfAdminResource {
             case SUBJECT_NOT_FOUND:
                 return invalidRequest(emitErrorCode, emitMessage,
                         "Subject referenced by the request does not exist");
+            case SUBJECT_MISMATCH:
+                return invalidRequest(emitErrorCode, emitMessage,
+                        "User subject is not a member of the tenant organization");
             case STREAM_NOT_FOUND:
                 // Defensive — the early stream check above usually catches
                 // this before emit() runs, but emit() can also return it

--- a/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
+++ b/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
@@ -954,7 +954,7 @@ public class SsfAdminResource {
      * their wiring without enabling verbose logging. Complex subjects
      * that name both a user and a tenant are additionally required to
      * be internally consistent — the user must be a member of the
-     * tenant organization — so a subscribed tenant facet cannot carry
+     * tenant organization — so a subscribed tenant subject member cannot carry
      * an unrelated, unsubscribed user subject past the subject filter
      * (keycloak/keycloak#50812).
      *
@@ -1137,40 +1137,45 @@ public class SsfAdminResource {
         // Each 4xx case uses the status's wire value as the error code
         // so callers can distinguish categories (unknown_event_type,
         // subject_not_found, ...) from the wire response without having
-        // to parse a free-form description.
+        // to parse a free-form description. Any structured params the
+        // emitter attached (e.g. the failing complex-subject member, or
+        // the user/tenant pairing behind a subject_mismatch) are
+        // forwarded verbatim so the admin UI can parameterize a
+        // translated message without parsing error_description.
         String emitMessage = emitResult.message();
         String emitErrorCode = emitResult.status().wireValue();
+        Map<String, String> emitParams = emitResult.params();
         switch (emitResult.status()) {
             case INVALID_REQUEST:
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "Event payload could not be deserialized for the given eventType");
+                        "Event payload could not be deserialized for the given eventType", emitParams);
             case INVALID_EVENT_DATA:
-                return invalidRequest(emitErrorCode, emitMessage, "Invalid event data");
+                return invalidRequest(emitErrorCode, emitMessage, "Invalid event data", emitParams);
             case UNKNOWN_EVENT_TYPE:
-                return invalidRequest(emitErrorCode, emitMessage, "Unknown eventType");
+                return invalidRequest(emitErrorCode, emitMessage, "Unknown eventType", emitParams);
             case EVENT_TYPE_NOT_EMITTABLE:
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "Requested event type not emittable");
+                        "Requested event type not emittable", emitParams);
             case SUBJECT_NOT_FOUND:
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "Subject referenced by the request does not exist");
+                        "Subject referenced by the request does not exist", emitParams);
             case SUBJECT_MISMATCH:
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "User subject is not a member of the tenant organization");
+                        "User subject is not a member of the tenant organization", emitParams);
             case STREAM_NOT_FOUND:
                 // Defensive — the early stream check above usually catches
                 // this before emit() runs, but emit() can also return it
                 // (e.g. on a stream that was deleted between check and emit).
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "No SSF stream registered for client");
+                        "No SSF stream registered for client", emitParams);
             case RECEIVER_DISABLED:
                 // Receiver is configured but its client is disabled
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "Receiver client is disabled");
+                        "Receiver client is disabled", emitParams);
             case NO_DELIVERY_CONFIG:
                 // Stream exists but is not deliverable
                 return invalidRequest(emitErrorCode, emitMessage,
-                        "Stream has no delivery configuration");
+                        "Stream has no delivery configuration", emitParams);
             case DISPATCHED:
             case DROPPED_UNSUBSCRIBED:
             case DROPPED_FILTERED:
@@ -1781,7 +1786,7 @@ public class SsfAdminResource {
      * shape), looks up the concrete class through
      * {@link SubjectIds#getSubjectIdType} and deserialises into it.
      * When there's no {@code format} key (legacy SSE CAEP, where the
-     * facets are sibling keys under {@code subject} without an outer
+     * subject members are sibling keys under {@code subject} without an outer
      * marker), falls back to {@link ComplexSubjectId}.
      */
     protected SubjectId toTypedSubjectId(Map<String, Object> subjectMap) {
@@ -1812,7 +1817,7 @@ public class SsfAdminResource {
      *         as-is with its {@code format} discriminator.</li>
      *     <li><b>Legacy SSE CAEP</b> — no top-level {@code sub_id}; the
      *         subject lives under {@code events.<type>.subject} with
-     *         complex-subject facets (user / session / tenant / …) as
+     *         complex-subject members (user / session / tenant / …) as
      *         sibling keys and no outer {@code format}. Returned as-is
      *         from there.</li>
      * </ul>

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -11,6 +11,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.Profile;
@@ -361,7 +363,7 @@ public class SsfTransmitterEventEmitterTests {
         // Remove the notify attribute so the subject is no longer
         // subscribed — default_subjects=NONE means the subject filter
         // will drop.
-        bestEffortRemoveNotify();
+        removeNotifySubscription();
 
         String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
         try (SimpleHttpResponse res = emit(mgmtToken, "CaepCredentialChange", TEST_EMAIL,
@@ -497,6 +499,259 @@ public class SsfTransmitterEventEmitterTests {
                     res.asJson().get("status").asText(),
                     "unsubscribed org should be filtered like an unsubscribed user");
         }
+    }
+
+    @Test
+    public void emit_complexUserTenantMismatch_returnsSubjectMismatch() throws Exception {
+        // Regression guard for keycloak/keycloak#50812: an unsubscribed
+        // user combined with a subscribed-but-unrelated tenant org must
+        // not dispatch. Before the fix, the tenant facet alone counted
+        // as an allow signal, so the org's subscription carried the
+        // user subject past the per-user filter and the receiver got a
+        // SET asserting a user↔tenant association that doesn't exist.
+        // Setup and payload mirror the issue's proof test
+        // (emit_complexUserTenantMismatchDispatchesViaSubscribedTenant)
+        // with the assertions inverted to pin the fixed behaviour.
+        removeNotifySubscription();
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "user+tenant subject whose user is not a member of the tenant must be rejected");
+            Assertions.assertEquals("subject_mismatch", res.asJson().get("error").asText(),
+                    "error code should name the user/tenant membership mismatch");
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "mismatched user+tenant subject must not reach the receiver");
+    }
+
+    @Test
+    public void emit_complexUserTenantMember_dispatchesViaOrgSubscription() throws Exception {
+        // Legitimate counterpart of the mismatch case: the user is not
+        // individually subscribed but IS a member of the subscribed
+        // tenant org, so the org subscription covers the user — the
+        // same "any of the user's organizations is notified" semantics
+        // the native dispatcher applies. Asserting removal — if the
+        // user stayed individually subscribed, isUserNotified would
+        // short-circuit the gate and this test would pass without
+        // exercising the org membership path at all.
+        removeNotifySubscription();
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "org membership + org subscription should dispatch for the member user");
+        }
+
+        String push = pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertNotNull(push, "member user+tenant event should reach the mock receiver");
+        JsonNode set = decodeSet(push);
+        Assertions.assertEquals(userUuid, set.path("sub_id").path("user").path("sub").asText());
+        Assertions.assertEquals(orgAlias, set.path("sub_id").path("tenant").path("id").asText(),
+                "both facets must be forwarded verbatim");
+    }
+
+    @Test
+    public void emit_complexUnresolvableUserWithSubscribedTenant_returnsSubjectNotFound() throws Exception {
+        // Sibling of the mismatch case: a user facet that resolves to
+        // nothing must not silently degrade the subject to tenant-only —
+        // the sub_id is forwarded verbatim, so the receiver would see a
+        // user facet Keycloak never validated, gated only by the org's
+        // subscription.
+        String orgAlias = createOrgWithNotify();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer,
+                                        "sub", "00000000-0000-0000-0000-000000000000"),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "unresolvable user facet must fail the whole subject, not fall back to tenant-only");
+            Assertions.assertEquals("subject_not_found", res.asJson().get("error").asText());
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "subject with an unresolvable user facet must not reach the receiver");
+    }
+
+    @Test
+    public void emit_complexSubscribedUserUnknownTenant_returnsSubjectNotFound() throws Exception {
+        // Inverse of the unresolvable-user case: a tenant facet that
+        // resolves to no organization must fail the whole subject even
+        // when the user facet is valid and subscribed — the sub_id is
+        // forwarded verbatim, so the receiver would otherwise see a
+        // tenant facet Keycloak never validated. TEST_USER is
+        // pre-subscribed in setup(), so only the tenant is at fault.
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", "no-such-org-" + System.nanoTime())),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "unresolvable tenant facet must fail the whole subject, not fall back to user-only");
+            Assertions.assertEquals("subject_not_found", res.asJson().get("error").asText());
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "subject with an unresolvable tenant facet must not reach the receiver");
+    }
+
+    @Test
+    public void emit_complexIgnoredMemberOfNotifiedOrg_returnsDroppedUnsubscribed() throws Exception {
+        // Per-user explicit settings must win over org-membership
+        // inheritance, exactly as the native filter and the
+        // subjects/check endpoint codify: a user ignored via
+        // ssf.notify.<clientId>=false who IS a member of a notified org
+        // must not be dispatched through the org's subscription.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        ignoreTestUser();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dropped_unsubscribed", res.asJson().get("status").asText(),
+                    "per-user ignore must win over the member org's subscription");
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "ignored member's event must not reach the receiver despite the notified org");
+    }
+
+    @Test
+    public void emit_allModeExcludedViaOtherOrg_returnsDroppedUnsubscribed() throws Exception {
+        // In default_subjects=ALL the native filter drops a user when
+        // ANY of their organizations is excluded (getByMember scan). If
+        // the emitter honoured only the tenant the caller named, naming
+        // a different, non-excluded membership would sidestep an
+        // exclusion on another one.
+        setReceiverDefaultSubjects("ALL");
+        try {
+            removeNotifySubscription();
+            String plainOrgAlias = createOrgWithoutNotify();
+            String excludedOrgAlias = createOrgWithExcludeNotify();
+            String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+            addUserToOrganization(plainOrgAlias, userUuid);
+            String issuer = realm.getBaseUrl();
+            String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+
+            Map<String, Object> body = Map.of(
+                    "eventType", "CaepCredentialChange",
+                    "sub_id", Map.of(
+                            "format", "complex",
+                            "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                            "tenant", Map.of("format", "opaque", "id", plainOrgAlias)),
+                    "event", Map.of("credential_type", "password", "change_type", "update"));
+
+            // Control: with no exclusion anywhere, ALL mode delivers —
+            // proves the mode switch took effect and the drop below is
+            // really caused by the other-org exclusion.
+            try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                    .auth(mgmtToken).json(body).asResponse()) {
+                Assertions.assertEquals(200, res.getStatus());
+                Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                        "ALL mode should deliver a user with no exclusions");
+            }
+            Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                    "control emit should reach the mock receiver");
+
+            // Now the user also joins the excluded org — the same
+            // request naming the non-excluded tenant must drop.
+            addUserToOrganization(excludedOrgAlias, userUuid);
+            try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                    .auth(mgmtToken).json(body).asResponse()) {
+                Assertions.assertEquals(200, res.getStatus());
+                Assertions.assertEquals("dropped_unsubscribed", res.asJson().get("status").asText(),
+                        "an exclusion on any membership must drop, regardless of which tenant the caller names");
+            }
+            Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                    "excluded-via-other-org user's event must not reach the receiver");
+        } finally {
+            setReceiverDefaultSubjects("NONE");
+        }
+    }
+
+    @Test
+    public void emit_issSubTenantFormat_resolvesAndDispatches() throws Exception {
+        // Tenant facets follow the shared SubjectResolver contract, so
+        // formats beyond opaque (iss_sub, email/domain, uri) must
+        // resolve too — the mandatory facet-resolution gate would
+        // otherwise reject requests the subject-management endpoints
+        // consider valid. iss_sub carries the org UUID in `sub`.
+        String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "iss_sub", "iss", issuer, "sub", orgId)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "iss_sub tenant facet naming an existing org must resolve, not subject_not_found");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "iss_sub-tenant event should reach the mock receiver");
     }
 
     @Test
@@ -672,12 +927,44 @@ public class SsfTransmitterEventEmitterTests {
         }
     }
 
+    /**
+     * Sets {@code ssf.notify.<receiverClientId>=false} on TEST_USER via
+     * the {@code /subjects/ignore} endpoint — the explicit per-user
+     * exclusion that must override any org-level subscription. The
+     * marker is reset by {@link #subscribeTestUser()} in the next
+     * test's setup.
+     */
+    protected void ignoreTestUser() throws IOException {
+        String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/subjects/ignore";
+        try (SimpleHttpResponse ignored = http.doPost(url)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of("type", "user-email", "value", TEST_EMAIL))
+                .asResponse()) {
+        }
+    }
+
     protected void setReceiverAttributes(boolean allowEmit, String role) {
         ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
         ClientRepresentation rep = clientResource.toRepresentation();
         Map<String, String> attrs = rep.getAttributes();
         attrs.put(ClientStreamStore.SSF_ALLOW_EMIT_EVENTS_KEY, String.valueOf(allowEmit));
         attrs.put(ClientStreamStore.SSF_EMIT_EVENTS_ROLE_KEY, role);
+        rep.setAttributes(attrs);
+        clientResource.update(rep);
+    }
+
+    /**
+     * Switches the receiver's {@code default_subjects} mode. The realm
+     * config seeds {@code NONE}; tests that flip to {@code ALL} must
+     * restore {@code NONE} in a finally block since the attribute
+     * persists on the client across tests.
+     */
+    protected void setReceiverDefaultSubjects(String defaultSubjects) {
+        ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
+        ClientRepresentation rep = clientResource.toRepresentation();
+        Map<String, String> attrs = rep.getAttributes();
+        attrs.put(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, defaultSubjects);
         rep.setAttributes(attrs);
         clientResource.update(rep);
     }
@@ -759,6 +1046,10 @@ public class SsfTransmitterEventEmitterTests {
         }
     }
 
+    /** Cleanup-only variant of {@link #removeNotifySubscription()} —
+     * swallows failures so {@code @AfterEach} never masks the test
+     * result. Tests whose behaviour depends on the user being
+     * unsubscribed must use the asserting variant instead. */
     protected void bestEffortRemoveNotify() {
         try {
             String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
@@ -768,6 +1059,28 @@ public class SsfTransmitterEventEmitterTests {
                     .json(Map.of("type", "user-email", "value", TEST_EMAIL))
                     .asResponse().close();
         } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Removes TEST_USER's per-user subscription and asserts the
+     * resulting subject state, so a silently failing removal cannot
+     * leave the user notified and let a test pass on the wrong gate
+     * (isUserNotified short-circuits before the org checks). Call
+     * before creating member orgs — the reported state is the
+     * user-explicit one only while no org membership can influence it.
+     */
+    protected void removeNotifySubscription() throws IOException {
+        String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/subjects/remove";
+        try (SimpleHttpResponse res = http.doPost(url)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of("type", "user-email", "value", TEST_EMAIL))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus(),
+                    "subject removal must succeed for tests that rely on an unsubscribed user");
+            Assertions.assertEquals("not_notified", res.asJson().get("status").asText(),
+                    "TEST_USER must not be individually notified after removal");
         }
     }
 
@@ -784,40 +1097,60 @@ public class SsfTransmitterEventEmitterTests {
      */
     protected String createOrgWithNotify() {
         String alias = "emit-org-notified-" + System.nanoTime();
-        return createTestOrganization(alias, true);
+        return createTestOrganization(alias, "true");
     }
 
     protected String createOrgWithoutNotify() {
         String alias = "emit-org-silent-" + System.nanoTime();
-        return createTestOrganization(alias, false);
+        return createTestOrganization(alias, null);
     }
 
-    protected String createTestOrganization(String alias, boolean withNotifyAttribute) {
+    protected String createOrgWithExcludeNotify() {
+        String alias = "emit-org-excluded-" + System.nanoTime();
+        return createTestOrganization(alias, "false");
+    }
+
+    protected String createTestOrganization(String alias, String notifyValue) {
         OrganizationRepresentation rep = new OrganizationRepresentation();
         rep.setName(alias);
         rep.setAlias(alias);
         rep.addDomain(new org.keycloak.representations.idm.OrganizationDomainRepresentation(alias + ".local.test"));
-        if (withNotifyAttribute) {
-            // ssf.notify.<receiverClientId>=true so the synthetic emitter's
-            // subscription gate accepts the org in default_subjects=NONE
-            // mode. The emitter implementation uses
-            // SsfNotifyAttributes.isOrganizationNotified, which reads exactly
-            // this attribute.
-            rep.singleAttribute("ssf.notify." + RECEIVER, "true");
+        if (notifyValue != null) {
+            // ssf.notify.<receiverClientId> drives the emitter's org-level
+            // subscription gate: "true" subscribes the org
+            // (default_subjects=NONE include), "false" excludes it
+            // (default_subjects=ALL skip). The emitter implementation uses
+            // SsfNotifyAttributes.isOrganizationNotified/-Excluded, which
+            // read exactly this attribute.
+            rep.singleAttribute("ssf.notify." + RECEIVER, notifyValue);
         }
-        try (jakarta.ws.rs.core.Response response = realm.admin().organizations().create(rep)) {
+        try (Response response = realm.admin().organizations().create(rep)) {
             Assertions.assertEquals(201, response.getStatus(),
                     "test organization creation should succeed");
         }
         return alias;
     }
 
+    protected String findOrganizationIdByAlias(String alias) {
+        return realm.admin().organizations().getAll().stream()
+                .filter(o -> alias.equals(o.getAlias()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected organization '" + alias + "' to exist"))
+                .getId();
+    }
+
+    protected void addUserToOrganization(String orgAlias, String userId) {
+        try (Response response = realm.admin().organizations()
+                .get(findOrganizationIdByAlias(orgAlias)).members().addMember(userId)) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    "adding the test user as an org member should succeed");
+        }
+    }
+
     protected void bestEffortDeleteTestOrganizations() {
         try {
             realm.admin().organizations().getAll().stream()
-                    .filter(o -> o.getAlias() != null
-                            && (o.getAlias().startsWith("emit-org-notified-")
-                                    || o.getAlias().startsWith("emit-org-silent-")))
+                    .filter(o -> o.getAlias() != null && o.getAlias().startsWith("emit-org-"))
                     .forEach(o -> realm.admin().organizations().get(o.getId()).delete());
         } catch (Exception ignored) {
         }

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -778,6 +778,112 @@ public class SsfTransmitterEventEmitterTests {
     }
 
     @Test
+    public void emit_issSubTenantForeignIssuer_returnsSubjectNotFound() throws Exception {
+        // Adversarial counterpart of the iss_sub happy path: the sub_id
+        // travels verbatim in the SET, so an iss_sub tenant whose iss
+        // is not this realm's issuer must not resolve even when its
+        // sub names an existing local org, because otherwise an emitter could
+        // have Keycloak sign a tenant assertion tying a local
+        // organization to a foreign issuer the server never validated.
+        // Unlike user iss_sub lookups there is no IdP fallback for
+        // organizations, so only the realm's own issuer is accepted.
+        String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "iss_sub",
+                                        "iss", "https://foreign.example/realms/other", "sub", orgId)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "iss_sub tenant with a foreign issuer must be rejected even when sub names a local org");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            Assertions.assertEquals("tenant", body.path("params").path("subjectMember").asText(),
+                    "params.subjectMember should identify the tenant subject member as the one that failed to resolve");
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "foreign-issuer tenant subject must not reach the receiver");
+    }
+
+    @Test
+    public void emit_uriTenantKeycloakUrn_resolvesAndDispatches() throws Exception {
+        // The uri tenant format accepts the Keycloak-scoped URN form
+        // urn:keycloak:org:<alias>, becase this is the one URI shape this server can
+        // authoritatively interpret as one of its own organizations.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "uri",
+                                        "uri", "urn:keycloak:org:" + orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "urn:keycloak:org URN naming an existing org must resolve and dispatch");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "URN-tenant event should reach the mock receiver");
+    }
+
+    @Test
+    public void emit_uriTenantForeignUri_returnsSubjectNotFound() throws Exception {
+        // Sibling of the foreign-iss_sub case for the uri format: an
+        // earlier resolver revision took any https URI and resolved its
+        // last path segment as an org alias, so a caller could pair
+        // "https://evil.example/orgs/<alias>" with a subscribed local
+        // org and have the SET assert a URI namespace Keycloak never
+        // validated (the sub_id is forwarded verbatim). Only the
+        // urn:keycloak:org:<alias> URN form may resolve.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "uri",
+                                        "uri", "https://evil.example/orgs/" + orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "non-URN tenant URI must be rejected even when its last path segment names a local org");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            Assertions.assertEquals("tenant", body.path("params").path("subjectMember").asText(),
+                    "params.subjectMember should identify the tenant subject member as the one that failed to resolve");
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "foreign-URI tenant subject must not reach the receiver");
+    }
+
+    @Test
     public void emit_userInRemovalGraceWindow_dispatches() throws Exception {
         // The emit path delegates its user gate to the dispatcher's
         // config-aware SubjectSubscriptionFilter, so the SSF §9.3

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -118,6 +118,10 @@ public class SsfTransmitterEventEmitterTests {
 
     static final long PUSH_WAIT_SECONDS = 5;
 
+    /** Transmitter-wide §9.3 removal grace — large enough that no
+     * wallclock drift can push the grace test past the window. */
+    static final int REMOVAL_GRACE_SECONDS = 300;
+
     @InjectRealm(config = EmitRealm.class)
     ManagedRealm realm;
 
@@ -756,6 +760,35 @@ public class SsfTransmitterEventEmitterTests {
     }
 
     @Test
+    public void emit_userInRemovalGraceWindow_dispatches() throws Exception {
+        // The emit path delegates its user gate to the dispatcher's
+        // config-aware SubjectSubscriptionFilter, so the SSF §9.3
+        // removal-grace window must apply to synthetic events too: a
+        // receiver-driven remove leaves a tombstone, and events for the
+        // subject must keep flowing until the configured grace expires —
+        // exactly as native events do. A receiver that could silence
+        // synthetic events immediately by self-removing a subject would
+        // reopen the §9.3 malicious-removal hole for this path.
+        String receiverToken = obtainReceiverManageToken();
+        String streamId = readReceiverStreamId(receiverToken);
+
+        // setup() subscribed TEST_USER via the admin add endpoint. A
+        // receiver-driven remove clears that include marker AND stamps
+        // the grace tombstone (admin removes deliberately don't).
+        receiverRemoveSubject(receiverToken, streamId, TEST_EMAIL);
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = emit(mgmtToken, "CaepCredentialChange", TEST_EMAIL,
+                Map.of("credential_type", "password", "change_type", "update"))) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "synthetic event for a subject inside the §9.3 grace window must still dispatch");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "grace-window synthetic event should reach the mock receiver");
+    }
+
+    @Test
     public void emit_streamLifecycleEvent_returnsEventTypeNotEmittable() throws Exception {
         // SsfStreamVerificationEvent + SsfStreamUpdatedEvent are
         // protocol-internal lifecycle signals owned by the transmitter.
@@ -900,6 +933,40 @@ public class SsfTransmitterEventEmitterTests {
                 .asResponse()) {
             Assertions.assertEquals(200, response.getStatus());
             return response.asJson().get("access_token").asText();
+        }
+    }
+
+    /** Reads the receiver's registered stream id via GET /streams —
+     * needed for the receiver-driven subject endpoints, which key off
+     * the stream rather than the client. */
+    protected String readReceiverStreamId(String receiverToken) throws IOException {
+        try (SimpleHttpResponse response = http.doGet(SsfTransmitterUrls.getStreamsEndpointUrl(realm.getBaseUrl()))
+                .auth(receiverToken)
+                .acceptJson()
+                .asResponse()) {
+            Assertions.assertEquals(200, response.getStatus());
+            JsonNode arr = response.asJson();
+            Assertions.assertTrue(arr.isArray() && arr.size() > 0,
+                    "expected /streams to return a non-empty array for the receiver");
+            return arr.get(0).get("stream_id").asText();
+        }
+    }
+
+    /**
+     * Receiver-driven subject remove (the SSF §7.1.3.3 endpoint the
+     * receiver calls on its own stream). Unlike the admin remove
+     * endpoint the other tests use, this stamps the §9.3 grace
+     * tombstone, so it's the setup for the grace-window emit test.
+     */
+    protected void receiverRemoveSubject(String receiverToken, String streamId, String email) throws IOException {
+        String url = realm.getBaseUrl() + "/ssf/transmitter/subjects/remove";
+        try (SimpleHttpResponse res = http.doPost(url)
+                .auth(receiverToken)
+                .json(Map.of("stream_id", streamId,
+                        "subject", Map.of("format", "email", "email", email)))
+                .asResponse()) {
+            Assertions.assertEquals(204, res.getStatus(),
+                    "receiver-driven subjects/remove should succeed");
         }
     }
 
@@ -1213,6 +1280,16 @@ public class SsfTransmitterEventEmitterTests {
                     DefaultSsfTransmitterProviderFactory.CONFIG_OUTBOX_DRAINER_INTERVAL, "500ms");
             config.spiOption("ssf-transmitter", "default",
                     SsfTransmitterConfig.CONFIG_MIN_VERIFICATION_INTERVAL_SECONDS, "0");
+            // Enable the SSF §9.3 removal-grace window transmitter-wide so
+            // emit_userInRemovalGraceWindow_dispatches can prove the emit
+            // path inherits the dispatcher's grace-aware subject gate. All
+            // other tests unsubscribe via the ADMIN remove endpoint, which
+            // stamps no tombstone, so they are unaffected by a positive
+            // grace. The window is large enough that wallclock drift can't
+            // make the grace test flaky.
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_SUBJECT_REMOVAL_GRACE_SECONDS,
+                    String.valueOf(REMOVAL_GRACE_SECONDS));
             // Test pushes to a local mock server on a loopback URL (http://127.0.0.1:NNNN/...).
             // Relax the http-scheme + private-host gate so the mock URL is accepted; the
             // per-client ssf.validPushUrls allow-list configured on each receiver below

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -436,7 +436,7 @@ public class SsfTransmitterEventEmitterTests {
                 .asResponse()) {
             Assertions.assertEquals(200, res.getStatus());
             Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
-                    "complex sub_id should resolve via the user facet and dispatch");
+                    "complex sub_id should resolve via the user subject member and dispatch");
         }
 
         String push = pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
@@ -448,13 +448,13 @@ public class SsfTransmitterEventEmitterTests {
         Assertions.assertEquals("iss_sub", subId.path("user").path("format").asText());
         Assertions.assertEquals(userUuid, subId.path("user").path("sub").asText());
         Assertions.assertEquals("fake-session-id-123", subId.path("session").path("id").asText(),
-                "session facet must round-trip through the dispatch + sign + push pipeline");
+                "session subject member must round-trip through the dispatch + sign + push pipeline");
     }
 
     @Test
     public void emit_orgSubjectViaTenant_dispatches() throws Exception {
         // Org-only emission: the sub_id is a complex subject whose only
-        // facet is the tenant (org alias). The user facet is omitted, so
+        // subject member is the tenant (org alias). The user subject member is omitted, so
         // resolution lands on the org and the receiver's per-org notify
         // attribute drives the subscription gate.
         String orgAlias = createOrgWithNotify();
@@ -479,7 +479,7 @@ public class SsfTransmitterEventEmitterTests {
         JsonNode set = decodeSet(push);
         Assertions.assertEquals("complex", set.path("sub_id").path("format").asText());
         Assertions.assertEquals(orgAlias, set.path("sub_id").path("tenant").path("id").asText(),
-                "tenant facet must be forwarded verbatim");
+                "tenant subject member must be forwarded verbatim");
     }
 
     @Test
@@ -510,7 +510,7 @@ public class SsfTransmitterEventEmitterTests {
     public void emit_complexUserTenantMismatch_returnsSubjectMismatch() throws Exception {
         // Regression guard for keycloak/keycloak#50812: an unsubscribed
         // user combined with a subscribed-but-unrelated tenant org must
-        // not dispatch. Before the fix, the tenant facet alone counted
+        // not dispatch. Before the fix, the tenant subject member alone counted
         // as an allow signal, so the org's subscription carried the
         // user subject past the per-user filter and the receiver got a
         // SET asserting a user↔tenant association that doesn't exist.
@@ -535,8 +535,16 @@ public class SsfTransmitterEventEmitterTests {
                 .asResponse()) {
             Assertions.assertEquals(400, res.getStatus(),
                     "user+tenant subject whose user is not a member of the tenant must be rejected");
-            Assertions.assertEquals("subject_mismatch", res.asJson().get("error").asText(),
+            JsonNode mismatchBody = res.asJson();
+            Assertions.assertEquals("subject_mismatch", mismatchBody.get("error").asText(),
                     "error code should name the user/tenant membership mismatch");
+            // params names the resolved pairing machine-readably so the
+            // admin UI can render a translated message with the concrete
+            // user/tenant instead of parsing the English description.
+            Assertions.assertEquals(TEST_USER, mismatchBody.path("params").path("user").asText(),
+                    "params.user should carry the resolved username behind the mismatch");
+            Assertions.assertEquals(orgAlias, mismatchBody.path("params").path("tenant").asText(),
+                    "params.tenant should carry the resolved organization alias behind the mismatch");
         }
         Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
                 "mismatched user+tenant subject must not reach the receiver");
@@ -579,15 +587,15 @@ public class SsfTransmitterEventEmitterTests {
         JsonNode set = decodeSet(push);
         Assertions.assertEquals(userUuid, set.path("sub_id").path("user").path("sub").asText());
         Assertions.assertEquals(orgAlias, set.path("sub_id").path("tenant").path("id").asText(),
-                "both facets must be forwarded verbatim");
+                "both subject members must be forwarded verbatim");
     }
 
     @Test
     public void emit_complexUnresolvableUserWithSubscribedTenant_returnsSubjectNotFound() throws Exception {
-        // Sibling of the mismatch case: a user facet that resolves to
+        // Sibling of the mismatch case: a user subject member that resolves to
         // nothing must not silently degrade the subject to tenant-only —
         // the sub_id is forwarded verbatim, so the receiver would see a
-        // user facet Keycloak never validated, gated only by the org's
+        // user subject member Keycloak never validated, gated only by the org's
         // subscription.
         String orgAlias = createOrgWithNotify();
         String issuer = realm.getBaseUrl();
@@ -605,20 +613,25 @@ public class SsfTransmitterEventEmitterTests {
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(400, res.getStatus(),
-                    "unresolvable user facet must fail the whole subject, not fall back to tenant-only");
-            Assertions.assertEquals("subject_not_found", res.asJson().get("error").asText());
+                    "unresolvable user subject member must fail the whole subject, not fall back to tenant-only");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            // Both subject member failures share the subject_not_found wire code —
+            // params.subjectMember is the machine-readable discriminator.
+            Assertions.assertEquals("user", body.path("params").path("subjectMember").asText(),
+                    "params.subjectMember should identify the user subject member as the one that failed to resolve");
         }
         Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
-                "subject with an unresolvable user facet must not reach the receiver");
+                "subject with an unresolvable user subject member must not reach the receiver");
     }
 
     @Test
     public void emit_complexSubscribedUserUnknownTenant_returnsSubjectNotFound() throws Exception {
-        // Inverse of the unresolvable-user case: a tenant facet that
+        // Inverse of the unresolvable-user case: a tenant subject member that
         // resolves to no organization must fail the whole subject even
-        // when the user facet is valid and subscribed — the sub_id is
+        // when the user subject member is valid and subscribed — the sub_id is
         // forwarded verbatim, so the receiver would otherwise see a
-        // tenant facet Keycloak never validated. TEST_USER is
+        // tenant subject member Keycloak never validated. TEST_USER is
         // pre-subscribed in setup(), so only the tenant is at fault.
         String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
         String issuer = realm.getBaseUrl();
@@ -635,11 +648,16 @@ public class SsfTransmitterEventEmitterTests {
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(400, res.getStatus(),
-                    "unresolvable tenant facet must fail the whole subject, not fall back to user-only");
-            Assertions.assertEquals("subject_not_found", res.asJson().get("error").asText());
+                    "unresolvable tenant subject member must fail the whole subject, not fall back to user-only");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            // Both subject member failures share the subject_not_found wire code —
+            // params.subjectMember is the machine-readable discriminator.
+            Assertions.assertEquals("tenant", body.path("params").path("subjectMember").asText(),
+                    "params.subjectMember should identify the tenant subject member as the one that failed to resolve");
         }
         Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
-                "subject with an unresolvable tenant facet must not reach the receiver");
+                "subject with an unresolvable tenant subject member must not reach the receiver");
     }
 
     @Test
@@ -729,9 +747,9 @@ public class SsfTransmitterEventEmitterTests {
 
     @Test
     public void emit_issSubTenantFormat_resolvesAndDispatches() throws Exception {
-        // Tenant facets follow the shared SubjectResolver contract, so
+        // Tenant subject members follow the shared SubjectResolver contract, so
         // formats beyond opaque (iss_sub, email/domain, uri) must
-        // resolve too — the mandatory facet-resolution gate would
+        // resolve too — the mandatory subject-member-resolution gate would
         // otherwise reject requests the subject-management endpoints
         // consider valid. iss_sub carries the org UUID in `sub`.
         String orgAlias = createOrgWithNotify();
@@ -753,7 +771,7 @@ public class SsfTransmitterEventEmitterTests {
                 .asResponse()) {
             Assertions.assertEquals(200, res.getStatus());
             Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
-                    "iss_sub tenant facet naming an existing org must resolve, not subject_not_found");
+                    "iss_sub tenant subject member naming an existing org must resolve, not subject_not_found");
         }
         Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
                 "iss_sub-tenant event should reach the mock receiver");

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -11,6 +11,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.Profile;
@@ -362,7 +364,7 @@ public class SsfTransmitterEventEmitterTests {
         // Remove the notify attribute so the subject is no longer
         // subscribed — default_subjects=NONE means the subject filter
         // will drop.
-        bestEffortRemoveNotify();
+        removeNotifySubscription();
 
         String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
         try (SimpleHttpResponse res = emit(mgmtToken, "CaepCredentialChange", TEST_EMAIL,
@@ -498,6 +500,259 @@ public class SsfTransmitterEventEmitterTests {
                     res.asJson().get("status").asText(),
                     "unsubscribed org should be filtered like an unsubscribed user");
         }
+    }
+
+    @Test
+    public void emit_complexUserTenantMismatch_returnsSubjectMismatch() throws Exception {
+        // Regression guard for keycloak/keycloak#50812: an unsubscribed
+        // user combined with a subscribed-but-unrelated tenant org must
+        // not dispatch. Before the fix, the tenant facet alone counted
+        // as an allow signal, so the org's subscription carried the
+        // user subject past the per-user filter and the receiver got a
+        // SET asserting a user↔tenant association that doesn't exist.
+        // Setup and payload mirror the issue's proof test
+        // (emit_complexUserTenantMismatchDispatchesViaSubscribedTenant)
+        // with the assertions inverted to pin the fixed behaviour.
+        removeNotifySubscription();
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "user+tenant subject whose user is not a member of the tenant must be rejected");
+            Assertions.assertEquals("subject_mismatch", res.asJson().get("error").asText(),
+                    "error code should name the user/tenant membership mismatch");
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "mismatched user+tenant subject must not reach the receiver");
+    }
+
+    @Test
+    public void emit_complexUserTenantMember_dispatchesViaOrgSubscription() throws Exception {
+        // Legitimate counterpart of the mismatch case: the user is not
+        // individually subscribed but IS a member of the subscribed
+        // tenant org, so the org subscription covers the user — the
+        // same "any of the user's organizations is notified" semantics
+        // the native dispatcher applies. Asserting removal — if the
+        // user stayed individually subscribed, isUserNotified would
+        // short-circuit the gate and this test would pass without
+        // exercising the org membership path at all.
+        removeNotifySubscription();
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "org membership + org subscription should dispatch for the member user");
+        }
+
+        String push = pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertNotNull(push, "member user+tenant event should reach the mock receiver");
+        JsonNode set = decodeSet(push);
+        Assertions.assertEquals(userUuid, set.path("sub_id").path("user").path("sub").asText());
+        Assertions.assertEquals(orgAlias, set.path("sub_id").path("tenant").path("id").asText(),
+                "both facets must be forwarded verbatim");
+    }
+
+    @Test
+    public void emit_complexUnresolvableUserWithSubscribedTenant_returnsSubjectNotFound() throws Exception {
+        // Sibling of the mismatch case: a user facet that resolves to
+        // nothing must not silently degrade the subject to tenant-only —
+        // the sub_id is forwarded verbatim, so the receiver would see a
+        // user facet Keycloak never validated, gated only by the org's
+        // subscription.
+        String orgAlias = createOrgWithNotify();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer,
+                                        "sub", "00000000-0000-0000-0000-000000000000"),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "unresolvable user facet must fail the whole subject, not fall back to tenant-only");
+            Assertions.assertEquals("subject_not_found", res.asJson().get("error").asText());
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "subject with an unresolvable user facet must not reach the receiver");
+    }
+
+    @Test
+    public void emit_complexSubscribedUserUnknownTenant_returnsSubjectNotFound() throws Exception {
+        // Inverse of the unresolvable-user case: a tenant facet that
+        // resolves to no organization must fail the whole subject even
+        // when the user facet is valid and subscribed — the sub_id is
+        // forwarded verbatim, so the receiver would otherwise see a
+        // tenant facet Keycloak never validated. TEST_USER is
+        // pre-subscribed in setup(), so only the tenant is at fault.
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", "no-such-org-" + System.nanoTime())),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "unresolvable tenant facet must fail the whole subject, not fall back to user-only");
+            Assertions.assertEquals("subject_not_found", res.asJson().get("error").asText());
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "subject with an unresolvable tenant facet must not reach the receiver");
+    }
+
+    @Test
+    public void emit_complexIgnoredMemberOfNotifiedOrg_returnsDroppedUnsubscribed() throws Exception {
+        // Per-user explicit settings must win over org-membership
+        // inheritance, exactly as the native filter and the
+        // subjects/check endpoint codify: a user ignored via
+        // ssf.notify.<clientId>=false who IS a member of a notified org
+        // must not be dispatched through the org's subscription.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        ignoreTestUser();
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dropped_unsubscribed", res.asJson().get("status").asText(),
+                    "per-user ignore must win over the member org's subscription");
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "ignored member's event must not reach the receiver despite the notified org");
+    }
+
+    @Test
+    public void emit_allModeExcludedViaOtherOrg_returnsDroppedUnsubscribed() throws Exception {
+        // In default_subjects=ALL the native filter drops a user when
+        // ANY of their organizations is excluded (getByMember scan). If
+        // the emitter honoured only the tenant the caller named, naming
+        // a different, non-excluded membership would sidestep an
+        // exclusion on another one.
+        setReceiverDefaultSubjects("ALL");
+        try {
+            removeNotifySubscription();
+            String plainOrgAlias = createOrgWithoutNotify();
+            String excludedOrgAlias = createOrgWithExcludeNotify();
+            String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+            addUserToOrganization(plainOrgAlias, userUuid);
+            String issuer = realm.getBaseUrl();
+            String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+
+            Map<String, Object> body = Map.of(
+                    "eventType", "CaepCredentialChange",
+                    "sub_id", Map.of(
+                            "format", "complex",
+                            "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                            "tenant", Map.of("format", "opaque", "id", plainOrgAlias)),
+                    "event", Map.of("credential_type", "password", "change_type", "update"));
+
+            // Control: with no exclusion anywhere, ALL mode delivers —
+            // proves the mode switch took effect and the drop below is
+            // really caused by the other-org exclusion.
+            try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                    .auth(mgmtToken).json(body).asResponse()) {
+                Assertions.assertEquals(200, res.getStatus());
+                Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                        "ALL mode should deliver a user with no exclusions");
+            }
+            Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                    "control emit should reach the mock receiver");
+
+            // Now the user also joins the excluded org — the same
+            // request naming the non-excluded tenant must drop.
+            addUserToOrganization(excludedOrgAlias, userUuid);
+            try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                    .auth(mgmtToken).json(body).asResponse()) {
+                Assertions.assertEquals(200, res.getStatus());
+                Assertions.assertEquals("dropped_unsubscribed", res.asJson().get("status").asText(),
+                        "an exclusion on any membership must drop, regardless of which tenant the caller names");
+            }
+            Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                    "excluded-via-other-org user's event must not reach the receiver");
+        } finally {
+            setReceiverDefaultSubjects("NONE");
+        }
+    }
+
+    @Test
+    public void emit_issSubTenantFormat_resolvesAndDispatches() throws Exception {
+        // Tenant facets follow the shared SubjectResolver contract, so
+        // formats beyond opaque (iss_sub, email/domain, uri) must
+        // resolve too — the mandatory facet-resolution gate would
+        // otherwise reject requests the subject-management endpoints
+        // consider valid. iss_sub carries the org UUID in `sub`.
+        String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "iss_sub", "iss", issuer, "sub", orgId)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "iss_sub tenant facet naming an existing org must resolve, not subject_not_found");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "iss_sub-tenant event should reach the mock receiver");
     }
 
     @Test
@@ -710,12 +965,44 @@ public class SsfTransmitterEventEmitterTests {
         }
     }
 
+    /**
+     * Sets {@code ssf.notify.<receiverClientId>=false} on TEST_USER via
+     * the {@code /subjects/ignore} endpoint — the explicit per-user
+     * exclusion that must override any org-level subscription. The
+     * marker is reset by {@link #subscribeTestUser()} in the next
+     * test's setup.
+     */
+    protected void ignoreTestUser() throws IOException {
+        String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/subjects/ignore";
+        try (SimpleHttpResponse ignored = http.doPost(url)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of("type", "user-email", "value", TEST_EMAIL))
+                .asResponse()) {
+        }
+    }
+
     protected void setReceiverAttributes(boolean allowEmit, String role) {
         ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
         ClientRepresentation rep = clientResource.toRepresentation();
         Map<String, String> attrs = rep.getAttributes();
         attrs.put(ClientStreamStore.SSF_ALLOW_EMIT_EVENTS_KEY, String.valueOf(allowEmit));
         attrs.put(ClientStreamStore.SSF_EMIT_EVENTS_ROLE_KEY, role);
+        rep.setAttributes(attrs);
+        clientResource.update(rep);
+    }
+
+    /**
+     * Switches the receiver's {@code default_subjects} mode. The realm
+     * config seeds {@code NONE}; tests that flip to {@code ALL} must
+     * restore {@code NONE} in a finally block since the attribute
+     * persists on the client across tests.
+     */
+    protected void setReceiverDefaultSubjects(String defaultSubjects) {
+        ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
+        ClientRepresentation rep = clientResource.toRepresentation();
+        Map<String, String> attrs = rep.getAttributes();
+        attrs.put(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, defaultSubjects);
         rep.setAttributes(attrs);
         clientResource.update(rep);
     }
@@ -797,6 +1084,10 @@ public class SsfTransmitterEventEmitterTests {
         }
     }
 
+    /** Cleanup-only variant of {@link #removeNotifySubscription()} —
+     * swallows failures so {@code @AfterEach} never masks the test
+     * result. Tests whose behaviour depends on the user being
+     * unsubscribed must use the asserting variant instead. */
     protected void bestEffortRemoveNotify() {
         try {
             String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
@@ -806,6 +1097,28 @@ public class SsfTransmitterEventEmitterTests {
                     .json(Map.of("type", "user-email", "value", TEST_EMAIL))
                     .asResponse().close();
         } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Removes TEST_USER's per-user subscription and asserts the
+     * resulting subject state, so a silently failing removal cannot
+     * leave the user notified and let a test pass on the wrong gate
+     * (isUserNotified short-circuits before the org checks). Call
+     * before creating member orgs — the reported state is the
+     * user-explicit one only while no org membership can influence it.
+     */
+    protected void removeNotifySubscription() throws IOException {
+        String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/subjects/remove";
+        try (SimpleHttpResponse res = http.doPost(url)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of("type", "user-email", "value", TEST_EMAIL))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus(),
+                    "subject removal must succeed for tests that rely on an unsubscribed user");
+            Assertions.assertEquals("not_notified", res.asJson().get("status").asText(),
+                    "TEST_USER must not be individually notified after removal");
         }
     }
 
@@ -822,40 +1135,60 @@ public class SsfTransmitterEventEmitterTests {
      */
     protected String createOrgWithNotify() {
         String alias = "emit-org-notified-" + System.nanoTime();
-        return createTestOrganization(alias, true);
+        return createTestOrganization(alias, "true");
     }
 
     protected String createOrgWithoutNotify() {
         String alias = "emit-org-silent-" + System.nanoTime();
-        return createTestOrganization(alias, false);
+        return createTestOrganization(alias, null);
     }
 
-    protected String createTestOrganization(String alias, boolean withNotifyAttribute) {
+    protected String createOrgWithExcludeNotify() {
+        String alias = "emit-org-excluded-" + System.nanoTime();
+        return createTestOrganization(alias, "false");
+    }
+
+    protected String createTestOrganization(String alias, String notifyValue) {
         OrganizationRepresentation rep = new OrganizationRepresentation();
         rep.setName(alias);
         rep.setAlias(alias);
         rep.addDomain(new org.keycloak.representations.idm.OrganizationDomainRepresentation(alias + ".local.test"));
-        if (withNotifyAttribute) {
-            // ssf.notify.<receiverClientId>=true so the synthetic emitter's
-            // subscription gate accepts the org in default_subjects=NONE
-            // mode. The emitter implementation uses
-            // SsfNotifyAttributes.isOrganizationNotified, which reads exactly
-            // this attribute.
-            rep.singleAttribute("ssf.notify." + RECEIVER, "true");
+        if (notifyValue != null) {
+            // ssf.notify.<receiverClientId> drives the emitter's org-level
+            // subscription gate: "true" subscribes the org
+            // (default_subjects=NONE include), "false" excludes it
+            // (default_subjects=ALL skip). The emitter implementation uses
+            // SsfNotifyAttributes.isOrganizationNotified/-Excluded, which
+            // read exactly this attribute.
+            rep.singleAttribute("ssf.notify." + RECEIVER, notifyValue);
         }
-        try (jakarta.ws.rs.core.Response response = realm.admin().organizations().create(rep)) {
+        try (Response response = realm.admin().organizations().create(rep)) {
             Assertions.assertEquals(201, response.getStatus(),
                     "test organization creation should succeed");
         }
         return alias;
     }
 
+    protected String findOrganizationIdByAlias(String alias) {
+        return realm.admin().organizations().getAll().stream()
+                .filter(o -> alias.equals(o.getAlias()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected organization '" + alias + "' to exist"))
+                .getId();
+    }
+
+    protected void addUserToOrganization(String orgAlias, String userId) {
+        try (Response response = realm.admin().organizations()
+                .get(findOrganizationIdByAlias(orgAlias)).members().addMember(userId)) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    "adding the test user as an org member should succeed");
+        }
+    }
+
     protected void bestEffortDeleteTestOrganizations() {
         try {
             realm.admin().organizations().getAll().stream()
-                    .filter(o -> o.getAlias() != null
-                            && (o.getAlias().startsWith("emit-org-notified-")
-                                    || o.getAlias().startsWith("emit-org-silent-")))
+                    .filter(o -> o.getAlias() != null && o.getAlias().startsWith("emit-org-"))
                     .forEach(o -> realm.admin().organizations().get(o.getId()).delete());
         } catch (Exception ignored) {
         }

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -454,10 +454,12 @@ public class SsfTransmitterEventEmitterTests {
     @Test
     public void emit_orgSubjectViaTenant_dispatches() throws Exception {
         // Org-only emission: the sub_id is a complex subject whose only
-        // subject member is the tenant (org alias). The user subject member is omitted, so
-        // resolution lands on the org and the receiver's per-org notify
-        // attribute drives the subscription gate.
+        // subject member is the tenant (opaque = internal org id). The
+        // user subject member is omitted, so resolution lands on the
+        // org and the receiver's per-org notify attribute drives the
+        // subscription gate.
         String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
 
         String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
         try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
@@ -466,7 +468,7 @@ public class SsfTransmitterEventEmitterTests {
                         "eventType", "CaepCredentialChange",
                         "sub_id", Map.of(
                                 "format", "complex",
-                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                                "tenant", Map.of("format", "opaque", "id", orgId)),
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(200, res.getStatus());
@@ -478,16 +480,23 @@ public class SsfTransmitterEventEmitterTests {
         Assertions.assertNotNull(push, "org-subject event should reach the mock receiver");
         JsonNode set = decodeSet(push);
         Assertions.assertEquals("complex", set.path("sub_id").path("format").asText());
-        Assertions.assertEquals(orgAlias, set.path("sub_id").path("tenant").path("id").asText(),
+        Assertions.assertEquals(orgId, set.path("sub_id").path("tenant").path("id").asText(),
                 "tenant subject member must be forwarded verbatim");
     }
 
     @Test
-    public void emit_orgSubjectNotSubscribed_returnsDroppedUnsubscribed() throws Exception {
-        // Org exists but has no ssf.notify attribute set for the receiver;
-        // default_subjects=NONE on the receiver means the dispatch is
-        // refused.
-        String orgAlias = createOrgWithoutNotify();
+    public void emit_opaqueTenantAlias_returnsSubjectNotFound() throws Exception {
+        // Opaque tenant values resolve strictly by internal org id —
+        // never by alias, which is addressed via the explicit
+        // urn:keycloak:org:alias: URN form instead. An alias fallback
+        // here would reintroduce alias/id shadowing (an alias equal to
+        // another organization's UUID routing the subject to the wrong
+        // org, or vice versa). The valid user member pins the failure
+        // to the tenant via params.subjectMember.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
 
         String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
         try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
@@ -496,7 +505,36 @@ public class SsfTransmitterEventEmitterTests {
                         "eventType", "CaepCredentialChange",
                         "sub_id", Map.of(
                                 "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
                                 "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "opaque tenant carrying an alias must not resolve via alias fallback");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            Assertions.assertEquals("tenant", body.path("params").path("subjectMember").asText());
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "alias-as-opaque tenant subject must not reach the receiver");
+    }
+
+    @Test
+    public void emit_orgSubjectNotSubscribed_returnsDroppedUnsubscribed() throws Exception {
+        // Org exists but has no ssf.notify attribute set for the receiver;
+        // default_subjects=NONE on the receiver means the dispatch is
+        // refused.
+        String orgAlias = createOrgWithoutNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "tenant", Map.of("format", "opaque", "id", orgId)),
                         "event", Map.of("credential_type", "password")))
                 .asResponse()) {
             Assertions.assertEquals(200, res.getStatus());
@@ -519,6 +557,7 @@ public class SsfTransmitterEventEmitterTests {
         // with the assertions inverted to pin the fixed behaviour.
         removeNotifySubscription();
         String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
         String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
         String issuer = realm.getBaseUrl();
 
@@ -530,7 +569,7 @@ public class SsfTransmitterEventEmitterTests {
                         "sub_id", Map.of(
                                 "format", "complex",
                                 "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
-                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                                "tenant", Map.of("format", "opaque", "id", orgId)),
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(400, res.getStatus(),
@@ -562,6 +601,7 @@ public class SsfTransmitterEventEmitterTests {
         // exercising the org membership path at all.
         removeNotifySubscription();
         String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
         String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
         addUserToOrganization(orgAlias, userUuid);
         String issuer = realm.getBaseUrl();
@@ -574,7 +614,7 @@ public class SsfTransmitterEventEmitterTests {
                         "sub_id", Map.of(
                                 "format", "complex",
                                 "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
-                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                                "tenant", Map.of("format", "opaque", "id", orgId)),
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(200, res.getStatus());
@@ -586,7 +626,7 @@ public class SsfTransmitterEventEmitterTests {
         Assertions.assertNotNull(push, "member user+tenant event should reach the mock receiver");
         JsonNode set = decodeSet(push);
         Assertions.assertEquals(userUuid, set.path("sub_id").path("user").path("sub").asText());
-        Assertions.assertEquals(orgAlias, set.path("sub_id").path("tenant").path("id").asText(),
+        Assertions.assertEquals(orgId, set.path("sub_id").path("tenant").path("id").asText(),
                 "both subject members must be forwarded verbatim");
     }
 
@@ -598,6 +638,7 @@ public class SsfTransmitterEventEmitterTests {
         // user subject member Keycloak never validated, gated only by the org's
         // subscription.
         String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
         String issuer = realm.getBaseUrl();
 
         String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
@@ -609,7 +650,7 @@ public class SsfTransmitterEventEmitterTests {
                                 "format", "complex",
                                 "user", Map.of("format", "iss_sub", "iss", issuer,
                                         "sub", "00000000-0000-0000-0000-000000000000"),
-                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                                "tenant", Map.of("format", "opaque", "id", orgId)),
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(400, res.getStatus(),
@@ -668,6 +709,7 @@ public class SsfTransmitterEventEmitterTests {
         // ssf.notify.<clientId>=false who IS a member of a notified org
         // must not be dispatched through the org's subscription.
         String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
         String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
         addUserToOrganization(orgAlias, userUuid);
         ignoreTestUser();
@@ -681,7 +723,7 @@ public class SsfTransmitterEventEmitterTests {
                         "sub_id", Map.of(
                                 "format", "complex",
                                 "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
-                                "tenant", Map.of("format", "opaque", "id", orgAlias)),
+                                "tenant", Map.of("format", "opaque", "id", orgId)),
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
             Assertions.assertEquals(200, res.getStatus());
@@ -703,6 +745,7 @@ public class SsfTransmitterEventEmitterTests {
         try {
             removeNotifySubscription();
             String plainOrgAlias = createOrgWithoutNotify();
+            String plainOrgId = findOrganizationIdByAlias(plainOrgAlias);
             String excludedOrgAlias = createOrgWithExcludeNotify();
             String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
             addUserToOrganization(plainOrgAlias, userUuid);
@@ -714,7 +757,7 @@ public class SsfTransmitterEventEmitterTests {
                     "sub_id", Map.of(
                             "format", "complex",
                             "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
-                            "tenant", Map.of("format", "opaque", "id", plainOrgAlias)),
+                            "tenant", Map.of("format", "opaque", "id", plainOrgId)),
                     "event", Map.of("credential_type", "password", "change_type", "update"));
 
             // Control: with no exclusion anywhere, ALL mode delivers —
@@ -817,10 +860,106 @@ public class SsfTransmitterEventEmitterTests {
     }
 
     @Test
-    public void emit_uriTenantKeycloakUrn_resolvesAndDispatches() throws Exception {
-        // The uri tenant format accepts the Keycloak-scoped URN form
-        // urn:keycloak:org:<alias>, becase this is the one URI shape this server can
-        // authoritatively interpret as one of its own organizations.
+    public void emit_uriTenantAliasUrn_resolvesAndDispatches() throws Exception {
+        // The uri tenant format accepts only the explicit Keycloak URN
+        // forms; urn:keycloak:org:alias:<alias> resolves strictly by
+        // organization alias — the URN itself names the lookup, so no
+        // alias/id heuristic is involved.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "uri",
+                                        "uri", "urn:keycloak:org:alias:" + orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "alias URN naming an existing org must resolve and dispatch");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "alias-URN tenant event should reach the mock receiver");
+    }
+
+    @Test
+    public void emit_uriTenantIdUrn_resolvesAndDispatches() throws Exception {
+        // Sibling of the alias-URN test: urn:keycloak:org:id:<id>
+        // resolves strictly by the internal organization id — the
+        // stable identifier that survives alias renames.
+        String orgAlias = createOrgWithNotify();
+        String orgId = findOrganizationIdByAlias(orgAlias);
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "uri",
+                                        "uri", "urn:keycloak:org:id:" + orgId)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(200, res.getStatus());
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "id URN naming an existing org must resolve and dispatch");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "id-URN tenant event should reach the mock receiver");
+    }
+
+    @Test
+    public void emit_uriTenantIdUrnWithAlias_returnsSubjectNotFound() throws Exception {
+        // Strictness guard: the explicit URN segments must not fall
+        // back to the other identifier kind — an id URN carrying an
+        // alias value stays unresolved. Cross-fallback would reintroduce
+        // exactly the alias/id ambiguity the explicit grammar removes.
+        String orgAlias = createOrgWithNotify();
+        String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
+        addUserToOrganization(orgAlias, userUuid);
+        String issuer = realm.getBaseUrl();
+
+        String mgmtToken = obtainServiceAccountToken(MGMT_EMITTER, MGMT_EMITTER_SECRET);
+        try (SimpleHttpResponse res = http.doPost(emitEndpointUrl())
+                .auth(mgmtToken)
+                .json(Map.of(
+                        "eventType", "CaepCredentialChange",
+                        "sub_id", Map.of(
+                                "format", "complex",
+                                "user", Map.of("format", "iss_sub", "iss", issuer, "sub", userUuid),
+                                "tenant", Map.of("format", "uri",
+                                        "uri", "urn:keycloak:org:id:" + orgAlias)),
+                        "event", Map.of("credential_type", "password", "change_type", "update")))
+                .asResponse()) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "id URN carrying an alias must not resolve via alias fallback");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            Assertions.assertEquals("tenant", body.path("params").path("subjectMember").asText());
+        }
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "unresolved id-URN tenant subject must not reach the receiver");
+    }
+
+    @Test
+    public void emit_uriTenantBareUrn_returnsSubjectNotFound() throws Exception {
+        // The bare urn:keycloak:org:<value> shorthand from earlier
+        // revisions is gone — the feature is experimental, so the URN
+        // grammar requires an explicit alias:/id: segment instead of a
+        // heuristic lookup.
         String orgAlias = createOrgWithNotify();
         String userUuid = realm.admin().users().searchByEmail(TEST_EMAIL, true).get(0).getId();
         addUserToOrganization(orgAlias, userUuid);
@@ -838,12 +977,14 @@ public class SsfTransmitterEventEmitterTests {
                                         "uri", "urn:keycloak:org:" + orgAlias)),
                         "event", Map.of("credential_type", "password", "change_type", "update")))
                 .asResponse()) {
-            Assertions.assertEquals(200, res.getStatus());
-            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
-                    "urn:keycloak:org URN naming an existing org must resolve and dispatch");
+            Assertions.assertEquals(400, res.getStatus(),
+                    "bare urn:keycloak:org URN without alias:/id: segment must be rejected");
+            JsonNode body = res.asJson();
+            Assertions.assertEquals("subject_not_found", body.get("error").asText());
+            Assertions.assertEquals("tenant", body.path("params").path("subjectMember").asText());
         }
-        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
-                "URN-tenant event should reach the mock receiver");
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "bare-URN tenant subject must not reach the receiver");
     }
 
     @Test

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterEventEmitterTests.java
@@ -577,13 +577,15 @@ public class SsfTransmitterEventEmitterTests {
             JsonNode mismatchBody = res.asJson();
             Assertions.assertEquals("subject_mismatch", mismatchBody.get("error").asText(),
                     "error code should name the user/tenant membership mismatch");
-            // params names the resolved pairing machine-readably so the
-            // admin UI can render a translated message with the concrete
-            // user/tenant instead of parsing the English description.
-            Assertions.assertEquals(TEST_USER, mismatchBody.path("params").path("user").asText(),
-                    "params.user should carry the resolved username behind the mismatch");
-            Assertions.assertEquals(orgAlias, mismatchBody.path("params").path("tenant").asText(),
-                    "params.tenant should carry the resolved organization alias behind the mismatch");
+            // Disclosure guard: emit is callable by service accounts
+            // holding only the configured emit role, so the response
+            // must not echo resolved entity data (username, org alias)
+            // for the otherwise-opaque ids the caller submitted.
+            String rawBody = mismatchBody.toString();
+            Assertions.assertFalse(rawBody.contains(TEST_USER),
+                    "mismatch response must not disclose the resolved username");
+            Assertions.assertFalse(rawBody.contains(orgAlias),
+                    "mismatch response must not disclose the resolved organization alias");
         }
         Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
                 "mismatched user+tenant subject must not reach the receiver");

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterPushDeliveryTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterPushDeliveryTests.java
@@ -268,9 +268,9 @@ public class SsfTransmitterPushDeliveryTests {
                 "SSE CAEP event should carry a nested 'subject' object");
         Assertions.assertTrue(event.path("subject").path("user").isObject(),
                 "SSE CAEP event.subject should wrap a 'user' entry");
-        // Per SSE 1.0 §3.2 each facet of a complex subject is a sibling
+        // Per SSE 1.0 §3.2 each subject member of a complex subject is a sibling
         // key under `subject`. The native CaepSessionRevoked path always
-        // carries a complex subject (user + session), so both facets
+        // carries a complex subject (user + session), so both subject members
         // must appear at the same depth — not nested under user.
         Assertions.assertTrue(event.path("subject").path("session").isObject(),
                 "SSE CAEP event.subject.session must be a sibling of subject.user, not nested under it");

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/admin/SsfEmitEventRequest.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/admin/SsfEmitEventRequest.java
@@ -74,7 +74,7 @@ public class SsfEmitEventRequest {
      *         buildSubjectForReceiver} so the shape honors the receiver's
      *         configured {@code ssf.userSubjectFormat}.</li>
      *     <li>{@code org-alias} → resolves to an organization; transmitter
-     *         emits a complex subject with a {@code tenant} facet only
+     *         emits a complex subject with a {@code tenant} subject member only
      *         (no user) so the receiver routes it as an org-scoped
      *         event.</li>
      * </ul>

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/delivery/SseCaepEventConverter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/delivery/SseCaepEventConverter.java
@@ -60,11 +60,11 @@ public class SseCaepEventConverter {
      * Builds the SSE 1.0 {@code subject} object that replaces the SSF 1.0
      * top-level {@code sub_id}.
      *
-     * <p>Per SSE 1.0 §3.2 a complex subject carries each facet ({@code user},
+     * <p>Per SSE 1.0 §3.2 a complex subject carries each subject member ({@code user},
      * {@code session}, {@code device}, {@code application}, {@code tenant},
      * {@code org_unit}, {@code group}) as a sibling key under
      * {@code subject}. A simple (non-complex) subject is wrapped as the
-     * {@code user} facet — that's the right call for events like
+     * {@code user} subject member — that's the right call for events like
      * {@code CaepCredentialChange} that only carry a user identity.
      */
     protected static Map<String, Object> buildSseCaepSubject(SubjectId subjectId) {
@@ -73,7 +73,7 @@ public class SseCaepEventConverter {
             return subjectMap;
         }
         if (subjectId instanceof ComplexSubjectId complex) {
-            // Flatten each non-null facet into siblings of subject — this
+            // Flatten each non-null subject member into siblings of subject — this
             // is the shape SSE 1.0 receivers expect for complex subjects.
             if (complex.getUser() != null) subjectMap.put("user", complex.getUser());
             if (complex.getSession() != null) subjectMap.put("session", complex.getSession());

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventResult.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventResult.java
@@ -1,5 +1,7 @@
 package org.keycloak.ssf.transmitter.emit;
 
+import java.util.Map;
+
 import org.keycloak.ssf.event.SsfEvent;
 
 /**
@@ -9,18 +11,28 @@ import org.keycloak.ssf.event.SsfEvent;
  * an optional human-readable message used to surface validation
  * failures (e.g. payload-shape mismatch against the registered event
  * class) so the admin endpoint can return a 400 with a useful body.
+ * The optional {@code params} map carries machine-readable fields tied
+ * to the specific failure (e.g. which subject member of a complex subject failed
+ * to resolve, or the user/tenant pairing behind a membership mismatch)
+ * so REST callers can localize or react programmatically without
+ * parsing the English {@code message}.
  */
-public record EmitEventResult(EmitEventStatus status, String jti, String message, SsfEvent event) {
+public record EmitEventResult(EmitEventStatus status, String jti, String message, SsfEvent event,
+                              Map<String, String> params) {
 
     public static EmitEventResult dispatched(String jti, SsfEvent typedEvent) {
-        return new EmitEventResult(EmitEventStatus.DISPATCHED, jti, null, typedEvent);
+        return new EmitEventResult(EmitEventStatus.DISPATCHED, jti, null, typedEvent, null);
     }
 
     public static EmitEventResult dropped(EmitEventStatus status) {
-        return new EmitEventResult(status, null, null, null);
+        return new EmitEventResult(status, null, null, null, null);
     }
 
     public static EmitEventResult dropped(EmitEventStatus status, String message) {
-        return new EmitEventResult(status, null, message, null);
+        return new EmitEventResult(status, null, message, null, null);
+    }
+
+    public static EmitEventResult dropped(EmitEventStatus status, String message, Map<String, String> params) {
+        return new EmitEventResult(status, null, message, null, params);
     }
 }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventResult.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventResult.java
@@ -12,10 +12,12 @@ import org.keycloak.ssf.event.SsfEvent;
  * failures (e.g. payload-shape mismatch against the registered event
  * class) so the admin endpoint can return a 400 with a useful body.
  * The optional {@code params} map carries machine-readable fields tied
- * to the specific failure (e.g. which subject member of a complex subject failed
- * to resolve, or the user/tenant pairing behind a membership mismatch)
- * so REST callers can localize or react programmatically without
- * parsing the English {@code message}.
+ * to the specific failure (e.g. which subject member of a complex
+ * subject failed to resolve) so REST callers can localize or react
+ * programmatically without parsing the English {@code message}. Params
+ * must never carry resolved entity data (usernames, aliases) — emit is
+ * callable by role-scoped service accounts, so echoing resolved
+ * identifiers would disclose realm metadata.
  */
 public record EmitEventResult(EmitEventStatus status, String jti, String message, SsfEvent event,
                               Map<String, String> params) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventStatus.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventStatus.java
@@ -22,6 +22,17 @@ public enum EmitEventStatus {
     /** Subject couldn't be resolved to a Keycloak user or organization. */
     SUBJECT_NOT_FOUND("subject_not_found"),
 
+    /**
+     * Complex subject carries both a user and a tenant facet, but the
+     * resolved user is not a member of the resolved organization. Such
+     * a subject is internally inconsistent — accepting it would let an
+     * emitter attach any subscribed tenant to any user and ride the
+     * tenant's subscription past the per-user subject filter
+     * (keycloak/keycloak#50812), and would present the receiver a
+     * user↔tenant association Keycloak knows to be false.
+     */
+    SUBJECT_MISMATCH("subject_mismatch"),
+
     /** Receiver has no SSF stream registered yet. */
     STREAM_NOT_FOUND("stream_not_found"),
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventStatus.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventStatus.java
@@ -23,7 +23,7 @@ public enum EmitEventStatus {
     SUBJECT_NOT_FOUND("subject_not_found"),
 
     /**
-     * Complex subject carries both a user and a tenant facet, but the
+     * Complex subject carries both a user and a tenant subject member, but the
      * resolved user is not a member of the resolved organization. Such
      * a subject is internally inconsistent — accepting it would let an
      * emitter attach any subscribed tenant to any user and ride the

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitSubjectResolution.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitSubjectResolution.java
@@ -5,7 +5,7 @@ import org.keycloak.models.UserModel;
 
 /**
  * Tuple of subjects resolved from the emitter's {@code sub_id}. Either
- * field may be {@code null} when the corresponding facet is absent
+ * field may be {@code null} when the corresponding subject member is absent
  * or unresolvable; both being null is reported as
  * {@link EmitEventStatus#SUBJECT_NOT_FOUND}.
  */

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -17,8 +17,9 @@ import org.keycloak.ssf.event.SsfEventValidationException;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
 import org.keycloak.ssf.metadata.DefaultSubjects;
 import org.keycloak.ssf.subject.ComplexSubjectId;
-import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
+import org.keycloak.ssf.subject.SubjectResolution;
+import org.keycloak.ssf.subject.SubjectResolver;
 import org.keycloak.ssf.subject.SubjectUserLookup;
 import org.keycloak.ssf.transmitter.delivery.SecurityEventTokenDispatcher;
 import org.keycloak.ssf.transmitter.event.SecurityEventTokenMapper;
@@ -168,13 +169,37 @@ public class EventEmitterService {
         }
 
         // 5. Subject resolution + subscription filter. ComplexSubjectId
-        //    can carry a user, an org (via the tenant slot), or both —
-        //    we accept any resolvable combination and apply the
-        //    receiver's notify-attribute subscription on whichever
-        //    facets resolve.
+        //    can carry a user, an org (via the tenant slot), or both.
+        //    Every facet the emitter names must resolve — the sub_id
+        //    travels verbatim in the SET, so a user or tenant facet that
+        //    doesn't match anything is a subject error, not a facet to
+        //    silently ignore: otherwise a forged facet would reach the
+        //    receiver while only the other facet was actually gated.
         EmitSubjectResolution resolved = resolveSubject(subjectId);
         if (resolved.user() == null && resolved.organization() == null) {
             return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND);
+        }
+        if (subjectId instanceof ComplexSubjectId complex) {
+            if (complex.getUser() != null && resolved.user() == null) {
+                return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND,
+                        "User facet of the complex sub_id could not be resolved");
+            }
+            if (complex.getTenant() != null && resolved.organization() == null) {
+                return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND,
+                        "Tenant facet of the complex sub_id could not be resolved to an organization");
+            }
+            // A user+tenant subject must be internally consistent: the
+            // user has to be a member of the named organization.
+            // Without this, any subscribed tenant could be attached to
+            // any unsubscribed user and the tenant's subscription would
+            // carry the user subject past the per-user filter
+            // (keycloak/keycloak#50812) — and the receiver would be
+            // handed a user↔tenant association Keycloak knows is false.
+            if (resolved.user() != null && resolved.organization() != null
+                    && !isUserMemberOfOrganization(resolved.user(), resolved.organization())) {
+                return EmitEventResult.dropped(EmitEventStatus.SUBJECT_MISMATCH,
+                        "User subject is not a member of the tenant organization");
+            }
         }
         // Drop early so the emitter sees a clean status without
         // paying the SET signing cost for a filtered subject.
@@ -243,10 +268,12 @@ public class EventEmitterService {
      * tenant facet drives the org-level notify subscription. For a
      * non-complex {@link SubjectId} only the user is resolved.
      *
-     * <p>Org resolution treats an {@link OpaqueSubjectId} {@code id} as
-     * the org's alias first, falling back to the org UUID. Other
-     * {@link SubjectId} formats in the tenant slot are not currently
-     * understood — they resolve to no organization.
+     * <p>Org resolution delegates to
+     * {@link SubjectResolver#resolveOrganization} so the emit path
+     * understands the same tenant formats (opaque, iss_sub,
+     * email/domain, uri) as the subject-management endpoints —
+     * mandatory since a supplied-but-unresolved tenant facet fails the
+     * whole subject.
      */
     protected EmitSubjectResolution resolveSubject(SubjectId subjectId) {
         RealmModel realm = session.getContext().getRealm();
@@ -264,20 +291,24 @@ public class EventEmitterService {
     }
 
     protected OrganizationModel resolveOrganization(SubjectId tenantFacet) {
-        if (tenantFacet == null || !Organizations.isEnabled(session)) {
+        if (tenantFacet == null) {
             return null;
         }
-        if (!(tenantFacet instanceof OpaqueSubjectId opaque) || opaque.getId() == null) {
-            return null;
+        if (SubjectResolver.resolveOrganization(session, tenantFacet)
+                instanceof SubjectResolution.Organization org) {
+            return org.organization();
         }
-        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
-        // Prefer alias (matches the admin shorthand 'org-alias' convention),
-        // then fall back to UUID for emitters that prefer stable identifiers.
-        OrganizationModel org = orgProvider.getByAlias(opaque.getId());
-        if (org == null) {
-            org = orgProvider.getById(opaque.getId());
-        }
-        return org;
+        return null;
+    }
+
+    /**
+     * Membership consistency check for user+tenant complex subjects.
+     * Only called when both facets resolved, which implies the
+     * Organizations feature is enabled (org resolution short-circuits
+     * to {@code null} otherwise).
+     */
+    protected boolean isUserMemberOfOrganization(UserModel user, OrganizationModel organization) {
+        return session.getProvider(OrganizationProvider.class).isMember(organization, user);
     }
 
     protected boolean isStreamEvent(String eventTypeUri) {
@@ -292,13 +323,30 @@ public class EventEmitterService {
      * Subscription gate that mirrors the native dispatcher's
      * {@code SubjectSubscriptionFilter} but operates on a pre-resolved
      * user / org pair so the emitter can also emit org-only events.
+     * The precedence matches the native filter's
+     * {@code evaluateSubjectSubscription}:
      *
-     * <ul>
-     *     <li>{@code default_subjects=ALL}: deliver unless either the
-     *         user or the org is explicitly excluded.</li>
-     *     <li>{@code default_subjects=NONE}: deliver only when at least
-     *         one of the user / org facets is explicitly notified.</li>
-     * </ul>
+     * <ol>
+     *     <li>Per-user explicit settings win over org state and the
+     *         {@code default_subjects} fallback — an admin who clicked
+     *         "Include" or "Ignore" on a specific user expects that
+     *         decision to stick regardless of org-level subscriptions.</li>
+     *     <li>{@code default_subjects=ALL}: deliver unless an org gate
+     *         is explicitly excluded.</li>
+     *     <li>{@code default_subjects=NONE}: deliver only when an org
+     *         gate is explicitly notified.</li>
+     * </ol>
+     *
+     * <p>For a user subject the org gates scan every organization the
+     * user belongs to, exactly like the native filter's
+     * {@code getByMember} scan — honouring only the tenant the emitter
+     * named would let a caller pick one non-excluded membership to
+     * sidestep an exclusion on another. The emitter-named tenant is
+     * itself one of those memberships, because {@link #emit} has
+     * already rejected user+tenant subjects whose user is not a member
+     * of the org (keycloak/keycloak#50812). The direct
+     * {@code resolved.organization()} checks apply only to tenant-only
+     * subjects, where the org itself is the subject.
      */
     protected boolean isSubjectDispatchable(EmitSubjectResolution resolved,
                                             StreamConfig stream,
@@ -306,19 +354,42 @@ public class EventEmitterService {
         String receiverClientId = receiverClient.getClientId();
         DefaultSubjects defaultSubjects = stream.getDefaultSubjects();
 
-        if (defaultSubjects == DefaultSubjects.ALL) {
-            boolean userExcluded = resolved.user() != null
-                    && subjectInclusionResolver.isUserExcluded(session, resolved.user(), receiverClientId);
-            boolean orgExcluded = resolved.organization() != null
-                    && subjectInclusionResolver.isOrganizationExcluded(session, resolved.organization(), receiverClientId);
-            return !userExcluded && !orgExcluded;
+        if (resolved.user() != null) {
+            if (subjectInclusionResolver.isUserNotified(session, resolved.user(), receiverClientId)) {
+                return true;
+            }
+            if (subjectInclusionResolver.isUserExcluded(session, resolved.user(), receiverClientId)) {
+                return false;
+            }
+            if (defaultSubjects == DefaultSubjects.ALL) {
+                return !isAnyUserOrganizationExcluded(resolved.user(), receiverClientId);
+            }
+            return isAnyUserOrganizationNotified(resolved.user(), receiverClientId);
         }
 
-        boolean userNotified = resolved.user() != null
-                && subjectInclusionResolver.isUserNotified(session, resolved.user(), receiverClientId);
-        boolean orgNotified = resolved.organization() != null
+        if (defaultSubjects == DefaultSubjects.ALL) {
+            return resolved.organization() == null
+                    || !subjectInclusionResolver.isOrganizationExcluded(session, resolved.organization(), receiverClientId);
+        }
+
+        return resolved.organization() != null
                 && subjectInclusionResolver.isOrganizationNotified(session, resolved.organization(), receiverClientId);
-        return userNotified || orgNotified;
+    }
+
+    protected boolean isAnyUserOrganizationExcluded(UserModel user, String receiverClientId) {
+        if (!Organizations.isEnabled(session)) {
+            return false;
+        }
+        return session.getProvider(OrganizationProvider.class).getByMember(user)
+                .anyMatch(org -> subjectInclusionResolver.isOrganizationExcluded(session, org, receiverClientId));
+    }
+
+    protected boolean isAnyUserOrganizationNotified(UserModel user, String receiverClientId) {
+        if (!Organizations.isEnabled(session)) {
+            return false;
+        }
+        return session.getProvider(OrganizationProvider.class).getByMember(user)
+                .anyMatch(org -> subjectInclusionResolver.isOrganizationNotified(session, org, receiverClientId));
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -167,13 +167,21 @@ public class EventEmitterService {
             return EmitEventResult.dropped(EmitEventStatus.DROPPED_FILTERED);
         }
 
-        // 5. Subject resolution + subscription filter. ComplexSubjectId
-        //    can carry a user, an org (via the tenant slot), or both.
-        //    Every subject member the emitter names must resolve — the sub_id
-        //    travels verbatim in the SET, so a user or tenant subject member that
-        //    doesn't match anything is a subject error, not a subject member to
-        //    silently ignore: otherwise a forged subject member would reach the
-        //    receiver while only the other subject member was actually gated.
+        // 5. Subject resolution + subscription filter. Of the members a
+        //    ComplexSubjectId can carry, only user and tenant map to
+        //    Keycloak entities, so exactly those two are resolved and
+        //    gated: when the emitter names one it must resolve — the
+        //    sub_id travels verbatim in the SET, so a user or tenant
+        //    subject member that doesn't match anything is a subject
+        //    error, not a subject member to silently ignore; otherwise
+        //    a forged subject member would reach the receiver while
+        //    only the other subject member was actually gated. The
+        //    remaining members are currently not mapped to Keycloak
+        //    entities and are forwarded UNVALIDATED alongside the gated
+        //    ones: session and group do have Keycloak-side counterparts
+        //    and may gain resolution/gating in the future, while
+        //    device, application, and org_unit have nothing to resolve
+        //    against.
         EmitSubjectResolution resolved = resolveSubject(subjectId);
         if (resolved.user() == null && resolved.organization() == null) {
             return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND);

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -169,23 +169,31 @@ public class EventEmitterService {
 
         // 5. Subject resolution + subscription filter. ComplexSubjectId
         //    can carry a user, an org (via the tenant slot), or both.
-        //    Every facet the emitter names must resolve — the sub_id
-        //    travels verbatim in the SET, so a user or tenant facet that
-        //    doesn't match anything is a subject error, not a facet to
-        //    silently ignore: otherwise a forged facet would reach the
-        //    receiver while only the other facet was actually gated.
+        //    Every subject member the emitter names must resolve — the sub_id
+        //    travels verbatim in the SET, so a user or tenant subject member that
+        //    doesn't match anything is a subject error, not a subject member to
+        //    silently ignore: otherwise a forged subject member would reach the
+        //    receiver while only the other subject member was actually gated.
         EmitSubjectResolution resolved = resolveSubject(subjectId);
         if (resolved.user() == null && resolved.organization() == null) {
             return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND);
         }
         if (subjectId instanceof ComplexSubjectId complex) {
+            // params.subjectMember discriminates the two subject-member-resolution
+            // failures machine-readably — both reuse the
+            // subject_not_found wire code, so without it a client
+            // wanting to localize (or react to) "user subject member didn't
+            // resolve" vs "tenant subject member didn't resolve" would have to
+            // parse the English description.
             if (complex.getUser() != null && resolved.user() == null) {
                 return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND,
-                        "User facet of the complex sub_id could not be resolved");
+                        "User subject member of the complex sub_id could not be resolved",
+                        Map.of("subjectMember", "user"));
             }
             if (complex.getTenant() != null && resolved.organization() == null) {
                 return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND,
-                        "Tenant facet of the complex sub_id could not be resolved to an organization");
+                        "Tenant subject member of the complex sub_id could not be resolved to an organization",
+                        Map.of("subjectMember", "tenant"));
             }
             // A user+tenant subject must be internally consistent: the
             // user has to be a member of the named organization.
@@ -196,8 +204,14 @@ public class EventEmitterService {
             // handed a user↔tenant association Keycloak knows is false.
             if (resolved.user() != null && resolved.organization() != null
                     && !isUserMemberOfOrganization(resolved.user(), resolved.organization())) {
+                // params names the resolved pairing that failed the
+                // membership check so the admin UI can render a
+                // translated message with the concrete user/tenant
+                // instead of interpolating the English description.
                 return EmitEventResult.dropped(EmitEventStatus.SUBJECT_MISMATCH,
-                        "User subject is not a member of the tenant organization");
+                        "User subject is not a member of the tenant organization",
+                        Map.of("user", resolved.user().getUsername(),
+                                "tenant", resolved.organization().getAlias()));
             }
         }
         // Drop early so the emitter sees a clean status without
@@ -265,15 +279,15 @@ public class EventEmitterService {
      * Resolves the entities referenced by the emitter's {@code sub_id}.
      * For a {@link ComplexSubjectId} we drill into both
      * {@link ComplexSubjectId#getUser()} and {@link ComplexSubjectId#getTenant()}
-     * — the user facet drives the per-user notify subscription and the
-     * tenant facet drives the org-level notify subscription. For a
+     * — the user subject member drives the per-user notify subscription and the
+     * tenant subject member drives the org-level notify subscription. For a
      * non-complex {@link SubjectId} only the user is resolved.
      *
      * <p>Org resolution delegates to
      * {@link SubjectResolver#resolveOrganization} so the emit path
      * understands the same tenant formats (opaque, iss_sub,
      * email/domain, uri) as the subject-management endpoints —
-     * mandatory since a supplied-but-unresolved tenant facet fails the
+     * mandatory since a supplied-but-unresolved tenant subject member fails the
      * whole subject.
      */
     protected EmitSubjectResolution resolveSubject(SubjectId subjectId) {
@@ -291,11 +305,11 @@ public class EventEmitterService {
         return new EmitSubjectResolution(user, null);
     }
 
-    protected OrganizationModel resolveOrganization(SubjectId tenantFacet) {
-        if (tenantFacet == null) {
+    protected OrganizationModel resolveOrganization(SubjectId tenantSubjectMember) {
+        if (tenantSubjectMember == null) {
             return null;
         }
-        if (SubjectResolver.resolveOrganization(session, tenantFacet)
+        if (SubjectResolver.resolveOrganization(session, tenantSubjectMember)
                 instanceof SubjectResolution.Organization org) {
             return org.organization();
         }
@@ -304,7 +318,7 @@ public class EventEmitterService {
 
     /**
      * Membership consistency check for user+tenant complex subjects.
-     * Only called when both facets resolved, which implies the
+     * Only called when both subject members resolved, which implies the
      * Organizations feature is enabled (org resolution short-circuits
      * to {@code null} otherwise).
      */
@@ -333,7 +347,7 @@ public class EventEmitterService {
      * bypass, a dropped grace window); delegation keeps them in lockstep.
      *
      * <p>Only the org-as-subject case — a tenant-only complex subject
-     * with no user facet, which the native dispatcher never produces —
+     * with no user subject member, which the native dispatcher never produces —
      * is handled locally, gating directly on the org's own notify
      * attribute:
      * <ul>
@@ -343,7 +357,7 @@ public class EventEmitterService {
      *         is explicitly notified.</li>
      * </ul>
      *
-     * <p>A user+tenant subject reaches the user branch; its tenant facet
+     * <p>A user+tenant subject reaches the user branch; its tenant subject member
      * needs no separate allow check because {@link #emit} has already
      * rejected the subject unless the user is a member of that org
      * (keycloak/keycloak#50812), so the org is covered by the

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -17,8 +17,9 @@ import org.keycloak.ssf.event.SsfEventValidationException;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
 import org.keycloak.ssf.metadata.DefaultSubjects;
 import org.keycloak.ssf.subject.ComplexSubjectId;
-import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
+import org.keycloak.ssf.subject.SubjectResolution;
+import org.keycloak.ssf.subject.SubjectResolver;
 import org.keycloak.ssf.subject.SubjectUserLookup;
 import org.keycloak.ssf.transmitter.delivery.SecurityEventTokenDispatcher;
 import org.keycloak.ssf.transmitter.event.SecurityEventTokenMapper;
@@ -168,13 +169,37 @@ public class EventEmitterService {
         }
 
         // 5. Subject resolution + subscription filter. ComplexSubjectId
-        //    can carry a user, an org (via the tenant slot), or both —
-        //    we accept any resolvable combination and apply the
-        //    receiver's notify-attribute subscription on whichever
-        //    facets resolve.
+        //    can carry a user, an org (via the tenant slot), or both.
+        //    Every facet the emitter names must resolve — the sub_id
+        //    travels verbatim in the SET, so a user or tenant facet that
+        //    doesn't match anything is a subject error, not a facet to
+        //    silently ignore: otherwise a forged facet would reach the
+        //    receiver while only the other facet was actually gated.
         EmitSubjectResolution resolved = resolveSubject(subjectId);
         if (resolved.user() == null && resolved.organization() == null) {
             return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND);
+        }
+        if (subjectId instanceof ComplexSubjectId complex) {
+            if (complex.getUser() != null && resolved.user() == null) {
+                return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND,
+                        "User facet of the complex sub_id could not be resolved");
+            }
+            if (complex.getTenant() != null && resolved.organization() == null) {
+                return EmitEventResult.dropped(EmitEventStatus.SUBJECT_NOT_FOUND,
+                        "Tenant facet of the complex sub_id could not be resolved to an organization");
+            }
+            // A user+tenant subject must be internally consistent: the
+            // user has to be a member of the named organization.
+            // Without this, any subscribed tenant could be attached to
+            // any unsubscribed user and the tenant's subscription would
+            // carry the user subject past the per-user filter
+            // (keycloak/keycloak#50812) — and the receiver would be
+            // handed a user↔tenant association Keycloak knows is false.
+            if (resolved.user() != null && resolved.organization() != null
+                    && !isUserMemberOfOrganization(resolved.user(), resolved.organization())) {
+                return EmitEventResult.dropped(EmitEventStatus.SUBJECT_MISMATCH,
+                        "User subject is not a member of the tenant organization");
+            }
         }
         // Drop early so the emitter sees a clean status without
         // paying the SET signing cost for a filtered subject.
@@ -245,10 +270,12 @@ public class EventEmitterService {
      * tenant facet drives the org-level notify subscription. For a
      * non-complex {@link SubjectId} only the user is resolved.
      *
-     * <p>Org resolution treats an {@link OpaqueSubjectId} {@code id} as
-     * the org's alias first, falling back to the org UUID. Other
-     * {@link SubjectId} formats in the tenant slot are not currently
-     * understood — they resolve to no organization.
+     * <p>Org resolution delegates to
+     * {@link SubjectResolver#resolveOrganization} so the emit path
+     * understands the same tenant formats (opaque, iss_sub,
+     * email/domain, uri) as the subject-management endpoints —
+     * mandatory since a supplied-but-unresolved tenant facet fails the
+     * whole subject.
      */
     protected EmitSubjectResolution resolveSubject(SubjectId subjectId) {
         RealmModel realm = session.getContext().getRealm();
@@ -266,20 +293,24 @@ public class EventEmitterService {
     }
 
     protected OrganizationModel resolveOrganization(SubjectId tenantFacet) {
-        if (tenantFacet == null || !Organizations.isEnabled(session)) {
+        if (tenantFacet == null) {
             return null;
         }
-        if (!(tenantFacet instanceof OpaqueSubjectId opaque) || opaque.getId() == null) {
-            return null;
+        if (SubjectResolver.resolveOrganization(session, tenantFacet)
+                instanceof SubjectResolution.Organization org) {
+            return org.organization();
         }
-        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
-        // Prefer alias (matches the admin shorthand 'org-alias' convention),
-        // then fall back to UUID for emitters that prefer stable identifiers.
-        OrganizationModel org = orgProvider.getByAlias(opaque.getId());
-        if (org == null) {
-            org = orgProvider.getById(opaque.getId());
-        }
-        return org;
+        return null;
+    }
+
+    /**
+     * Membership consistency check for user+tenant complex subjects.
+     * Only called when both facets resolved, which implies the
+     * Organizations feature is enabled (org resolution short-circuits
+     * to {@code null} otherwise).
+     */
+    protected boolean isUserMemberOfOrganization(UserModel user, OrganizationModel organization) {
+        return session.getProvider(OrganizationProvider.class).isMember(organization, user);
     }
 
     protected boolean isStreamEvent(String eventTypeUri) {
@@ -294,13 +325,30 @@ public class EventEmitterService {
      * Subscription gate that mirrors the native dispatcher's
      * {@code SubjectSubscriptionFilter} but operates on a pre-resolved
      * user / org pair so the emitter can also emit org-only events.
+     * The precedence matches the native filter's
+     * {@code evaluateSubjectSubscription}:
      *
-     * <ul>
-     *     <li>{@code default_subjects=ALL}: deliver unless either the
-     *         user or the org is explicitly excluded.</li>
-     *     <li>{@code default_subjects=NONE}: deliver only when at least
-     *         one of the user / org facets is explicitly notified.</li>
-     * </ul>
+     * <ol>
+     *     <li>Per-user explicit settings win over org state and the
+     *         {@code default_subjects} fallback — an admin who clicked
+     *         "Include" or "Ignore" on a specific user expects that
+     *         decision to stick regardless of org-level subscriptions.</li>
+     *     <li>{@code default_subjects=ALL}: deliver unless an org gate
+     *         is explicitly excluded.</li>
+     *     <li>{@code default_subjects=NONE}: deliver only when an org
+     *         gate is explicitly notified.</li>
+     * </ol>
+     *
+     * <p>For a user subject the org gates scan every organization the
+     * user belongs to, exactly like the native filter's
+     * {@code getByMember} scan — honouring only the tenant the emitter
+     * named would let a caller pick one non-excluded membership to
+     * sidestep an exclusion on another. The emitter-named tenant is
+     * itself one of those memberships, because {@link #emit} has
+     * already rejected user+tenant subjects whose user is not a member
+     * of the org (keycloak/keycloak#50812). The direct
+     * {@code resolved.organization()} checks apply only to tenant-only
+     * subjects, where the org itself is the subject.
      */
     protected boolean isSubjectDispatchable(EmitSubjectResolution resolved,
                                             StreamConfig stream,
@@ -308,19 +356,42 @@ public class EventEmitterService {
         String receiverClientId = receiverClient.getClientId();
         DefaultSubjects defaultSubjects = stream.getDefaultSubjects();
 
-        if (defaultSubjects == DefaultSubjects.ALL) {
-            boolean userExcluded = resolved.user() != null
-                    && subjectInclusionResolver.isUserExcluded(session, resolved.user(), receiverClientId);
-            boolean orgExcluded = resolved.organization() != null
-                    && subjectInclusionResolver.isOrganizationExcluded(session, resolved.organization(), receiverClientId);
-            return !userExcluded && !orgExcluded;
+        if (resolved.user() != null) {
+            if (subjectInclusionResolver.isUserNotified(session, resolved.user(), receiverClientId)) {
+                return true;
+            }
+            if (subjectInclusionResolver.isUserExcluded(session, resolved.user(), receiverClientId)) {
+                return false;
+            }
+            if (defaultSubjects == DefaultSubjects.ALL) {
+                return !isAnyUserOrganizationExcluded(resolved.user(), receiverClientId);
+            }
+            return isAnyUserOrganizationNotified(resolved.user(), receiverClientId);
         }
 
-        boolean userNotified = resolved.user() != null
-                && subjectInclusionResolver.isUserNotified(session, resolved.user(), receiverClientId);
-        boolean orgNotified = resolved.organization() != null
+        if (defaultSubjects == DefaultSubjects.ALL) {
+            return resolved.organization() == null
+                    || !subjectInclusionResolver.isOrganizationExcluded(session, resolved.organization(), receiverClientId);
+        }
+
+        return resolved.organization() != null
                 && subjectInclusionResolver.isOrganizationNotified(session, resolved.organization(), receiverClientId);
-        return userNotified || orgNotified;
+    }
+
+    protected boolean isAnyUserOrganizationExcluded(UserModel user, String receiverClientId) {
+        if (!Organizations.isEnabled(session)) {
+            return false;
+        }
+        return session.getProvider(OrganizationProvider.class).getByMember(user)
+                .anyMatch(org -> subjectInclusionResolver.isOrganizationExcluded(session, org, receiverClientId));
+    }
+
+    protected boolean isAnyUserOrganizationNotified(UserModel user, String receiverClientId) {
+        if (!Organizations.isEnabled(session)) {
+            return false;
+        }
+        return session.getProvider(OrganizationProvider.class).getByMember(user)
+                .anyMatch(org -> subjectInclusionResolver.isOrganizationNotified(session, org, receiverClientId));
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -212,14 +212,16 @@ public class EventEmitterService {
             // handed a user↔tenant association Keycloak knows is false.
             if (resolved.user() != null && resolved.organization() != null
                     && !isUserMemberOfOrganization(resolved.user(), resolved.organization())) {
-                // params names the resolved pairing that failed the
-                // membership check so the admin UI can render a
-                // translated message with the concrete user/tenant
-                // instead of interpolating the English description.
+                // Deliberately NO params naming the resolved pairing:
+                // this endpoint is also callable by service accounts
+                // holding only the receiver-configured emit role, and
+                // echoing the resolved username / org alias would
+                // disclose realm metadata to a caller that may only
+                // hold opaque ids. The stable error code is enough for
+                // callers and the admin UI to render a translated
+                // (generic) mismatch message.
                 return EmitEventResult.dropped(EmitEventStatus.SUBJECT_MISMATCH,
-                        "User subject is not a member of the tenant organization",
-                        Map.of("user", resolved.user().getUsername(),
-                                "tenant", resolved.organization().getAlias()));
+                        "User subject is not a member of the tenant organization");
             }
         }
         // Drop early so the emitter sees a clean status without

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -9,7 +9,6 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
-import org.keycloak.organization.utils.Organizations;
 import org.keycloak.ssf.SsfException;
 import org.keycloak.ssf.event.SsfEvent;
 import org.keycloak.ssf.event.SsfEventRegistry;
@@ -322,76 +321,49 @@ public class EventEmitterService {
     }
 
     /**
-     * Subscription gate that mirrors the native dispatcher's
-     * {@code SubjectSubscriptionFilter} but operates on a pre-resolved
-     * user / org pair so the emitter can also emit org-only events.
-     * The precedence matches the native filter's
-     * {@code evaluateSubjectSubscription}:
+     * Subscription gate for a pre-resolved user / org pair. A user
+     * subject is delegated to the dispatcher's own
+     * {@link SecurityEventTokenDispatcher#shouldDispatchForUser} so the
+     * synthetic path and the native path apply byte-for-byte the same
+     * config-aware rule: per-user include/ignore precedence, the
+     * {@code getByMember} scan across every organization the user
+     * belongs to, and the SSF §9.3 removal-grace window with its
+     * per-receiver override and transmitter-wide default. Reimplementing
+     * a subset here is what let earlier revisions drift (an org-scan
+     * bypass, a dropped grace window); delegation keeps them in lockstep.
      *
-     * <ol>
-     *     <li>Per-user explicit settings win over org state and the
-     *         {@code default_subjects} fallback — an admin who clicked
-     *         "Include" or "Ignore" on a specific user expects that
-     *         decision to stick regardless of org-level subscriptions.</li>
-     *     <li>{@code default_subjects=ALL}: deliver unless an org gate
-     *         is explicitly excluded.</li>
-     *     <li>{@code default_subjects=NONE}: deliver only when an org
-     *         gate is explicitly notified.</li>
-     * </ol>
+     * <p>Only the org-as-subject case — a tenant-only complex subject
+     * with no user facet, which the native dispatcher never produces —
+     * is handled locally, gating directly on the org's own notify
+     * attribute:
+     * <ul>
+     *     <li>{@code default_subjects=ALL}: deliver unless the org is
+     *         explicitly excluded.</li>
+     *     <li>{@code default_subjects=NONE}: deliver only when the org
+     *         is explicitly notified.</li>
+     * </ul>
      *
-     * <p>For a user subject the org gates scan every organization the
-     * user belongs to, exactly like the native filter's
-     * {@code getByMember} scan — honouring only the tenant the emitter
-     * named would let a caller pick one non-excluded membership to
-     * sidestep an exclusion on another. The emitter-named tenant is
-     * itself one of those memberships, because {@link #emit} has
-     * already rejected user+tenant subjects whose user is not a member
-     * of the org (keycloak/keycloak#50812). The direct
-     * {@code resolved.organization()} checks apply only to tenant-only
-     * subjects, where the org itself is the subject.
+     * <p>A user+tenant subject reaches the user branch; its tenant facet
+     * needs no separate allow check because {@link #emit} has already
+     * rejected the subject unless the user is a member of that org
+     * (keycloak/keycloak#50812), so the org is covered by the
+     * membership scan above.
      */
     protected boolean isSubjectDispatchable(EmitSubjectResolution resolved,
                                             StreamConfig stream,
                                             ClientModel receiverClient) {
-        String receiverClientId = receiverClient.getClientId();
-        DefaultSubjects defaultSubjects = stream.getDefaultSubjects();
-
         if (resolved.user() != null) {
-            if (subjectInclusionResolver.isUserNotified(session, resolved.user(), receiverClientId)) {
-                return true;
-            }
-            if (subjectInclusionResolver.isUserExcluded(session, resolved.user(), receiverClientId)) {
-                return false;
-            }
-            if (defaultSubjects == DefaultSubjects.ALL) {
-                return !isAnyUserOrganizationExcluded(resolved.user(), receiverClientId);
-            }
-            return isAnyUserOrganizationNotified(resolved.user(), receiverClientId);
+            return eventTokenDispatcher.shouldDispatchForUser(resolved.user(), stream);
         }
 
-        if (defaultSubjects == DefaultSubjects.ALL) {
+        String receiverClientId = receiverClient.getClientId();
+        if (stream.getDefaultSubjects() == DefaultSubjects.ALL) {
             return resolved.organization() == null
                     || !subjectInclusionResolver.isOrganizationExcluded(session, resolved.organization(), receiverClientId);
         }
 
         return resolved.organization() != null
                 && subjectInclusionResolver.isOrganizationNotified(session, resolved.organization(), receiverClientId);
-    }
-
-    protected boolean isAnyUserOrganizationExcluded(UserModel user, String receiverClientId) {
-        if (!Organizations.isEnabled(session)) {
-            return false;
-        }
-        return session.getProvider(OrganizationProvider.class).getByMember(user)
-                .anyMatch(org -> subjectInclusionResolver.isOrganizationExcluded(session, org, receiverClientId));
-    }
-
-    protected boolean isAnyUserOrganizationNotified(UserModel user, String receiverClientId) {
-        if (!Organizations.isEnabled(session)) {
-            return false;
-        }
-        return session.getProvider(OrganizationProvider.class).getByMember(user)
-                .anyMatch(org -> subjectInclusionResolver.isOrganizationNotified(session, org, receiverClientId));
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -42,6 +42,8 @@ import org.keycloak.ssf.subject.EmailSubjectId;
 import org.keycloak.ssf.subject.IssuerSubjectId;
 import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
+import org.keycloak.ssf.subject.SubjectResolver;
+import org.keycloak.ssf.subject.UriSubjectId;
 import org.keycloak.ssf.transmitter.SsfTransmitterConfig;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
 import org.keycloak.ssf.transmitter.support.SsfUtil;
@@ -600,8 +602,9 @@ public class SecurityEventTokenMapper {
     }
 
     /**
-     * Builds an {@link OpaqueSubjectId} carrying the user's primary
-     * Keycloak organization alias. Throws {@link SsfException} when
+     * Builds a {@link UriSubjectId} carrying the user's primary
+     * Keycloak organization as an {@code urn:keycloak:org:alias:} URN.
+     * Throws {@link SsfException} when
      * the user belongs to no organization — see
      * {@link #addTenantIfConfigured} for why fail-loud is the right
      * choice.
@@ -641,17 +644,18 @@ public class SecurityEventTokenMapper {
             throw new SsfException("Configured user subject format includes '+tenant' but user " + userId
                     + " belongs to no organization (stream " + (stream != null ? stream.getStreamId() : null) + ")");
         }
-        // Emit alias rather than the internal UUID — alias is the stable,
-        // human-readable organization identifier and the receiver-side
-        // SubjectResolver tries getByAlias as a fallback to getById, so
-        // this resolves on round-trip without requiring receivers to
-        // know the transmitter's internal UUIDs.
+        // Emit the self-describing alias URN rather than an opaque id:
+        // opaque tenant values resolve strictly by internal org id,
+        // while urn:keycloak:org:alias:<alias> names its lookup
+        // explicitly — so the subject round-trips unambiguously through
+        // SubjectResolver and the wire value stays human-readable
+        // without exposing the transmitter's internal UUIDs.
         return createTenantSubjectId(org, user);
     }
 
-    protected OpaqueSubjectId createTenantSubjectId(OrganizationModel org, UserModel user) {
-        OpaqueSubjectId tenantSubject = new OpaqueSubjectId();
-        tenantSubject.setId(org.getAlias());
+    protected UriSubjectId createTenantSubjectId(OrganizationModel org, UserModel user) {
+        UriSubjectId tenantSubject = new UriSubjectId();
+        tenantSubject.setUri(SubjectResolver.ORG_URN_ALIAS_PREFIX + org.getAlias());
         return tenantSubject;
     }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectManagementService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectManagementService.java
@@ -10,11 +10,11 @@ import org.keycloak.organization.utils.Organizations;
 import org.keycloak.ssf.SsfException;
 import org.keycloak.ssf.metadata.DefaultSubjects;
 import org.keycloak.ssf.subject.ComplexSubjectId;
-import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.ssf.subject.SubjectNotFoundException;
 import org.keycloak.ssf.subject.SubjectResolution;
 import org.keycloak.ssf.subject.SubjectResolver;
+import org.keycloak.ssf.subject.UriSubjectId;
 import org.keycloak.ssf.transmitter.SsfTransmitterProvider;
 import org.keycloak.ssf.transmitter.resources.AddSubjectRequest;
 import org.keycloak.ssf.transmitter.resources.RemoveSubjectRequest;
@@ -433,9 +433,11 @@ public class SubjectManagementService {
                     .buildSubjectForReceiver(stream, userRes.user().getId());
         }
         if (resolution instanceof SubjectResolution.Organization orgRes) {
+            // Self-describing alias URN (urn:keycloak:org:alias:<alias>)
+            // rather than an opaque id
             ComplexSubjectId complex = new ComplexSubjectId();
-            OpaqueSubjectId tenant = new OpaqueSubjectId();
-            tenant.setId(orgRes.organization().getAlias());
+            UriSubjectId tenant = new UriSubjectId();
+            tenant.setUri(SubjectResolver.ORG_URN_ALIAS_PREFIX + orgRes.organization().getAlias());
             complex.setTenant(tenant);
             return complex;
         }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectManagementService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectManagementService.java
@@ -414,7 +414,7 @@ public class SubjectManagementService {
      * via {@link org.keycloak.ssf.transmitter.event.SecurityEventTokenMapper#buildSubjectForReceiver
      * buildSubjectForReceiver} so it honors the receiver's configured
      * {@code ssf.userSubjectFormat}. For {@code org-alias} the result
-     * is a {@link ComplexSubjectId} with only a {@code tenant} facet
+     * is a {@link ComplexSubjectId} with only a {@code tenant} subject member
      * (so the emitter routes it as an org-scoped event).
      *
      * <p>Throws {@link SsfException} with an operator-friendly message


### PR DESCRIPTION
A complex sub_id combining an unsubscribed user with a subscribed but unrelated tenant organization previously dispatched, because the emitter's subscription gate treated
the tenant subject member as an independent allow signal. Now every supplied user/tenant subject member must resolve, and the user must be a member of the tenant organization, which is mirroring the
native dispatcher's membership-scoped org subscription semantics. The user-subject gate is delegated to the dispatcher's own SubjectSubscriptionFilter, so per-user include/ignore
precedence, the org-membership scan, and the SSF §9.3 removal-grace window apply identically to synthetic and native events.

Fixes #50812

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
