### PR TITLE
Upgrade jackson-databind to 2.21.5 to fix CVE-2026-59888 and CVE-2026-59889

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,13 @@
 
         <dependencies>
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.21.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-bom</artifactId>
                 <version>${infinispan.version}</version>


### PR DESCRIPTION
Closes #50955

Adds a `jackson-bom` 2.21.5 import before the Quarkus BOM in `<dependencyManagement>` to override the jackson-databind version from 2.21.2 to 2.21.5.

**CVEs addressed:**
- **CVE-2026-59888** (CVSS 6.5): `@JsonIgnore` bypass on Java Records with `PropertyNamingStrategy`. Fixed in 2.21.4.
- **CVE-2026-59889** (CVSS 6.5): `@JsonUnwrapped` bypasses `@JsonView` visibility. Fixed in 2.21.5.

**Why not wait for Quarkus BOM update:**
The Quarkus BOM includes jackson-databind 2.21.4 only from Quarkus 3.36.1 (jackson-databind 2.21.5 from Quarkus 3.37.0). KC currently uses Quarkus 3.33.2.1. Waiting for a full Quarkus uplift delays the security fix unnecessarily.

**Risk assessment:**
This is a patch-level bump (2.21.2 → 2.21.5) within the same minor. The jackson-databind 2.21.3/4/5 changelogs contain only bug fixes and security fixes with no API-breaking changes. KC does not use the affected patterns (Java Records for deserialization, `@JsonView` + `@JsonUnwrapped`) but the vulnerable library is shipped.

**Note:** This override can be removed once KC upgrades to Quarkus >= 3.37.0 which natively includes jackson-databind >= 2.22.0.