### PR TITLE
Implementation for the ldap connect server metric.

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/LDAPQuery.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/query/internal/LDAPQuery.java
@@ -219,7 +219,8 @@ public class LDAPQuery implements AutoCloseable {
 
     public LDAPQuery initPagination() throws NamingException {
         this.ldapContextManager = LDAPContextManager.create(ldapFedProvider.getSession(),
-                ldapFedProvider.getLdapIdentityStore().getConfig());
+                ldapFedProvider.getLdapIdentityStore().getConfig(),
+                ldapFedProvider.getLdapIdentityStore().getRequestTimer());
         this.paginationContext = new PaginationContext(ldapContextManager.getLdapContext());
         return this;
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -40,7 +40,7 @@ public final class LDAPContextManager implements AutoCloseable {
     private StartTlsResponse tlsResponse;
     private LdapContext ldapContext;
 
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "26.8")
     public LDAPContextManager(KeycloakSession session, LDAPConfig connectionProperties) {
         this(session, connectionProperties, null);
     }
@@ -51,7 +51,7 @@ public final class LDAPContextManager implements AutoCloseable {
         this.requestTimer = requestTimer;
     }
 
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "26.8")
     public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties) {
         return new LDAPContextManager(session, connectionProperties, null);
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -40,6 +40,7 @@ public final class LDAPContextManager implements AutoCloseable {
     private StartTlsResponse tlsResponse;
     private LdapContext ldapContext;
 
+    @Deprecated(forRemoval = true)
     public LDAPContextManager(KeycloakSession session, LDAPConfig connectionProperties) {
         this(session, connectionProperties, null);
     }
@@ -50,6 +51,7 @@ public final class LDAPContextManager implements AutoCloseable {
         this.requestTimer = requestTimer;
     }
 
+    @Deprecated(forRemoval = true)
     public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties) {
         return new LDAPContextManager(session, connectionProperties, null);
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import javax.naming.AuthenticationException;
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -20,6 +21,8 @@ import org.keycloak.tracing.TracingProvider;
 import org.keycloak.truststore.TruststoreProvider;
 import org.keycloak.vault.VaultStringSecret;
 
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
 import org.jboss.logging.Logger;
 
 import static javax.naming.Context.SECURITY_CREDENTIALS;
@@ -33,22 +36,45 @@ public final class LDAPContextManager implements AutoCloseable {
 
     private final KeycloakSession session;
     private final LDAPConfig ldapConfig;
+    private final Meter.MeterProvider<Timer> requestTimer;
     private StartTlsResponse tlsResponse;
     private LdapContext ldapContext;
 
     public LDAPContextManager(KeycloakSession session, LDAPConfig connectionProperties) {
+        this(session, connectionProperties, null);
+    }
+
+    public LDAPContextManager(KeycloakSession session, LDAPConfig connectionProperties, Meter.MeterProvider<Timer> requestTimer) {
         this.session = session;
         this.ldapConfig = connectionProperties;
+        this.requestTimer = requestTimer;
     }
 
     public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties) {
-        return new LDAPContextManager(session, connectionProperties);
+        return new LDAPContextManager(session, connectionProperties, null);
+    }
+
+    public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties, Meter.MeterProvider<Timer> requestTimer) {
+        return new LDAPContextManager(session, connectionProperties, requestTimer);
+    }
+
+    private void recordLdapRequest(boolean success, long startTimeNanos) {
+        if (requestTimer == null) {
+            return;
+        }
+        long durationNanos = System.nanoTime() - startTimeNanos;
+        requestTimer.withTags("operation", "connect", "outcome", success ? "success" : "error")
+                .record(durationNanos, TimeUnit.NANOSECONDS);
     }
 
     // Create connection that is authenticated as admin user.
     private void createLdapContext() throws NamingException {
         var tracing = session.getProvider(TracingProvider.class);
         tracing.startSpan(LDAPContextManager.class, "createLdapContext");
+
+        long startTimeNanos = System.nanoTime();
+        boolean success = false;
+
         try {
             Hashtable<Object, Object> connProp = getNonAuthConnectionProperties(ldapConfig);
 
@@ -82,10 +108,12 @@ public final class LDAPContextManager implements AutoCloseable {
                 // StartTLS must complete before authenticating, so bind only now.
                 setAdminConnectionAuthProperties(ldapContext);
             }
+            success = true;
         } catch (NamingException e) {
             tracing.error(e);
             throw e;
         } finally {
+            recordLdapRequest(success, startTimeNanos);
             tracing.endSpan();
         }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPContextManager.java
@@ -51,11 +51,16 @@ public final class LDAPContextManager implements AutoCloseable {
         this.requestTimer = requestTimer;
     }
 
-    @Deprecated(forRemoval = true, since = "26.8")
+    /**
+     * Use this method only when the operation should not be tracked by metrics, for example when testing a connection.
+     */
     public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties) {
         return new LDAPContextManager(session, connectionProperties, null);
     }
 
+    /**
+     * This is the default method to create the context manager. It will track metrics for LDAP requests.
+     */
     public static LDAPContextManager create(KeycloakSession session, LDAPConfig connectionProperties, Meter.MeterProvider<Timer> requestTimer) {
         return new LDAPContextManager(session, connectionProperties, requestTimer);
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -81,6 +81,7 @@ public class LDAPIdentityStore implements IdentityStore {
 
     private final LDAPConfig config;
     private final LDAPOperationManager operationManager;
+    private final Meter.MeterProvider<Timer> requestTimer;
 
     public LDAPIdentityStore(KeycloakSession session, LDAPConfig config) {
         this(session, config, null);
@@ -88,7 +89,12 @@ public class LDAPIdentityStore implements IdentityStore {
 
     public LDAPIdentityStore(KeycloakSession session, LDAPConfig config, Meter.MeterProvider<Timer> requestTimer) {
         this.config = config;
+        this.requestTimer = requestTimer;
         this.operationManager = new LDAPOperationManager(session, config, requestTimer);
+    }
+
+    public Meter.MeterProvider<Timer> getRequestTimer() {
+        return requestTimer;
     }
 
     @Override

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -774,6 +774,14 @@ public class LDAPOperationManager {
 
     private <R> R execute(LdapOperation<R> operation, LDAPOperationDecorator decorator) throws NamingException {
         try (LDAPContextManager ldapContextManager = LDAPContextManager.create(session, config)) {
+            long connectStartNanos = System.nanoTime();
+            boolean connectSuccess = false;
+            try {
+                ldapContextManager.getLdapContext();
+                connectSuccess = true;
+            } finally {
+                recordLdapRequest("connect", connectSuccess, connectStartNanos);
+            }
             return execute(operation, ldapContextManager.getLdapContext(), decorator);
         }
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -773,15 +773,7 @@ public class LDAPOperationManager {
     }
 
     private <R> R execute(LdapOperation<R> operation, LDAPOperationDecorator decorator) throws NamingException {
-        try (LDAPContextManager ldapContextManager = LDAPContextManager.create(session, config)) {
-            long connectStartNanos = System.nanoTime();
-            boolean connectSuccess = false;
-            try {
-                ldapContextManager.getLdapContext();
-                connectSuccess = true;
-            } finally {
-                recordLdapRequest("connect", connectSuccess, connectStartNanos);
-            }
+        try (LDAPContextManager ldapContextManager = LDAPContextManager.create(session, config, requestTimer)) {
             return execute(operation, ldapContextManager.getLdapContext(), decorator);
         }
     }


### PR DESCRIPTION
This PR adds a implementation for a  metric that tracks LDAP connection attempts.

 In LDAPOperationManager.execute() — the method every LDAP operation (search, create, modify, delete, etc.) flows through before talking to the LDAP server.

**RESULTS:**

<img width="1248" height="322" alt="image" src="https://github.com/user-attachments/assets/ce40ab8b-e30c-4b1d-a600-e6d9b93969c8" />



Closes #50840

Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
