### PR TITLE
Group hierarchy search discloses hidden parent groups under FGAP v2

### DIFF
--- a/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
@@ -135,6 +135,12 @@ set of management operations:
 | *manage-membership-of-members* | Defines if a realm administrator can grant or deny `manage-group-membership` for members of a group.
 |===
 
+When a delegated administrator has `view` permission on a group but not on its ancestor groups, the Admin REST API returns the full group hierarchy so the administrator can understand where the group belongs. Ancestor groups without `view` permission are returned as stripped representations containing only `id`, `name`, `path`, `parentId`, and `description`. Sensitive fields such as `attributes`, `realmRoles`, `clientRoles`, and `access` are omitted from these ancestors.
+
+The `subGroupCount` field on stripped ancestors reflects the number of visible children included in the response rather than the total child count. In the admin console, non-viewable ancestor groups appear greyed out and are not clickable.
+
+NOTE: When a delegated administrator has `view` permission only on groups that are not at the top level of the hierarchy, the admin console Groups page initially appears empty because only top-level groups are loaded on the initial page load. The administrator must use the search field to find their permitted groups. The search results then display the full hierarchy with stripped ancestors as described above.
+
 ===== Clients Resource Type
 
 The *Clients* realm resource type represents the clients in a realm. You can manage permissions for clients based on the following

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -14,6 +14,14 @@ If you have delegated administrators that assign client scopes using Fine-Graine
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 
+=== Group hierarchy search returns stripped ancestors under Fine-Grained Admin Permissions
+
+When Fine-Grained Admin Permissions is enabled and a delegated administrator has `view` permission on a group but not on its ancestors, the Admin REST API now returns the full group hierarchy with non-viewable ancestor groups represented as stripped representations. Stripped ancestor representations contain only `id`, `name`, `path`, `parentId`, and `description` — sensitive fields such as `attributes`, `realmRoles`, `clientRoles`, and `access` are omitted.
+
+The `subGroupCount` field on stripped ancestors reflects the number of visible children included in the response, not the total number of children in the database. This prevents leaking information about groups the administrator cannot access.
+
+In the admin console, non-viewable ancestor groups now appear greyed out and are not clickable in the group tree and breadcrumb navigation. Clicking a viewable child group navigates to its details as expected. Note that when a delegated administrator has `view` permission only on groups that are not at the top level, the Groups page initially appears empty. The administrator must use the search field to locate their permitted groups.
+
 === AuthZEN changes
 
 When calling {project_name}'s experimental AuthZEN endpoints, the caller now needs to be an authenticated confidential client's access token. Previously, it could be called with a user's access token.

--- a/js/apps/admin-ui/src/components/bread-crumb/GroupBreadCrumbs.tsx
+++ b/js/apps/admin-ui/src/components/bread-crumb/GroupBreadCrumbs.tsx
@@ -3,15 +3,22 @@ import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
 
+import { useAccess } from "../../context/access/Access";
 import { useSubGroups } from "../../groups/SubGroupsContext";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useGroupResource } from "../../context/group-resource/GroupResourceContext";
+
+import "../../groups/components/group-tree.css";
 
 export const GroupBreadCrumbs = () => {
   const { t } = useTranslation();
   const { clear, remove, subGroups } = useSubGroups();
   const { realm } = useRealm();
+  const { hasAccess } = useAccess();
   const location = useLocation();
+  const canViewDetails =
+    hasAccess("query-groups", "view-users") ||
+    hasAccess("manage-users", "query-groups");
 
   const isOrgGroups = useGroupResource().isOrgGroups();
   const orgId = useGroupResource().getOrgId();
@@ -34,9 +41,10 @@ export const GroupBreadCrumbs = () => {
       </BreadcrumbItem>
       {subGroups.map((group, i) => {
         const isLastGroup = i === subGroups.length - 1;
+        const canView = isOrgGroups || canViewDetails || group.access?.view;
         return (
           <BreadcrumbItem key={group.id} isActive={isLastGroup}>
-            {!isLastGroup && (
+            {!isLastGroup && canView && (
               <Link
                 to={location.pathname.substring(
                   0,
@@ -46,6 +54,11 @@ export const GroupBreadCrumbs = () => {
               >
                 {group.name}
               </Link>
+            )}
+            {!isLastGroup && !canView && (
+              <span className="keycloak-groups-tree__non-viewable">
+                {group.name}
+              </span>
             )}
             {isLastGroup &&
               (group.id === "search" ? group.name : t("groupDetails"))}

--- a/js/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
+++ b/js/apps/admin-ui/src/components/group/GroupPickerDialog.tsx
@@ -23,6 +23,7 @@ import {
   ModalVariant,
 } from "@patternfly/react-core";
 import { AngleRightIcon } from "@patternfly/react-icons";
+import { NetworkError } from "@keycloak/keycloak-admin-client/lib/utils/fetchWithError";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../admin-client";
@@ -58,6 +59,7 @@ export const GroupPickerDialog = ({
 }: GroupPickerDialogProps) => {
   const { adminClient } = useAdminClient();
   const groupResource = useGroupResource();
+  const isOrgGroups = groupResource.isOrgGroups();
 
   const { t } = useTranslation();
   const [selectedRows, setSelectedRows] = useState<SelectableGroup[]>([]);
@@ -92,7 +94,18 @@ export const GroupPickerDialog = ({
         groups = await groupResource.find(args);
       } else {
         if (!navigation.map(({ id }) => id).includes(groupId)) {
-          group = await groupResource.findOne({ id: groupId });
+          try {
+            group = await groupResource.findOne({ id: groupId });
+          } catch (error) {
+            if (
+              error instanceof NetworkError &&
+              error.response.status === 403
+            ) {
+              group = undefined;
+            } else {
+              throw error;
+            }
+          }
           if (!group) {
             throw new Error(t("notFound"));
           }
@@ -245,6 +258,7 @@ export const GroupPickerDialog = ({
             : groups
                 .map((g) => deepGroup([g]))
                 .flat()
+                .filter((g) => isOrgGroups || g.access)
                 .map((g) => (
                   <GroupRow
                     key={g.id}

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -1,4 +1,5 @@
 import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
+import { NetworkError } from "@keycloak/keycloak-admin-client/lib/utils/fetchWithError";
 import { useFetch } from "@keycloak/keycloak-ui-shared";
 import {
   Button,
@@ -92,19 +93,51 @@ export default function GroupsSection({ orgId }: { orgId?: string } = {}) {
 
       if (isNavigationStateInValid) {
         const groups: GroupRepresentation[] = [];
+        const lastId = ids!.at(-1);
         for (const i of ids!) {
-          let group = undefined;
-          if (i !== "search") {
-            group = await groupResource.findOne({ id: i });
+          if (i === "search") {
+            groups.push({ name: t("searchGroups"), id: "search" });
+          } else if (i === lastId) {
+            const group = await groupResource.findOne({ id: i });
+            if (group) {
+              groups.push(group);
+            } else {
+              throw new Error(t("notFound"));
+            }
           } else {
-            group = { name: t("searchGroups"), id: "search" };
-          }
-          if (group) {
-            groups.push(group);
-          } else {
-            throw new Error(t("notFound"));
+            try {
+              const group = await groupResource.findOne({ id: i });
+              if (group) {
+                groups.push(group);
+              } else {
+                groups.push({ id: i, name: i, access: {} });
+              }
+            } catch (error) {
+              if (
+                error instanceof NetworkError &&
+                error.response.status === 403
+              ) {
+                groups.push({ id: i, name: i, access: {} });
+              } else {
+                throw error;
+              }
+            }
           }
         }
+
+        // Derive ancestor names from the last group's path.
+        // Path is like "/grandparent/parent/child" — segments map
+        // positionally to the groups array.
+        const lastGroup = groups.at(-1);
+        if (lastGroup?.path) {
+          const segments = lastGroup.path.split("/").filter(Boolean);
+          for (let idx = 0; idx < groups.length - 1; idx++) {
+            if (groups[idx].id === groups[idx].name && segments[idx]) {
+              groups[idx] = { ...groups[idx], name: segments[idx] };
+            }
+          }
+        }
+
         return groups;
       }
       return [];

--- a/js/apps/admin-ui/src/groups/Members.tsx
+++ b/js/apps/admin-ui/src/groups/Members.tsx
@@ -71,7 +71,7 @@ export const Members = () => {
   useFetch(() => groups.findOne({ id: group()!.id! }), setCurrentGroup, []);
 
   const isManager =
-    hasAccess("manage-users") || currentGroup?.access!.manageMembership;
+    hasAccess("manage-users") || currentGroup?.access?.manageMembership;
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(new Date().getTime());

--- a/js/apps/admin-ui/src/groups/components/GroupTree.tsx
+++ b/js/apps/admin-ui/src/groups/components/GroupTree.tsx
@@ -1,6 +1,5 @@
 import type GroupRepresentation from "@keycloak/keycloak-admin-client/lib/defs/groupRepresentation";
 import {
-  AlertVariant,
   Button,
   Checkbox,
   Divider,
@@ -16,11 +15,7 @@ import {
   TreeViewDataItem,
 } from "@patternfly/react-core";
 
-import {
-  PaginatingTableToolbar,
-  useAlerts,
-  useFetch,
-} from "@keycloak/keycloak-ui-shared";
+import { PaginatingTableToolbar, useFetch } from "@keycloak/keycloak-ui-shared";
 import { AngleRightIcon, EllipsisVIcon } from "@patternfly/react-icons";
 import { useGroupResource } from "../../context/group-resource/GroupResourceContext";
 import { unionBy } from "lodash-es";
@@ -43,6 +38,7 @@ import "./group-tree.css";
 
 type ExtendedTreeViewDataItem = TreeViewDataItem & {
   access?: Record<string, boolean>;
+  group?: GroupRepresentation;
 };
 
 type GroupTreeContextMenuProps = {
@@ -178,11 +174,10 @@ export const GroupTree = ({
   const { t } = useTranslation();
   const { realm } = useRealm();
   const navigate = useNavigate();
-  const { addAlert } = useAlerts();
   const { hasAccess } = useAccess();
 
   const [data, setData] = useState<ExtendedTreeViewDataItem[]>();
-  const { subGroups, clear } = useSubGroups();
+  const { subGroups, setSubGroups, clear } = useSubGroups();
 
   const [search, setSearch] = useState("");
   const [max, setMax] = useState(20);
@@ -211,12 +206,22 @@ export const GroupTree = ({
       id: group.id,
       name: (
         <Tooltip content={group.name}>
-          <span>{group.name}</span>
+          <span
+            className={
+              !canViewDetails && !isOrgGroups && !group.access?.view
+                ? "keycloak-groups-tree__non-viewable"
+                : undefined
+            }
+          >
+            {group.name}
+          </span>
         </Tooltip>
       ),
+      group,
       access: group.access || {},
       children: hasSubGroups
-        ? search.length === 0
+        ? search.length === 0 &&
+          (!group.subGroups || group.subGroups.length === 0)
           ? LOADING_TREE
           : group.subGroups?.map((g) => mapGroup(g, refresh))
         : undefined,
@@ -340,26 +345,28 @@ export const GroupTree = ({
 
   const nav = (item: TreeViewDataItem, data: ExtendedTreeViewDataItem[]) => {
     if (item.id === "next") return;
-    setActiveItem(item);
 
     const path = findGroup(data, item.id!, []);
-    if (!subGroups.every(({ id }) => path.find((t) => t.id === id))) clear();
-    if (
-      canViewDetails ||
-      path.at(-1)?.access?.view ||
-      subGroups.at(-1)?.access?.view
-    ) {
-      navigate(
-        toGroups({
-          realm,
-          id: path.map((g) => g.id).join("/"),
-          orgId,
-        }),
-      );
-    } else {
-      addAlert(t("noViewRights"), AlertVariant.warning);
-      navigate(toGroups({ realm, orgId }));
+    if (!(canViewDetails || isOrgGroups || path.at(-1)?.access?.view)) {
+      return;
     }
+
+    setActiveItem(item);
+    const groups = path
+      .map((p) => p.group)
+      .filter((g): g is GroupRepresentation => g !== undefined);
+    if (groups.length === path.length) {
+      setSubGroups(groups);
+    } else if (!subGroups.every(({ id }) => path.find((t) => t.id === id))) {
+      clear();
+    }
+    navigate(
+      toGroups({
+        realm,
+        id: path.map((g) => g.id).join("/"),
+        orgId,
+      }),
+    );
   };
 
   return data ? (

--- a/js/apps/admin-ui/src/groups/components/group-tree.css
+++ b/js/apps/admin-ui/src/groups/components/group-tree.css
@@ -4,3 +4,8 @@
   text-overflow: ellipsis;
   display: block;
 }
+
+.keycloak-groups-tree__non-viewable {
+  color: var(--pf-v5-global--Color--200);
+  cursor: default;
+}

--- a/services/src/main/java/org/keycloak/utils/GroupUtils.java
+++ b/services/src/main/java/org/keycloak/utils/GroupUtils.java
@@ -89,18 +89,23 @@ public class GroupUtils {
             while (currGroup.getParentId() != null && !currGroup.getParentId().equals(stopAtParentId)) {
                 GroupModel parentModel = session.groups().getGroupById(realm, currGroup.getParentId());
 
-                // Permission check for parent
-                if (!filter.shouldInclude(parentModel)) {
-                    groupIdToGroups.remove(currGroup.getId());
-                    break;
+                boolean canViewParent = filter.shouldInclude(parentModel);
+
+                if (!canViewParent) {
+                    if (!AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
+                        groupIdToGroups.remove(currGroup.getId());
+                        break;
+                    }
                 }
 
                 GroupRepresentation parent = groupIdToGroups.computeIfAbsent(
                     currGroup.getParentId(),
-                    id -> mapper.apply(parentModel)
+                    id -> canViewParent ?
+                            mapper.apply(parentModel) :
+                            ModelToRepresentation.groupToBriefRepresentation(parentModel)
                 );
 
-                if (subGroupsCount) {
+                if (subGroupsCount && canViewParent) {
                     populateSubGroupCount(parentModel, parent);
                 }
 
@@ -124,6 +129,10 @@ public class GroupUtils {
             }
         });
 
+        if (subGroupsCount) {
+            groupIdToGroups.values().forEach(GroupUtils::deriveSubGroupCountFromChildren);
+        }
+
         return groupIdToGroups.values().stream()
             .sorted(Comparator.comparing(GroupRepresentation::getName));
     }
@@ -144,14 +153,7 @@ public class GroupUtils {
             groups,
             // Mapper with permission-aware representation
             group -> toRepresentation(groupEvaluator, group, full),
-            // Filter with permission checks
-            group -> {
-                if (AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
-                    return true; // FGAP v2 handles permissions differently
-                }
-                //TODO GROUPS do permissions work in such a way that if you can view the children you can definitely view the parents?
-                return groupEvaluator.canView() || groupEvaluator.canView(group);
-            },
+            groupEvaluator::canView,
             subGroupsCount
         );
     }
@@ -178,6 +180,15 @@ public class GroupUtils {
             subGroupsCount,
             stopAtParentId
         );
+    }
+
+    private static void deriveSubGroupCountFromChildren(GroupRepresentation group) {
+        if (group.getSubGroups() != null) {
+            group.getSubGroups().forEach(GroupUtils::deriveSubGroupCountFromChildren);
+            if (group.getSubGroupCount() == null && !group.getSubGroups().isEmpty()) {
+                group.setSubGroupCount((long) group.getSubGroups().size());
+            }
+        }
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeFilteringTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.tests.admin.authz.fgap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,6 +61,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -93,6 +95,150 @@ public class GroupResourceTypeFilteringTest extends AbstractPermissionTest {
                 groupResource.subGroup(subGroup).close();
             }
         }
+    }
+
+    @Test
+    public void testVisibleSubGroupSearchReturnsStrippedParent() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,
+                "Only My Admin User Policy", myadmin.getId());
+
+        GroupRepresentation parentGroup = realm.admin().groups().groups("group-0", -1, -1).get(0);
+        parentGroup.setAttributes(Map.of(
+                "hidden-parent-attribute", List.of("hidden-parent-value")));
+        realm.admin().groups().group(parentGroup.getId()).update(parentGroup);
+
+        GroupRepresentation visibleSubGroup = parentGroup.getSubGroups().stream()
+                .filter(group -> group.getName().equals("subgroup-0.1"))
+                .findFirst()
+                .orElseThrow();
+        createPermission(adminPermissionsClient, visibleSubGroup.getId(),
+                GROUPS_RESOURCE_TYPE, Set.of(VIEW), policy);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .groups().group(parentGroup.getId()).toRepresentation());
+
+        List<GroupRepresentation> search = realmAdminClient.realm(realm.getName())
+                .groups().groups(visibleSubGroup.getName(), -1, -1, false);
+        assertEquals(1, search.size());
+
+        GroupRepresentation strippedParent = search.get(0);
+        assertEquals(parentGroup.getId(), strippedParent.getId());
+        assertEquals(parentGroup.getName(), strippedParent.getName());
+        assertNull(strippedParent.getAttributes());
+        assertNull(strippedParent.getRealmRoles());
+        assertNull(strippedParent.getClientRoles());
+        assertNull(strippedParent.getAccess());
+        assertEquals(1L, strippedParent.getSubGroupCount());
+
+        assertEquals(1, strippedParent.getSubGroups().size());
+        assertEquals(visibleSubGroup.getId(), strippedParent.getSubGroups().get(0).getId());
+    }
+
+    @Test
+    public void testDeepHierarchyWithMultipleHiddenAncestors() {
+        String topId = ApiUtil.getCreatedId(realm.admin().groups().add(GroupBuilder.create().name("top-group").build()));
+        String midId = ApiUtil.getCreatedId(realm.admin().groups().group(topId).subGroup(GroupBuilder.create().name("mid-group").build()));
+        String leafId = ApiUtil.getCreatedId(realm.admin().groups().group(midId).subGroup(GroupBuilder.create().name("leaf-group").build()));
+        realm.cleanup().add(r -> r.groups().group(topId).remove());
+
+        GroupRepresentation topGroup = realm.admin().groups().group(topId).toRepresentation();
+        topGroup.setAttributes(Map.of("secret-attr", List.of("secret-value")));
+        realm.admin().groups().group(topId).update(topGroup);
+
+        GroupRepresentation midGroup = realm.admin().groups().group(midId).toRepresentation();
+        midGroup.setAttributes(Map.of("secret-attr", List.of("secret-value")));
+        realm.admin().groups().group(midId).update(midGroup);
+
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,
+                "Only My Admin User Policy", myadmin.getId());
+        createPermission(adminPermissionsClient, leafId, GROUPS_RESOURCE_TYPE, Set.of(VIEW), policy);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .groups().group(topId).toRepresentation());
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .groups().group(midId).toRepresentation());
+
+        List<GroupRepresentation> search = realmAdminClient.realm(realm.getName())
+                .groups().groups("leaf-group", -1, -1, false);
+        assertEquals(1, search.size());
+
+        GroupRepresentation strippedTop = search.get(0);
+        assertEquals(topId, strippedTop.getId());
+        assertEquals("top-group", strippedTop.getName());
+        assertNull(strippedTop.getAttributes());
+        assertNull(strippedTop.getRealmRoles());
+        assertNull(strippedTop.getClientRoles());
+        assertNull(strippedTop.getAccess());
+        assertEquals(1L, strippedTop.getSubGroupCount());
+
+        assertEquals(1, strippedTop.getSubGroups().size());
+        GroupRepresentation strippedMid = strippedTop.getSubGroups().get(0);
+        assertEquals(midId, strippedMid.getId());
+        assertEquals("mid-group", strippedMid.getName());
+        assertNull(strippedMid.getAttributes());
+        assertNull(strippedMid.getRealmRoles());
+        assertNull(strippedMid.getClientRoles());
+        assertNull(strippedMid.getAccess());
+        assertEquals(1L, strippedMid.getSubGroupCount());
+
+        assertEquals(1, strippedMid.getSubGroups().size());
+        assertEquals(leafId, strippedMid.getSubGroups().get(0).getId());
+    }
+
+    @Test
+    public void testStrippedParentSubGroupCountReflectsOnlyVisibleChildren() {
+        String parentId = ApiUtil.getCreatedId(realm.admin().groups().add(GroupBuilder.create().name("hidden-parent").build()));
+        String hiddenChildId = ApiUtil.getCreatedId(realm.admin().groups().group(parentId).subGroup(GroupBuilder.create().name("hidden-child").build()));
+        String visibleChildId = ApiUtil.getCreatedId(realm.admin().groups().group(parentId).subGroup(GroupBuilder.create().name("visible-child").build()));
+        realm.cleanup().add(r -> r.groups().group(parentId).remove());
+
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,
+                "Only My Admin User Policy", myadmin.getId());
+        createPermission(adminPermissionsClient, visibleChildId, GROUPS_RESOURCE_TYPE, Set.of(VIEW), policy);
+
+        List<GroupRepresentation> search = realmAdminClient.realm(realm.getName())
+                .groups().groups("visible-child", -1, -1, false);
+        assertEquals(1, search.size());
+
+        GroupRepresentation strippedParent = search.get(0);
+        assertEquals(parentId, strippedParent.getId());
+        assertEquals(1L, strippedParent.getSubGroupCount());
+        assertEquals(1, strippedParent.getSubGroups().size());
+        assertEquals(visibleChildId, strippedParent.getSubGroups().get(0).getId());
+    }
+
+    @Test
+    public void testStrippedParentSubGroupCountWithMultipleVisibleSiblings() {
+        String parentId = ApiUtil.getCreatedId(realm.admin().groups().add(GroupBuilder.create().name("hidden-parent").build()));
+        String child1Id = ApiUtil.getCreatedId(realm.admin().groups().group(parentId).subGroup(GroupBuilder.create().name("visible-sibling-1").build()));
+        String child2Id = ApiUtil.getCreatedId(realm.admin().groups().group(parentId).subGroup(GroupBuilder.create().name("visible-sibling-2").build()));
+        String hiddenChildId = ApiUtil.getCreatedId(realm.admin().groups().group(parentId).subGroup(GroupBuilder.create().name("hidden-child").build()));
+        realm.cleanup().add(r -> r.groups().group(parentId).remove());
+
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient,
+                "Only My Admin User Policy", myadmin.getId());
+        createPermission(adminPermissionsClient, child1Id, GROUPS_RESOURCE_TYPE, Set.of(VIEW), policy);
+        createPermission(adminPermissionsClient, child2Id, GROUPS_RESOURCE_TYPE, Set.of(VIEW), policy);
+
+        List<GroupRepresentation> search = realmAdminClient.realm(realm.getName())
+                .groups().groups("visible-sibling", -1, -1, false);
+        assertEquals(1, search.size());
+
+        GroupRepresentation strippedParent = search.get(0);
+        assertEquals(parentId, strippedParent.getId());
+        assertEquals(2L, strippedParent.getSubGroupCount());
+        assertEquals(2, strippedParent.getSubGroups().size());
+
+        Set<String> childIds = strippedParent.getSubGroups().stream()
+                .map(GroupRepresentation::getId)
+                .collect(Collectors.toSet());
+        assertTrue(childIds.contains(child1Id));
+        assertTrue(childIds.contains(child2Id));
+        assertFalse(childIds.contains(hiddenChildId));
     }
 
     @Test


### PR DESCRIPTION
Closes #50966

**Design decision**: Align with industry standard — parent existence (name, ID, path) is inherent to the child's identity and not hidden. Only parent content (attributes, role mappings, access) is protected. Non-viewable parents are included in the hierarchy as stripped/brief representations.

**Approach**: when populating group hierarchy under FGAP v2, non-viewable parent groups are represented with only structural fields (id, name, description, path, parentId) — no attributes, role mappings, or access map. The hierarchy walk continues through stripped parents so the full tree structure is preserved.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
