### PR TITLE
Allow clients with view-users or manage-users to access user profile endpoints

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
@@ -78,7 +78,7 @@ public class UserProfileResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public UPConfig getConfiguration() {
-        if (auth.realm().canViewRealm() || auth.users().canQuery()) {
+        if (auth.realm().canViewRealm() || auth.users().canQuery() || auth.users().canView()) {
             return session.getProvider(UserProfileProvider.class).getConfiguration();
         } else {
             throw new ForbiddenException();
@@ -95,7 +95,7 @@ public class UserProfileResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public UserProfileMetadata getMetadata() {
-        if (auth.realm().canViewRealm() || auth.users().canQuery()) {
+        if (auth.realm().canViewRealm() || auth.users().canQuery() || auth.users().canView()) {
             UserProfile profile = session.getProvider(UserProfileProvider.class).create(UserProfileContext.USER_API, Collections.emptyMap());
             return createUserProfileMetadata(session, profile);
         } else {


### PR DESCRIPTION
Closes #50950

The CVE-2025-14083 fix (#45493) narrowed the permission check for `GET /admin/realms/{realm}/users/profile` and `GET /admin/realms/{realm}/users/profile/metadata` from `requireAnyAdminRole()` to `canViewRealm() || canQuery()`.

While this correctly blocks the `create-client`-only attack vector (the CVE), it also blocks legitimate service accounts that have `manage-users` or `view-users` roles but not specifically `view-realm` or `query-users`.

A client with `manage-users` legitimately needs access to the user profile schema to correctly create and update users via the admin API.

**Change:** Add `|| auth.users().canView()` to the permission check in both `getConfiguration()` and `getMetadata()`. 

`canView()` returns true when the client has `view-users` or `manage-users` roles. This grants access to clients that work with users while maintaining CVE-2025-14083 protection - a client with only `create-client` still cannot access user profile data since it has none of: `view-realm`, `query-users`, `view-users`, or `manage-users`.