### PR TITLE
Silently disable connection pooling when StartTLS is enabled during LDAP validation

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -307,9 +307,11 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
             }
         }
 
-        // This parses the configuration directly as cfg.getConnectionPooling() will take into account the current StartTLS setting
-        if(cfg.isStartTls() && Boolean.parseBoolean(config.getConfig().getFirst(LDAPConstants.CONNECTION_POOLING))) {
-            throw new ComponentValidationException("ldapErrorCantEnableStartTlsAndConnectionPooling");
+        // Silently disable connection pooling when StartTLS is enabled, rather than rejecting.
+        // This handles the case where connectionPooling=true was stored (e.g. by the Admin UI default)
+        // before StartTLS was enabled, or when a programmatic client sets both.
+        if (cfg.isStartTls() && Boolean.parseBoolean(config.getConfig().getFirst(LDAPConstants.CONNECTION_POOLING))) {
+            config.getConfig().putSingle(LDAPConstants.CONNECTION_POOLING, "false");
         }
 
         // editMode is mandatory


### PR DESCRIPTION
Closes #50949

When an LDAP federation has both `startTls=true` and `connectionPooling=true` stored in its config (e.g. from the Admin UI default introduced in #35852), the validation in `LDAPStorageProviderFactory.validateConfiguration()` throws `ComponentValidationException("ldapErrorCantEnableStartTlsAndConnectionPooling")`.

The runtime already handles this correctly via `LDAPConfig.getConnectionPooling()` returning `null` when StartTLS is active (connection pooling is effectively disabled). The validation should match this behavior by auto-correcting the stored value rather than rejecting.

**Change:** Replace the `throw` with `config.getConfig().putSingle(CONNECTION_POOLING, "false")` - silently fix the incompatible combination on save, matching the runtime semantics.

This is a regression from #35852 (commit 4ef178242fab). The original validation used `cfg.getConnectionPooling()` which always returned null when StartTLS was on. The new validation correctly identifies the incompatibility but rejects where it should correct.