### PR TITLE
CIMD same-domain restriction skips additional redirect_uris before persistence

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
@@ -762,7 +762,9 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
                 throw invalidClientIdMetadata(ERR_METADATA_URIS_SAMEDOMAIN);
             }
 
-            List<String> l = Stream.of(clientOIDC.getClientId(), clientOIDC.getClientUri(), clientOIDC.getLogoUri(), clientOIDC.getTosUri(), clientOIDC.getPolicyUri(), clientOIDC.getJwksUri())
+            List<String> l = Stream.concat(
+                        Stream.of(clientOIDC.getClientId(), clientOIDC.getClientUri(), clientOIDC.getLogoUri(), clientOIDC.getTosUri(), clientOIDC.getPolicyUri(), clientOIDC.getJwksUri()),
+                        clientOIDC.getRedirectUris() == null ? Stream.<String>empty() : clientOIDC.getRedirectUris().stream())
                     .filter(Objects::nonNull).toList();
             try {
                 for (String s : l) {

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientIdMetadataDocumentTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientIdMetadataDocumentTest.java
@@ -965,6 +965,27 @@ public class ClientIdMetadataDocumentTest {
     }
 
     @Test
+    public void testRestrictSameDomainChecksAdditionalRedirectUris() throws Exception {
+        ClientIdUriSchemeCondition.Configuration conditionConfig = new ClientIdUriSchemeCondition.Configuration();
+        conditionConfig.setClientIdUriSchemes(List.of("http", "https"));
+        conditionConfig.setTrustedDomains(List.of("localhost"));
+        ClientIdMetadataDocumentExecutor.Configuration executorConfig = new ClientIdMetadataDocumentExecutor.Configuration();
+        executorConfig.setAllowHttpScheme(true);
+        executorConfig.setOnlyAllowConfidentialClient(false);
+        executorConfig.setTrustedDomains(List.of("localhost", "www.example.com"));
+        executorConfig.setRestrictSameDomain(true);
+        updatePolicy(conditionConfig, executorConfig);
+
+        setCimdPublicClient();
+        oauth.redirectUri(REDIRECT_URI);
+        cimd.getRepresentation().setRedirectUris(List.of(REDIRECT_URI, "https://www.example.com/callback"));
+        assertLoginAndError(ClientIdMetadataDocumentExecutor.ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
+
+        // The client with the cross-domain redirect URI must not have been persisted
+        Assertions.assertTrue(realm.admin().clients().findByClientId(CLIENT_ID).isEmpty());
+    }
+
+    @Test
     public void testClientIdMetadataDocumentExecutorValidateClientMetadataRequiredProperties() throws Exception {
         ClientIdUriSchemeCondition.Configuration conditionConfig = new ClientIdUriSchemeCondition.Configuration();
         conditionConfig.setClientIdUriSchemes(List.of("http", "https"));


### PR DESCRIPTION

closes #50748

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
