### PR TITLE
Make ProviderConfigPropertyBuilder a static inner class

### DIFF
--- a/server-spi/src/main/java/org/keycloak/provider/ProviderConfigurationBuilder.java
+++ b/server-spi/src/main/java/org/keycloak/provider/ProviderConfigurationBuilder.java
@@ -42,7 +42,7 @@ public class ProviderConfigurationBuilder {
     }
 
     public ProviderConfigPropertyBuilder property() {
-        return new ProviderConfigPropertyBuilder();
+        return new ProviderConfigPropertyBuilder(this);
     }
 
     public ProviderConfigurationBuilder property(ProviderConfigProperty property) {
@@ -73,7 +73,7 @@ public class ProviderConfigurationBuilder {
         return properties;
     }
 
-    public class ProviderConfigPropertyBuilder {
+    public static class ProviderConfigPropertyBuilder {
 
         private String name;
         private String label;
@@ -83,6 +83,27 @@ public class ProviderConfigurationBuilder {
         private List<String> options;
         private boolean secret;
         private boolean required;
+
+        private final ProviderConfigurationBuilder parent;
+
+        /**
+         * Creates a standalone property builder that is not attached to a {@link ProviderConfigurationBuilder}.
+         * Use {@link #build()} to obtain the resulting {@link ProviderConfigProperty} in this case, since
+         * {@link #add()} requires a parent builder to add the property to.
+         */
+        public ProviderConfigPropertyBuilder() {
+            this(null);
+        }
+
+        /**
+         * Creates a property builder attached to the given parent {@link ProviderConfigurationBuilder}.
+         * This constructor is public (rather than package-private) to preserve binary compatibility.
+         *
+         * @param parent the parent builder this property will be added to via {@link #add()}
+         */
+        public ProviderConfigPropertyBuilder(ProviderConfigurationBuilder parent) {
+            this.parent = parent;
+        }
 
         public ProviderConfigPropertyBuilder name(String name) {
             this.name = name;
@@ -184,11 +205,29 @@ public class ProviderConfigurationBuilder {
         }
 
         /**
-         * Add the current property, and start building the next one
+         * Add the current property to the parent builder, and start building the next one.
          *
-         * @return
+         * @return the parent {@link ProviderConfigurationBuilder}
+         * @throws IllegalStateException if this builder was created standalone, i.e. without a parent
+         *      {@link ProviderConfigurationBuilder}. Use {@link #build()} instead in that case.
          */
         public ProviderConfigurationBuilder add() {
+            if (parent == null) {
+                throw new IllegalStateException("This " + ProviderConfigPropertyBuilder.class.getSimpleName()
+                        + " has no parent " + ProviderConfigurationBuilder.class.getSimpleName()
+                        + " to add to. Use build() instead");
+            }
+            parent.add(build());
+            return parent;
+        }
+
+        /**
+         * Builds the {@link ProviderConfigProperty} from the values configured so far, without adding it
+         * to a parent {@link ProviderConfigurationBuilder}. Useful when using this builder standalone.
+         *
+         * @return the built property
+         */
+        public ProviderConfigProperty build() {
             ProviderConfigProperty property = new ProviderConfigProperty();
             property.setName(name);
             property.setLabel(label);
@@ -198,18 +237,17 @@ public class ProviderConfigurationBuilder {
             property.setOptions(options);
             property.setSecret(secret);
             property.setRequired(required);
-            ProviderConfigurationBuilder.this.add(property);
-            return ProviderConfigurationBuilder.this;
+            return property;
         }
 
     }
 
-  private boolean add(ProviderConfigProperty property) {
-    String name = property.getName();
-    if (!propertyNames.add(name)) {
-      throw new ProviderConfigPropertyNameNotUniqueException("ProviderConfigProperty with name '" + name + "' already exists.");
+    private boolean add(ProviderConfigProperty property) {
+        String name = property.getName();
+        if (!propertyNames.add(name)) {
+            throw new ProviderConfigPropertyNameNotUniqueException("ProviderConfigProperty with name '" + name + "' already exists.");
+        }
+        return properties.add(property);
     }
-    return properties.add(property);
-  }
 
 }

--- a/server-spi/src/test/java/org/keycloak/provider/ProviderConfigurationBuilderTest.java
+++ b/server-spi/src/test/java/org/keycloak/provider/ProviderConfigurationBuilderTest.java
@@ -7,60 +7,123 @@ import org.junit.Test;
 
 public class ProviderConfigurationBuilderTest {
 
-  @Test
-  public void testAddProperty() {
-    ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+    @Test
+    public void testAddProperty() {
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
 
-    builder.property()
-        .name("property1")
-        .label("Property 1")
-        .helpText("Help text for property 1")
-        .type("string")
-        .defaultValue("default1")
-        .add();
-
-    builder.property()
-        .name("property2")
-        .label("Property 2")
-        .helpText("Help text for property 2")
-        .type("int")
-        .defaultValue(10)
-        .add();
-
-    List<ProviderConfigProperty> properties = builder.build();
-
-    Assert.assertEquals(2, properties.size());
-    Assert.assertEquals("property1", properties.get(0).getName());
-    Assert.assertEquals("Property 1", properties.get(0).getLabel());
-    Assert.assertEquals("default1", properties.get(0).getDefaultValue());
-
-    Assert.assertEquals("property2", properties.get(1).getName());
-    Assert.assertEquals(10, properties.get(1).getDefaultValue());
-  }
-
-  @Test
-  public void testDuplicatePropertyNameThrowsException() {
-    ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
-
-    builder.property()
-        .name("property1")
-        .label("Property 1")
-        .helpText("Help text for property 1")
-        .type("string")
-        .defaultValue("default1")
-        .add();
-
-    ProviderConfigPropertyNameNotUniqueException exception = Assert.assertThrows(
-        ProviderConfigPropertyNameNotUniqueException.class,
-        () -> builder.property()
+        builder.property()
             .name("property1")
-            .label("Duplicate Property 1")
-            .helpText("Help text for duplicate property 1")
+            .label("Property 1")
+            .helpText("Help text for property 1")
             .type("string")
-            .defaultValue("default2")
-            .add()
-    );
+            .defaultValue("default1")
+            .add();
 
-    Assert.assertEquals("ProviderConfigProperty with name 'property1' already exists.", exception.getMessage());
-  }
+        builder.property()
+            .name("property2")
+            .label("Property 2")
+            .helpText("Help text for property 2")
+            .type("int")
+            .defaultValue(10)
+            .add();
+
+        List<ProviderConfigProperty> properties = builder.build();
+
+        Assert.assertEquals(2, properties.size());
+        Assert.assertEquals("property1", properties.get(0).getName());
+        Assert.assertEquals("Property 1", properties.get(0).getLabel());
+        Assert.assertEquals("default1", properties.get(0).getDefaultValue());
+
+        Assert.assertEquals("property2", properties.get(1).getName());
+        Assert.assertEquals(10, properties.get(1).getDefaultValue());
+    }
+
+    @Test
+    public void testDuplicatePropertyNameThrowsException() {
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+
+        builder.property()
+            .name("property1")
+            .label("Property 1")
+            .helpText("Help text for property 1")
+            .type("string")
+            .defaultValue("default1")
+            .add();
+
+        ProviderConfigPropertyNameNotUniqueException exception = Assert.assertThrows(
+            ProviderConfigPropertyNameNotUniqueException.class,
+            () -> builder.property()
+                .name("property1")
+                .label("Duplicate Property 1")
+                .helpText("Help text for duplicate property 1")
+                .type("string")
+                .defaultValue("default2")
+                .add()
+        );
+
+        Assert.assertEquals("ProviderConfigProperty with name 'property1' already exists.", exception.getMessage());
+    }
+
+    @Test
+    public void testPropertyBuilderCanBeUsedStandalone() {
+        ProviderConfigProperty property = new ProviderConfigurationBuilder.ProviderConfigPropertyBuilder()
+            .name("standalone")
+            .label("Standalone Property")
+            .helpText("Built without a parent builder")
+            .type("string")
+            .defaultValue("value")
+            .secret(true)
+            .required(true)
+            .build();
+
+        Assert.assertEquals("standalone", property.getName());
+        Assert.assertEquals("Standalone Property", property.getLabel());
+        Assert.assertEquals("Built without a parent builder", property.getHelpText());
+        Assert.assertEquals("string", property.getType());
+        Assert.assertEquals("value", property.getDefaultValue());
+        Assert.assertTrue(property.isSecret());
+        Assert.assertTrue(property.isRequired());
+    }
+
+    @Test
+    public void testStandaloneBuilderCannotAddWithoutParent() {
+        ProviderConfigurationBuilder.ProviderConfigPropertyBuilder standalone =
+            new ProviderConfigurationBuilder.ProviderConfigPropertyBuilder()
+                .name("orphan")
+                .label("Orphan Property");
+
+        IllegalStateException exception = Assert.assertThrows(
+            IllegalStateException.class,
+            standalone::add
+        );
+
+        Assert.assertTrue(exception.getMessage().contains("build()"));
+    }
+
+    @Test
+    public void testStandaloneBuiltPropertyCanLaterBeAddedToAParentBuilder() {
+        ProviderConfigProperty property = new ProviderConfigurationBuilder.ProviderConfigPropertyBuilder()
+            .name("added-later")
+            .label("Added Later")
+            .build();
+
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+        List<ProviderConfigProperty> properties = builder.property(property).build();
+
+        Assert.assertEquals(1, properties.size());
+        Assert.assertSame(property, properties.get(0));
+    }
+
+    @Test
+    public void testPropertyReturnedByFactoryMethodAddsBackToSameParent() {
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+
+        ProviderConfigurationBuilder returned = builder.property()
+            .name("chained")
+            .label("Chained")
+            .add();
+
+        Assert.assertSame(builder, returned);
+        Assert.assertEquals(1, builder.build().size());
+    }
 }


### PR DESCRIPTION
Closes #50817

## What
Makes `ProviderConfigurationBuilder.ProviderConfigPropertyBuilder` a static nested class, so it can be used standalone (independent of a `ProviderConfigurationBuilder` instance), while keeping the existing fluent API (`create().property()...add()...build()`) fully backward compatible.

Adds a `build()` method on `ProviderConfigPropertyBuilder` to obtain the constructed `ProviderConfigProperty` directly, and a public no-arg constructor for standalone use. `add()` now throws `IllegalStateException` if called on a builder without a parent.

## Testing
Extended `ProviderConfigurationBuilderTest` with tests covering standalone builder usage, the new `IllegalStateException` case, and that the existing fluent API is unaffected.

## AI disclosure
Generative AI (Claude) was used to draft the test additions in this PR, based on my own requirement/design decision. I have reviewed and understand all changes.