### PR TITLE
[26.6] Fix BruteForceProtector failure counter not resetting when failures are spaced apart > maxDelta

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -143,7 +143,7 @@ public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtect
     }
 
     @Override
-    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
+    public void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
         // remove the user from concurrent login attemps once it's processed
         enlistRemoval(session, userId);
         super.failure(session, realm, userId, remoteAddr, failureTime, categories);

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -80,34 +80,34 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
         this.factory = factory;
     }
 
-    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
+    public void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
         UserLoginFailureModel userLoginFailure = getUserFailureModel(session, realm, userId);
         if (userLoginFailure == null) {
             userLoginFailure = session.loginFailures().addUserLoginFailure(realm, userId);
         }
-        userLoginFailure.setLastIPFailure(remoteAddr);
         long last = userLoginFailure.getLastFailure();
         long deltaTime = 0;
         if (last > 0) {
             deltaTime = failureTime - last;
         }
-        userLoginFailure.setLastFailure(failureTime);
 
         if (!(realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) && deltaTime > 0) {
             // if last failure was more than MAX_DELTA clear failures
-            if (deltaTime > (long) realm.getMaxDeltaTimeSeconds() * 1000L) {
+            if (deltaTime > realm.getMaxDeltaTimeSeconds() * 1000L) {
                 userLoginFailure.clearFailures();
             }
         }
+        userLoginFailure.setLastIPFailure(remoteAddr);
+        userLoginFailure.setLastFailure(failureTime);
         userLoginFailure.incrementFailures();
         logger.debugf("new num failures: %s", userLoginFailure.getNumFailures());
 
         long waitSeconds = 0L;
         if (!(realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0)) {
             if (RealmRepresentation.BruteForceStrategy.MULTIPLE.equals(realm.getBruteForceStrategy())) {
-                waitSeconds = (long) realm.getWaitIncrementSeconds() *  ((long) userLoginFailure.getNumFailures() / realm.getFailureFactor());
+                waitSeconds = realm.getWaitIncrementSeconds() *  ((long) userLoginFailure.getNumFailures() / realm.getFailureFactor());
             } else {
-                waitSeconds = (long) realm.getWaitIncrementSeconds() * ((long) 1 + userLoginFailure.getNumFailures() - realm.getFailureFactor());
+                waitSeconds = realm.getWaitIncrementSeconds() * ((long) 1 + userLoginFailure.getNumFailures() - realm.getFailureFactor());
             }
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -43,6 +43,7 @@ import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.BruteForceProtector;
+import org.keycloak.services.managers.DefaultBruteForceProtector;
 import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.AssertEvents.ExpectedEvent;
@@ -546,6 +547,56 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
 
             loginInvalidPassword();
             loginSuccess();
+        } finally {
+            realm.setMaxDeltaTimeSeconds(20);
+            testRealm().update(realm);
+        }
+    }
+
+    @Test
+    public void testRepeatedFailureResetForTemporaryLockout() {
+        RealmRepresentation realm = testRealm().toRepresentation();
+        try {
+            // Using a large maxDeltaTimeSeconds to prevent cache expiration happening due to
+            // Infinispan cache expiration in dev environment, between the two failure() calls inside the server lambda.
+            realm.setMaxDeltaTimeSeconds(3600);
+            testRealm().update(realm);
+
+            UserRepresentation user = findUser("test-user@localhost");
+            String userId = user.getId();
+            String realmId = realm.getId();
+
+            // Calling failure() directly on the server side with custom failureTime values, this ensures 
+            // bypassing the async executor so both calls share the same session/transaction. 
+            // This allows to observing the entity state without cache expiration.
+            testingClient.server().run(session -> {
+
+                RealmModel realmModel = session.realms().getRealm(realmId);
+                DefaultBruteForceProtector protector = (DefaultBruteForceProtector)session.getProvider(BruteForceProtector.class);
+
+                // Now attempting Failure 1
+                long T1 = org.keycloak.common.util.Time.currentTimeMillis();
+                protector.failure(session, realmModel, userId, "127.0.0.1", T1, null);
+                UserLoginFailureModel lf = session.loginFailures()
+                        .getUserLoginFailure(realmModel, userId);
+                Assert.assertNotNull(lf);
+                Assert.assertEquals(1, lf.getNumFailures());
+
+                // Now attempting Failure 2 with delta > maxDeltaTimeSeconds (3600s)
+                long T2 = T1 + 3601 * 1000L;
+                protector.failure(session, realmModel, userId, "127.0.0.1", T2, null);
+                lf = session.loginFailures().getUserLoginFailure(realmModel, userId);
+
+                // Counter should have been cleared then re-incremented
+                Assert.assertEquals("numFailures should be 1 after counter reset", 1, lf.getNumFailures());
+                
+                Assert.assertEquals("last ip should be retained", "127.0.0.1", lf.getLastIPFailure());
+
+                // The Core Test Assertion: setLastFailure must run AFTER clearFailures so lastFailure is not wiped to 0.
+                // If setLastFailure runs before clearFailures (the behavior causing the bug), clearFailures() sets lastFailure to 0, 
+                // then subsequent failures lose the ability to compute the correct delta time.
+                Assert.assertTrue("lastFailure must be preserved after counter reset, got: " + lf.getLastFailure(), lf.getLastFailure() > 0);
+            });
         } finally {
             realm.setMaxDeltaTimeSeconds(20);
             testRealm().update(realm);


### PR DESCRIPTION
Closes #46634 

(cherry picked from commit 114a44a92c94eb9800c8c332493ce6baddcc4730)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
