### PR TITLE
[OID4VCI]: Fix JWT proof JWK claim type confusion causing proof validation failure

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwk/JWK.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWK.java
@@ -183,7 +183,14 @@ public class JWK {
     @JsonIgnore
     public <T> T getOtherClaim(String claimName, Class<T> claimType) {
         Object o = getOtherClaims().get(claimName);
-        return o == null ? null : claimType.cast(o);
+        if (o == null) {
+            return null;
+        }
+        try {
+            return claimType.cast(o);
+        } catch (ClassCastException e) {
+            return null;
+        }
     }
 
 }

--- a/core/src/main/java/org/keycloak/jose/jwk/JWK.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWK.java
@@ -183,14 +183,7 @@ public class JWK {
     @JsonIgnore
     public <T> T getOtherClaim(String claimName, Class<T> claimType) {
         Object o = getOtherClaims().get(claimName);
-        if (o == null) {
-            return null;
-        }
-        try {
-            return claimType.cast(o);
-        } catch (ClassCastException e) {
-            return null;
-        }
+        return claimType.isInstance(o) ? claimType.cast(o) : null;
     }
 
 }

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKOtherClaimTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKOtherClaimTest.java
@@ -1,0 +1,66 @@
+package org.keycloak.jose.jwk;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link JWK#getOtherClaim(String, Class)} type safety.
+ * <p>
+ * Verifies that the method gracefully handles type mismatches in the otherClaims map
+ * instead of throwing {@link ClassCastException}.
+ */
+public class JWKOtherClaimTest {
+
+    @Test
+    public void getOtherClaimReturnsValueWhenTypeMatches() {
+        JWK jwk = new JWK();
+        jwk.setOtherClaims("crv", "P-256");
+
+        String result = jwk.getOtherClaim("crv", String.class);
+
+        assertEquals("P-256", result);
+    }
+
+    @Test
+    public void getOtherClaimReturnsNullWhenClaimIsAbsent() {
+        JWK jwk = new JWK();
+
+        String result = jwk.getOtherClaim("crv", String.class);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getOtherClaimReturnsNullWhenValueIsWrongType() {
+        JWK jwk = new JWK();
+        jwk.setOtherClaims("crv", new ArrayList<>());
+
+        String result = jwk.getOtherClaim("crv", String.class);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getOtherClaimNullValueReturnsNull() {
+        JWK jwk = new JWK();
+        jwk.setOtherClaims("crv", null);
+
+        String result = jwk.getOtherClaim("crv", String.class);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getOtherClaimIntegerValueRetrievedAsInteger() {
+        JWK jwk = new JWK();
+        jwk.setOtherClaims("x", 42);
+
+        Integer result = jwk.getOtherClaim("x", Integer.class);
+
+        assertEquals(Integer.valueOf(42), result);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AbstractProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AbstractProofValidator.java
@@ -42,7 +42,7 @@ public abstract class AbstractProofValidator implements ProofValidator {
         return signatureProvider.verifier(keyWrapper);
     }
 
-    private KeyWrapper getKeyWrapper(JWK jwk, String algorithm) {
+    private KeyWrapper getKeyWrapper(JWK jwk, String algorithm) throws VerificationException {
         KeyWrapper keyWrapper = new KeyWrapper();
         keyWrapper.setType(jwk.getKeyType());
 
@@ -56,7 +56,11 @@ public abstract class AbstractProofValidator implements ProofValidator {
         }
 
         JWKParser parser = JWKParser.create(jwk);
-        keyWrapper.setPublicKey(parser.toPublicKey());
+        try {
+            keyWrapper.setPublicKey(parser.toPublicKey());
+        } catch (RuntimeException e) {
+            throw new VerificationException("Failed to parse JWK into a public key", e);
+        }
         return keyWrapper;
     }
 }

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
@@ -1,25 +1,14 @@
 package org.keycloak.protocol.oid4vc.issuance.keybinding;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.keycloak.common.util.Base64Url;
-import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
-import org.keycloak.protocol.oid4vc.model.CredentialRequest;
-import org.keycloak.protocol.oid4vc.model.ErrorType;
-import org.keycloak.protocol.oid4vc.model.ProofTypesSupported;
-import org.keycloak.protocol.oid4vc.model.Proofs;
-import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
-import org.keycloak.protocol.oid4vc.model.SupportedProofTypeData;
 import org.keycloak.utils.AbstractUtilSessionTest;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JwtProofValidatorTest extends AbstractUtilSessionTest {
@@ -72,56 +61,6 @@ public class JwtProofValidatorTest extends AbstractUtilSessionTest {
     public void testValidateNoPrivateKeyInHeaderClaims_UnknownAlgorithm_Blocked() {
         // FAKE256 has no registered provider, should throw
         assertBlocked("FAKE256", "RSA", "d", "secret");
-    }
-
-    /**
-     * Regression test for OID4VC JWT proof JWK claim type confusion.
-     * <p>
-     * Verifies that a malformed JWT proof with {@code "crv": []} (array instead of string)
-     * in the JWK header does NOT throw {@link ClassCastException}, but instead
-     * produces a proper {@link VCIssuerException} with {@link ErrorType#INVALID_PROOF}.
-     * <p>
-     * Before the fix, the attacker-supplied array was stored as {@link java.util.ArrayList}
-     * in the JWK's otherClaims map, and the cast {@code String.class.cast(arrayList)}
-     * thrown an unchecked {@link ClassCastException} that escaped the expected error path.
-     */
-    @Test
-    public void testMalformedJwkCrvInJwtProofReturnsInvalidProof() {
-        // Build a compact JWT with malformed jwk: "crv": [] (array instead of string)
-        String headerJson = "{\"alg\":\"ES256\",\"typ\":\"openid4vci-proof+jwt\",\"jwk\":{\"crv\":[]}}";
-        // Payload is minimal since the malformed crv fails validation before payload checks are reached
-        String payloadJson = "{}";
-        String signature = Base64Url.encode("fake-signature".getBytes(StandardCharsets.UTF_8));
-
-        String compactJwt = Base64Url.encode(headerJson.getBytes(StandardCharsets.UTF_8)) + "."
-                + Base64Url.encode(payloadJson.getBytes(StandardCharsets.UTF_8)) + "."
-                + signature;
-
-        // Build a VCIssuanceContext with the malformed proof
-        SupportedCredentialConfiguration credentialConfig = new SupportedCredentialConfiguration();
-        ProofTypesSupported proofTypesSupported = new ProofTypesSupported();
-        SupportedProofTypeData jwtProofTypeData = new SupportedProofTypeData();
-        proofTypesSupported.setSupportedProofTypes("jwt", jwtProofTypeData);
-        credentialConfig.setProofTypesSupported(proofTypesSupported);
-        credentialConfig.setCryptographicBindingMethodsSupported(List.of("jwk"));
-
-        CredentialRequest credentialRequest = new CredentialRequest();
-        Proofs proofs = Proofs.create("jwt", compactJwt);
-        credentialRequest.setProofs(proofs);
-
-        VCIssuanceContext context = new VCIssuanceContext()
-                .setCredentialConfig(credentialConfig)
-                .setCredentialRequest(credentialRequest);
-
-        JwtProofValidator validator = new JwtProofValidator(session, null);
-
-        // The malformed proof should be rejected with INVALID_PROOF (not crash with ClassCastException)
-        VCIssuerException exception = assertThrows(
-                VCIssuerException.class,
-                () -> validator.validateProof(context));
-
-        // Verify the error is the expected INVALID_PROOF type
-        assertEquals(ErrorType.INVALID_PROOF, exception.getErrorType());
     }
 
     private void assertBlocked(String alg, String kty, String claim, Object value) {

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
@@ -1,14 +1,25 @@
 package org.keycloak.protocol.oid4vc.issuance.keybinding;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
+import org.keycloak.protocol.oid4vc.model.ErrorType;
+import org.keycloak.protocol.oid4vc.model.ProofTypesSupported;
+import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+import org.keycloak.protocol.oid4vc.model.SupportedProofTypeData;
 import org.keycloak.utils.AbstractUtilSessionTest;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JwtProofValidatorTest extends AbstractUtilSessionTest {
@@ -61,6 +72,56 @@ public class JwtProofValidatorTest extends AbstractUtilSessionTest {
     public void testValidateNoPrivateKeyInHeaderClaims_UnknownAlgorithm_Blocked() {
         // FAKE256 has no registered provider, should throw
         assertBlocked("FAKE256", "RSA", "d", "secret");
+    }
+
+    /**
+     * Regression test for OID4VC JWT proof JWK claim type confusion.
+     * <p>
+     * Verifies that a malformed JWT proof with {@code "crv": []} (array instead of string)
+     * in the JWK header does NOT throw {@link ClassCastException}, but instead
+     * produces a proper {@link VCIssuerException} with {@link ErrorType#INVALID_PROOF}.
+     * <p>
+     * Before the fix, the attacker-supplied array was stored as {@link java.util.ArrayList}
+     * in the JWK's otherClaims map, and the cast {@code String.class.cast(arrayList)}
+     * thrown an unchecked {@link ClassCastException} that escaped the expected error path.
+     */
+    @Test
+    public void testMalformedJwkCrvInJwtProofReturnsInvalidProof() {
+        // Build a compact JWT with malformed jwk: "crv": [] (array instead of string)
+        String headerJson = "{\"alg\":\"ES256\",\"typ\":\"openid4vci-proof+jwt\",\"jwk\":{\"crv\":[]}}";
+        // Payload is minimal since the malformed crv fails validation before payload checks are reached
+        String payloadJson = "{}";
+        String signature = Base64Url.encode("fake-signature".getBytes(StandardCharsets.UTF_8));
+
+        String compactJwt = Base64Url.encode(headerJson.getBytes(StandardCharsets.UTF_8)) + "."
+                + Base64Url.encode(payloadJson.getBytes(StandardCharsets.UTF_8)) + "."
+                + signature;
+
+        // Build a VCIssuanceContext with the malformed proof
+        SupportedCredentialConfiguration credentialConfig = new SupportedCredentialConfiguration();
+        ProofTypesSupported proofTypesSupported = new ProofTypesSupported();
+        SupportedProofTypeData jwtProofTypeData = new SupportedProofTypeData();
+        proofTypesSupported.setSupportedProofTypes("jwt", jwtProofTypeData);
+        credentialConfig.setProofTypesSupported(proofTypesSupported);
+        credentialConfig.setCryptographicBindingMethodsSupported(List.of("jwk"));
+
+        CredentialRequest credentialRequest = new CredentialRequest();
+        Proofs proofs = Proofs.create("jwt", compactJwt);
+        credentialRequest.setProofs(proofs);
+
+        VCIssuanceContext context = new VCIssuanceContext()
+                .setCredentialConfig(credentialConfig)
+                .setCredentialRequest(credentialRequest);
+
+        JwtProofValidator validator = new JwtProofValidator(session, null);
+
+        // The malformed proof should be rejected with INVALID_PROOF (not crash with ClassCastException)
+        VCIssuerException exception = assertThrows(
+                VCIssuerException.class,
+                () -> validator.validateProof(context));
+
+        // Verify the error is the expected INVALID_PROOF type
+        assertEquals(ErrorType.INVALID_PROOF, exception.getErrorType());
     }
 
     private void assertBlocked(String alg, String kty, String claim, Object value) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -847,6 +847,40 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     }
 
     @Test
+    public void testRequestCredentialWithMalformedJwkCrvRejected() {
+        final String scopeName = jwtTypeCredentialScope.getName();
+        String credConfigId = jwtTypeCredentialScope.getAttributes().get(CredentialScopeModel.VC_CONFIGURATION_ID);
+
+        CredentialIssuer credentialIssuer = getCredentialIssuerMetadata();
+        OID4VCAuthorizationDetail authDetail = new OID4VCAuthorizationDetail();
+        authDetail.setType(OPENID_CREDENTIAL);
+        authDetail.setCredentialConfigurationId(credConfigId);
+        authDetail.setLocations(List.of(credentialIssuer.getCredentialIssuer()));
+
+        String authCode = getAuthorizationCode(oauth, client, "john", scopeName);
+        AccessTokenResponse tokenResponse = getBearerToken(oauth, authCode, authDetail);
+        String token = tokenResponse.getAccessToken();
+        String credentialIdentifier = tokenResponse.getOID4VCAuthorizationDetails().get(0).getCredentialIdentifiers().get(0);
+        String cNonce = getCNonce();
+
+        String issuer = credentialIssuer.getCredentialIssuer();
+        String validJwtProof = generateJwtProof(issuer, cNonce);
+        String malformedCrvProof = withMalformedJwkCrvInHeader(validJwtProof);
+
+        CredentialRequest request = new CredentialRequest()
+                .setCredentialIdentifier(credentialIdentifier)
+                .setProofs(new Proofs().setJwt(List.of(malformedCrvProof)));
+
+        Oid4vcCredentialResponse response = oauth.oid4vc()
+                .credentialRequest(request)
+                .bearerToken(token)
+                .send();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+    }
+
+    @Test
     public void testRequestCredentialWithMissingIssuerInClientBoundFlowAllowed() {
         final String scopeName = jwtTypeCredentialScope.getName();
         String credConfigId = jwtTypeCredentialScope.getAttributes().get(CredentialScopeModel.VC_CONFIGURATION_ID);
@@ -1850,6 +1884,20 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             });
             jwk.put("d", "fake-private-material");
             header.put("jwk", jwk);
+            parts[0] = Base64Url.encode(JsonSerialization.writeValueAsString(header).getBytes(StandardCharsets.UTF_8));
+            return String.join(".", parts);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String withMalformedJwkCrvInHeader(String jwt) {
+        try {
+            String[] parts = jwt.split("\\.");
+            Map<String, Object> header = JsonSerialization.readValue(Base64Url.decode(parts[0]), new TypeReference<>() {
+            });
+            // Replace the jwk with a malformed one where crv is an empty array instead of a string
+            header.put("jwk", Map.of("crv", List.of()));
             parts[0] = Base64Url.encode(JsonSerialization.writeValueAsString(header).getBytes(StandardCharsets.UTF_8));
             return String.join(".", parts);
         } catch (IOException e) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -903,6 +903,40 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     }
 
     @Test
+    public void testRequestCredentialWithMalformedJwkCrvRejected() {
+        final String scopeName = jwtTypeCredentialScope.getName();
+        String credConfigId = jwtTypeCredentialScope.getAttributes().get(CredentialScopeModel.VC_CONFIGURATION_ID);
+
+        CredentialIssuer credentialIssuer = getCredentialIssuerMetadata();
+        OID4VCAuthorizationDetail authDetail = new OID4VCAuthorizationDetail();
+        authDetail.setType(OPENID_CREDENTIAL);
+        authDetail.setCredentialConfigurationId(credConfigId);
+        authDetail.setLocations(List.of(credentialIssuer.getCredentialIssuer()));
+
+        String authCode = getAuthorizationCode(oauth, client, "john", scopeName);
+        AccessTokenResponse tokenResponse = getBearerToken(oauth, authCode, authDetail);
+        String token = tokenResponse.getAccessToken();
+        String credentialIdentifier = tokenResponse.getOID4VCAuthorizationDetails().get(0).getCredentialIdentifiers().get(0);
+        String cNonce = getCNonce();
+
+        String issuer = credentialIssuer.getCredentialIssuer();
+        String validJwtProof = generateJwtProof(issuer, cNonce);
+        String malformedCrvProof = withMalformedJwkCrvInHeader(validJwtProof);
+
+        CredentialRequest request = new CredentialRequest()
+                .setCredentialIdentifier(credentialIdentifier)
+                .setProofs(new Proofs().setJwt(List.of(malformedCrvProof)));
+
+        Oid4vcCredentialResponse response = oauth.oid4vc()
+                .credentialRequest(request)
+                .bearerToken(token)
+                .send();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+    }
+
+    @Test
     public void testRequestCredentialWithMissingIssuerInClientBoundFlowAllowed() {
         final String scopeName = jwtTypeCredentialScope.getName();
         String credConfigId = jwtTypeCredentialScope.getAttributes().get(CredentialScopeModel.VC_CONFIGURATION_ID);
@@ -1970,6 +2004,20 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             });
             jwk.put("d", "fake-private-material");
             header.put("jwk", jwk);
+            parts[0] = Base64Url.encode(JsonSerialization.writeValueAsString(header).getBytes(StandardCharsets.UTF_8));
+            return String.join(".", parts);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String withMalformedJwkCrvInHeader(String jwt) {
+        try {
+            String[] parts = jwt.split("\\.");
+            Map<String, Object> header = JsonSerialization.readValue(Base64Url.decode(parts[0]), new TypeReference<>() {
+            });
+            // Replace the jwk with a malformed one where crv is an empty array instead of a string
+            header.put("jwk", Map.of("crv", List.of()));
             parts[0] = Base64Url.encode(JsonSerialization.writeValueAsString(header).getBytes(StandardCharsets.UTF_8));
             return String.join(".", parts);
         } catch (IOException e) {


### PR DESCRIPTION
**Issue**
- An attacker-supplied JWT proof containing `"crv": []` (an array instead of a string) in the JOSE header `jwk` field could trigger an unhandled `ClassCastException` in `AbstractProofValidator.getKeyWrapper()`, resulting in a **500 Internal Server Error** instead of the expected `invalid_proof` response.

**Root cause**
- `JWK.getOtherClaim("crv", String.class)` internally calls `String.class.cast(ArrayList)`, which throws a `ClassCastException` when the claim has an unexpected type. This exception was not handled by `JwtProofValidator.validateProof()`, whose catch block only handled `JWSInputException`, `VerificationException`, and `IOException`.

**Fix**
- **Fix 1 – `JWK.getOtherClaim()` (root cause):** Now catches `ClassCastException` and returns `null`. A type mismatch is treated the same as a missing claim, matching the method's contract. This provides a systemic fix for all callers, including `AbstractProofValidator`, `JWKSUtils`, and `EdECUtilsImpl`.
- **Fix 2 – `AbstractProofValidator.getKeyWrapper()` (defense in depth):** Wraps `JWKParser.toPublicKey()` in a `try-catch(RuntimeException)` and rethrows a `VerificationException`. This ensures malformed JWKs (for example, missing `kty` or required EC fields) follow the existing `INVALID_PROOF` error path instead of propagating unchecked exceptions.

**Why not catch `RuntimeException`?**
- Broadly catching `RuntimeException` in `JwtProofValidator` was intentionally avoided because `VCIssuerException` extends `RuntimeException`. Doing so would incorrectly convert issuer-specific errors (for example, `INVALID_NONCE`) into generic `INVALID_PROOF` responses.

**Tests**
- `JWKOtherClaimTest`: 5 unit tests covering valid retrieval, absent claim, wrong type returning `null`, `null` value, and correct type retrieval.
- `OID4VCJWTIssuerEndpointTest.testRequestCredentialWithMalformedJwkCrvRejected()`: Integration test verifying that a malformed `"crv": []` JWT proof returns **400 `INVALID_PROOF`** instead of causing an internal server error.

Closes #50749
