### PR TITLE
Ensure consistent transaction rollback across all error response paths

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/PermissionTicketAwareDecisionResultCollector.java
@@ -32,6 +32,8 @@ import org.keycloak.authorization.model.Scope;
 import org.keycloak.authorization.store.ResourceStore;
 import org.keycloak.authorization.store.ScopeStore;
 import org.keycloak.authorization.store.StoreFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.authorization.AuthorizationRequest;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.representations.idm.authorization.PermissionTicketToken;
@@ -87,65 +89,67 @@ public class PermissionTicketAwareDecisionResultCollector extends DecisionPermis
         super.onComplete();
 
         if (request.isSubmitRequest()) {
-            StoreFactory storeFactory = authorization.getStoreFactory();
-            ResourceStore resourceStore = storeFactory.getResourceStore();
+            // At this point, onGrant() has already removed granted permissions from the ticket,
+            // so ticket.getPermissions() contains only the denied ones that need permission tickets.
             List<Permission> permissions = ticket.getPermissions();
+            if (permissions == null || permissions.isEmpty()) return;
 
-            if (permissions != null) {
+            String resourceServerId = resourceServer.getId();
+            String identityId = identity.getId();
+            KeycloakSession session = authorization.getKeycloakSession();
+
+            // Create tickets in a separate transaction so they survive the rollback
+            KeycloakModelUtils.enlistAfterCompletion(session, ctx -> {
+                AuthorizationProvider authz = ctx.session().getProvider(AuthorizationProvider.class);
+                StoreFactory sf = authz.getStoreFactory();
+                ResourceServer rs = sf.getResourceServerStore().findById(resourceServerId);
+                if (rs == null) return;
+
+                ResourceStore resourceStore = sf.getResourceStore();
+                ScopeStore scopeStore = sf.getScopeStore();
+
                 for (Permission permission : permissions) {
-                    Resource resource = resourceStore.findById(resourceServer, permission.getResourceId());
-
+                    Resource resource = resourceStore.findById(rs, permission.getResourceId());
                     if (resource == null) {
-                        resource = resourceStore.findByName(resourceServer, permission.getResourceId(), identity.getId());
+                        resource = resourceStore.findByName(rs, permission.getResourceId(), identityId);
                     }
-
-                    if (resource == null || !resource.isOwnerManagedAccess() || resource.getOwner().equals(identity.getId()) || resource.getOwner().equals(resourceServer.getClientId())) {
+                    if (resource == null || !resource.isOwnerManagedAccess()
+                            || resource.getOwner().equals(identityId)
+                            || resource.getOwner().equals(rs.getClientId())) {
                         continue;
                     }
 
                     Set<String> scopes = permission.getScopes();
-
                     if (scopes.isEmpty()) {
                         scopes = resource.getScopes().stream().map(Scope::getName).collect(Collectors.toSet());
                     }
 
                     if (scopes.isEmpty()) {
-                        Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);
-
-                        filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
-                        filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
-                        filters.put(PermissionTicket.FilterOption.SCOPE_IS_NULL, Boolean.TRUE.toString());
-
-                        List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resourceServer, filters, null, null);
-
-                        if (tickets.isEmpty()) {
-                            authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource, null, identity.getId());
-                        }
+                        createTicketIfNotExists(sf, rs, resource, null, identityId);
                     } else {
-                        ScopeStore scopeStore = authorization.getStoreFactory().getScopeStore();
-
-                        for (String scopeId : scopes) {
-                            Scope scope = scopeStore.findByName(resourceServer, scopeId);
-
-                            if (scope == null) {
-                                scope = scopeStore.findById(resourceServer, scopeId);
-                            }
-
-                            Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);
-
-                            filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
-                            filters.put(PermissionTicket.FilterOption.REQUESTER, identity.getId());
-                            filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
-
-                            List<PermissionTicket> tickets = authorization.getStoreFactory().getPermissionTicketStore().find(resourceServer, filters, null, null);
-
-                            if (tickets.isEmpty()) {
-                                authorization.getStoreFactory().getPermissionTicketStore().create(resourceServer, resource, scope, identity.getId());
-                            }
+                        for (String scopeName : scopes) {
+                            Scope scope = scopeStore.findByName(rs, scopeName);
+                            if (scope == null) scope = scopeStore.findById(rs, scopeName);
+                            if (scope != null) createTicketIfNotExists(sf, rs, resource, scope, identityId);
                         }
                     }
                 }
-            }
+            });
+        }
+    }
+
+    private static void createTicketIfNotExists(StoreFactory sf, ResourceServer rs, Resource resource, Scope scope, String requester) {
+        Map<PermissionTicket.FilterOption, String> filters = new EnumMap<>(PermissionTicket.FilterOption.class);
+        filters.put(PermissionTicket.FilterOption.RESOURCE_ID, resource.getId());
+        filters.put(PermissionTicket.FilterOption.REQUESTER, requester);
+        if (scope != null) {
+            filters.put(PermissionTicket.FilterOption.SCOPE_ID, scope.getId());
+        } else {
+            filters.put(PermissionTicket.FilterOption.SCOPE_IS_NULL, Boolean.TRUE.toString());
+        }
+
+        if (sf.getPermissionTicketStore().find(rs, filters, null, null).isEmpty()) {
+            sf.getPermissionTicketStore().create(rs, resource, scope, requester);
         }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -61,6 +62,7 @@ import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.deployment.DeployedConfigurationsManager;
+import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -344,6 +346,57 @@ public final class KeycloakModelUtils {
         }
 
         return session.users().getUserByUsername(realm, username);
+    }
+
+    /**
+     * Enlists a task that will run in a new, independent transaction when the current
+     * transaction rolls back. The task is a no-op if the current transaction commits normally.
+     *
+     * <p>Use this for cleanup operations that must persist even when an error response
+     * causes the main transaction to roll back (e.g., session invalidation on token reuse).
+     * The task receives a {@link SessionLookup} backed by a fresh session
+     * with realm/client context cloned from the current one.</p>
+     *
+     * @see #enlistAfterCompletion(KeycloakSession, Consumer)
+     */
+    public static void enlistAfterRollback(KeycloakSession currentSession, Consumer<SessionLookup> task) {
+        enlistAfterCompletion(currentSession, task, false);
+    }
+
+    /**
+     * Enlists a task that will run in a new, independent transaction after the current
+     * transaction completes, regardless of whether it commits or rolls back.
+     *
+     * <p>Use this for operations that must persist in both success and error paths
+     * (e.g., creating UMA permission tickets).</p>
+     *
+     * @see #enlistAfterRollback(KeycloakSession, Consumer)
+     */
+    public static void enlistAfterCompletion(KeycloakSession currentSession, Consumer<SessionLookup> task) {
+        enlistAfterCompletion(currentSession, task, true);
+    }
+
+    private static void enlistAfterCompletion(KeycloakSession currentSession, Consumer<SessionLookup> task, boolean runOnCommit) {
+        KeycloakSessionFactory factory = currentSession.getKeycloakSessionFactory();
+        KeycloakContext context = currentSession.getContext();
+
+        currentSession.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
+            @Override
+            protected void commitImpl() {
+                if (runOnCommit) {
+                    execute();
+                }
+            }
+
+            @Override
+            protected void rollbackImpl() {
+                execute();
+            }
+
+            private void execute() {
+                runJobInTransaction(factory, context, sub -> task.accept(new SessionLookup(sub)));
+            }
+        });
     }
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/SessionLookup.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/SessionLookup.java
@@ -1,0 +1,53 @@
+package org.keycloak.models.utils;
+
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+
+/**
+ * Provides convenient entity lookups within a {@link KeycloakSession},
+ * resolving entities by their IDs against the session's realm context.
+ *
+ * <p>Primarily used inside {@link KeycloakModelUtils#enlistAfterRollback}
+ * to re-lookup entities from the outer session in a new independent transaction.</p>
+ */
+public class SessionLookup {
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+
+    public SessionLookup(KeycloakSession session) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
+    }
+
+    public KeycloakSession session() {
+        return session;
+    }
+
+    public RealmModel realm() {
+        return realm;
+    }
+
+    public UserSessionModel findUserSession(UserSessionModel outerSession) {
+        if (outerSession == null) return null;
+        if (outerSession.isOffline()) {
+            return session.sessions().getOfflineUserSession(realm, outerSession.getId());
+        }
+        return session.sessions().getUserSession(realm, outerSession.getId());
+    }
+
+    public AuthenticatedClientSessionModel findClientSession(AuthenticatedClientSessionModel outerSession) {
+        if (outerSession == null) return null;
+        UserSessionModel us = findUserSession(outerSession.getUserSession());
+        return us != null ? us.getAuthenticatedClientSessionByClient(outerSession.getClient().getId()) : null;
+    }
+
+    public RootAuthenticationSessionModel findRootAuthSession(AuthenticationSessionModel outerSession) {
+        if (outerSession == null) return null;
+        return session.authenticationSessions().getRootAuthenticationSession(realm, outerSession.getParentSession().getId());
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -183,7 +183,12 @@ public class TokenManager {
 
                 // Revoke timed out offline userSession
                 if (!AuthenticationManager.isSessionValid(realm, userSession)) {
-                    sessionManager.revokeOfflineUserSession(userSession);
+                    UserSessionModel offlineSession = userSession;
+                    // Revocation must persist even when the error response rolls back the main tx.
+                    KeycloakModelUtils.enlistAfterRollback(session, ctx -> {
+                        UserSessionModel us = ctx.findUserSession(offlineSession);
+                        if (us != null) new UserSessionManager(ctx.session()).revokeOfflineUserSession(us);
+                    });
                     throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Offline session not active", "Offline session not active");
                 }
 
@@ -194,7 +199,16 @@ public class TokenManager {
             // Find userSession regularly for online tokens
             userSession = session.sessions().getUserSession(realm, oldToken.getSessionState());
             if (!AuthenticationManager.isSessionValid(realm, userSession)) {
-                AuthenticationManager.backchannelLogout(session, realm, userSession, uriInfo, connection, headers, true);
+                if (userSession != null) {
+                    UserSessionModel onlineSession = userSession;
+                    // Logout must persist even when the error response rolls back the main tx.
+                    KeycloakModelUtils.enlistAfterRollback(session, ctx -> {
+                        UserSessionModel us = ctx.findUserSession(onlineSession);
+                        if (us != null) {
+                            AuthenticationManager.backchannelLogout(ctx.session(), ctx.realm(), us, uriInfo, connection, headers, true);
+                        }
+                    });
+                }
                 throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Session not active", "Session not active");
             }
         }
@@ -223,7 +237,12 @@ public class TokenManager {
 
         if (!AuthenticationManager.isClientSessionValid(realm, client, userSession, clientSession)) {
             logger.debug("Client session not active");
-            userSession.removeAuthenticatedClientSessions(Collections.singletonList(client.getId()));
+            UserSessionModel currentSession = userSession;
+            // Removal must persist even when the error response rolls back the main tx.
+            KeycloakModelUtils.enlistAfterRollback(session, ctx -> {
+                UserSessionModel us = ctx.findUserSession(currentSession);
+                if (us != null) us.removeAuthenticatedClientSessions(Collections.singletonList(client.getId()));
+            });
             throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Client session not active");
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -35,6 +35,7 @@ import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
@@ -86,12 +87,12 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
 
         OAuth2CodeParser.ParseResult parseResult = OAuth2CodeParser.parseCode(session, code, realm, event);
         if (parseResult.isIllegalCode()) {
-            AuthenticatedClientSessionModel clientSession = parseResult.getClientSession();
-
-            // Attempt to use same code twice should invalidate existing clientSession
-            if (clientSession != null) {
-                clientSession.detachFromUserSession();
-            }
+            // Attempt to use same code twice should invalidate existing clientSession.
+            // Detach must persist even when the error response rolls back the main tx.
+            KeycloakModelUtils.enlistAfterRollback(session, ctx -> {
+                AuthenticatedClientSessionModel cs = ctx.findClientSession(parseResult.getClientSession());
+                if (cs != null) cs.detachFromUserSession();
+            });
 
             event.error(Errors.INVALID_CODE);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
@@ -36,6 +36,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.AuthenticationFlowResolver;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessTokenResponse;
@@ -124,8 +125,13 @@ public class ResourceOwnerPasswordCredentialsGrantType extends OAuth2GrantTypeBa
         processor.evaluateRequiredActionTriggers();
         UserModel user = authSession.getAuthenticatedUser();
         if (user.getRequiredActionsStream().count() > 0 || authSession.getRequiredActions().size() > 0) {
-            // Remove authentication session as "Resource Owner Password Credentials Grant" is single-request scoped authentication
-            new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authSession, false);
+            // Auth session removal must persist even when the error response rolls back the main tx.
+            KeycloakModelUtils.enlistAfterRollback(session, ctx -> {
+                RootAuthenticationSessionModel root = ctx.findRootAuthSession(authSession);
+                if (root != null) {
+                    ctx.session().authenticationSessions().removeRootAuthenticationSession(ctx.realm(), root);
+                }
+            });
             String errorMessage = "Account is not fully set up";
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.RESOLVE_REQUIRED_ACTIONS);

--- a/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java
@@ -277,7 +277,11 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
                     logger.debugf("Failed validation of refresh token %s due it was used before. Realm: %s, client: %s, user: %s, user session: %s. Will detach client session from user session",
                             refreshToken.getId(), realm.getName(), clientSession.getClient().getClientId(), clientSession.getUserSession().getUser().getUsername(), clientSession.getUserSession().getId());
                 }
-                clientSession.detachFromUserSession();
+                // Detach must persist even when the error response rolls back the main tx.
+                KeycloakModelUtils.enlistAfterRollback(session, ctx -> {
+                    AuthenticatedClientSessionModel cs = ctx.findClientSession(clientSession);
+                    if (cs != null) cs.detachFromUserSession();
+                });
                 throw oee;
             }
         }

--- a/services/src/main/java/org/keycloak/services/CorsErrorResponseException.java
+++ b/services/src/main/java/org/keycloak/services/CorsErrorResponseException.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.services;
 
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -27,7 +26,7 @@ import org.keycloak.services.cors.Cors;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class CorsErrorResponseException extends WebApplicationException {
+public class CorsErrorResponseException extends RollbackWebApplicationException {
 
     private final Cors cors;
     private final String error;
@@ -47,7 +46,7 @@ public class CorsErrorResponseException extends WebApplicationException {
     }
 
     @Override
-    public Response getResponse() {
+    public Response createErrorResponse() {
         OAuth2ErrorRepresentation errorRep = new OAuth2ErrorRepresentation(error, errorDescription);
         Response.ResponseBuilder builder = Response.status(status).entity(errorRep).type(MediaType.APPLICATION_JSON_TYPE);
         return cors.add(builder);

--- a/services/src/main/java/org/keycloak/services/ErrorPage.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPage.java
@@ -27,7 +27,14 @@ import org.keycloak.sessions.AuthenticationSessionModel;
  */
 public class ErrorPage {
 
+    /**
+     * Builds an error page response and marks the current transaction for rollback.
+     *
+     * <p>Any state changes that must persist despite the error should be committed
+     * in a separate transaction before calling this method.</p>
+     */
     public static Response error(KeycloakSession session, AuthenticationSessionModel authenticationSession, Response.Status status, String message, Object... parameters) {
+        session.getTransactionManager().setRollbackOnly();
         return session.getProvider(LoginFormsProvider.class).setAuthenticationSession(authenticationSession).setError(message, parameters).createErrorPage(status);
     }
 

--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -17,17 +17,15 @@
 
 package org.keycloak.services;
 
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.sessions.AuthenticationSessionModel;
-import org.keycloak.utils.KeycloakSessionUtil;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class ErrorPageException extends WebApplicationException {
+public class ErrorPageException extends RollbackWebApplicationException {
 
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
         super(errorMessage, ErrorPage.error(session, null, status, errorMessage, parameters));
@@ -39,15 +37,5 @@ public class ErrorPageException extends WebApplicationException {
 
     public ErrorPageException(Response response) {
         super((Throwable) null, response);
-    }
-
-    @Override
-    public Response getResponse() {
-        KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
-        if (session != null) {
-            // set rollback if exception is thrown to not commit changes into database
-            session.getTransactionManager().setRollbackOnly();
-        }
-        return super.getResponse();
     }
 }

--- a/services/src/main/java/org/keycloak/services/ErrorResponseException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorResponseException.java
@@ -17,18 +17,15 @@
 
 package org.keycloak.services;
 
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
-import org.keycloak.utils.KeycloakSessionUtil;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class ErrorResponseException extends WebApplicationException {
+public class ErrorResponseException extends RollbackWebApplicationException {
 
     private final Response response;
     private final String error;
@@ -44,6 +41,7 @@ public class ErrorResponseException extends WebApplicationException {
     }
 
     public ErrorResponseException(Response response) {
+        super((String) null, response);
         this.response = response;
         this.error = null;
         this.errorDescription = null;
@@ -59,17 +57,7 @@ public class ErrorResponseException extends WebApplicationException {
     }
 
     @Override
-    public Response getResponse() {
-        KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
-        if (session != null) {
-            // This has to happen, since calling getResponse() with non-null result leads to
-            // directly returning the result instead of
-            // propagating exception to KeycloakErrorHandler.toResponse(Throwable) which would ensure rollback on other exception types.
-            //
-            // See org.jboss.resteasy.core.ExceptionHandler.unwrapException(HttpRequest, Throwable, RESTEasyTracingLogger)
-
-            session.getTransactionManager().setRollbackOnly();
-        }
+    public Response createErrorResponse() {
         if (response != null) {
             return response;
         } else {

--- a/services/src/main/java/org/keycloak/services/RollbackWebApplicationException.java
+++ b/services/src/main/java/org/keycloak/services/RollbackWebApplicationException.java
@@ -1,0 +1,55 @@
+package org.keycloak.services;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.utils.KeycloakSessionUtil;
+
+/**
+ * Base class for all Keycloak error exceptions that should roll back the current transaction.
+ *
+ * <p>Calling {@link #getResponse()} with a non-null result (containing an entity) leads to RESTEasy
+ * directly returning that response instead of propagating the exception to
+ * {@code KeycloakErrorHandler.toResponse(Throwable)}, which would normally ensure rollback.
+ * This base class ensures {@code setRollbackOnly()} is always called before the error response
+ * is returned.</p>
+ *
+ * <p>Subclasses must override {@link #createErrorResponse()} instead of {@link #getResponse()}.</p>
+ *
+ * @see org.keycloak.services.error.KeycloakErrorHandler
+ */
+public abstract class RollbackWebApplicationException extends WebApplicationException {
+
+    protected RollbackWebApplicationException(String message, Response.Status status) {
+        super(message, status);
+    }
+
+    protected RollbackWebApplicationException(String message, Response response) {
+        super(message, response);
+    }
+
+    protected RollbackWebApplicationException(Throwable cause, Response response) {
+        super(cause, response);
+    }
+
+    @Override
+    public final Response getResponse() {
+        KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
+        if (session != null) {
+            session.getTransactionManager().setRollbackOnly();
+        }
+        return createErrorResponse();
+    }
+
+    protected Response getOriginalResponse() {
+        return super.getResponse();
+    }
+
+    /**
+     * Builds the error response. Override this instead of {@link #getResponse()}.
+     */
+    public Response createErrorResponse() {
+        return getOriginalResponse();
+    }
+}

--- a/services/src/main/java/org/keycloak/transaction/AsyncResponseTransaction.java
+++ b/services/src/main/java/org/keycloak/transaction/AsyncResponseTransaction.java
@@ -52,7 +52,11 @@ public class AsyncResponseTransaction implements KeycloakTransaction {
 
     @Override
     public void rollback() {
-        responseToFinishInTransaction.resume(ErrorPage.error(session, null, Response.Status.INTERNAL_SERVER_ERROR, Messages.INTERNAL_SERVER_ERROR));
+        // Preserve the original error response on rollback — the caller already chose the appropriate status.
+        // For success responses, override with 500 since the state they depend on was not committed.
+        responseToFinishInTransaction.resume(responseToSend.getStatus() >= 400
+                ? responseToSend
+                : ErrorPage.error(session, null, Response.Status.INTERNAL_SERVER_ERROR, Messages.INTERNAL_SERVER_ERROR));
     }
 
     @Override


### PR DESCRIPTION
- Closes #50911
- Always rollback TX when the error is thrown by default - It helps to make Keycloak more consistent and not persist any side data that can change the state during the bad request phase
- For some cases, we need to persist(commit TX) some data - brute force detector, error events, token revocations,...
- most of them already run in a separate TX that does the commit, but for some of them, we needed to wrap them in a separate TX as well

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
