### PR TITLE
Manage null in BasicAuthHelper to avoid NPE

### DIFF
--- a/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
+++ b/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
@@ -32,7 +32,9 @@ import java.util.Base64;
  */
 public class BasicAuthHelper {
     public static String createHeader(String username, String password) {
-        return "Basic " + Base64.getEncoder().encodeToString((username + ':' + password).getBytes(StandardCharsets.UTF_8));
+        return "Basic " + Base64.getEncoder().encodeToString(
+                ((username != null ? username : "") + ':' + (password != null ? password : ""))
+                        .getBytes(StandardCharsets.UTF_8));
     }
 
     public static String[] parseHeader(String header) {
@@ -66,8 +68,8 @@ public class BasicAuthHelper {
         public static String createHeader(String username, String password) {
             try {
                 return BasicAuthHelper.createHeader(
-                    URLEncoder.encode(username, "UTF-8"),
-                    URLEncoder.encode(password, "UTF-8")
+                    username != null ? URLEncoder.encode(username, "UTF-8") : "",
+                    password != null ? URLEncoder.encode(password, "UTF-8") : ""
                 );
             } catch (UnsupportedEncodingException e) {
                 return null;

--- a/core/src/test/java/org/keycloak/util/BasicAuthHelperTest.java
+++ b/core/src/test/java/org/keycloak/util/BasicAuthHelperTest.java
@@ -50,4 +50,12 @@ public class BasicAuthHelperTest {
 
         assertArrayEquals(new String[] {username, password}, actual);
     }
+
+    @Test
+    public void testNull() {
+        assertArrayEquals(new String[]{"user", ""}, BasicAuthHelper.parseHeader(BasicAuthHelper.createHeader("user", null)));
+        assertArrayEquals(new String[]{"", "password"}, BasicAuthHelper.parseHeader(BasicAuthHelper.createHeader(null, "password")));
+        assertArrayEquals(new String[]{"user", ""}, BasicAuthHelper.RFC6749.parseHeader(BasicAuthHelper.RFC6749.createHeader("user", null)));
+        assertArrayEquals(new String[]{"", "password"}, BasicAuthHelper.RFC6749.parseHeader(BasicAuthHelper.RFC6749.createHeader(null, "password")));
+    }
 }


### PR DESCRIPTION
Closes #50791

Little PR to send empty username/password in the authentication header if the parameter is null. Currently it throws a NPE in the RFC6749 version and string `null` in teh common method.
