### PR TITLE
Fix confusing error when --optimized is placed before the subcommand

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -601,15 +601,17 @@ public class Picocli {
             // Completion is inheriting mixinStandardHelpOptions = true
         }
 
-        spec.addUnmatchedArgsBinding(CommandLine.Model.UnmatchedArgsBinding.forStringArrayConsumer(new ISetter() {
-            @Override
-            public <T> T set(T value) {
-                if (value != null) {
-                    unrecognizedArgs.addAll(Arrays.asList((String[]) value));
+        if (spec.subcommands().isEmpty() && spec.userObject() instanceof AbstractCommand ac && getIncludeOptions(ac).allowUnrecognized) {
+            spec.addUnmatchedArgsBinding(CommandLine.Model.UnmatchedArgsBinding.forStringArrayConsumer(new ISetter() {
+                @Override
+                public <T> T set(T value) {
+                    if (value != null) {
+                        unrecognizedArgs.addAll(Arrays.asList((String[]) value));
+                    }
+                    return null; // doesn't matter
                 }
-                return null; // doesn't matter
-            }
-        }));
+            }));
+        }
 
         spec.subcommands().values().forEach(c -> updateSpecHelpAndUnmatched(c.getCommandSpec(), unrecognizedArgs));
     }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -310,6 +310,27 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void failOptimizedBeforeCommand() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("--optimized", "export", "--dir=data");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: '--optimized'"));
+    }
+
+    @Test
+    public void failPropertyMapperBeforeCommand() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("--dir=data", "export");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: '--dir'"));
+    }
+
+    @Test
+    public void failUnknownOptionBeforeCommand() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("--foobar", "export", "--dir=data");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: '--foobar'"));
+    }
+
+    @Test
     public void failIfOptimizedUsedForFirstStartupExport() {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("export", "--optimized", "--dir=data");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -80,8 +80,8 @@ public class ShowConfigCommandDistTest {
         // keystore is shared with QuarkusPropertiesDistTest#testSmallRyeKeyStoreConfigSource
         CLIResult result = runner.run(
                 String.format("%s=%s", CONFIG_FILE_LONG_NAME, Paths.get("src/test/resources/ShowConfigCommandTest/keycloak-keystore.conf").toAbsolutePath().normalize()),
-                "--config-keystore=" + Paths.get("src/test/resources/keystore").toAbsolutePath().normalize(),
-                ShowConfig.NAME, "all");
+                ShowConfig.NAME, "all",
+                "--config-keystore=" + Paths.get("src/test/resources/keystore").toAbsolutePath().normalize());
         String output = result.getOutput();
         assertThat(output, containsString("kc.config-keystore-password =  " + PropertyMappers.VALUE_MASK));
         assertThat(output, containsString("kc.log-level =  " + PropertyMappers.VALUE_MASK));
@@ -113,8 +113,9 @@ public class ShowConfigCommandDistTest {
 
         result = runner.run(
                 String.format("%s=%s", CONFIG_FILE_LONG_NAME, Paths.get("src/test/resources/ShowConfigCommandTest/keycloak-keystore.conf").toAbsolutePath().normalize()),
+                ShowConfig.NAME, "all",
                 "--config-keystore=" + Paths.get("src/test/resources/keystore").toAbsolutePath().normalize(),
-                ShowConfig.NAME, "all", "--db=dev-file");
+                "--db=dev-file");
 
         result.assertMessage("(CLI)");
         result.assertMessage("(ENV)");


### PR DESCRIPTION
Closes #50788

~The circular suggestion ("Possible solutions: --optimized") is a symptom. The actual problem is that `--optimized` is a picocli-native option on subcommands but not on the root command - when placed before the subcommand, it's treated as truly unknown rather than mispositioned. Filtering the self-match alone would still say "Unknown option" with no hint about what went wrong. The fix detects this case and reports where the option should be placed.~

~Given the plan to deprecate and remove `--optimized` I assume it doesn't make sense to invest more time into making `--optimized` accepted regardless of position, or?~

The current approach is to fix the parsing so picocli rejects misplaced options at the root level.