### PR TITLE
[OID4VCI] Fix unbounded OID4VCI credential offer expiration

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -234,10 +234,24 @@ public class OID4VCIssuerEndpoint {
 
         this.credentialBuilders = loadCredentialBuilders(session);
 
-        RealmModel realm = keycloakSession.getContext().getRealm();
-        this.credentialOfferLifespan = Optional.ofNullable(realm.getAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY))
-                .map(Integer::valueOf)
-                .orElse(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
+        this.credentialOfferLifespan = getCredentialOfferLifespan(keycloakSession.getContext().getRealm());
+    }
+
+    /**
+     * Returns the configured credential-offer lifespan, falling back to the default for missing or malformed values.
+     */
+    public static int getCredentialOfferLifespan(RealmModel realm) {
+        String configuredLifespan = realm.getAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+        if (configuredLifespan == null) {
+            return DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
+        }
+        try {
+            return Integer.parseInt(configuredLifespan);
+        } catch (NumberFormatException e) {
+            LOGGER.warnf("Invalid credential offer lifespan '%s' configured for realm '%s'; using default of %d seconds",
+                    configuredLifespan, realm.getName(), DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
+            return DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
+        }
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -112,6 +112,8 @@ import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
 import org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils;
 import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
+import org.keycloak.protocol.oidc.encode.AccessTokenContext;
+import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantType;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
 import org.keycloak.representations.AccessToken;
@@ -480,7 +482,7 @@ public class OID4VCIssuerEndpoint {
             @QueryParam("credential_configuration_id") String credentialConfigurationId,
             @QueryParam("pre_authorized") @DefaultValue("false") Boolean preAuthorized,
             @QueryParam("target_user") String targetUser,
-            @QueryParam("expire") Integer expiresAt,
+            @QueryParam("expire") Long expiresAt,
             @QueryParam("type") @DefaultValue("uri") OfferResponseType responseType,
             @QueryParam("width") @DefaultValue("200") int width,
             @QueryParam("height") @DefaultValue("200") int height
@@ -534,8 +536,17 @@ public class OID4VCIssuerEndpoint {
             targetUser = loginUserModel.getUsername();
         }
 
+        long currentTime = timeProvider.currentTimeSeconds();
+        long maximumExpiresAt = currentTime + credentialOfferLifespan;
         if (expiresAt == null) {
-            expiresAt = timeProvider.currentTimeSeconds() + credentialOfferLifespan;
+            expiresAt = maximumExpiresAt;
+        }
+        if (expiresAt <= currentTime || expiresAt > maximumExpiresAt) {
+            var errorMessage = String.format(
+                    "Credential offer expiration must be after the current time and no later than %d", maximumExpiresAt);
+            eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_REQUEST.getValue());
+            throw new CorsErrorResponseException(cors,
+                    ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST.getValue(), errorMessage, Response.Status.BAD_REQUEST);
         }
 
         // Create the CredentialsOffer
@@ -550,6 +561,30 @@ public class OID4VCIssuerEndpoint {
             CredentialOfferProvider offerProvider = session.getProvider(CredentialOfferProvider.class);
             offerState = offerProvider.createCredentialOffer(loginUserModel, grantType,
                     credentialConfigurationIds, targetClientId, targetUser, expiresAt);
+            if (preAuthorized) {
+                offerState.setOriginatingUserId(loginUserModel.getId());
+                // Bearer authentication reconstructs request-scoped sessions for stateless tokens. Bind the offer to
+                // a session only when the access token identifies a persistent online or offline origin.
+                AccessTokenContext.SessionType originatingSessionType = session
+                        .getProvider(TokenContextEncoderProvider.class)
+                        .getTokenContextFromTokenId(getAuthResult().token().getId())
+                        .getSessionType();
+                boolean transientUserSession = originatingSessionType == AccessTokenContext.SessionType.TRANSIENT;
+                boolean originatingSessionOffline = switch (originatingSessionType) {
+                    case OFFLINE, OFFLINE_TRANSIENT_CLIENT -> true;
+                    case UNKNOWN -> userSession.isOffline();
+                    default -> false;
+                };
+                boolean bindOriginatingSession = !transientUserSession
+                        && (originatingSessionType != AccessTokenContext.SessionType.UNKNOWN
+                        || loginUserModel.getServiceAccountClientLink() == null);
+                if (bindOriginatingSession) {
+                    offerState.setOriginatingUserSessionId(userSession.getId());
+                    offerState.setOriginatingUserSessionOffline(originatingSessionOffline);
+                }
+                offerState.setOriginatingUserPasswordCredentialCreatedDate(
+                        OID4VCUtil.getPasswordCredentialTimestamp(loginUserModel));
+            }
 
         } catch (CredentialOfferException ex) {
             eventBuilder.detail(Details.REASON, ex.getMessage()).error(ex.getErrorType());

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OffsetTimeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OffsetTimeProvider.java
@@ -25,8 +25,8 @@ import org.keycloak.common.util.Time;
 public class OffsetTimeProvider implements TimeProvider {
 
     @Override
-    public int currentTimeSeconds() {
-        return Time.currentTime();
+    public long currentTimeSeconds() {
+        return Time.currentTimeSeconds();
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeProvider.java
@@ -27,7 +27,7 @@ public interface TimeProvider {
      *
      * @return see description
      */
-    int currentTimeSeconds();
+    long currentTimeSeconds();
 
     /**
      * Returns current time in milliseconds

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProvider.java
@@ -84,6 +84,24 @@ public interface CredentialOfferProvider extends Provider {
             Integer expireAt
     );
 
+    /**
+     * Creates a credential offer with a {@code long} expiration timestamp.
+     * <p>
+     * The overload preserves compatibility with providers implementing the original {@link Integer}-based SPI. Providers
+     * that need to support expiration timestamps beyond the integer range can override this method directly.
+     */
+    default CredentialOfferState createCredentialOffer(
+            UserModel user,
+            String grantType,
+            List<String> credentialConfigurationIds,
+            String targetClientId,
+            String targetUserId,
+            long expireAt
+    ) {
+        return createCredentialOffer(user, grantType, credentialConfigurationIds, targetClientId, targetUserId,
+                Integer.valueOf(Math.toIntExact(expireAt)));
+    }
+
     @Override
     default void close() {
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProvider.java
@@ -18,7 +18,9 @@ package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import java.util.List;
 
+import org.keycloak.events.Errors;
 import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oid4vc.issuance.CredentialOfferException;
 import org.keycloak.provider.Provider;
 
 /**
@@ -98,8 +100,12 @@ public interface CredentialOfferProvider extends Provider {
             String targetUserId,
             long expireAt
     ) {
+        if (expireAt < Integer.MIN_VALUE || expireAt > Integer.MAX_VALUE) {
+            throw new CredentialOfferException(Errors.INVALID_REQUEST,
+                    "Credential offer expiration is outside the integer range supported by this provider: " + expireAt);
+        }
         return createCredentialOffer(user, grantType, credentialConfigurationIds, targetClientId, targetUserId,
-                Integer.valueOf(Math.toIntExact(expireAt)));
+                Integer.valueOf((int) expireAt));
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
@@ -37,8 +37,13 @@ public class CredentialOfferState {
     private CredentialsOffer credentialsOffer;
     private String targetClientId;
     private String targetUserId;
+    private String originatingUserId;
+    private String originatingUserSessionId;
+    private Boolean originatingUserSessionOffline;
+    private Long originatingUserPasswordCredentialCreatedDate;
     private String nonce;
     private String txCode;
+    private Long createdAt;
     private long expiresAt;
     private List<OID4VCAuthorizationDetail> authDetails;
 
@@ -65,6 +70,7 @@ public class CredentialOfferState {
         this.credentialsOffer = credOffer;
         this.targetClientId = clientId;
         this.targetUserId = userId;
+        this.createdAt = Time.currentTimeSeconds();
         this.expiresAt = expiresAt;
         String nonceSecret = Base64Url.encode(RandomSecret.createRandomSecret(64));
         this.nonce = CredentialOfferLookupKey.embed(nonceSecret, credentialsOfferId);
@@ -94,12 +100,48 @@ public class CredentialOfferState {
         return targetUserId;
     }
 
+    public String getOriginatingUserId() {
+        return originatingUserId;
+    }
+
+    public void setOriginatingUserId(String originatingUserId) {
+        this.originatingUserId = originatingUserId;
+    }
+
+    public String getOriginatingUserSessionId() {
+        return originatingUserSessionId;
+    }
+
+    public void setOriginatingUserSessionId(String originatingUserSessionId) {
+        this.originatingUserSessionId = originatingUserSessionId;
+    }
+
+    public Boolean getOriginatingUserSessionOffline() {
+        return originatingUserSessionOffline;
+    }
+
+    public void setOriginatingUserSessionOffline(Boolean originatingUserSessionOffline) {
+        this.originatingUserSessionOffline = originatingUserSessionOffline;
+    }
+
+    public Long getOriginatingUserPasswordCredentialCreatedDate() {
+        return originatingUserPasswordCredentialCreatedDate;
+    }
+
+    public void setOriginatingUserPasswordCredentialCreatedDate(Long originatingUserPasswordCredentialCreatedDate) {
+        this.originatingUserPasswordCredentialCreatedDate = originatingUserPasswordCredentialCreatedDate;
+    }
+
     public String getNonce() {
         return nonce;
     }
 
     public String getTxCode() {
         return txCode;
+    }
+
+    public Long getCreatedAt() {
+        return createdAt;
     }
 
     public long getExpiresAt() {
@@ -142,7 +184,7 @@ public class CredentialOfferState {
 
     @JsonIgnore
     public boolean isExpired() {
-        int currentTime = Time.currentTime();
+        long currentTime = Time.currentTimeSeconds();
         return expiresAt <= currentTime;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
@@ -66,6 +66,18 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
             String targetClientId,
             String targetUsername,
             Integer expireAt) {
+        return createCredentialOffer(user, grantType, credentialConfigurationIds, targetClientId, targetUsername,
+                expireAt.longValue());
+    }
+
+    @Override
+    public CredentialOfferState createCredentialOffer(
+            UserModel user,
+            String grantType,
+            List<String> credentialConfigurationIds,
+            String targetClientId,
+            String targetUsername,
+            long expireAt) {
 
         // Checks whether `--feature=oid4vc_vci_preauth_code` is enabled
         //

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
@@ -56,7 +56,7 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
      * @return Lifespan in seconds, or 0 if the entry is already expired
      */
     private long calculateLifespanSeconds(long expiresAt) {
-        long currentTime = Time.currentTime();
+        long currentTime = Time.currentTimeSeconds();
         long lifespan = expiresAt - currentTime;
         
         // If already expired or about to expire immediately, skip storage

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
@@ -99,7 +99,7 @@ public class JwtPreAuthCodeHandler implements PreAuthCodeHandler {
             throw new VerificationException("Jwt pre-auth code has no expiration time");
         }
 
-        long now = Time.currentTime();
+        long now = Time.currentTimeSeconds();
         if (exp < now) {
             String message = String.format("Jwt pre-auth code not valid: %s (exp) < %s (now)", exp, now);
             throw new VerificationException(message, Errors.EXPIRED_CODE);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/VerifiableCredentialOfferAction.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/VerifiableCredentialOfferAction.java
@@ -169,7 +169,7 @@ public class VerifiableCredentialOfferAction implements RequiredActionProvider, 
         int credentialOfferLifespan = Optional.ofNullable(realm.getAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY))
                 .map(Integer::valueOf)
                 .orElse(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
-        int expiresAt = timeProvider.currentTimeSeconds() + credentialOfferLifespan;
+        long expiresAt = timeProvider.currentTimeSeconds() + credentialOfferLifespan;
 
         String credentialConfigurationId = actionConfig.getCredentialConfigurationId();
         event = event.clone().detail(Details.CREDENTIAL_TYPE, credentialConfigurationId);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/VerifiableCredentialOfferAction.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/VerifiableCredentialOfferAction.java
@@ -2,7 +2,6 @@ package org.keycloak.protocol.oid4vc.issuance.requiredactions;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import jakarta.ws.rs.core.Response;
 
@@ -39,8 +38,7 @@ import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_NONCE;
 import static org.keycloak.constants.OID4VCIConstants.IS_ADMIN_INITIATED;
 import static org.keycloak.constants.OID4VCIConstants.VERIFIABLE_CREDENTIAL_OFFER_PROVIDER_ID;
 import static org.keycloak.events.Details.REASON;
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY;
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.getCredentialOfferLifespan;
 import static org.keycloak.protocol.oid4vc.model.AuthorizationCodeGrant.AUTH_CODE_GRANT_TYPE;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.MISSING_CREDENTIAL_CONFIG;
@@ -166,9 +164,7 @@ public class VerifiableCredentialOfferAction implements RequiredActionProvider, 
                                                         VerifiableCredentialOfferActionConfig actionConfig) throws CredentialOfferException {
         boolean preAuthorized = actionConfig.getPreAuthorized() != null && actionConfig.getPreAuthorized();
         String grantType = preAuthorized ? PRE_AUTH_GRANT_TYPE : AUTH_CODE_GRANT_TYPE;
-        int credentialOfferLifespan = Optional.ofNullable(realm.getAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY))
-                .map(Integer::valueOf)
-                .orElse(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
+        int credentialOfferLifespan = getCredentialOfferLifespan(realm);
         long expiresAt = timeProvider.currentTimeSeconds() + credentialOfferLifespan;
 
         String credentialConfigurationId = actionConfig.getCredentialConfigurationId();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
@@ -12,6 +12,7 @@ import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserVerifiableCredentialModel;
+import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
@@ -44,6 +45,23 @@ public class OID4VCUtil {
     public static boolean hasVerifiableCredential(KeycloakSession session, UserModel user, CredentialScopeModel credentialScope) {
         return session.users().getVerifiableCredentialsByUser(user.getId())
                 .anyMatch(credential -> credential.getClientScopeId().equals(credentialScope.getId()));
+    }
+
+    /**
+     * Returns the timestamp exposed by the user's password credential.
+     * <p>
+     * The combined credential stream is important for federated users because providers such as LDAP expose their
+     * password modification timestamp as federated credential metadata rather than as a locally stored credential.
+     *
+     * @return the credential timestamp, {@code 0} when the credential has no timestamp, or {@code -1} when no password
+     * credential metadata is available
+     */
+    public static long getPasswordCredentialTimestamp(UserModel user) {
+        return user.credentialManager().getCredentials()
+                .filter(credential -> PasswordCredentialModel.TYPE.equals(credential.getType()))
+                .mapToLong(credential -> Optional.ofNullable(credential.getCreatedDate()).orElse(0L))
+                .max()
+                .orElse(-1L);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -41,10 +41,12 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakUriInfo;
 import org.keycloak.models.SingleUseObjectProvider;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
@@ -52,18 +54,22 @@ import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
 import org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils;
+import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager.AccessTokenResponseBuilder;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;
 import org.keycloak.services.CorsErrorResponseException;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.util.Strings;
 import org.keycloak.utils.MediaType;
 
 import org.jboss.logging.Logger;
 
 import static org.keycloak.events.Details.REASON;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION;
 import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
 import static org.keycloak.services.util.DefaultClientSessionContext.fromClientSessionAndScopeParameter;
@@ -120,6 +126,19 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
                     "Code is expired", Response.Status.BAD_REQUEST);
         }
+
+        int credentialOfferLifespan = Optional.ofNullable(realm.getAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY))
+                .map(Integer::valueOf)
+                .orElse(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
+        if (!isCredentialOfferLifespanValid(offerState, credentialOfferLifespan)) {
+            event.error(Errors.EXPIRED_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    "Code expiration is outside the configured credential offer lifespan", Response.Status.BAD_REQUEST);
+        }
+
+        validateOriginatingSession(offerState.getOriginatingUserId(), offerState.getOriginatingUserSessionId(),
+                offerState.getOriginatingUserSessionOffline(),
+                offerState.getOriginatingUserPasswordCredentialCreatedDate());
 
         String expTxCode = offerState.getTxCode();
         if (expTxCode != null) {
@@ -323,7 +342,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         // Pre-auth code is valid, but let's prevent replay attacks (for the remaining validity period)
         SingleUseObjectProvider singleUseStore = session.singleUseObjects();
         String key = getPreAuthCodeSingleObjectKey(code);
-        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTime();
+        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTimeSeconds();
         boolean firstInsertion = singleUseStore.putIfAbsent(key, expiresIn);
         if (!firstInsertion) {
             String errorMessage = "Pre-authorized code has already been used";
@@ -333,6 +352,57 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         }
 
         return preAuthCodeCtx;
+    }
+
+    static boolean isCredentialOfferLifespanValid(CredentialOfferState offerState, int credentialOfferLifespan) {
+        Long offerCreatedAt = offerState.getCreatedAt();
+        return offerCreatedAt != null
+                && offerCreatedAt > 0
+                && credentialOfferLifespan > 0
+                && offerState.getExpiresAt() > offerCreatedAt
+                && offerState.getExpiresAt() - offerCreatedAt <= credentialOfferLifespan;
+    }
+
+    private void validateOriginatingSession(String originatingUserId, String originatingUserSessionId,
+                                            Boolean originatingUserSessionOffline, Long passwordCredentialCreatedDate) {
+        // Offers created by the REST endpoint are bound to the user session that authorized their creation.
+        // Other offer creation mechanisms, such as the required-action flow, may run before a user session exists.
+        if (originatingUserId == null && originatingUserSessionId == null) {
+            return;
+        }
+
+        UserModel originatingUser = session.users().getUserById(realm, originatingUserId);
+        if (originatingUser == null || !originatingUser.isEnabled()) {
+            String errorMessage = "User that authorized the pre-authorized code is not active";
+            event.detail(REASON, errorMessage).error(Errors.USER_SESSION_NOT_FOUND);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        if (originatingUserSessionId != null) {
+            UserSessionModel originatingSession = Boolean.TRUE.equals(originatingUserSessionOffline)
+                    ? session.sessions().getOfflineUserSession(realm, originatingUserSessionId)
+                    : session.sessions().getUserSession(realm, originatingUserSessionId);
+            boolean validSession = originatingSession != null
+                    && originatingSession.getState() == UserSessionModel.State.LOGGED_IN
+                    && AuthenticationManager.isSessionValid(realm, originatingSession)
+                    && originatingSession.getUser() != null
+                    && originatingSession.getUser().getId().equals(originatingUserId);
+            if (!validSession) {
+                String errorMessage = "Session that authorized the pre-authorized code is not active";
+                event.detail(REASON, errorMessage).error(Errors.USER_SESSION_NOT_FOUND);
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                        errorMessage, Response.Status.BAD_REQUEST);
+            }
+        }
+
+        if (passwordCredentialCreatedDate != null && passwordCredentialCreatedDate.longValue()
+                != OID4VCUtil.getPasswordCredentialTimestamp(originatingUser)) {
+            String errorMessage = "Credentials of the user that authorized the pre-authorized code have changed";
+            event.detail(REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
     }
 
     private static String getPreAuthCodeSingleObjectKey(String code) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -68,8 +68,7 @@ import org.keycloak.utils.MediaType;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.events.Details.REASON;
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY;
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.getCredentialOfferLifespan;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION;
 import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
 import static org.keycloak.services.util.DefaultClientSessionContext.fromClientSessionAndScopeParameter;
@@ -127,9 +126,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                     "Code is expired", Response.Status.BAD_REQUEST);
         }
 
-        int credentialOfferLifespan = Optional.ofNullable(realm.getAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY))
-                .map(Integer::valueOf)
-                .orElse(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
+        int credentialOfferLifespan = getCredentialOfferLifespan(realm);
         if (!isCredentialOfferLifespanValid(offerState, credentialOfferLifespan)) {
             offerStorage.removeOfferState(offerState);
             event.error(Errors.EXPIRED_CODE);
@@ -139,9 +136,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         markPreAuthCodeAsUsed(preAuthCode, offerState.getExpiresAt());
 
-        validateOriginatingSession(offerState.getOriginatingUserId(), offerState.getOriginatingUserSessionId(),
-                offerState.getOriginatingUserSessionOffline(),
-                offerState.getOriginatingUserPasswordCredentialCreatedDate());
+        validateOriginatingSession(offerState, offerStorage);
 
         String expTxCode = offerState.getTxCode();
         if (expTxCode != null) {
@@ -367,12 +362,27 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                 && offerState.getExpiresAt() - offerCreatedAt <= credentialOfferLifespan;
     }
 
-    private void validateOriginatingSession(String originatingUserId, String originatingUserSessionId,
-                                            Boolean originatingUserSessionOffline, Long passwordCredentialCreatedDate) {
+    private void validateOriginatingSession(CredentialOfferState offerState, CredentialOfferStorage offerStorage) {
+        String originatingUserId = offerState.getOriginatingUserId();
+        String originatingUserSessionId = offerState.getOriginatingUserSessionId();
+        Boolean originatingUserSessionOffline = offerState.getOriginatingUserSessionOffline();
+        Long passwordCredentialCreatedDate = offerState.getOriginatingUserPasswordCredentialCreatedDate();
+
         // Offers created by the REST endpoint are bound to the user session that authorized their creation.
         // Other offer creation mechanisms, such as the required-action flow, may run before a user session exists.
-        if (originatingUserId == null && originatingUserSessionId == null) {
-            return;
+        if (originatingUserId == null) {
+            boolean hasPartialMetadata = originatingUserSessionId != null
+                    || originatingUserSessionOffline != null
+                    || passwordCredentialCreatedDate != null;
+            if (!hasPartialMetadata) {
+                return;
+            }
+
+            offerStorage.removeOfferState(offerState);
+            String errorMessage = "Pre-authorized code has incomplete originating session metadata";
+            event.detail(REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    errorMessage, Response.Status.BAD_REQUEST);
         }
 
         UserModel originatingUser = session.users().getUserById(realm, originatingUserId);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -131,10 +131,13 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                 .map(Integer::valueOf)
                 .orElse(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
         if (!isCredentialOfferLifespanValid(offerState, credentialOfferLifespan)) {
+            offerStorage.removeOfferState(offerState);
             event.error(Errors.EXPIRED_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
                     "Code expiration is outside the configured credential offer lifespan", Response.Status.BAD_REQUEST);
         }
+
+        markPreAuthCodeAsUsed(preAuthCode, offerState.getExpiresAt());
 
         validateOriginatingSession(offerState.getOriginatingUserId(), offerState.getOriginatingUserSessionId(),
                 offerState.getOriginatingUserSessionOffline(),
@@ -339,10 +342,13 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                     errorMessage, Response.Status.BAD_REQUEST);
         }
 
-        // Pre-auth code is valid, but let's prevent replay attacks (for the remaining validity period)
+        return preAuthCodeCtx;
+    }
+
+    private void markPreAuthCodeAsUsed(String code, long expiresAt) {
         SingleUseObjectProvider singleUseStore = session.singleUseObjects();
         String key = getPreAuthCodeSingleObjectKey(code);
-        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTimeSeconds();
+        long expiresIn = expiresAt - Time.currentTimeSeconds();
         boolean firstInsertion = singleUseStore.putIfAbsent(key, expiresIn);
         if (!firstInsertion) {
             String errorMessage = "Pre-authorized code has already been used";
@@ -350,8 +356,6 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
                     errorMessage, Response.Status.BAD_REQUEST);
         }
-
-        return preAuthCodeCtx;
     }
 
     static boolean isCredentialOfferLifespanValid(CredentialOfferState offerState, int credentialOfferLifespan) {

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProviderTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProviderTest.java
@@ -2,9 +2,13 @@ package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.keycloak.events.Errors;
+import org.keycloak.protocol.oid4vc.issuance.CredentialOfferException;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class CredentialOfferProviderTest {
 
@@ -20,5 +24,19 @@ public class CredentialOfferProviderTest {
         provider.createCredentialOffer(null, null, null, null, null, 123L);
 
         assertEquals(Integer.valueOf(123), delegatedExpiration.get());
+    }
+
+    @Test
+    public void shouldRejectLongExpirationOutsideIntegerSpiRange() {
+        CredentialOfferProvider provider = (user, grantType, credentialConfigurationIds, targetClientId, targetUserId,
+                                            expireAt) -> null;
+        long expireAt = (long) Integer.MAX_VALUE + 1;
+
+        CredentialOfferException exception = assertThrows(CredentialOfferException.class,
+                () -> provider.createCredentialOffer(null, null, null, null, null, expireAt));
+
+        assertEquals(Errors.INVALID_REQUEST, exception.getErrorType());
+        assertEquals("Credential offer expiration is outside the integer range supported by this provider: " + expireAt,
+                exception.getMessage());
     }
 }

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProviderTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProviderTest.java
@@ -1,0 +1,24 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CredentialOfferProviderTest {
+
+    @Test
+    public void shouldDelegateLongExpirationToIntegerSpiImplementation() {
+        AtomicReference<Integer> delegatedExpiration = new AtomicReference<>();
+        CredentialOfferProvider provider = (user, grantType, credentialConfigurationIds, targetClientId, targetUserId,
+                                            expireAt) -> {
+            delegatedExpiration.set(expireAt);
+            return null;
+        };
+
+        provider.createCredentialOffer(null, null, null, null, null, 123L);
+
+        assertEquals(Integer.valueOf(123), delegatedExpiration.get());
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantTypeTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantTypeTest.java
@@ -1,0 +1,134 @@
+package org.keycloak.protocol.oidc.grants;
+
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.protocol.oid4vc.issuance.OffsetTimeProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
+import org.keycloak.util.JsonSerialization;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PreAuthorizedCodeGrantTypeTest {
+
+    @Test
+    public void shouldAcceptOfferWithinConfiguredLifespan() {
+        CredentialOfferState offerState = createOfferState(300);
+
+        assertTrue(PreAuthorizedCodeGrantType.isCredentialOfferLifespanValid(offerState, 300));
+    }
+
+    @Test
+    public void shouldRejectOfferCreatedWithExcessiveLifespan() {
+        CredentialOfferState offerState = createOfferState(3600);
+
+        assertFalse(PreAuthorizedCodeGrantType.isCredentialOfferLifespanValid(offerState, 300));
+    }
+
+    @Test
+    public void shouldRejectLegacyOfferWithoutCreationTime() throws Exception {
+        CredentialOfferState legacyOfferState = JsonSerialization.readValue(
+                "{\"expiresAt\":2147483647}", CredentialOfferState.class);
+
+        assertFalse(PreAuthorizedCodeGrantType.isCredentialOfferLifespanValid(legacyOfferState, 300));
+    }
+
+    @Test
+    public void shouldAcceptOfferCreatedBeyondIntegerTimeRange() {
+        int originalOffset = Time.getOffset();
+        try {
+            Time.setOffset(Integer.MAX_VALUE);
+            assertTrue(new OffsetTimeProvider().currentTimeSeconds() > Integer.MAX_VALUE);
+
+            CredentialOfferState offerState = createOfferState(300);
+
+            assertTrue(offerState.getCreatedAt() > Integer.MAX_VALUE);
+            assertFalse(offerState.isExpired());
+            assertTrue(PreAuthorizedCodeGrantType.isCredentialOfferLifespanValid(offerState, 300));
+        } finally {
+            Time.setOffset(originalOffset);
+        }
+    }
+
+    @Test
+    public void shouldResolveFederatedPasswordTimestamp() {
+        CredentialModel federatedPassword = credential(PasswordCredentialModel.TYPE, 1234L);
+        federatedPassword.setFederationLink("ldap-provider");
+
+        assertEquals(1234L, OID4VCUtil.getPasswordCredentialTimestamp(userWithCredentials(federatedPassword)));
+    }
+
+    @Test
+    public void shouldIgnoreNonPasswordCredentialsBeforeFederatedPassword() {
+        CredentialModel localOtp = credential("otp", 1000L);
+        CredentialModel federatedPassword = credential(PasswordCredentialModel.TYPE, 2000L);
+        federatedPassword.setFederationLink("ldap-provider");
+
+        assertEquals(2000L,
+                OID4VCUtil.getPasswordCredentialTimestamp(userWithCredentials(localOtp, federatedPassword)));
+    }
+
+    @Test
+    public void shouldUseNewestLocalOrFederatedPasswordTimestamp() {
+        CredentialModel localPassword = credential(PasswordCredentialModel.TYPE, 2000L);
+        CredentialModel federatedPassword = credential(PasswordCredentialModel.TYPE, 1000L);
+        federatedPassword.setFederationLink("ldap-provider");
+        UserModel user = userWithCredentials(localPassword, federatedPassword);
+
+        assertEquals(2000L, OID4VCUtil.getPasswordCredentialTimestamp(user));
+
+        federatedPassword.setCreatedDate(3000L);
+        assertEquals(3000L, OID4VCUtil.getPasswordCredentialTimestamp(user));
+    }
+
+    @Test
+    public void shouldPreserveSentinelsForMissingPasswordMetadata() {
+        CredentialModel passwordWithoutTimestamp = credential(PasswordCredentialModel.TYPE, null);
+
+        assertEquals(0L, OID4VCUtil.getPasswordCredentialTimestamp(userWithCredentials(passwordWithoutTimestamp)));
+        assertEquals(-1L, OID4VCUtil.getPasswordCredentialTimestamp(userWithCredentials()));
+    }
+
+    private CredentialOfferState createOfferState(int lifespan) {
+        return new CredentialOfferState(new CredentialsOffer(), null, null, Time.currentTimeSeconds() + lifespan, null);
+    }
+
+    private CredentialModel credential(String type, Long createdDate) {
+        CredentialModel credential = new CredentialModel();
+        credential.setType(type);
+        credential.setCreatedDate(createdDate);
+        return credential;
+    }
+
+    private UserModel userWithCredentials(CredentialModel... credentials) {
+        SubjectCredentialManager credentialManager = (SubjectCredentialManager) Proxy.newProxyInstance(
+                SubjectCredentialManager.class.getClassLoader(),
+                new Class<?>[]{SubjectCredentialManager.class},
+                (proxy, method, args) -> {
+                    if ("getCredentials".equals(method.getName())) {
+                        return Arrays.stream(credentials);
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+        return (UserModel) Proxy.newProxyInstance(
+                UserModel.class.getClassLoader(),
+                new Class<?>[]{UserModel.class},
+                (proxy, method, args) -> {
+                    if ("credentialManager".equals(method.getName())) {
+                        return credentialManager;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                });
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantTypeTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantTypeTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
@@ -15,6 +16,9 @@ import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
 import org.keycloak.util.JsonSerialization;
 
 import org.junit.Test;
+
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.getCredentialOfferLifespan;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,6 +31,12 @@ public class PreAuthorizedCodeGrantTypeTest {
         CredentialOfferState offerState = createOfferState(300);
 
         assertTrue(PreAuthorizedCodeGrantType.isCredentialOfferLifespanValid(offerState, 300));
+    }
+
+    @Test
+    public void shouldUseDefaultCredentialOfferLifespanWhenRealmAttributeIsNotNumeric() {
+        assertEquals(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S,
+                getCredentialOfferLifespan(realmWithCredentialOfferLifespan("not-a-number")));
     }
 
     @Test
@@ -102,6 +112,17 @@ public class PreAuthorizedCodeGrantTypeTest {
 
     private CredentialOfferState createOfferState(int lifespan) {
         return new CredentialOfferState(new CredentialsOffer(), null, null, Time.currentTimeSeconds() + lifespan, null);
+    }
+
+    private RealmModel realmWithCredentialOfferLifespan(String lifespan) {
+        return (RealmModel) Proxy.newProxyInstance(
+                RealmModel.class.getClassLoader(),
+                new Class<?>[]{RealmModel.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getAttribute" -> lifespan;
+                    case "getName" -> "test";
+                    default -> null;
+                });
     }
 
     private CredentialModel credential(String type, Long createdDate) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -135,13 +135,16 @@ public class OID4VCBasicWallet {
         // Create CredentialOfferURI
         //
         CredentialOfferUriResponse credOfferUriRes;
+        CredentialOfferUriRequest uriRequest = null;
         try {
             String credConfigId = ctx.getCredentialConfigurationId();
-            var uriRequest = credentialOfferUriRequest(ctx, credConfigId);
+            uriRequest = credentialOfferUriRequest(ctx, credConfigId);
             consumer.accept(uriRequest.bearerToken(issToken));
             credOfferUriRes = uriRequest.send();
         } finally {
-            logout(ctx.getIssuer());
+            if (uriRequest == null || !uriRequest.isPreAuthorized()) {
+                logout(ctx.getIssuer());
+            }
         }
 
         return credOfferUriRes.getCredentialOfferURI();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCCredentialOfferCorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCCredentialOfferCorsTest.java
@@ -293,7 +293,7 @@ public class OID4VCCredentialOfferCorsTest extends OID4VCIssuerEndpointTest {
             CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
             // Create offer with expiration time just 1 second in the past
             // This ensures it's still findable in storage but marked as expired
-            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() - 1, null);
+            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTimeSeconds() - 1, null);
             offerStorage.putOfferState(offerState);
             return offerState.getNonce();
         });

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -478,7 +478,7 @@ public abstract class OID4VCIssuerTestBase {
     protected void setRealmAttributes(Map<String, String> extraAttributes) {
         RealmResource realmResource = testRealm.admin();
         RealmRepresentation realm = realmResource.toRepresentation();
-        Map<String, String> attributes = realm.getAttributesOrEmpty();
+        Map<String, String> attributes = new HashMap<>(realm.getAttributesOrEmpty());
         attributes.putAll(extraAttributes);
         realm.setAttributes(attributes);
         realmResource.update(realm);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -1132,14 +1132,14 @@ public abstract class OID4VCIssuerTestBase {
     }
 
     public static class StaticTimeProvider implements TimeProvider {
-        private final int currentTimeInS;
+        private final long currentTimeInS;
 
-        public StaticTimeProvider(int currentTimeInS) {
+        public StaticTimeProvider(long currentTimeInS) {
             this.currentTimeInS = currentTimeInS;
         }
 
         @Override
-        public int currentTimeSeconds() {
+        public long currentTimeSeconds() {
             return currentTimeInS;
         }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -231,7 +231,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     .setCredentialConfigurationIds(List.of("credential-configuration-id"));
 
             CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
-            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() + 60, null);
+            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTimeSeconds() + 60, null);
             offerStorage.putOfferState(offerState);
             return offerState.getNonce();
             // The cache transactions need to be committed

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -1,5 +1,6 @@
 package org.keycloak.tests.oid4vc.preauth;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -169,6 +170,22 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
     }
 
     @Test
+    public void mustUseDefaultLifespanWhenConfiguredValueIsNotNumeric() {
+        String originalLifespan = getRealmAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+        try {
+            setRealmAttributes(Map.of(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY, "not-a-number"));
+
+            String preAuthCode = createPreAuthOffer();
+            AccessTokenResponse response = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+
+            assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertNotNull(response.getAccessToken());
+        } finally {
+            restoreCredentialOfferLifespan(originalLifespan);
+        }
+    }
+
+    @Test
     public void mustRetireOfferStateWithExcessiveLifespan() throws JWSInputException {
         String preAuthCode = createPreAuthOffer();
         String offerId = new JWSInput(preAuthCode).readJsonContent(JwtPreAuthCode.class)
@@ -186,16 +203,43 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
             assertTrue(runOnServer.fetch(session -> session.getProvider(CredentialOfferStorage.class)
                     .getOfferStateById(offerId) == null, Boolean.class));
         } finally {
-            var realm = testRealm.admin().toRepresentation();
-            Map<String, String> attributes = realm.getAttributesOrEmpty();
-            if (originalLifespan == null) {
-                attributes.remove(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
-            } else {
-                attributes.put(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY, originalLifespan);
-            }
-            realm.setAttributes(attributes);
-            testRealm.admin().update(realm);
+            restoreCredentialOfferLifespan(originalLifespan);
         }
+    }
+
+    @Test
+    public void mustRetireOfferStateWithIncompleteOriginatingSessionMetadata() throws JWSInputException {
+        String preAuthCode = createPreAuthOffer();
+        String offerId = new JWSInput(preAuthCode).readJsonContent(JwtPreAuthCode.class)
+                .getContext().getCredentialsOfferId();
+        runOnServer.run(session -> {
+            CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
+            var offerState = offerStorage.getOfferStateById(offerId);
+            offerState.setOriginatingUserId(null);
+            offerState.setOriginatingUserSessionId("corrupt-session");
+            offerStorage.putOfferState(offerState);
+        });
+
+        AccessTokenResponse response = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals("invalid_grant", response.getError());
+        assertEquals("Pre-authorized code has incomplete originating session metadata",
+                response.getErrorDescription());
+        assertTrue(runOnServer.fetch(session -> session.getProvider(CredentialOfferStorage.class)
+                .getOfferStateById(offerId) == null, Boolean.class));
+    }
+
+    private void restoreCredentialOfferLifespan(String lifespan) {
+        var realm = testRealm.admin().toRepresentation();
+        Map<String, String> attributes = new HashMap<>(realm.getAttributesOrEmpty());
+        if (lifespan == null) {
+            attributes.remove(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+        } else {
+            attributes.put(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY, lifespan);
+        }
+        realm.setAttributes(attributes);
+        testRealm.admin().update(realm);
     }
 
     private String createPreAuthOffer() {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -86,7 +86,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
                     .issuer("issuer")
                     .addAudience("audience")
                     .issuedNow()
-                    .exp((long) (Time.currentTime() + 60));
+                    .exp(Time.currentTimeSeconds() + 60);
 
             // Sign to yield a valid JWT
             RealmModel realm = session.getContext().getRealm();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -1,6 +1,7 @@
 package org.keycloak.tests.oid4vc.preauth;
 
 import java.util.List;
+import java.util.Map;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
@@ -12,6 +13,7 @@ import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
@@ -29,6 +31,7 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
 import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled;
 
@@ -163,6 +166,36 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
         AccessTokenResponse replayResp = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
         assertEquals(HttpStatus.SC_BAD_REQUEST, replayResp.getStatusCode());
         assertEquals("Pre-authorized code has already been used", replayResp.getErrorDescription());
+    }
+
+    @Test
+    public void mustRetireOfferStateWithExcessiveLifespan() throws JWSInputException {
+        String preAuthCode = createPreAuthOffer();
+        String offerId = new JWSInput(preAuthCode).readJsonContent(JwtPreAuthCode.class)
+                .getContext().getCredentialsOfferId();
+        String originalLifespan = getRealmAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+
+        try {
+            setRealmAttributes(Map.of(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY, "1"));
+
+            AccessTokenResponse response = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+            assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+            assertEquals("invalid_grant", response.getError());
+            assertEquals("Code expiration is outside the configured credential offer lifespan",
+                    response.getErrorDescription());
+            assertTrue(runOnServer.fetch(session -> session.getProvider(CredentialOfferStorage.class)
+                    .getOfferStateById(offerId) == null, Boolean.class));
+        } finally {
+            var realm = testRealm.admin().toRepresentation();
+            Map<String, String> attributes = realm.getAttributesOrEmpty();
+            if (originalLifespan == null) {
+                attributes.remove(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+            } else {
+                attributes.put(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY, originalLifespan);
+            }
+            realm.setAttributes(attributes);
+            testRealm.admin().update(realm);
+        }
     }
 
     private String createPreAuthOffer() {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
@@ -2,9 +2,11 @@ package org.keycloak.tests.oid4vc.preauth;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.common.util.Time;
 import org.keycloak.protocol.oid4vc.model.CredentialDefinition;
 import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
@@ -12,15 +14,25 @@ import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriResponse;
 import org.keycloak.util.JsonSerialization;
 
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,6 +55,167 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled.class)
 public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
+
+    @Test
+    public void testPreAuthOffer_RejectsExpirationBeyondConfiguredLifespan() {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> wallet.createCredentialOfferUri(ctx, req -> {
+                    req.targetUser(ctx.getHolder());
+                    req.preAuthorized(true);
+                    req.expireAt(Time.currentTimeSeconds() + DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S + 60);
+                }));
+
+        CredentialOfferUriResponse response = ctx.getCredentialsOfferUriResponse();
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals("invalid_credential_offer_request", response.getError());
+        assertTrue(response.getErrorDescription()
+                .contains("Credential offer expiration must be after the current time and no later than"));
+        assertEquals(String.format("[%s] %s", response.getError(), response.getErrorDescription()), error.getMessage());
+    }
+
+    @Test
+    public void testPreAuthOffer_RejectsLongMaximumExpiration() {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        assertThrows(IllegalStateException.class,
+                () -> wallet.createCredentialOfferUri(ctx, req -> {
+                    req.targetUser(ctx.getHolder());
+                    req.preAuthorized(true);
+                    req.expireAt(Long.MAX_VALUE);
+                }));
+
+        CredentialOfferUriResponse response = ctx.getCredentialsOfferUriResponse();
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals("invalid_credential_offer_request", response.getError());
+    }
+
+    @Test
+    public void testPreAuthOffer_RejectsExpirationInThePast() {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        assertThrows(IllegalStateException.class,
+                () -> wallet.createCredentialOfferUri(ctx, req -> {
+                    req.targetUser(ctx.getHolder());
+                    req.preAuthorized(true);
+                    req.expireAt(Time.currentTimeSeconds() - 1L);
+                }));
+
+        CredentialOfferUriResponse response = ctx.getCredentialsOfferUriResponse();
+        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertEquals("invalid_credential_offer_request", response.getError());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1 })
+    public void testPreAuthOffer_RejectsDefaultExpirationForNonPositiveConfiguredLifespan(int invalidLifespan) {
+        String originalLifespan = getRealmAttribute(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+        try {
+            setRealmAttributes(Map.of(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY,
+                    Integer.toString(invalidLifespan)));
+            var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+            assertThrows(IllegalStateException.class,
+                    () -> wallet.createCredentialOfferUri(ctx, req -> {
+                        req.targetUser(ctx.getHolder());
+                        req.preAuthorized(true);
+                    }));
+
+            CredentialOfferUriResponse response = ctx.getCredentialsOfferUriResponse();
+            assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+            assertEquals("invalid_credential_offer_request", response.getError());
+        } finally {
+            var realm = testRealm.admin().toRepresentation();
+            Map<String, String> attributes = realm.getAttributesOrEmpty();
+            if (originalLifespan == null) {
+                attributes.remove(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
+            } else {
+                attributes.put(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY, originalLifespan);
+            }
+            realm.setAttributes(attributes);
+            testRealm.admin().update(realm);
+        }
+    }
+
+    @Test
+    public void testPreAuthOffer_OriginatingSessionLogoutRevokesCode() {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
+            req.targetUser(ctx.getHolder());
+            req.preAuthorized(true);
+        });
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "preAuthCode");
+
+        wallet.logout(ctx.getIssuer());
+
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+        assertFalse(tokenResponse.isSuccess(), "Token request should have failed");
+        assertEquals("invalid_grant", tokenResponse.getError());
+        assertEquals("Session that authorized the pre-authorized code is not active", tokenResponse.getErrorDescription());
+    }
+
+    @Test
+    public void testPreAuthOffer_OriginatingUserPasswordChangeRevokesCode() {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
+            req.targetUser(ctx.getHolder());
+            req.preAuthorized(true);
+        });
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "preAuthCode");
+
+        UserRepresentation issuer = testRealm.admin().users().search(ctx.getIssuer(), true).get(0);
+        UserResource issuerResource = testRealm.admin().users().get(issuer.getId());
+        try {
+            issuerResource.resetPassword(passwordCredential("updated-password"));
+
+            AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+            assertFalse(tokenResponse.isSuccess(), "Token request should have failed");
+            assertEquals("invalid_grant", tokenResponse.getError());
+            assertEquals("Credentials of the user that authorized the pre-authorized code have changed",
+                    tokenResponse.getErrorDescription());
+        } finally {
+            issuerResource.resetPassword(passwordCredential(TEST_PASSWORD));
+        }
+    }
+
+    @Test
+    public void testPreAuthOffer_ServiceAccountCanRedeemCode() {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+        UserRepresentation serviceAccount = testRealm.admin().clients().get(client.getId()).getServiceAccountUser();
+        UserResource serviceAccountResource = testRealm.admin().users().get(serviceAccount.getId());
+        RoleRepresentation credentialOfferRole = testRealm.admin().roles()
+                .get(CREDENTIAL_OFFER_CREATE.getName()).toRepresentation();
+        serviceAccountResource.roles().realmLevel().add(List.of(credentialOfferRole));
+
+        try {
+            AccessTokenResponse clientCredentialsResponse = oauth
+                    .client(client.getClientId(), client.getSecret())
+                    .clientCredentialsGrantRequest()
+                    .send();
+            assertTrue(clientCredentialsResponse.isSuccess(), clientCredentialsResponse.getErrorDescription());
+
+            CredentialOfferURI offerUri = oauth.oid4vc()
+                    .credentialOfferUriRequest(ctx.getCredentialConfigurationId())
+                    .targetUser(ctx.getHolder())
+                    .preAuthorized(true)
+                    .bearerToken(clientCredentialsResponse.getAccessToken())
+                    .send()
+                    .getCredentialOfferURI();
+            CredentialsOffer credentialOffer = oauth.oid4vc().doCredentialOfferRequest(offerUri).getCredentialsOffer();
+
+            AccessTokenResponse tokenResponse = wallet
+                    .accessTokenRequestPreAuth(ctx, credentialOffer.getPreAuthorizedCode())
+                    .send();
+            assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+        } finally {
+            serviceAccountResource.roles().realmLevel().remove(List.of(credentialOfferRole));
+        }
+    }
 
     @Test
     public void testPreAuthOffer_DisabledUser() {
@@ -188,6 +361,13 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
     }
 
     // Private ---------------------------------------------------------------------------------------------------------
+
+    private CredentialRepresentation passwordCredential(String password) {
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setValue(password);
+        credential.setTemporary(false);
+        return credential;
+    }
 
     private void verifyCredentialResponse(OID4VCTestContext ctx, String expUser, CredentialResponse credResponse) throws Exception {
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
@@ -1,6 +1,7 @@
 package org.keycloak.tests.oid4vc.preauth;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -127,7 +128,7 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
             assertEquals("invalid_credential_offer_request", response.getError());
         } finally {
             var realm = testRealm.admin().toRepresentation();
-            Map<String, String> attributes = realm.getAttributesOrEmpty();
+            Map<String, String> attributes = new HashMap<>(realm.getAttributesOrEmpty());
             if (originalLifespan == null) {
                 attributes.remove(CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY);
             } else {

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/CredentialOfferUriRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/CredentialOfferUriRequest.java
@@ -16,7 +16,7 @@ public class CredentialOfferUriRequest extends AbstractHttpGetRequest<Credential
     private String credConfigId;
     private Boolean preAuthorized;
     private String targetUser;
-    private Integer expireAt;
+    private Long expireAt;
     private OfferResponseType responseType;
     private Integer width, height;
 
@@ -35,12 +35,21 @@ public class CredentialOfferUriRequest extends AbstractHttpGetRequest<Credential
         return this;
     }
 
+    public boolean isPreAuthorized() {
+        return Boolean.TRUE.equals(preAuthorized);
+    }
+
     public CredentialOfferUriRequest targetUser(String targetUser) {
         this.targetUser = targetUser;
         return this;
     }
 
     public CredentialOfferUriRequest expireAt(Integer expireAt) {
+        this.expireAt = expireAt == null ? null : expireAt.longValue();
+        return this;
+    }
+
+    public CredentialOfferUriRequest expireAt(long expireAt) {
         this.expireAt = expireAt;
         return this;
     }


### PR DESCRIPTION
This change prevents `/create-credential-offer` from creating credential
offers and pre-authorized codes with an unbounded expiration.

It also binds REST-created pre-authorized offers to the session that
authorized their creation, allowing logout and password changes to revoke
outstanding pre-authorized codes.

## Changes

- Validate the `expire` parameter:
  - It must be later than the current time.
  - It must not exceed the configured credential-offer lifespan.
- Use `long` expiration timestamps to avoid integer overflow.
- Record the creation time of credential offers.
- Reject offers whose lifetime exceeds the configured maximum.
- Reject legacy pre-authorized offers without creation-time information.
- Store the originating user and user-session identifiers for REST-created
  pre-authorized offers.
- Record the originating user's password credential creation timestamp.
- Reject pre-authorized code redemption when:
  - The originating session no longer exists or is no longer active.
  - The originating user is disabled or no longer matches the session.
  - The originating user's password has changed.
- Keep the originating session active in wallet tests until the
  pre-authorized code is redeemed.
- Preserve compatibility with existing `CredentialOfferProvider`
  implementations through the existing `Integer`-based SPI method.

closes https://github.com/keycloak/keycloak/issues/50520