### PR TITLE
Fix SCIM listing returning empty Resources for query-only role

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
@@ -88,13 +88,8 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
             throw new ForbiddenException();
         }
 
-        return getModels(searchRequest).map(m -> {
-            try {
-                return get(m.getId(), searchRequest.getAttributes(), searchRequest.getExcludedAttributes());
-            } catch (ForbiddenException fe) {
-                return null;
-            }
-        }).filter(Objects::nonNull);
+        return getModels(searchRequest)
+                .map(m -> createResourceTypeInstance(m, searchRequest.getAttributes(), searchRequest.getExcludedAttributes()));
     }
 
     @Override

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AuthorizationTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AuthorizationTest.java
@@ -91,7 +91,11 @@ public class AuthorizationTest extends AbstractScimTest {
     @Test
     public void testUsersCanQueryIfQueryRoleGranted() {
         grantAdminRole(AdminRoles.QUERY_USERS);
-        assertEquals(1, noAccessClient.users().search("").getTotalResults());
+        ListResponse<User> response = noAccessClient.users().search("");
+        assertEquals(1, response.getTotalResults());
+        assertNotNull(response.getResources(), "Resources array should not be null");
+        assertEquals(1, response.getResources().size(), "Resources size should match totalResults");
+        assertEquals(1, response.getItemsPerPage(), "itemsPerPage should match resources size");
     }
 
     @Test
@@ -211,7 +215,11 @@ public class AuthorizationTest extends AbstractScimTest {
     public void testGroupsCanQueryIfQueryRoleGranted() {
         createGroup();
         grantAdminRole(AdminRoles.QUERY_GROUPS);
-        assertEquals(1, noAccessClient.groups().getAll("").getTotalResults());
+        ListResponse<Group> response = noAccessClient.groups().getAll("");
+        assertEquals(1, response.getTotalResults());
+        assertNotNull(response.getResources(), "Resources array should not be null");
+        assertEquals(1, response.getResources().size(), "Resources size should match totalResults");
+        assertEquals(1, response.getItemsPerPage(), "itemsPerPage should match resources size");
     }
 
     @Test


### PR DESCRIPTION
- enhance SCIM AuthorizationTest to verify Resources size and itemsPerPage, not just totalResults

Closes #50800

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
