### PR TITLE
Throw exception and rollback when token verification fails in reset credentials

### DIFF
--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.utils.KeycloakSessionUtil;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -38,5 +39,15 @@ public class ErrorPageException extends WebApplicationException {
 
     public ErrorPageException(Response response) {
         super((Throwable) null, response);
+    }
+
+    @Override
+    public Response getResponse() {
+        KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
+        if (session != null) {
+            // set rollback if exception is thrown to not commit changes into database
+            session.getTransactionManager().setRollbackOnly();
+        }
+        return super.getResponse();
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -107,6 +107,7 @@ import org.keycloak.rar.AuthorizationDetails;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;
 import org.keycloak.services.ErrorPage;
+import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
@@ -1070,9 +1071,9 @@ public class AuthenticationManager {
 
     }
 
-    private static Response handleActionTokenVerificationException(KeycloakSession session, EventBuilder event, String eventError, String errorMessage) {
+    private static void handleActionTokenVerificationException(KeycloakSession session, EventBuilder event, String eventError, String errorMessage) {
         event.error(eventError);
-        return ErrorPage.error(session, null, Response.Status.BAD_REQUEST, errorMessage == null ? Messages.INVALID_CODE : errorMessage);
+        throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, errorMessage == null ? Messages.INVALID_CODE : errorMessage);
     }
 
 
@@ -1084,12 +1085,12 @@ public class AuthenticationManager {
             if (actionTokenKey != null) {
                 // Token has expired. We must not accept it, as it will have been removed from the single use provider already
                 if (Time.currentTime() > actionTokenKey.getExp()) {
-                    return handleActionTokenVerificationException(session, event, Errors.EXPIRED_CODE, Messages.EXPIRED_ACTION);
+                    handleActionTokenVerificationException(session, event, Errors.EXPIRED_CODE, Messages.EXPIRED_ACTION);
                 }
 
                 var revokedTokens = session.revokedTokens();
                 if (!revokedTokens.put(actionTokenKeyToInvalidate, actionTokenKey.getExp() - Time.currentTime() + CLOCK_SKEW_SECONDS)) {
-                    return handleActionTokenVerificationException(session, event, Errors.EXPIRED_CODE, Messages.EXPIRED_ACTION);
+                    handleActionTokenVerificationException(session, event, Errors.EXPIRED_CODE, Messages.EXPIRED_ACTION);
                 }
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -459,9 +459,14 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         assertThat(driver2.getPageSource(), Matchers.containsString("Back to Application"));
 
         // Updating the password in the first browser should now fail.
-        updatePasswordPage.changePassword(password, password);
+        updatePasswordPage.changePassword("invalid-new-password", "invalid-new-password");
         errorPage.assertCurrent();
         assertEquals("Action expired. Please continue with login now.", errorPage.getError());
+
+        // check the password works
+        oauth.openLoginForm();
+        loginPage.login(username, "resetPassword");
+        assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
     }
 
     public void assertSecondPasswordResetFails(String changePasswordUrl, String clientId) {


### PR DESCRIPTION
Closes #50850

Throw an exception and rollback the transaction when `ErrorPageException` is thrown. I have changed to do the rollback when this exception is thrown. I think that it's OK as it is used just a few times and it makes sense (we are doing the same in other exceptions). If you think that it is better just do the rollback for the the reset credentials case, just let me know.