### PR TITLE
[OID4VP] Add support for direct_post.jwt response mode

### DIFF
--- a/core/src/main/java/org/keycloak/OID4VCConstants.java
+++ b/core/src/main/java/org/keycloak/OID4VCConstants.java
@@ -78,6 +78,11 @@ public class OID4VCConstants {
     public static final String SD_JWT_ALG_VALUES = "sd-jwt_alg_values";
     public static final String KB_JWT_ALG_VALUES = "kb-jwt_alg_values";
     public static final String RESPONSE_MODE_DIRECT_POST = "direct_post";
+    public static final String RESPONSE_MODE_DIRECT_POST_JWT = "direct_post.jwt";
+    // client_metadata parameters advertising the verifier's ephemeral response encryption key material.
+    public static final String JWKS = "jwks";
+    public static final String JWKS_KEYS = "keys";
+    public static final String ENCRYPTED_RESPONSE_ENC_VALUES_SUPPORTED = "encrypted_response_enc_values_supported";
     public static final String FORMAT_SD_JWT_VC = "dc+sd-jwt";
     public static final String SELF_ISSUED_V2 = "https://self-issued.me/v2";
     public static final String REQUEST_OBJECT_TYPE = "oauth-authz-req+jwt";

--- a/services/src/main/java/org/keycloak/broker/oid4vp/DecryptedResponse.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/DecryptedResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+/**
+ * The response parameters unsealed from a {@code direct_post.jwt} JWE, together with the request
+ * context they were resolved against.
+ */
+public record DecryptedResponse(String vpToken, String state, RequestContext context) {
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/EphemeralKey.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/EphemeralKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.util.Base64;
+
+import org.keycloak.common.util.DerUtils;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwe.JWEConstants;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+
+/**
+ * The per request response encryption key for the {@code direct_post.jwt} response mode. The public
+ * JWK is advertised to the wallet in the request object client metadata, the private key stays with
+ * the verifier to decrypt the response. Generation takes no algorithm because HAIP pins the key
+ * management to {@link JWEConstants#ECDH_ES} over secp256r1. The advertised content encryption
+ * algorithms only select the length of the content key derived during key agreement, so the one key
+ * serves them all.
+ */
+public record EphemeralKey(String kid, JWK publicJwk, String privateKeyPkcs8Base64) {
+
+    private static final String CURVE_SEC = "secp256r1";
+
+    public static EphemeralKey generate(String kid) {
+        KeyPair keyPair = KeyUtils.generateEcKeyPair(CURVE_SEC);
+        JWK publicJwk = JWKBuilder.create()
+                .algorithm(ResponseEncryption.KEY_MANAGEMENT_ALG)
+                .ec(keyPair.getPublic(), KeyUse.ENC);
+        publicJwk.setKeyId(kid);
+        String encoded = Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded());
+        return new EphemeralKey(kid, publicJwk, encoded);
+    }
+
+    // The private key is PKCS8 encoded so it can live in the single use object store.
+    public PrivateKey privateKey() {
+        try {
+            return DerUtils.decodePrivateKey(Base64.getDecoder().decode(privateKeyPkcs8Base64));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to restore the ephemeral response encryption key", e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProvider.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -74,10 +74,13 @@ public class OID4VPIdentityProvider extends AbstractIdentityProvider<OID4VPIdent
 
     private static final Logger logger = Logger.getLogger(OID4VPIdentityProvider.class);
 
-    // The flow object is written when the login page is rendered and read while serving the request
-    // object and the presentation. It holds the root authentication session id and tab id needed to
-    // recover that session, and the nonce the wallet must echo in the key binding JWT.
-    public static final String FLOW_PREFIX = "oid4vp.flow.";
+    // TODO the accepted presentation signature algorithms are hardcoded to match the advertised client
+    // metadata. Derive both from configuration or the available verification key material.
+    public static final List<String> ACCEPTED_ALGORITHMS = List.of(Algorithm.ES256);
+
+    // The request context is written when the login page is rendered and read while serving the request
+    // object and the presentation.
+    public static final String CONTEXT_PREFIX = "oid4vp.context.";
     // The deferred object is written once the presentation is verified and read when the browser
     // returns to complete-auth. It marks that a verified identity, serialized under IDENTITY_NOTE in
     // the authentication session, is waiting to finish the broker login.
@@ -85,7 +88,6 @@ public class OID4VPIdentityProvider extends AbstractIdentityProvider<OID4VPIdent
     public static final String IDENTITY_NOTE = "OID4VP_IDENTITY";
     public static final String KEY_ROOT_SESSION_ID = "rootSessionId";
     public static final String KEY_TAB_ID = "tabId";
-    public static final String KEY_NONCE = "nonce";
 
     public OID4VPIdentityProvider(KeycloakSession session, OID4VPIdentityProviderConfig config) {
         super(session, config);
@@ -103,13 +105,19 @@ public class OID4VPIdentityProvider extends AbstractIdentityProvider<OID4VPIdent
                     ? authSession.getParentSession().getId()
                     : null;
 
-            session.singleUseObjects().put(
-                    FLOW_PREFIX + state,
-                    loginTimeoutSeconds(),
-                    Map.of(
-                            KEY_ROOT_SESSION_ID, rootSessionId != null ? rootSessionId : "",
-                            KEY_TAB_ID, authSession.getTabId() != null ? authSession.getTabId() : "",
-                            KEY_NONCE, nonce));
+            EphemeralKey encryptionKey = null;
+            if (getConfig().isEncryptedResponse()) {
+                // A fresh encryption key per authorization request, as HAIP requires. Its kid is the
+                // state, so the cleartext JWE kid resolves the context although the response seals
+                // the state inside the ciphertext. Assumes the one key per request HAIP mandates.
+                encryptionKey = EphemeralKey.generate(state);
+            }
+
+            RequestContext context = new RequestContext(
+                    rootSessionId != null ? rootSessionId : "",
+                    authSession.getTabId() != null ? authSession.getTabId() : "",
+                    nonce, encryptionKey);
+            session.singleUseObjects().put(CONTEXT_PREFIX + state, loginTimeoutSeconds(), context.toMap());
 
             URI requestUri = OID4VPIdentityProviderEndpoint
                     .endpointBaseUri(request.getUriInfo().getBaseUriBuilder(), request.getRealm().getName(),

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderConfig.java
@@ -18,6 +18,7 @@
 package org.keycloak.broker.oid4vp;
 
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.utils.StringUtil;
 
 public class OID4VPIdentityProviderConfig extends IdentityProviderModel {
@@ -27,6 +28,7 @@ public class OID4VPIdentityProviderConfig extends IdentityProviderModel {
     public static final String PRINCIPAL_ATTRIBUTE = "principalAttribute";
     public static final String WALLET_SCHEME = "walletScheme";
     public static final String SIGNING_KEY_ID = "signingKeyId";
+    public static final String RESPONSE_MODE = "responseMode";
 
     public static final String DEFAULT_WALLET_SCHEME = "openid4vp://";
 
@@ -68,6 +70,28 @@ public class OID4VPIdentityProviderConfig extends IdentityProviderModel {
 
     public void setSigningKeyId(String signingKeyId) {
         getConfig().put(SIGNING_KEY_ID, signingKeyId);
+    }
+
+    public ResponseMode getResponseMode() {
+        String value = getConfig().get(RESPONSE_MODE);
+        return StringUtil.isBlank(value) ? ResponseMode.DIRECT_POST : ResponseMode.from(value);
+    }
+
+    public void setResponseMode(ResponseMode responseMode) {
+        getConfig().put(RESPONSE_MODE, responseMode.value());
+    }
+
+    public boolean isEncryptedResponse() {
+        return getResponseMode() == ResponseMode.DIRECT_POST_JWT;
+    }
+
+    @Override
+    public void validate(RealmModel realm) {
+        super.validate(realm);
+        String responseMode = getConfig().get(RESPONSE_MODE);
+        if (StringUtil.isNotBlank(responseMode)) {
+            ResponseMode.from(responseMode);
+        }
     }
 
     public String getWalletScheme() {

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderEndpoint.java
@@ -43,11 +43,11 @@ import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.UserAuthenticationIdentityProvider.AuthenticationCallback;
 import org.keycloak.common.VerificationException;
-import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
+import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.IDToken;
@@ -83,7 +83,7 @@ import org.jboss.logging.Logger;
  *   <li>{@code GET /complete-auth} resolves the deferred identity and hands control back to Keycloak.</li>
  * </ul>
  *
- * <p>TODO add the cross device flow and {@code direct_post.jwt} response encryption.
+ * <p>TODO add the cross device flow.
  */
 public class OID4VPIdentityProviderEndpoint {
 
@@ -91,10 +91,6 @@ public class OID4VPIdentityProviderEndpoint {
 
     private static final int CLOCK_SKEW_SECONDS = 60;
     private static final int KB_JWT_MAX_AGE_SECONDS = 300;
-
-    // TODO the accepted presentation signature algorithms are hardcoded to match the advertised client
-    // metadata. Derive both from configuration or the available verification key material.
-    private static final List<String> ACCEPTED_ALGORITHMS = List.of(Algorithm.ES256);
 
     // Broker-internal endpoint routing, not part of the OID4VP protocol.
     public static final String REQUEST_OBJECT_PATH = "request-object";
@@ -122,14 +118,15 @@ public class OID4VPIdentityProviderEndpoint {
     @GET
     @Path("/request-object/{state}")
     public Response requestObject(@PathParam("state") String state) {
-        Map<String, String> flow = session.singleUseObjects().get(OID4VPIdentityProvider.FLOW_PREFIX + state);
-        if (flow == null) {
+        Map<String, String> stored = session.singleUseObjects().get(OID4VPIdentityProvider.CONTEXT_PREFIX + state);
+        if (stored == null) {
             return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
                     "Unknown or expired state", Errors.INVALID_REQUEST);
         }
         String requestObject;
         try {
-            requestObject = buildRequestObject(state, flow).sign(provider.signingKey());
+            requestObject = buildRequestObject(state, RequestContext.fromMap(stored))
+                    .sign(provider.signingKey());
         } catch (RuntimeException e) {
             logger.errorf(e, "Failed to build the OID4VP request object: %s", e.getMessage());
             return loginError(Response.Status.INTERNAL_SERVER_ERROR, OAuthErrorException.SERVER_ERROR,
@@ -143,19 +140,42 @@ public class OID4VPIdentityProviderEndpoint {
     @Path("/")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public Response directPost(@FormParam(OID4VCConstants.VP_TOKEN) String vpToken,
-            @FormParam(OAuth2Constants.STATE) String state) {
-        if (StringUtil.isBlank(vpToken) || StringUtil.isBlank(state)) {
-            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
-                    "Missing vp_token or state", Errors.INVALID_REQUEST);
-        }
-        Map<String, String> flow = session.singleUseObjects().get(OID4VPIdentityProvider.FLOW_PREFIX + state);
-        if (flow == null) {
-            return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
-                    "Unknown or expired state", Errors.INVALID_REQUEST);
+            @FormParam(OAuth2Constants.STATE) String state,
+            @FormParam(OAuth2Constants.RESPONSE) String response) {
+        RequestContext requestContext;
+        if (StringUtil.isNotBlank(response)) {
+            // direct_post.jwt, a JWE whose plaintext carries vp_token and state.
+            DecryptedResponse decrypted;
+            try {
+                decrypted = decryptResponse(response);
+            } catch (VerificationException e) {
+                logger.warnf("OID4VP encrypted response rejected: %s", e.getMessage());
+                return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                        e.getMessage(), Errors.INVALID_REQUEST);
+            }
+            vpToken = decrypted.vpToken();
+            state = decrypted.state();
+            requestContext = decrypted.context();
+        } else {
+            if (StringUtil.isBlank(vpToken) || StringUtil.isBlank(state)) {
+                return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                        "Missing vp_token or state", Errors.INVALID_REQUEST);
+            }
+            Map<String, String> stored = session.singleUseObjects().get(OID4VPIdentityProvider.CONTEXT_PREFIX + state);
+            if (stored == null) {
+                return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                        "Unknown or expired state", Errors.INVALID_REQUEST);
+            }
+            requestContext = RequestContext.fromMap(stored);
+            // The request object promised an encrypted response, so a plain post is a downgrade.
+            if (requestContext.isEncrypted()) {
+                return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
+                        "Expected an encrypted response", Errors.INVALID_REQUEST);
+            }
         }
 
         AuthenticationSessionModel authSession =
-                resolveAuthSession(flow.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID), flow.get(OID4VPIdentityProvider.KEY_TAB_ID));
+                resolveAuthSession(requestContext.rootSessionId(), requestContext.tabId());
         if (authSession == null) {
             return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST,
                     "Authentication session not found", Errors.INVALID_REQUEST);
@@ -163,7 +183,7 @@ public class OID4VPIdentityProviderEndpoint {
 
         BrokeredIdentityContext context;
         try {
-            SdJwtVpVerificationResult result = verifyPresentation(vpToken, flow.get(OID4VPIdentityProvider.KEY_NONCE));
+            SdJwtVpVerificationResult result = verifyPresentation(vpToken, requestContext.nonce());
             context = toBrokeredContext(result, authSession);
         } catch (Exception e) {
             logger.warnf("OID4VP presentation rejected: %s", e.getMessage());
@@ -182,9 +202,9 @@ public class OID4VPIdentityProviderEndpoint {
                 OID4VPIdentityProvider.DEFERRED_PREFIX + responseCode,
                 realm.getAccessCodeLifespanLogin(),
                 Map.of(
-                        OID4VPIdentityProvider.KEY_ROOT_SESSION_ID, flow.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID),
-                        OID4VPIdentityProvider.KEY_TAB_ID, flow.get(OID4VPIdentityProvider.KEY_TAB_ID)));
-        session.singleUseObjects().remove(OID4VPIdentityProvider.FLOW_PREFIX + state);
+                        OID4VPIdentityProvider.KEY_ROOT_SESSION_ID, requestContext.rootSessionId(),
+                        OID4VPIdentityProvider.KEY_TAB_ID, requestContext.tabId()));
+        session.singleUseObjects().remove(OID4VPIdentityProvider.CONTEXT_PREFIX + state);
 
         return Response.ok(Map.of(OAuth2Constants.REDIRECT_URI, completeAuthUrl(responseCode)))
                 .type(MediaType.APPLICATION_JSON_TYPE).cacheControl(CacheControlUtil.noCache()).build();
@@ -229,18 +249,20 @@ public class OID4VPIdentityProviderEndpoint {
         return callback.authenticated(context);
     }
 
-    protected RequestObject buildRequestObject(String state, Map<String, String> flow) {
+    protected RequestObject buildRequestObject(String state, RequestContext requestContext) {
         String clientId = provider.clientId();
         Instant now = Instant.now();
 
         RequestObject requestObject = new RequestObject()
                 .clientId(clientId)
                 .responseType(OID4VCConstants.VP_TOKEN)
-                .responseMode(OID4VCConstants.RESPONSE_MODE_DIRECT_POST)
+                .responseMode(requestContext.isEncrypted()
+                        ? OID4VCConstants.RESPONSE_MODE_DIRECT_POST_JWT
+                        : OID4VCConstants.RESPONSE_MODE_DIRECT_POST)
                 .responseUri(endpointBaseUrl())
-                .nonce(flow.get(OID4VPIdentityProvider.KEY_NONCE))
+                .nonce(requestContext.nonce())
                 .state(state)
-                .clientMetadata(clientMetadata())
+                .clientMetadata(requestContext.clientMetadata())
                 .dcqlQuery(dcqlQuery());
         requestObject.id(UUID.randomUUID().toString());
         requestObject.iat(now.getEpochSecond());
@@ -263,12 +285,57 @@ public class OID4VPIdentityProviderEndpoint {
         }
     }
 
-    // TODO infer from configuration / available verification key material
-    protected Map<String, Object> clientMetadata() {
-        return Map.of(OID4VCConstants.VP_FORMATS_SUPPORTED, Map.of(
-                OID4VCConstants.FORMAT_SD_JWT_VC, Map.of(
-                        OID4VCConstants.SD_JWT_ALG_VALUES, ACCEPTED_ALGORITHMS,
-                        OID4VCConstants.KB_JWT_ALG_VALUES, ACCEPTED_ALGORITHMS)));
+    protected DecryptedResponse decryptResponse(String response) throws VerificationException {
+        ParsedResponse parsed;
+        try {
+            parsed = ResponseEncryption.parse(response);
+        } catch (JWEException e) {
+            throw new VerificationException("Malformed encrypted response", e);
+        }
+        // The ephemeral key was issued with the state as its kid.
+        String state = parsed.keyId();
+        if (StringUtil.isBlank(state)) {
+            throw new VerificationException("Encrypted response is missing the key id");
+        }
+
+        Map<String, String> stored = session.singleUseObjects().get(OID4VPIdentityProvider.CONTEXT_PREFIX + state);
+        if (stored == null) {
+            throw new VerificationException("Unknown or expired response encryption key");
+        }
+        RequestContext requestContext = RequestContext.fromMap(stored);
+        if (!requestContext.isEncrypted()) {
+            // A plain flow never advertised a key, so a JWE naming its state as kid must not resolve one.
+            throw new VerificationException("Unknown or expired response encryption key");
+        }
+
+        JsonNode payload;
+        try {
+            String plaintext = ResponseEncryption.decrypt(parsed,
+                    requestContext.encryptionKey().privateKey());
+            payload = JsonSerialization.readValue(plaintext, JsonNode.class);
+        } catch (JWEException | IOException e) {
+            throw new VerificationException("Failed to decrypt the response", e);
+        }
+
+        JsonNode vpTokenNode = payload.get(OID4VCConstants.VP_TOKEN);
+        if (vpTokenNode == null || vpTokenNode.isNull()
+                || (vpTokenNode.isTextual() && StringUtil.isBlank(vpTokenNode.asText()))) {
+            throw new VerificationException("Encrypted response is missing vp_token");
+        }
+        // The state sealed inside the ciphertext must match the one this key id was issued for.
+        JsonNode stateNode = payload.get(OAuth2Constants.STATE);
+        if (stateNode == null || !state.equals(stateNode.asText())) {
+            throw new VerificationException("Encrypted response state mismatch");
+        }
+
+        String vpToken;
+        try {
+            vpToken = vpTokenNode.isTextual() ? vpTokenNode.asText()
+                    : JsonSerialization.writeValueAsString(vpTokenNode);
+        } catch (IOException e) {
+            throw new VerificationException("Malformed vp_token in the encrypted response", e);
+        }
+        return new DecryptedResponse(vpToken, state, requestContext);
     }
 
     protected SdJwtVpVerificationResult verifyPresentation(String vpToken, String nonce) throws VerificationException {
@@ -313,7 +380,7 @@ public class OID4VPIdentityProviderEndpoint {
     }
 
     private static void requireAcceptedAlgorithm(String algorithm, String jwt) throws VerificationException {
-        if (!ACCEPTED_ALGORITHMS.contains(algorithm)) {
+        if (!OID4VPIdentityProvider.ACCEPTED_ALGORITHMS.contains(algorithm)) {
             throw new VerificationException("Unsupported " + jwt + " signature algorithm " + algorithm);
         }
     }

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderFactory.java
@@ -18,6 +18,7 @@
 package org.keycloak.broker.oid4vp;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.keycloak.Config;
 import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
@@ -66,6 +67,17 @@ public class OID4VPIdentityProviderFactory extends AbstractIdentityProviderFacto
                         + "constraints CA=false and digitalSignature key usage, e.g. supplied through a Java keystore "
                         + "key provider.")
                 .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+            .property()
+                .name(OID4VPIdentityProviderConfig.RESPONSE_MODE)
+                .label("Response Mode")
+                .helpText("How the wallet returns the presentation. direct_post.jwt encrypts it with a fresh ephemeral "
+                        + "verifier key published in the request object, as required for HAIP compliance.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options(Stream.of(ResponseMode.values())
+                        .map(ResponseMode::value).toList())
+                .defaultValue(ResponseMode.DIRECT_POST.value())
+                .required(true)
                 .add()
             .property()
                 .name(OID4VPIdentityProviderConfig.WALLET_SCHEME)

--- a/services/src/main/java/org/keycloak/broker/oid4vp/ParsedResponse.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/ParsedResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEHeader;
+
+/**
+ * A {@code direct_post.jwt} response JWE with its parsed header. The header carries the kid that
+ * locates the ephemeral decryption key, so it must be readable before the response can be decrypted.
+ */
+public record ParsedResponse(JWE jwe, JWEHeader header) {
+
+    public String keyId() {
+        return header.getKeyId();
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/RequestContext.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/RequestContext.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * The verifier side state of one wallet login, written to the single use object store when the login
+ * page is rendered and read while serving the request object and the presentation. It carries the ids
+ * to recover the authentication session, the nonce the wallet must echo in the key binding JWT, and
+ * (for {@code direct_post.jwt}) the ephemeral response encryption key.
+ */
+public record RequestContext(String rootSessionId, String tabId, String nonce,
+        EphemeralKey encryptionKey) {
+
+    private static final String KEY_NONCE = "nonce";
+    private static final String KEY_ENC_KID = "encKid";
+    private static final String KEY_ENC_PRIVATE_KEY = "encPrivateKey";
+    private static final String KEY_ENC_PUBLIC_JWK = "encPublicJwk";
+
+    public boolean isEncrypted() {
+        return encryptionKey != null;
+    }
+
+    // The client_metadata advertised in the request object, including the ephemeral encryption key for
+    // an encrypted response.
+    public Map<String, Object> clientMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(OID4VCConstants.VP_FORMATS_SUPPORTED, Map.of(
+                OID4VCConstants.FORMAT_SD_JWT_VC, Map.of(
+                        OID4VCConstants.SD_JWT_ALG_VALUES, OID4VPIdentityProvider.ACCEPTED_ALGORITHMS,
+                        OID4VCConstants.KB_JWT_ALG_VALUES, OID4VPIdentityProvider.ACCEPTED_ALGORITHMS)));
+        if (isEncrypted()) {
+            metadata.put(OID4VCConstants.JWKS,
+                    Map.of(OID4VCConstants.JWKS_KEYS, List.of(encryptionKey.publicJwk())));
+            metadata.put(OID4VCConstants.ENCRYPTED_RESPONSE_ENC_VALUES_SUPPORTED,
+                    ResponseEncryption.CONTENT_ENCRYPTION_ALGS);
+        }
+        return metadata;
+    }
+
+    public Map<String, String> toMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID, rootSessionId);
+        map.put(OID4VPIdentityProvider.KEY_TAB_ID, tabId);
+        map.put(KEY_NONCE, nonce);
+        if (encryptionKey != null) {
+            try {
+                map.put(KEY_ENC_KID, encryptionKey.kid());
+                map.put(KEY_ENC_PRIVATE_KEY, encryptionKey.privateKeyPkcs8Base64());
+                map.put(KEY_ENC_PUBLIC_JWK, JsonSerialization.writeValueAsString(encryptionKey.publicJwk()));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to serialize the ephemeral response encryption key", e);
+            }
+        }
+        return map;
+    }
+
+    public static RequestContext fromMap(Map<String, String> map) {
+        EphemeralKey encryptionKey = null;
+        if (map.containsKey(KEY_ENC_KID)) {
+            try {
+                JWK publicJwk = JsonSerialization.readValue(map.get(KEY_ENC_PUBLIC_JWK), JWK.class);
+                encryptionKey = new EphemeralKey(map.get(KEY_ENC_KID), publicJwk,
+                        map.get(KEY_ENC_PRIVATE_KEY));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to restore the ephemeral response encryption key", e);
+            }
+        }
+        return new RequestContext(
+                map.get(OID4VPIdentityProvider.KEY_ROOT_SESSION_ID),
+                map.get(OID4VPIdentityProvider.KEY_TAB_ID),
+                map.get(KEY_NONCE),
+                encryptionKey);
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/ResponseEncryption.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/ResponseEncryption.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.util.List;
+
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEConstants;
+import org.keycloak.jose.jwe.JWEException;
+import org.keycloak.jose.jwe.JWEHeader;
+
+/**
+ * Response encryption for the OID4VP {@code direct_post.jwt} response mode, following HAIP. The
+ * verifier hands the wallet a fresh {@link EphemeralKey} with every authorization request
+ * (ephemeral {@link JWEConstants#ECDH_ES} over secp256r1) and decrypts the wallet's JWE with it.
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-8.3">OID4VP 1.0 §8.3 — Encrypted Responses</a>
+ */
+public final class ResponseEncryption {
+
+    public static final String KEY_MANAGEMENT_ALG = JWEConstants.ECDH_ES;
+    // HAIP section 5 requires the verifier to advertise both, the wallet picks one.
+    public static final List<String> CONTENT_ENCRYPTION_ALGS =
+            List.of(JWEConstants.A128GCM, JWEConstants.A256GCM);
+
+    // The JWE parser raises unchecked exceptions on malformed input, wrapped here so a rejected
+    // response stays a client error.
+    public static ParsedResponse parse(String compactJwe) throws JWEException {
+        try {
+            JWE jwe = new JWE(compactJwe);
+            if (jwe.getHeader() instanceof JWEHeader header) {
+                return new ParsedResponse(jwe, header);
+            }
+        } catch (RuntimeException e) {
+            throw new JWEException("Malformed encrypted response");
+        }
+        throw new JWEException("Encrypted response is not a JWE");
+    }
+
+    public static String decrypt(ParsedResponse parsed, PrivateKey privateKey) throws JWEException {
+        String enc = parsed.header().getEncryptionAlgorithm();
+        if (!KEY_MANAGEMENT_ALG.equals(parsed.header().getAlgorithm()) || enc == null
+                || !CONTENT_ENCRYPTION_ALGS.contains(enc)) {
+            throw new JWEException("Unsupported response encryption algorithms "
+                    + parsed.header().getAlgorithm() + "/" + enc);
+        }
+        parsed.jwe().getKeyStorage().setDecryptionKey(privateKey);
+        parsed.jwe().verifyAndDecodeJwe();
+        return new String(parsed.jwe().getContent(), StandardCharsets.UTF_8);
+    }
+
+    private ResponseEncryption() {
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/ResponseMode.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/ResponseMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp;
+
+import org.keycloak.OID4VCConstants;
+
+public enum ResponseMode {
+
+    DIRECT_POST(OID4VCConstants.RESPONSE_MODE_DIRECT_POST),
+    DIRECT_POST_JWT(OID4VCConstants.RESPONSE_MODE_DIRECT_POST_JWT);
+
+    private final String value;
+
+    ResponseMode(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static ResponseMode from(String value) {
+        for (ResponseMode mode : values()) {
+            if (mode.value.equals(value)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException("Unsupported OID4VP response mode " + value);
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -1,6 +1,9 @@
 package org.keycloak.tests.oid4vc;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -11,6 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jakarta.ws.rs.HttpMethod;
 
@@ -19,13 +24,18 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ClientAttestationPoPJwt;
+import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.AsymmetricSignatureSignerContext;
 import org.keycloak.crypto.ECDSASignatureSignerContext;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEConstants;
+import org.keycloak.jose.jwe.JWEHeader;
 import org.keycloak.jose.jwk.ECPublicJWK;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jwk.JWKParser;
 import org.keycloak.jose.jwk.RSAPublicJWK;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSBuilder;
@@ -63,11 +73,14 @@ import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcNonceRequest;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpDirectPostResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpRequestObjectResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.PreAuthorizedCodeGrantRequest;
 import org.keycloak.util.DPoPGenerator;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
@@ -279,6 +292,80 @@ public class OID4VCBasicWallet {
         keyBindingClaims.put("iat", Time.currentTimeSeconds());
         return SdJwtVP.of(sdJwtVc)
                 .present(null, true, keyBindingClaims, new ECDSASignatureSignerContext(holderKey));
+    }
+
+    public String requestUri(String walletUrl) {
+        Matcher matcher = Pattern.compile("request_uri=([^&]+)").matcher(walletUrl);
+        if (!matcher.find()) {
+            throw new IllegalStateException("Wallet link is missing request_uri: " + walletUrl);
+        }
+        return URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8);
+    }
+
+    public Oid4vpRequestObjectResponse fetchRequestObject(String requestUri) {
+        return oauth.oid4vc().doOid4vpRequestObjectRequest(requestUri);
+    }
+
+    public String present(OID4VCTestContext ctx, JsonNode request) {
+        return present(ctx, request, request.path("nonce").asText());
+    }
+
+    public String present(OID4VCTestContext ctx, JsonNode request, String nonce) {
+        String sdJwtVc = (String) ctx.getCredentialResponse().getCredentials().get(0).getCredential();
+        return present(sdJwtVc, getECKeyPair(ctx), request.path("client_id").asText(), nonce);
+    }
+
+    public Oid4vpDirectPostResponse directPost(JsonNode request, String vpToken) {
+        return oauth.oid4vc().oid4vpDirectPostRequest(request.path("response_uri").asText())
+                .vpToken(vpToken)
+                .state(request.path("state").asText())
+                .send();
+    }
+
+    public Oid4vpDirectPostResponse directPostJwt(JsonNode request, String encryptedResponse) {
+        return oauth.oid4vc().oid4vpDirectPostRequest(request.path("response_uri").asText())
+                .response(encryptedResponse)
+                .send();
+    }
+
+    public static JsonNode encryptionJwk(JsonNode request) {
+        return request.path("client_metadata").path("jwks").path("keys").path(0);
+    }
+
+    public String encryptedResponse(JsonNode request, String vpToken) {
+        JsonNode jwk = encryptionJwk(request);
+        return encryptResponse(request, vpToken, request.path("state").asText(), jwk, jwk.path("kid").asText());
+    }
+
+    // Encrypts as a HAIP wallet would (apv bound to the request nonce).
+    public String encryptResponse(JsonNode request, String vpToken, String state, JsonNode jwkNode, String kid) {
+        return encryptResponse(request, vpToken, state, jwkNode, kid, JWEConstants.A128GCM);
+    }
+
+    public String encryptResponse(JsonNode request, String vpToken, String state, JsonNode jwkNode, String kid,
+            String enc) {
+        try {
+            JWK jwk = JsonSerialization.mapper.convertValue(jwkNode, JWK.class);
+            PublicKey publicKey = JWKParser.create(jwk).toPublicKey();
+
+            ObjectNode payload = JsonSerialization.mapper.createObjectNode();
+            payload.put(OID4VCConstants.VP_TOKEN, vpToken);
+            payload.put("state", state);
+
+            JWEHeader header = JWEHeader.builder()
+                    .algorithm(JWEConstants.ECDH_ES)
+                    .encryptionAlgorithm(enc)
+                    .keyId(kid)
+                    .agreementPartyVInfo(Base64Url.encode(request.path("nonce").asText().getBytes(StandardCharsets.UTF_8)))
+                    .build();
+
+            JWE jwe = new JWE().header(header)
+                    .content(JsonSerialization.writeValueAsBytes(payload));
+            jwe.getKeyStorage().setEncryptionKey(publicKey);
+            return jwe.encodeJwe();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to encrypt the wallet response", e);
+        }
     }
 
     public KeyWrapper getECKeyPair(OID4VCTestContext ctx) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPDirectPostJwtTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPDirectPostJwtTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc.presentation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import jakarta.ws.rs.BadRequestException;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.tests.oid4vc.OID4VCBasicWallet;
+import org.keycloak.tests.oid4vc.OID4VCTestContext;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpDirectPostResponse;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the OID4VP wallet login for the encrypted {@code direct_post.jwt} response mode, where the
+ * wallet encrypts a JWE carrying the {@code vp_token} and {@code state} to the ephemeral key the
+ * verifier publishes in the request object client metadata, same device.
+ */
+@KeycloakIntegrationTest(config = PresentationServerConfig.class)
+public class OID4VPDirectPostJwtTest extends OID4VPVerifierTestBase {
+
+    @Override
+    @TestSetup
+    public void configureTestRealm() {
+        super.configureTestRealm();
+        createVerifierIdp(Map.of(
+                OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS, realmSigningJwks(),
+                OID4VPIdentityProviderConfig.DCQL_QUERY, dcqlQuery(),
+                OID4VPIdentityProviderConfig.RESPONSE_MODE, OID4VCConstants.RESPONSE_MODE_DIRECT_POST_JWT,
+                OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "email"));
+    }
+
+    @Test
+    public void requestObjectAdvertisesEncryptedResponseMode() throws Exception {
+        JsonNode request = requestObject();
+
+        Assertions.assertEquals("direct_post.jwt", request.path("response_mode").asText());
+        JsonNode metadata = request.path("client_metadata");
+        // HAIP requires advertising both A128GCM and A256GCM.
+        Assertions.assertEquals(List.of("A128GCM", "A256GCM"), JsonSerialization.mapper.convertValue(
+                metadata.path("encrypted_response_enc_values_supported"), List.class));
+
+        JsonNode jwk = OID4VCBasicWallet.encryptionJwk(request);
+        Assertions.assertEquals("EC", jwk.path("kty").asText());
+        Assertions.assertEquals("P-256", jwk.path("crv").asText());
+        Assertions.assertEquals("enc", jwk.path("use").asText());
+        Assertions.assertTrue(jwk.hasNonNull("kid"), "Ephemeral encryption key must carry a kid");
+        Assertions.assertTrue(jwk.hasNonNull("x") && jwk.hasNonNull("y"), "EC public key must expose x and y");
+    }
+
+    @Test
+    public void happyFlowDecryptsPresentationAndContinuesLogin() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+        Oid4vpDirectPostResponse response =
+                wallet.directPostJwt(request, wallet.encryptedResponse(request, wallet.present(credential, request)));
+        assertNotCacheable(response);
+
+        driver.open(response.getRedirectUri());
+        assertLoginContinued();
+    }
+
+    @Test
+    public void directPostRejectsUnencryptedPresentation() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+
+        // A plain post for a flow that promised encryption would be a downgrade.
+        Oid4vpDirectPostResponse response = wallet.directPost(request, wallet.present(credential, request));
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsMalformedEncryptedResponse() throws Exception {
+        JsonNode request = requestObject();
+
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, "not-a-jwe");
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsEncryptedResponseWithoutEncAlgorithm() throws Exception {
+        JsonNode request = requestObject();
+        String kid = OID4VCBasicWallet.encryptionJwk(request).path("kid").asText();
+
+        // A structurally valid JWE that names the issued key but omits the enc header.
+        String header = Base64Url.encode(("{\"alg\":\"ECDH-ES\",\"kid\":\"" + kid + "\"}")
+                .getBytes(StandardCharsets.UTF_8));
+        String jwe = header + ".." + Base64Url.encode(new byte[12]) + "." + Base64Url.encode(new byte[16])
+                + "." + Base64Url.encode(new byte[16]);
+
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, jwe);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsBlankVpTokenInEncryptedResponse() throws Exception {
+        JsonNode request = requestObject();
+
+        String encrypted = wallet.encryptResponse(request, "", request.path("state").asText(),
+                OID4VCBasicWallet.encryptionJwk(request), OID4VCBasicWallet.encryptionJwk(request).path("kid").asText());
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, encrypted);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsResponseEncryptedToWrongKey() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+        String kid = OID4VCBasicWallet.encryptionJwk(request).path("kid").asText();
+
+        // Encrypted to a different key than advertised while claiming the advertised kid, so the
+        // derived content key mismatches and decryption fails.
+        JWK wrongKey = JWKBuilder.create().kid(kid).algorithm("ECDH-ES")
+                .ec(KeyUtils.generateEcKeyPair("secp256r1").getPublic(), KeyUse.ENC);
+        String encrypted = wallet.encryptResponse(request, wallet.present(credential, request),
+                request.path("state").asText(), JsonSerialization.mapper.valueToTree(wrongKey), kid);
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, encrypted);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsContentEncryptionOutsideHaipSet() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+        JsonNode jwk = OID4VCBasicWallet.encryptionJwk(request);
+
+        // A192GCM is a valid JWE algorithm but outside the advertised HAIP pair.
+        String encrypted = wallet.encryptResponse(request, wallet.present(credential, request),
+                request.path("state").asText(), jwk, jwk.path("kid").asText(), "A192GCM");
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, encrypted);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsPresentationWithWrongNonce() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+
+        // The response decrypts, but the presentation then fails verification like a plain direct_post.
+        String encrypted = wallet.encryptedResponse(request, wallet.present(credential, request, "not-the-issued-nonce"));
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, encrypted);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("access_denied", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsUnknownEncryptionKey() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+
+        // Encrypted to a key id the verifier never issued.
+        String encrypted = wallet.encryptResponse(request, wallet.present(credential, request),
+                request.path("state").asText(), OID4VCBasicWallet.encryptionJwk(request), UUID.randomUUID().toString());
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, encrypted);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void invalidResponseModeIsRejectedOnUpdate() {
+        Assertions.assertThrows(BadRequestException.class,
+                () -> updateIdpConfig(OID4VPIdentityProviderConfig.RESPONSE_MODE, "fragment"));
+    }
+
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPVerifierTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPVerifierTestBase.java
@@ -18,7 +18,6 @@
 package org.keycloak.tests.oid4vc.presentation;
 
 import java.io.IOException;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
@@ -44,22 +43,19 @@ import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.KeysMetadataRepresentation;
 import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
-import org.keycloak.util.JsonSerialization;
+import org.keycloak.testsuite.util.oauth.AbstractHttpResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpRequestObjectResponse;
 import org.keycloak.util.KeyWrapperUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.http.Header;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
 
@@ -71,10 +67,20 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
     @InjectHttpClient
     protected CloseableHttpClient httpClient;
 
-    private String ecKeyComponentId;
+    // Static so the value set on the first test instance is visible to the later ones.
+    private static String ecKeyComponentId;
 
-    @BeforeEach
-    void addVerifierSigningKey() {
+    @Override
+    @TestSetup
+    public void configureTestRealm() {
+        super.configureTestRealm();
+        addVerifierSigningKey();
+        // The verifier enforces ES256, so the issued credential must be signed with it.
+        setCredentialScopeAttributes(requireExistingCredentialScope(sdJwtTypeCredentialScopeName),
+                Map.of(VC_SIGNING_ALG, Algorithm.ES256));
+    }
+
+    private void addVerifierSigningKey() {
         ComponentRepresentation keyProvider = new ComponentRepresentation();
         keyProvider.setName("oid4vp-verifier-signing-key");
         keyProvider.setParentId(testRealm.getId());
@@ -92,28 +98,17 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
             String location = response.getHeaderString("Location");
             ecKeyComponentId = location.substring(location.lastIndexOf('/') + 1);
         }
-        testRealm.cleanup().add(r -> r.components().component(ecKeyComponentId).remove());
     }
 
-    @BeforeEach
-    void signIssuedCredentialWithEs256() {
-        // The verifier enforces ES256, so the issued credential must be signed with it.
-        setCredentialScopeAttributes(sdJwtTypeCredentialScope, Map.of(VC_SIGNING_ALG, Algorithm.ES256));
-    }
-
-    protected record IssuedCredential(String sdJwtVc, KeyWrapper holderKey) {
-    }
-
-    protected IssuedCredential issueCredential() {
+    protected OID4VCTestContext issueCredential() {
         OID4VCTestContext ctx = new OID4VCTestContext(client, sdJwtTypeCredentialScope);
         wallet.fetchCredentialByScope(ctx, ctx.getScope());
-        String sdJwtVc = (String) ctx.getCredentialResponse().getCredentials().get(0).getCredential();
-        Assertions.assertNotNull(sdJwtVc, "No SD-JWT VC issued");
-        IssuedCredential credential = new IssuedCredential(sdJwtVc, wallet.getECKeyPair(ctx));
+        Assertions.assertNotNull(ctx.getCredentialResponse().getCredentials().get(0).getCredential(),
+                "No SD-JWT VC issued");
         wallet.logout();
         driver.cookies().deleteAll();
         driver.open("about:blank");
-        return credential;
+        return ctx;
     }
 
     protected void createVerifierIdp(Map<String, String> config) {
@@ -125,7 +120,26 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
         try (Response response = testRealm.admin().identityProviders().create(idp)) {
             Assertions.assertEquals(201, response.getStatus(), "Failed to create OID4VP identity provider");
         }
-        testRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
+    }
+
+    protected static String dcqlQuery() {
+        return """
+                {
+                  "credentials": [
+                    {
+                      "id": "identity",
+                      "format": "dc+sd-jwt",
+                      "meta": { "vct_values": ["%s"] },
+                      "claims": [{ "path": ["email"] }, { "path": ["lastName"] }]
+                    }
+                  ]
+                }""".formatted(sdJwtTypeCredentialVct);
+    }
+
+    protected void assertLoginContinued() {
+        // TODO assert the presented claims (email, given and family name) were mapped to the user
+        Assertions.assertTrue(driver.driver().getCurrentUrl().contains("login-actions"),
+                "Expected to continue into the login flow, was: " + driver.driver().getCurrentUrl());
     }
 
     protected String realmSigningJwks() {
@@ -138,33 +152,18 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
         }
     }
 
-    // Wallet exchange -------------------------------------------------------------------------------------------------
-
-    protected JsonNode requestObject() throws Exception {
-        return requestObjectClaims(requestUri(openWalletPage()));
+    protected JsonNode requestObject() {
+        Oid4vpRequestObjectResponse response = wallet.fetchRequestObject(wallet.requestUri(openWalletPage()));
+        assertNotCacheable(response);
+        return response.getClaims();
     }
 
-    protected String present(IssuedCredential credential, JsonNode request) {
-        return present(credential, request, request.path("nonce").asText());
-    }
-
-    protected String present(IssuedCredential credential, JsonNode request, String nonce) {
-        return wallet.present(credential.sdJwtVc(), credential.holderKey(),
-                request.path("client_id").asText(), nonce);
-    }
-
-    protected JsonNode directPost(JsonNode request, String vpToken, int expectedStatus) throws IOException {
-        HttpPost post = new HttpPost(request.path("response_uri").asText());
-        post.setEntity(new UrlEncodedFormEntity(List.of(
-                new BasicNameValuePair("vp_token", vpToken),
-                new BasicNameValuePair("state", request.path("state").asText()))));
-        try (CloseableHttpResponse response = httpClient.execute(post)) {
-            int status = response.getStatusLine().getStatusCode();
-            JsonNode body = JsonSerialization.readValue(EntityUtils.toByteArray(response.getEntity()), JsonNode.class);
-            Assertions.assertEquals(expectedStatus, status, "Unexpected direct_post status, body: " + body);
-            assertNotCacheable(response);
-            return body;
-        }
+    // Wallet facing responses carry login correlating secrets and must not be cacheable.
+    protected static void assertNotCacheable(AbstractHttpResponse response) {
+        String cacheControl = response.getHeader("Cache-Control");
+        Assertions.assertNotNull(cacheControl, "Wallet facing responses must send Cache-Control");
+        Assertions.assertTrue(cacheControl.contains("no-store"),
+                "Wallet facing responses must not be cacheable, was: " + cacheControl);
     }
 
     protected static boolean verifyEs256(JWSInput jws, X509Certificate certificate) throws Exception {
@@ -219,17 +218,12 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
     }
 
     protected void updateIdpConfig(String key, String value) {
-        var idpResource = testRealm.admin().identityProviders().get(IDP_ALIAS);
-        IdentityProviderRepresentation idp = idpResource.toRepresentation();
-        idp.getConfig().put(key, value);
-        idpResource.update(idp);
+        testRealm.updateIdentityProvider(IDP_ALIAS, idp -> idp.getConfig().put(key, value));
     }
 
     protected void disableVerifierSigningKey() {
-        var componentResource = testRealm.admin().components().component(ecKeyComponentId);
-        ComponentRepresentation component = componentResource.toRepresentation();
-        component.getConfig().putSingle(Attributes.ENABLED_KEY, "false");
-        componentResource.update(component);
+        testRealm.updateComponent(ecKeyComponentId,
+                component -> component.getConfig().putSingle(Attributes.ENABLED_KEY, "false"));
     }
 
     protected String verifierSigningKeyKid() {
@@ -247,29 +241,4 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
                 .orElseThrow(() -> new IllegalStateException("Verifier signing key not found in the realm keys"));
     }
 
-    protected static String requestUri(String walletUrl) {
-        Matcher matcher = Pattern.compile("request_uri=([^&]+)").matcher(walletUrl);
-        Assertions.assertTrue(matcher.find(), "Wallet link is missing request_uri: " + walletUrl);
-        return URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8);
-    }
-
-    protected JsonNode requestObjectClaims(String requestUri) throws Exception {
-        return JsonSerialization.readValue(new JWSInput(fetchRequestObject(requestUri)).getContent(), JsonNode.class);
-    }
-
-    protected String fetchRequestObject(String requestUri) throws IOException {
-        try (CloseableHttpResponse response = httpClient.execute(new HttpGet(requestUri))) {
-            Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
-            assertNotCacheable(response);
-            return EntityUtils.toString(response.getEntity());
-        }
-    }
-
-    // Wallet facing responses carry login correlating secrets and must not be cacheable.
-    protected static void assertNotCacheable(CloseableHttpResponse response) {
-        Header cacheControl = response.getFirstHeader("Cache-Control");
-        Assertions.assertNotNull(cacheControl, "Wallet facing responses must send Cache-Control");
-        Assertions.assertTrue(cacheControl.getValue().contains("no-store"),
-                "Wallet facing responses must not be cacheable, was: " + cacheControl.getValue());
-    }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPX509HashDirectPostTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPX509HashDirectPostTest.java
@@ -24,20 +24,23 @@ import java.util.UUID;
 
 import org.keycloak.OID4VCConstants;
 import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.tests.oid4vc.OID4VCTestContext;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpDirectPostResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpRequestObjectResponse;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
@@ -50,31 +53,19 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
 @KeycloakIntegrationTest(config = PresentationServerConfig.class)
 public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
 
-    @BeforeEach
-    void registerVerifier() {
+    @Override
+    @TestSetup
+    public void configureTestRealm() {
+        super.configureTestRealm();
         createVerifierIdp(Map.of(
                 OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS, realmSigningJwks(),
                 OID4VPIdentityProviderConfig.DCQL_QUERY, dcqlQuery(),
                 OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "email"));
     }
 
-    private static String dcqlQuery() {
-        return """
-                {
-                  "credentials": [
-                    {
-                      "id": "identity",
-                      "format": "dc+sd-jwt",
-                      "meta": { "vct_values": ["%s"] },
-                      "claims": [{ "path": ["email"] }, { "path": ["lastName"] }]
-                    }
-                  ]
-                }""".formatted(sdJwtTypeCredentialVct);
-    }
-
     @Test
     public void requestObjectIsSignedByRealmKeyAndWellFormed() throws Exception {
-        JWSInput signedRequest = new JWSInput(fetchRequestObject(requestUri(openWalletPage())));
+        JWSInput signedRequest = new JWSInput(wallet.fetchRequestObject(wallet.requestUri(openWalletPage())).getRequestObject());
 
         JWSHeader header = signedRequest.getHeader();
         Assertions.assertEquals(OID4VCConstants.REQUEST_OBJECT_TYPE, header.getType());
@@ -95,19 +86,20 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
 
     @Test
     public void happyFlowVerifiesPresentationAndContinuesLogin() throws Exception {
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
-        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+        Oid4vpDirectPostResponse response = wallet.directPost(request, wallet.present(credential, request));
+        assertNotCacheable(response);
 
-        driver.open(completeAuth);
+        driver.open(response.getRedirectUri());
         assertLoginContinued();
     }
 
     @Test
     public void completeAuthRejectsUnknownResponseCode() throws Exception {
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
-        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+        String completeAuth = wallet.directPost(request, wallet.present(credential, request)).getRedirectUri();
 
         driver.open(completeAuth.replaceAll("response_code=[^&]+", "response_code=" + UUID.randomUUID()));
         assertLoginRejected();
@@ -115,9 +107,9 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
 
     @Test
     public void completeAuthRejectsMismatchedBrowserSession() throws Exception {
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
-        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+        String completeAuth = wallet.directPost(request, wallet.present(credential, request)).getRedirectUri();
 
         driver.cookies().deleteAll();
         driver.open(completeAuth);
@@ -126,9 +118,9 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
 
     @Test
     public void completeAuthResponseCodeIsSingleUse() throws Exception {
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
-        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+        String completeAuth = wallet.directPost(request, wallet.present(credential, request)).getRedirectUri();
 
         driver.open(completeAuth);
         assertLoginContinued();
@@ -138,46 +130,45 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
 
     @Test
     public void directPostRejectsPresentationWithWrongNonce() throws Exception {
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
 
-        JsonNode body = directPost(request, present(credential, request, "not-the-issued-nonce"), 400);
-        Assertions.assertEquals("access_denied", body.path("error").asText());
+        Oid4vpDirectPostResponse response = wallet.directPost(request, wallet.present(credential, request, "not-the-issued-nonce"));
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("access_denied", response.getError());
     }
 
     @Test
     public void requestObjectRejectsUnknownState() throws Exception {
-        String unknownStateUri = requestUri(openWalletPage()).replaceAll("[^/]+$", UUID.randomUUID().toString());
+        String unknownStateUri = wallet.requestUri(openWalletPage()).replaceAll("[^/]+$", UUID.randomUUID().toString());
 
-        try (CloseableHttpResponse response = httpClient.execute(new HttpGet(unknownStateUri))) {
-            Assertions.assertEquals(400, response.getStatusLine().getStatusCode());
-            JsonNode body = JsonSerialization.readValue(EntityUtils.toByteArray(response.getEntity()), JsonNode.class);
-            Assertions.assertEquals("invalid_request", body.path("error").asText());
-        }
+        Oid4vpRequestObjectResponse response = wallet.fetchRequestObject(unknownStateUri);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
     }
 
     @Test
     public void directPostRejectsMissingParameters() throws Exception {
         JsonNode request = requestObject();
 
-        HttpPost post = new HttpPost(request.path("response_uri").asText());
-        try (CloseableHttpResponse response = httpClient.execute(post)) {
-            Assertions.assertEquals(400, response.getStatusLine().getStatusCode());
-            JsonNode body = JsonSerialization.readValue(EntityUtils.toByteArray(response.getEntity()), JsonNode.class);
-            Assertions.assertEquals("invalid_request", body.path("error").asText());
-        }
+        Oid4vpDirectPostResponse response = oauth.oid4vc()
+                .oid4vpDirectPostRequest(request.path("response_uri").asText()).send();
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
     }
 
     @Test
     public void directPostRejectsUnsupportedSignatureAlgorithm() throws Exception {
-        setCredentialScopeAttributes(sdJwtTypeCredentialScope, Map.of(VC_SIGNING_ALG, Algorithm.RS256));
-        IssuedCredential credential = issueCredential();
+        testRealm.updateClientScope(sdJwtTypeCredentialScope.getId(),
+                scope -> scope.attribute(VC_SIGNING_ALG, Algorithm.RS256));
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
 
-        JsonNode body = directPost(request, present(credential, request), 400);
-        Assertions.assertEquals("access_denied", body.path("error").asText());
-        Assertions.assertTrue(body.path("error_description").asText().contains("algorithm"),
-                "Expected an unsupported algorithm error, was: " + body);
+        Oid4vpDirectPostResponse response = wallet.directPost(request, wallet.present(credential, request));
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("access_denied", response.getError());
+        Assertions.assertTrue(response.getErrorDescription().contains("algorithm"),
+                "Expected an unsupported algorithm error, was: " + response.getErrorDescription());
     }
 
     @Test
@@ -191,12 +182,12 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
 
     @Test
     public void configuredSigningKeyIdPinsTheRequestSigningKey() throws Exception {
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         updateIdpConfig(OID4VPIdentityProviderConfig.SIGNING_KEY_ID, verifierSigningKeyKid());
         disableVerifierSigningKey();
         addActiveEs256KeyWithoutCertificate();
 
-        JWSInput signedRequest = new JWSInput(fetchRequestObject(requestUri(openWalletPage())));
+        JWSInput signedRequest = new JWSInput(wallet.fetchRequestObject(wallet.requestUri(openWalletPage())).getRequestObject());
         X509Certificate leaf = PemUtils.decodeCertificate(signedRequest.getHeader().getX5c().get(0));
         Assertions.assertEquals(verifierSigningKeyPublicKeyPem(), PemUtils.encodeKey(leaf.getPublicKey()),
                 "Request object is not signed with the pinned signing key");
@@ -204,7 +195,7 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
                 "Request object signature does not match the certificate in x5c");
 
         JsonNode request = JsonSerialization.readValue(signedRequest.getContent(), JsonNode.class);
-        String completeAuth = directPost(request, present(credential, request), 200).path("redirect_uri").asText();
+        String completeAuth = wallet.directPost(request, wallet.present(credential, request)).getRedirectUri();
 
         driver.open(completeAuth);
         assertLoginContinued();
@@ -220,13 +211,31 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
     }
 
     @Test
-    public void directPostRejectsMultipleCredentials() throws Exception {
-        IssuedCredential credential = issueCredential();
+    public void directPostRejectsEncryptedResponseForPlainFlow() throws Exception {
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
-        String vpToken = present(credential, request);
+        String state = request.path("state").asText();
 
-        JsonNode body = directPost(request, "[\"" + vpToken + "\",\"" + vpToken + "\"]", 400);
-        Assertions.assertEquals("access_denied", body.path("error").asText());
+        // The flow never advertised an encryption key, so a JWE naming its state as kid must not
+        // resolve one.
+        JWK attackerKey = JWKBuilder.create().kid(state).algorithm("ECDH-ES")
+                .ec(KeyUtils.generateEcKeyPair("secp256r1").getPublic(), KeyUse.ENC);
+        String encrypted = wallet.encryptResponse(request, wallet.present(credential, request), state,
+                JsonSerialization.mapper.valueToTree(attackerKey), state);
+        Oid4vpDirectPostResponse response = wallet.directPostJwt(request, encrypted);
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("invalid_request", response.getError());
+    }
+
+    @Test
+    public void directPostRejectsMultipleCredentials() throws Exception {
+        OID4VCTestContext credential = issueCredential();
+        JsonNode request = requestObject();
+        String vpToken = wallet.present(credential, request);
+
+        Oid4vpDirectPostResponse response = wallet.directPost(request, "[\"" + vpToken + "\",\"" + vpToken + "\"]");
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("access_denied", response.getError());
     }
 
     @Test
@@ -234,19 +243,14 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
         // address is an object claim, so configuring it as the principal must be rejected rather than
         // mapped onto an empty user id.
         updatePrincipalAttribute("address");
-        IssuedCredential credential = issueCredential();
+        OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
 
-        JsonNode body = directPost(request, present(credential, request), 400);
-        Assertions.assertEquals("access_denied", body.path("error").asText());
-        Assertions.assertTrue(body.path("error_description").asText().contains("principal attribute"),
-                "Expected a principal attribute error, was: " + body);
-    }
-
-    private void assertLoginContinued() {
-        // TODO assert the presented claims (email, given and family name) were mapped to the user
-        Assertions.assertTrue(driver.driver().getCurrentUrl().contains("login-actions"),
-                "Expected to continue into the login flow, was: " + driver.driver().getCurrentUrl());
+        Oid4vpDirectPostResponse response = wallet.directPost(request, wallet.present(credential, request));
+        Assertions.assertEquals(400, response.getStatusCode());
+        Assertions.assertEquals("access_denied", response.getError());
+        Assertions.assertTrue(response.getErrorDescription().contains("principal attribute"),
+                "Expected a principal attribute error, was: " + response.getErrorDescription());
     }
 
     private void assertLoginRejected() {

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierEncryptedInvalidKbJwtNonceTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierEncryptedInvalidKbJwtNonceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier rejects a key binding JWT carrying the wrong nonce, presented as an encrypted
+ * {@code direct_post.jwt} response.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierEncryptedInvalidKbJwtNonceTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpEncryptedConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post.jwt"),
+                "oid4vp-1final-verifier-invalid-kb-jwt-nonce");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierEncryptedSameDeviceHappyFlowTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VerifierEncryptedSameDeviceHappyFlowTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+/**
+ * The verifier accepts a valid same device SD-JWT VC presentation returned as an encrypted
+ * {@code direct_post.jwt} response.
+ */
+@KeycloakIntegrationTest(config = VpConformanceRealmConfig.ServerConfig.class)
+public class VerifierEncryptedSameDeviceHappyFlowTest extends AbstractVpConformanceTest {
+
+    @InjectRealm(config = VpEncryptedConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vp-1final-verifier-test-plan",
+                Map.of(
+                        "vp_profile", "plain_vp",
+                        "credential_format", "sd_jwt_vc",
+                        "client_id_prefix", "x509_hash",
+                        "request_method", "request_uri_signed",
+                        "response_mode", "direct_post.jwt"),
+                "oid4vp-1final-verifier-happy-flow");
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpConformanceRealmConfig.java
@@ -80,11 +80,16 @@ public class VpConformanceRealmConfig implements RealmConfig {
         idp.setProviderId(OID4VPIdentityProviderFactory.PROVIDER_ID);
         idp.setEnabled(true);
         idp.setFirstBrokerLoginFlowAlias("first broker login");
-        idp.setConfig(Map.of(
+        idp.setConfig(idpConfig());
+        return idp;
+    }
+
+    // Overridable so the encrypted direct_post.jwt variant can enable response encryption.
+    protected Map<String, String> idpConfig() {
+        return Map.of(
                 OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS, VpVerifierKey.publicJwks().toString(),
                 OID4VPIdentityProviderConfig.DCQL_QUERY, DCQL_QUERY,
-                OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "given_name"));
-        return idp;
+                OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "given_name");
     }
 
     // The verifier's request-signing key, holding the CA-issued certificate the suite trusts.

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpEncryptedConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpEncryptedConformanceRealmConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+
+/**
+ * The verifier realm for the encrypted {@code direct_post.jwt} response mode: same as the plain
+ * verifier but with the OID4VP identity provider configured to require encrypted responses.
+ */
+public class VpEncryptedConformanceRealmConfig extends VpConformanceRealmConfig {
+
+    @Override
+    protected Map<String, String> idpConfig() {
+        Map<String, String> config = new HashMap<>(super.idpConfig());
+        config.put(OID4VPIdentityProviderConfig.RESPONSE_MODE, OID4VCConstants.RESPONSE_MODE_DIRECT_POST_JWT);
+        return config;
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/OID4VCClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/OID4VCClient.java
@@ -60,4 +60,16 @@ public class OID4VCClient {
     public Oid4vcNonceResponse doNonceRequest() {
         return nonceRequest().send();
     }
+
+    public Oid4vpRequestObjectRequest oid4vpRequestObjectRequest(String requestUri) {
+        return new Oid4vpRequestObjectRequest(client, requestUri);
+    }
+
+    public Oid4vpRequestObjectResponse doOid4vpRequestObjectRequest(String requestUri) {
+        return oid4vpRequestObjectRequest(requestUri).send();
+    }
+
+    public Oid4vpDirectPostRequest oid4vpDirectPostRequest(String responseUri) {
+        return new Oid4vpDirectPostRequest(client, responseUri);
+    }
 }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpDirectPostRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpDirectPostRequest.java
@@ -1,0 +1,56 @@
+package org.keycloak.testsuite.util.oauth.oid4vc;
+
+import java.io.IOException;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OID4VCConstants;
+import org.keycloak.testsuite.util.oauth.AbstractHttpPostRequest;
+import org.keycloak.testsuite.util.oauth.AbstractOAuthClient;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class Oid4vpDirectPostRequest extends AbstractHttpPostRequest<Oid4vpDirectPostRequest, Oid4vpDirectPostResponse> {
+
+    private final String responseUri;
+    private String vpToken;
+    private String state;
+    private String response;
+
+    public Oid4vpDirectPostRequest(AbstractOAuthClient<?> client, String responseUri) {
+        super(client);
+        this.responseUri = responseUri;
+    }
+
+    public Oid4vpDirectPostRequest vpToken(String vpToken) {
+        this.vpToken = vpToken;
+        return this;
+    }
+
+    public Oid4vpDirectPostRequest state(String state) {
+        this.state = state;
+        return this;
+    }
+
+    // The encrypted direct_post.jwt response parameter (a compact JWE)
+    public Oid4vpDirectPostRequest response(String response) {
+        this.response = response;
+        return this;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return responseUri;
+    }
+
+    @Override
+    protected void initRequest() {
+        parameter(OID4VCConstants.VP_TOKEN, vpToken);
+        parameter(OAuth2Constants.STATE, state);
+        parameter(OAuth2Constants.RESPONSE, response);
+    }
+
+    @Override
+    protected Oid4vpDirectPostResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new Oid4vpDirectPostResponse(response);
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpDirectPostResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpDirectPostResponse.java
@@ -1,0 +1,31 @@
+package org.keycloak.testsuite.util.oauth.oid4vc;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.testsuite.util.oauth.AbstractHttpResponse;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class Oid4vpDirectPostResponse extends AbstractHttpResponse {
+
+    private ObjectNode body;
+
+    public Oid4vpDirectPostResponse(CloseableHttpResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void parseContent() throws IOException {
+        body = asJson();
+    }
+
+    // The browser url that finishes the login after a verified presentation
+    public String getRedirectUri() {
+        return Optional.ofNullable(body)
+                .map(node -> node.path(OAuth2Constants.REDIRECT_URI).textValue())
+                .orElseThrow(() -> new IllegalStateException(String.format("[%s] %s", getError(), getErrorDescription())));
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpRequestObjectRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpRequestObjectRequest.java
@@ -1,0 +1,33 @@
+package org.keycloak.testsuite.util.oauth.oid4vc;
+
+import java.io.IOException;
+
+import org.keycloak.testsuite.util.oauth.AbstractHttpGetRequest;
+import org.keycloak.testsuite.util.oauth.AbstractOAuthClient;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class Oid4vpRequestObjectRequest extends AbstractHttpGetRequest<Oid4vpRequestObjectRequest, Oid4vpRequestObjectResponse> {
+
+    private final String requestUri;
+
+    public Oid4vpRequestObjectRequest(AbstractOAuthClient<?> client, String requestUri) {
+        super(client);
+        this.requestUri = requestUri;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return requestUri;
+    }
+
+    @Override
+    protected void initRequest() {
+        header("Accept", "application/oauth-authz-req+jwt");
+    }
+
+    @Override
+    protected Oid4vpRequestObjectResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new Oid4vpRequestObjectResponse(response);
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpRequestObjectResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vpRequestObjectResponse.java
@@ -1,0 +1,42 @@
+package org.keycloak.testsuite.util.oauth.oid4vc;
+
+import java.io.IOException;
+
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.testsuite.util.oauth.AbstractHttpResponse;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class Oid4vpRequestObjectResponse extends AbstractHttpResponse {
+
+    private String requestObject;
+
+    public Oid4vpRequestObjectResponse(CloseableHttpResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void parseContent() throws IOException {
+        requestObject = asString();
+    }
+
+    // The compact JWS of the signed authorization request object
+    public String getRequestObject() {
+        if (requestObject == null) {
+            throw new IllegalStateException(String.format("[%s] %s", getError(), getErrorDescription()));
+        }
+        return requestObject;
+    }
+
+    // The OID4VP authorization request parameters
+    public JsonNode getClaims() {
+        try {
+            return JsonSerialization.readValue(new JWSInput(getRequestObject()).getContent(), JsonNode.class);
+        } catch (IOException | JWSInputException e) {
+            throw new IllegalStateException("Failed to parse the request object", e);
+        }
+    }
+}


### PR DESCRIPTION
@rmartinc @vaceksimon 

Closes #50644

## Conformance results

Single run on the final state of this branch. Common variant:
`credential_format=sd_jwt_vc`, `client_id_prefix=x509_hash`, `request_method=request_uri_signed`.

### Plan `oid4vp-1final-verifier-test-plan`

| Variant | Modules | Result |
|---|---|---|
| `vp_profile=plain_vp`, `response_mode=direct_post` | happy-flow, minimal-cnf-jwk, invalid-kb-jwt-{signature, nonce, aud}, invalid-credential-signature, invalid-sd-hash, kb-jwt-iat-in-{past, future} | 9 passed |
| `vp_profile=plain_vp`, `response_mode=direct_post.jwt` | happy-flow, invalid-kb-jwt-nonce | 2 passed |

### Plan `oid4vp-1final-verifier-haip-test-plan` (new in 5.2.0, mandates `direct_post.jwt`)

Ran locally, has to be implemented in main as soon as the suite version has been bumped (see #51060 )

| Variant | Modules | Result |
|---|---|---|
| `response_mode=direct_post.jwt` (`vp_profile=haip`) | same 9 modules as the plain plan | 9 passed |

**Totals: 20 modules passed, 0 failed, 2 disabled.**

Disabled (`@Disabled` with TODO, same module in both plans): `verifier-request-uri-method-post` —
request_uri retrieval via POST is not implemented, the request object endpoint answers GET only.
These can be enabled as soon as #50661 is implemented.

Not run (plan variants for unimplemented features): `credential_format=iso_mdl`,
`client_id_prefix=x509_san_dns|redirect_uri`, `request_method=url_query`.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
