### PR TITLE
feat(email): support CID inline images in HTML emails

### DIFF
--- a/docs/guides/ui-customization/themes.adoc
+++ b/docs/guides/ui-customization/themes.adoc
@@ -344,6 +344,19 @@ To reference images from common theme resources in email templates, use `url.res
 
 NOTE: Email clients require absolute URLs for images since they cannot resolve relative paths. Use `url.resourcesCommonUrl` or `url.resourcesUrl` instead of their `Path` counterparts (`url.resourcesCommonPath`, `url.resourcesPath`) in email templates.
 
+Alternatively, you can embed images inline using `cid:` references. {project_name} loads the matching file from the email theme resources directory and attaches it to the email as a MIME inline part. This works without external URLs and displays even when email clients block remote images.
+
+To embed an image from `themes/mytheme/email/resources/img/logo.png`, add the following to a custom HTML template:
+
+[source,html]
+----
+<img src="cid:img/logo.png" alt="My logo">
+----
+
+The path in the `cid:` reference is relative to the `email/resources/` directory of the theme. Use the same path you would pass to theme resources, for example `img/logo.png` for a file stored in `email/resources/img/logo.png`.
+
+NOTE: `cid:` references must be quoted in HTML attributes (for example `src="cid:img/logo.png"` or `url('cid:img/bg.png')` in CSS).
+
 [[custom-identity-providers-icons]]
 === Adding custom Identity Providers icons
 

--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -323,11 +323,20 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
         if (htmlBody == null) {
             return null;
         }
-        String resolved = htmlBody;
-        for (Map.Entry<String, String> entry : pathToContentId.entrySet()) {
-            resolved = resolved.replace("cid:" + entry.getKey(), "cid:" + entry.getValue());
+        Matcher matcher = CID_PATTERN.matcher(htmlBody);
+        StringBuilder resolved = new StringBuilder();
+        while (matcher.find()) {
+            String path = matcher.group(1);
+            String contentId = pathToContentId.get(path);
+            if (contentId != null) {
+                char quote = matcher.group().charAt(0);
+                matcher.appendReplacement(resolved, Matcher.quoteReplacement(quote + "cid:" + contentId + quote));
+            } else {
+                matcher.appendReplacement(resolved, Matcher.quoteReplacement(matcher.group()));
+            }
         }
-        return resolved;
+        matcher.appendTail(resolved);
+        return resolved.toString();
     }
 
     static String fileNameFor(String path) {

--- a/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/DefaultEmailSenderProvider.java
@@ -17,14 +17,23 @@
 
 package org.keycloak.email;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
+import jakarta.activation.DataHandler;
 import jakarta.mail.Address;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -37,11 +46,14 @@ import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.internet.MimeUtility;
+import jakarta.mail.util.ByteArrayDataSource;
 
 import org.keycloak.common.enums.HostnameVerificationPolicy;
+import org.keycloak.common.util.MimeTypeUtil;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.theme.Theme;
 import org.keycloak.truststore.JSSETruststoreConfigurator;
 import org.keycloak.utils.EmailValidationUtil;
 import org.keycloak.utils.SMTPUtil;
@@ -57,6 +69,7 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
 
     private static final Logger logger = Logger.getLogger(DefaultEmailSenderProvider.class);
     private static final String SUPPORTED_SSL_PROTOCOLS = getSupportedSslProtocols();
+    private static final Pattern CID_PATTERN = Pattern.compile("[\"']cid:(.*?)[\"']");
 
     private final Map<EmailAuthenticator.AuthenticatorType, EmailAuthenticator> authenticators;
 
@@ -201,25 +214,125 @@ public class DefaultEmailSenderProvider implements EmailSenderProvider {
     }
 
     private Multipart buildMultipartBody(String textBody, String htmlBody) throws EmailException {
-        Multipart multipart = new MimeMultipart("alternative");
+        Theme theme = null;
+        if (htmlBody != null && session != null && !extractCidReferences(htmlBody).isEmpty()) {
+            try {
+                theme = session.theme().getTheme(Theme.Type.EMAIL);
+            } catch (IOException e) {
+                throw new EmailException("Failed to load email theme for embedded resources", e);
+            }
+        }
+        return buildMultipartBody(textBody, htmlBody, theme);
+    }
+
+    Multipart buildMultipartBody(String textBody, String htmlBody, Theme theme) throws EmailException {
+        Set<String> paths = extractCidReferences(htmlBody);
+        Map<String, String> pathToContentId = contentIdsFor(paths);
+        String resolvedHtml = paths.isEmpty() ? htmlBody : rewriteCidReferences(htmlBody, pathToContentId);
 
         try {
+            MimeMultipart alternative = new MimeMultipart("alternative");
+
             if (textBody != null) {
                 MimeBodyPart textPart = new MimeBodyPart();
                 textPart.setText(textBody, "UTF-8");
-                multipart.addBodyPart(textPart);
+                alternative.addBodyPart(textPart);
             }
 
-            if (htmlBody != null) {
+            if (resolvedHtml != null) {
                 MimeBodyPart htmlPart = new MimeBodyPart();
-                htmlPart.setContent(htmlBody, "text/html; charset=UTF-8");
-                multipart.addBodyPart(htmlPart);
+                htmlPart.setContent(resolvedHtml, "text/html; charset=UTF-8");
+                alternative.addBodyPart(htmlPart);
             }
-        } catch (MessagingException e) {
-            throw new EmailException("Error encoding email body parts", e);
+
+            if (paths.isEmpty() || theme == null) {
+                return alternative;
+            }
+
+            // RFC 2387 / RFC 2557 (MHTML): related root, alternative + inline images as siblings
+            MimeMultipart related = new MimeMultipart("related");
+
+            MimeBodyPart alternativePart = new MimeBodyPart();
+            alternativePart.setContent(alternative);
+            related.addBodyPart(alternativePart);
+
+            for (String path : paths) {
+                String contentId = pathToContentId.get(path);
+                try (InputStream inputStream = theme.getResourceAsStream(path)) {
+                    if (inputStream == null) {
+                        logger.warnf("Embedded email resource not found in theme: %s", path);
+                        continue;
+                    }
+
+                    byte[] bytes = inputStream.readAllBytes();
+                    String mimeType = MimeTypeUtil.getContentType(path);
+                    if (mimeType == null) {
+                        mimeType = "application/octet-stream";
+                    }
+
+                    MimeBodyPart imagePart = new MimeBodyPart();
+                    imagePart.setDataHandler(new DataHandler(new ByteArrayDataSource(bytes, mimeType)));
+                    imagePart.setHeader("Content-ID", "<" + contentId + ">");
+                    imagePart.setDisposition(MimeBodyPart.INLINE);
+                    imagePart.setFileName(fileNameFor(path));
+                    related.addBodyPart(imagePart);
+                }
+            }
+
+            return related;
+        } catch (IOException | MessagingException e) {
+            throw new EmailException("Error embedding email resources", e);
+        }
+    }
+
+    static Set<String> extractCidReferences(String htmlBody) {
+        Set<String> paths = new HashSet<>();
+        if (htmlBody == null) {
+            return paths;
+        }
+        Matcher matcher = CID_PATTERN.matcher(htmlBody);
+        while (matcher.find()) {
+            paths.add(matcher.group(1));
+        }
+        return paths;
+    }
+
+    /**
+     * Maps theme paths to URL-safe Content-IDs (filename only, no slashes).
+     * RFC 2392: cid URLs are matched against Content-ID headers; many clients reject slashes in IDs.
+     */
+    static Map<String, String> contentIdsFor(Set<String> paths) {
+        Map<String, String> pathToContentId = new LinkedHashMap<>();
+        Map<String, String> usedIds = new HashMap<>();
+
+        for (String path : paths) {
+            String baseId = fileNameFor(path);
+            String contentId = baseId;
+            int suffix = 2;
+            while (usedIds.containsKey(contentId)) {
+                contentId = baseId + "-" + suffix++;
+            }
+            usedIds.put(contentId, path);
+            pathToContentId.put(path, contentId);
         }
 
-        return multipart;
+        return pathToContentId;
+    }
+
+    static String rewriteCidReferences(String htmlBody, Map<String, String> pathToContentId) {
+        if (htmlBody == null) {
+            return null;
+        }
+        String resolved = htmlBody;
+        for (Map.Entry<String, String> entry : pathToContentId.entrySet()) {
+            resolved = resolved.replace("cid:" + entry.getKey(), "cid:" + entry.getValue());
+        }
+        return resolved;
+    }
+
+    static String fileNameFor(String path) {
+        int slash = path.lastIndexOf('/');
+        return slash >= 0 ? path.substring(slash + 1) : path;
     }
 
     private EmailAuthenticator selectAuthenticatorBasedOnConfig(Map<String, String> config) {

--- a/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
@@ -1,13 +1,29 @@
 package org.keycloak.email;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+
+import jakarta.mail.BodyPart;
+import jakarta.mail.Multipart;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMultipart;
+
+import org.keycloak.models.RealmModel;
+import org.keycloak.theme.Theme;
 
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -81,5 +97,151 @@ class DefaultEmailSenderProviderTest {
 
         // then
         assertThat(exception.getMessage(), containsString("Invalid reply-to address"));
+    }
+
+    @Test
+    void testExtractCidReferences() {
+        String html = "<html><body><img src=\"cid:img/logo.png\" /><div style=\"background: url('cid:img/bg.png')\"></div></body></html>";
+
+        Set<String> paths = DefaultEmailSenderProvider.extractCidReferences(html);
+
+        assertThat(paths.size(), is(2));
+        assertThat(paths.contains("img/logo.png"), is(true));
+        assertThat(paths.contains("img/bg.png"), is(true));
+    }
+
+    @Test
+    void testContentIdsForUsesFileNameAndHandlesCollisions() {
+        Set<String> paths = new LinkedHashSet<>();
+        paths.add("assets/logo.png");
+        paths.add("other/logo.png");
+
+        Map<String, String> ids = DefaultEmailSenderProvider.contentIdsFor(paths);
+
+        assertThat(ids.get("assets/logo.png"), is("logo.png"));
+        assertThat(ids.get("other/logo.png"), is("logo.png-2"));
+    }
+
+    @Test
+    void testRewriteCidReferences() {
+        String html = "<img src=\"cid:assets/logo.png\" />";
+        Map<String, String> mapping = Map.of("assets/logo.png", "logo.png");
+
+        String resolved = DefaultEmailSenderProvider.rewriteCidReferences(html, mapping);
+
+        assertThat(resolved, is("<img src=\"cid:logo.png\" />"));
+    }
+
+    @Test
+    void testBuildMultipartBodyWithoutCidReferences() throws Exception {
+        DefaultEmailSenderProvider provider = new DefaultEmailSenderProvider(null, null);
+
+        Multipart multipart = provider.buildMultipartBody("text", "<html>plain</html>", null);
+
+        assertThat(multipart.getCount(), is(2));
+        assertThat(multipart.getContentType(), containsString("alternative"));
+    }
+
+    @Test
+    void testBuildMultipartBodyWithCidEmbeddedImage() throws Exception {
+        byte[] logoBytes = new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47};
+        Theme theme = new TestTheme(Map.of("assets/logo.png", logoBytes));
+        DefaultEmailSenderProvider provider = new DefaultEmailSenderProvider(null, null);
+        String html = "<html><body><img src=\"cid:assets/logo.png\" /></body></html>";
+
+        Multipart multipart = provider.buildMultipartBody("text", html, theme);
+
+        assertThat(multipart.getContentType(), containsString("related"));
+        assertThat(multipart.getCount(), is(2));
+
+        BodyPart alternativeWrapper = multipart.getBodyPart(0);
+        assertThat(alternativeWrapper.getContent(), is(instanceOf(MimeMultipart.class)));
+        MimeMultipart alternative = (MimeMultipart) alternativeWrapper.getContent();
+        assertThat(alternative.getContentType(), containsString("alternative"));
+        assertThat(alternative.getCount(), is(2));
+
+        BodyPart htmlPart = alternative.getBodyPart(1);
+        assertThat(htmlPart.getContent().toString(), containsString("cid:logo.png"));
+        assertThat(htmlPart.getContent().toString(), not(containsString("cid:assets/logo.png")));
+
+        MimeBodyPart imagePart = (MimeBodyPart) multipart.getBodyPart(1);
+        assertThat(imagePart.getContentID(), is("<logo.png>"));
+        assertThat(imagePart.getDisposition(), is(MimeBodyPart.INLINE));
+        assertThat(imagePart.getFileName(), is("logo.png"));
+    }
+
+    @Test
+    void testBuildMultipartBodyWithMissingCidResource() throws Exception {
+        Theme theme = new TestTheme(Map.of());
+        DefaultEmailSenderProvider provider = new DefaultEmailSenderProvider(null, null);
+        String html = "<html><body><img src=\"cid:assets/missing.png\" /></body></html>";
+
+        Multipart multipart = provider.buildMultipartBody(null, html, theme);
+
+        assertThat(multipart.getContentType(), containsString("related"));
+        assertThat(multipart.getCount(), is(1));
+
+        MimeMultipart alternative = (MimeMultipart) multipart.getBodyPart(0).getContent();
+        assertThat(alternative.getBodyPart(0).getContent().toString(), containsString("cid:missing.png"));
+    }
+
+    private static class TestTheme implements Theme {
+
+        private final Map<String, byte[]> resources;
+
+        private TestTheme(Map<String, byte[]> resources) {
+            this.resources = resources;
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public String getParentName() {
+            return null;
+        }
+
+        @Override
+        public String getImportName() {
+            return null;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.EMAIL;
+        }
+
+        @Override
+        public URL getTemplate(String name) {
+            return null;
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String path) {
+            byte[] resource = resources.get(path);
+            return resource != null ? new ByteArrayInputStream(resource) : null;
+        }
+
+        @Override
+        public Properties getMessages(Locale locale) {
+            return new Properties();
+        }
+
+        @Override
+        public Properties getMessages(String baseBundlename, Locale locale) {
+            return new Properties();
+        }
+
+        @Override
+        public Properties getEnhancedMessages(RealmModel realm, Locale locale) {
+            return new Properties();
+        }
+
+        @Override
+        public Properties getProperties() {
+            return new Properties();
+        }
     }
 }

--- a/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/DefaultEmailSenderProviderTest.java
@@ -133,6 +133,18 @@ class DefaultEmailSenderProviderTest {
     }
 
     @Test
+    void testRewriteCidReferencesDoesNotCorruptPrefixPaths() {
+        String html = "<img src=\"cid:img/logo\" /><img src=\"cid:img/logo/icon.png\" />";
+        Map<String, String> mapping = Map.of(
+                "img/logo", "logo",
+                "img/logo/icon.png", "icon.png");
+
+        String resolved = DefaultEmailSenderProvider.rewriteCidReferences(html, mapping);
+
+        assertThat(resolved, is("<img src=\"cid:logo\" /><img src=\"cid:icon.png\" />"));
+    }
+
+    @Test
     void testBuildMultipartBodyWithoutCidReferences() throws Exception {
         DefaultEmailSenderProvider provider = new DefaultEmailSenderProvider(null, null);
 


### PR DESCRIPTION
Hello,

Embed email theme resources referenced as cid:path in HTML templates (ex : cid:assets/logo.png → email/resources/assets/logo.png).

Unlike base64-encoded images, which webmail clients such as Gmail and Outlook often block, cid: references use standard MIME inline attachments that these clients accept.

Documentation and unit tests included.

Closes #26347

Thomas