### PR TITLE
Restrict marking email as verified to explicit email verification flow

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -38,6 +38,15 @@ Custom login themes that override `social-providers.ftl` or apply CSS targeting 
 
 Test your custom login theme to ensure the identity provider buttons display correctly.
 
+=== Email is no longer marked as verified by other flows
+
+Previously, some flows marked the email of a user as verified even though their purpose was not email verification.
+This could make an account registered by a different party than the owner of the email address look trusted.
+An email is now marked as verified only when the user completes an email verification.
+This changes the behavior of identity provider account linking by email, of admin-initiated action emails that do not include the *Verify Email* action,
+and of the verifiable credential offer emails of the experimental OID4VCI feature.
+The *Trust Email* setting of identity providers and LDAP federation is not affected, as it is an explicit decision of the administrator to trust the email from the external source.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 
@@ -55,4 +64,3 @@ link:{securing_apps_token_exchange_link}[Token Exchange].
 The following features have been removed from this release.
 
 === <TODO>
-

--- a/server-spi-private/src/main/java/org/keycloak/events/Errors.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Errors.java
@@ -48,6 +48,7 @@ public interface Errors {
     String USERNAME_IN_USE = "username_in_use";
     String EMAIL_IN_USE = "email_in_use";
     String EMAIL_ALREADY_VERIFIED = "email_already_verified";
+    String IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY = "identity_provider_link_confirmed_already";
     String ORG_NOT_FOUND = "org_not_found";
     String ORG_DISABLED = "org_disabled";
     String USER_ORG_MEMBER_ALREADY = "user_org_member_already";

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
@@ -118,8 +118,9 @@ public class ExecuteActionsActionTokenHandler extends AbstractActionTokenHandler
         token.getRequiredActions().stream().forEach(authSession::addRequiredAction);
 
         UserModel user = tokenContext.getAuthenticationSession().getAuthenticatedUser();
-        // verify user email as we know it is valid as this entry point would never have gotten here.
-        user.setEmailVerified(true);
+        if (token.getRequiredActions().contains(UserModel.RequiredAction.VERIFY_EMAIL.name())) {
+            user.setEmailVerified(true);
+        }
 
         String nextAction = AuthenticationManager.nextRequiredAction(tokenContext.getSession(), authSession, tokenContext.getRequest(), tokenContext.getEvent());
         return AuthenticationManager.redirectToRequiredActions(tokenContext.getSession(), tokenContext.getRealm(), authSession, tokenContext.getUriInfo(), nextAction);

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/idpverifyemail/IdpVerifyAccountLinkActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/idpverifyemail/IdpVerifyAccountLinkActionTokenHandler.java
@@ -85,7 +85,7 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
         AuthenticationSessionModel authSession = tokenContext.getAuthenticationSession();
 
         if (authSession.getAuthNote(IdpEmailVerificationAuthenticator.VERIFY_ACCOUNT_IDP_USERNAME) != null) {
-            return sendEmailAlreadyVerified(session, event, user);
+            return sendLinkConfirmedAlready(session, event, user, token);
         }
 
         AuthenticationSessionManager asm = new AuthenticationSessionManager(session);
@@ -96,7 +96,7 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
             AuthenticationSessionModel origAuthSession = asm.getAuthenticationSessionByIdAndClient(realm,
                     compoundId.getRootSessionId(), originalClient, compoundId.getTabId());
             if (origAuthSession == null || origAuthSession.getAuthNote(IdpEmailVerificationAuthenticator.VERIFY_ACCOUNT_IDP_USERNAME) != null) {
-                return sendEmailAlreadyVerified(session, event, user);
+                return sendLinkConfirmedAlready(session, event, user, token);
             }
 
             token.setOriginalCompoundAuthenticationSessionId(token.getCompoundAuthenticationSessionId());
@@ -115,8 +115,6 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
                     .createInfoPage();
         }
 
-        // verify user email as we know it is valid as this entry point would never have gotten here.
-        user.setEmailVerified(true);
         event.success();
 
         if (token.getOriginalCompoundAuthenticationSessionId() != null) {
@@ -134,6 +132,7 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
 
             return session.getProvider(LoginFormsProvider.class)
                     .setAuthenticationSession(authSession)
+                    .setAttribute("messageHeader", Messages.IDENTITY_PROVIDER_LINK_SUCCESS_HEADER)
                     .setSuccess(Messages.IDENTITY_PROVIDER_LINK_SUCCESS, token.getIdentityProviderAlias(), token.getIdentityProviderUsername())
                     .setAttribute(Constants.SKIP_LINK, true)
                     .createInfoPage();
@@ -171,11 +170,12 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
         return "kc.brokering.user.verified." + userId  + "." + idpAlias + "." + externalId;
     }
 
-    private Response sendEmailAlreadyVerified(KeycloakSession session, EventBuilder event, UserModel user) {
-        event.user(user).error(Errors.EMAIL_ALREADY_VERIFIED);
+    private Response sendLinkConfirmedAlready(KeycloakSession session, EventBuilder event, UserModel user, IdpVerifyAccountLinkActionToken token) {
+        event.user(user).error(Errors.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY);
         return session.getProvider(LoginFormsProvider.class)
                 .setAuthenticationSession(session.getContext().getAuthenticationSession())
-                .setInfo(Messages.EMAIL_VERIFIED_ALREADY, user.getEmail())
+                .setAttribute("messageHeader", Messages.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY_HEADER)
+                .setInfo(Messages.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY, token.getIdentityProviderAlias(), token.getIdentityProviderUsername())
                 .createInfoPage();
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpEmailVerificationAuthenticator.java
@@ -62,6 +62,8 @@ public class IdpEmailVerificationAuthenticator extends AbstractIdpAuthenticator 
 
     public static final String VERIFY_ACCOUNT_IDP_USERNAME = "VERIFY_ACCOUNT_IDP_USERNAME";
 
+    public static final String IDP_LINK_CONFIRMATION_EMAIL_KEY = "IDP_LINK_CONFIRMATION_EMAIL_KEY";
+
     @Override
     protected void authenticateImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
         KeycloakSession session = context.getSession();
@@ -95,8 +97,8 @@ public class IdpEmailVerificationAuthenticator extends AbstractIdpAuthenticator 
         UserModel existingUser = getExistingUser(session, realm, authSession);
 
         // Do not allow resending e-mail by simple page refresh
-        if (! Objects.equals(authSession.getAuthNote(Constants.VERIFY_EMAIL_KEY), existingUser.getEmail())) {
-            authSession.setAuthNote(Constants.VERIFY_EMAIL_KEY, existingUser.getEmail());
+        if (! Objects.equals(authSession.getAuthNote(IDP_LINK_CONFIRMATION_EMAIL_KEY), existingUser.getEmail())) {
+            authSession.setAuthNote(IDP_LINK_CONFIRMATION_EMAIL_KEY, existingUser.getEmail());
             sendVerifyEmail(session, context, existingUser, brokerContext);
         } else {
             showEmailSentPage(context, brokerContext);
@@ -108,7 +110,7 @@ public class IdpEmailVerificationAuthenticator extends AbstractIdpAuthenticator 
         logger.debugf("Re-sending email requested for user, details follow");
 
         // This will allow user to re-send email again
-        context.getAuthenticationSession().removeAuthNote(Constants.VERIFY_EMAIL_KEY);
+        context.getAuthenticationSession().removeAuthNote(IDP_LINK_CONFIRMATION_EMAIL_KEY);
 
         authenticateImpl(context, serializedCtx, brokerContext);
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialEmail.java
@@ -150,7 +150,6 @@ public class ResetCredentialEmail implements Authenticator, AuthenticatorFactory
 
     @Override
     public void action(AuthenticationFlowContext context) {
-        context.getUser().setEmailVerified(true);
         context.success();
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/CredentialOfferActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/CredentialOfferActionTokenHandler.java
@@ -121,9 +121,6 @@ public class CredentialOfferActionTokenHandler extends AbstractActionTokenHandle
             throw ErrorResponse.error("Invalid credential configuration action", Response.Status.BAD_REQUEST);
         }
 
-        // verify user email as we know it is valid as this entry point would never have gotten here.
-        user.setEmailVerified(true);
-
         String nextAction = AuthenticationManager.nextRequiredAction(tokenContext.getSession(), authSession, tokenContext.getRequest(), tokenContext.getEvent());
         return AuthenticationManager.redirectToRequiredActions(tokenContext.getSession(), tokenContext.getRealm(), authSession, tokenContext.getUriInfo(), nextAction);
     }

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -230,6 +230,12 @@ public class Messages {
 
     public static final String IDENTITY_PROVIDER_LINK_SUCCESS = "identityProviderLinkSuccess";
 
+    public static final String IDENTITY_PROVIDER_LINK_SUCCESS_HEADER = "identityProviderLinkSuccessHeader";
+
+    public static final String IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY = "identityProviderLinkConfirmedAlreadyMessage";
+
+    public static final String IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY_HEADER = "identityProviderLinkConfirmedAlreadyMessageHeader";
+
     public static final String CONFIRM_ACCOUNT_LINKING = "confirmAccountLinking";
 
     public static final String CONFIRM_ACCOUNT_LINKING_BODY = "confirmAccountLinkingBody";

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserEmailTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserEmailTest.java
@@ -214,6 +214,72 @@ public class UserEmailTest extends AbstractUserTest {
     }
 
     @Test
+    public void sendExecuteActionsEmailWithoutVerifyEmailDoesNotVerifyEmail() throws IOException {
+        UserRepresentation userRep = UserBuilder.create()
+                .username("user1").name("User", "One").email("user1@test.com").emailVerified(false).build();
+
+        String id = createUser(userRep);
+
+        UserResource user = managedRealm.admin().users().get(id);
+        Assertions.assertFalse(user.toRepresentation().isEmailVerified());
+
+        user.executeActionsEmail(Collections.singletonList(UserModel.RequiredAction.UPDATE_PASSWORD.name()));
+        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.ACTION, AdminEventPaths.userResourcePath(id) + "/execute-actions-email", ResourceType.USER);
+
+        Assertions.assertEquals(1, mailServer.getReceivedMessages().length);
+
+        String link = MailUtils.getPasswordResetEmailLink(mailServer.getReceivedMessages()[0]);
+
+        driver.open(link);
+
+        proceedPage.assertCurrent();
+        assertThat(proceedPage.getInfo(), Matchers.containsString("Update Password"));
+        proceedPage.clickProceedLink();
+        passwordUpdatePage.assertCurrent();
+
+        passwordUpdatePage.changePassword("new-pass", "new-pass");
+
+        assertEquals("Your account has been updated.", infoPage.getInfo());
+
+        //the email should not be marked as verified as VERIFY_EMAIL was not among the actions
+        Assertions.assertFalse(user.toRepresentation().isEmailVerified());
+    }
+
+    @Test
+    public void sendExecuteActionsEmailWithVerifyEmailVerifiesEmail() throws IOException {
+        UserRepresentation userRep = UserBuilder.create()
+                .username("user1").name("User", "One").email("user1@test.com").emailVerified(false).build();
+
+        String id = createUser(userRep);
+
+        UserResource user = managedRealm.admin().users().get(id);
+        Assertions.assertFalse(user.toRepresentation().isEmailVerified());
+
+        user.executeActionsEmail(Arrays.asList(
+                UserModel.RequiredAction.VERIFY_EMAIL.name(),
+                UserModel.RequiredAction.UPDATE_PASSWORD.name()));
+        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.ACTION, AdminEventPaths.userResourcePath(id) + "/execute-actions-email", ResourceType.USER);
+
+        Assertions.assertEquals(1, mailServer.getReceivedMessages().length);
+
+        String link = MailUtils.getPasswordResetEmailLink(mailServer.getReceivedMessages()[0]);
+
+        driver.open(link);
+
+        proceedPage.assertCurrent();
+        proceedPage.clickProceedLink();
+
+        // VERIFY_EMAIL was among the actions, so the email is marked as verified
+        passwordUpdatePage.assertCurrent();
+
+        passwordUpdatePage.changePassword("new-pass", "new-pass");
+
+        assertEquals("Your account has been updated.", infoPage.getInfo());
+
+        Assertions.assertTrue(user.toRepresentation().isEmailVerified());
+    }
+
+    @Test
     public void sendTermsAndConditionsEmailSuccess() throws IOException {
         RequiredActionProviderRepresentation termsAndConds = managedRealm.admin().flows().getRequiredAction(UserModel.RequiredAction.TERMS_AND_CONDITIONS.name());
         termsAndConds.setEnabled(true);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAdminActionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAdminActionTest.java
@@ -145,6 +145,28 @@ public class OID4VCAdminActionTest extends OID4VCIssuerTestBase {
     }
 
     @Test
+    public void testAdminCredentialOfferDoesNotSetEmailVerified() throws Exception {
+        user.updateWithCleanup(u -> u.emailVerified(false));
+        adminEvents.clear();
+
+        String link = sendEmailAndGetLink(null, null, null, "This link will expire within 12 hours");
+
+        driver.open(link);
+
+        proceedPage.assertCurrent();
+        proceedPage.clickProceedLink();
+
+        credentialOfferPage.assertCurrent();
+        credentialOfferPage.clickContinueButton();
+
+        infoPage.assertCurrent();
+        assertEquals("Your account has been updated.", infoPage.getInfo());
+
+        assertFalse(user.admin().toRepresentation().isEmailVerified(),
+                "Opening the credential offer link must not mark the user's email as verified");
+    }
+
+    @Test
     public void testAdminCredentialOfferClientId() throws Exception {
         String link = sendEmailAndGetLink("oidc-client", null, 7200, "This link will expire within 2 hours");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -893,6 +893,17 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         log.info("navigating to url from email: " + url);
         driver.navigate().to(url);
 
+
+        verifyEmailPage.assertCurrent();
+        assertFalse(realm.users().get(linkedUserId).toRepresentation().isEmailVerified());
+
+        assertEquals(2, mail.getReceivedMessages().length);
+        String verificationUrl = assertEmailAndGetUrl(mail.getLastReceivedMessage(), MailServerConfiguration.FROM, USER_EMAIL,
+                "verify your email address");
+
+        log.info("navigating to url from email: " + verificationUrl);
+        driver.navigate().to(verificationUrl.trim());
+
         //test if user is logged in
         assertTrue(driver.getCurrentUrl().startsWith(getConsumerRoot() + "/auth/realms/master/app/"));
 
@@ -1165,20 +1176,30 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         String url = assertEmailAndGetUrl(mail.getLastReceivedMessage(), MailServerConfiguration.FROM, USER_EMAIL,
                 "Someone wants to link your ");
         driver.navigate().to(url);
+
+        //confirm the account linking does not verify the email, the verify email required action follows
+        verifyEmailPage.assertCurrent();
+        assertFalse(adminClient.realm(bc.consumerRealmName()).users().get(consumerUser.getId()).toRepresentation().isEmailVerified());
+
+        assertEquals(2, mail.getReceivedMessages().length);
+        String verificationUrl = assertEmailAndGetUrl(mail.getLastReceivedMessage(), MailServerConfiguration.FROM, USER_EMAIL,
+                "verify your email address");
+        driver.navigate().to(verificationUrl.trim());
+
         //test if user is logged in
         assertTrue(driver.getCurrentUrl().startsWith(getConsumerRoot() + "/auth/realms/master/app/"));
         //test if the user has verified email
         assertTrue(adminClient.realm(bc.consumerRealmName()).users().get(consumerUser.getId()).toRepresentation().isEmailVerified());
 
         driver.navigate().to(url);
-        waitForPage(driver, "your email address has been verified already.", false);
+        waitForPage(driver, "account linking already confirmed", false);
         AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), "consumer");
 
         driver.navigate().to(url);
-        waitForPage(driver, "your email address has been verified already.", false);
+        waitForPage(driver, "account linking already confirmed", false);
 
         driver2.navigate().to(url);
-        waitForPage(driver, "your email address has been verified already.", false);
+        waitForPage(driver, "account linking already confirmed", false);
     }
 
     @Test
@@ -1217,7 +1238,7 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         assertThat(driver2.findElement(By.id("kc-page-title")).getText(), startsWith("Confirm linking the account"));
         assertThat(driver2.findElement(By.className("instruction")).getText(), startsWith("If you link the account, you will also be able to login using account"));
         driver2.findElement(By.linkText("» Click here to proceed")).click();
-        assertThat(driver2.findElement(By.className("instruction")).getText(), startsWith("You successfully verified your email."));
+        assertThat(driver2.findElement(By.className("instruction")).getText(), startsWith("You successfully confirmed linking your account"));
 
         idpLinkEmailPage.continueLink();
 
@@ -1349,7 +1370,21 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
         MatcherAssert.assertThat(link, Matchers.containsString("client_id=broker-app"));
         proceedLink.click();
 
-        assertThat(driver2.getPageSource(), Matchers.containsString("You successfully verified your email. Please go back to your original browser and continue there with the login."));
+        assertThat(driver2.getPageSource(), Matchers.containsString("Please go back to your original browser and continue there with the login."));
+
+        //confirm the account linking does not verify the email
+        assertFalse(consumerRealm.users().get(linkedUserId).toRepresentation().isEmailVerified());
+
+        idpLinkEmailPage.continueLink();
+        verifyEmailPage.assertCurrent();
+
+        assertEquals(2, mail.getReceivedMessages().length);
+        String verificationUrl = assertEmailAndGetUrl(mail.getLastReceivedMessage(), MailServerConfiguration.FROM, USER_EMAIL,
+                "verify your email address");
+        driver.navigate().to(verificationUrl.trim());
+
+        //test if user is logged in and redirected to the client used for the login, which is preserved
+        assertTrue(driver.getCurrentUrl().startsWith(getConsumerRoot() + "/auth/realms/" + bc.consumerRealmName() + "/app"));
 
         //test if the user has verified email
         assertTrue(consumerRealm.users().get(linkedUserId).toRepresentation().isEmailVerified());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -342,6 +342,15 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void resetPasswordDoesNotSetEmailVerified() throws IOException {
+        assertFalse(managedRealm.admin().users().get(userId).toRepresentation().isEmailVerified());
+
+        resetPassword("login-test");
+
+        assertFalse(managedRealm.admin().users().get(userId).toRepresentation().isEmailVerified());
+    }
+
+    @Test
     public void resetPasswordTwice() throws IOException {
         String changePasswordUrl = resetPassword("login-test");
         events.clear();

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -179,9 +179,9 @@ emailVerifySendCooldown=You must wait {0} seconds before resending the verificat
 
 emailLinkIdpTitle=Link {0}
 emailLinkIdp1=An email with instructions to link {0} account {1} with your {2} account has been sent to you.
-emailLinkIdp2=Haven''t received a verification code in your email?
+emailLinkIdp2=Haven''t received the email?
 emailLinkIdp3=to re-send the email.
-emailLinkIdp4=If you already verified the email in a different browser
+emailLinkIdp4=If you already confirmed linking the account in a different browser
 emailLinkIdp5=to continue.
 
 backToLogin=« Back to Login
@@ -373,7 +373,10 @@ identityProviderMissingCodeOrErrorMessage=Missing code or error parameter in res
 identityProviderInvalidResponseMessage=Invalid response from identity provider.
 identityProviderInvalidSignatureMessage=Invalid signature in response from identity provider.
 identityProviderNotFoundMessage=Could not find an identity provider with the identifier.
-identityProviderLinkSuccess=You successfully verified your email. Please go back to your original browser and continue there with the login.
+identityProviderLinkSuccess=You successfully confirmed linking your account with {0} account {1}. Please go back to your original browser and continue there with the login.
+identityProviderLinkSuccessHeader=Account linking confirmed
+identityProviderLinkConfirmedAlreadyMessage=Linking of your account with {0} account {1} has been confirmed already.
+identityProviderLinkConfirmedAlreadyMessageHeader=Account linking already confirmed
 identityProviderAlreadyLinkedMessage=Federated identity returned by {0} is already linked to another user.
 identityProviderAlreadyLinkedToCurrentUserMessage=Your account is already linked to the identity provider {0}.
 staleCodeMessage=This page is no longer valid, please go back to your application and sign in again


### PR DESCRIPTION
The weakness is the emailVerified couldd transition to true as a side effect of flows which purpose is not email verification. With this PR, the email of a user is marked as verified only by an explicit email verification


after the fix, the toggle will only be turned on after user finished the verification step:

https://github.com/user-attachments/assets/2a566c5f-c957-440a-ac97-12be3aa4bc8d



master branch:

https://github.com/user-attachments/assets/cd274d0f-fac1-4644-b27e-6937dad93ee8

the difference between master branch and fix is: on master branch, the user just click confirm linking to the current exist account, but the verified Email toggle is on as a side effect, which is an vulnerability. the fix has an extra step, once you land on a Verify email page, a second email arrives, email verified stays OFF until user click the second link. also the page now says "Account linking confirmed" instead of the false "verified" claim.

Closes #50622

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
