### PR TITLE
Configurable may_act claim enforcement

### DIFF
--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -378,6 +378,7 @@ The `may_act` claim declares that the specified administrator (actor) is authori
 
 If the administrator (actor) does not have impersonation permission, the delegation scope is silently dropped and the `may_act` claim is not included in the token. The consent for delegation is always required and is not stored permanently - the user must approve delegation each login session.
 
+[[_adding_additional_claims_to_may_act]]
 ==== Adding additional claims to `may_act`
 
 By default, only the actor's `sub` (user ID) is included in the `may_act` claim. Additional claims can be added by configuring extra "Parameterized Scope User Property" mappers on the `delegation` client scope in the Admin Console.
@@ -402,6 +403,26 @@ The resulting token will then include:
 ----
 
 Other useful claims to add include `may_act.email` (user property `email`) or `may_act.iss` (for cross-realm delegation scenarios).
+
+==== Configuring enforced claims
+
+During token exchange, {project_name} validates that certain claims in `may_act` match the actor token. The default enforced claims (`sub` and `iss`) are always checked and cannot be removed. Additional enforced claim names can be configured via the `may_act enforce_claims` mapper on the `delegation` client scope — these are merged with the defaults. Since `iss` is not included in `may_act` by default (no mapper adds it), it is silently skipped unless explicitly mapped. If an enforced claim is absent from `may_act`, it is always silently skipped. If the mapper is removed, {project_name} falls back to enforcing only the defaults (`sub` and `iss`).
+
+[source,json]
+----
+{
+  "may_act": {
+    "sub": "f1234567-89ab-cdef-0123-456789abcdef",
+    "enforce_claims": ["sub", "iss"]
+  }
+}
+----
+
+To enforce additional claims during token exchange:
+
+. Navigate to *Client scopes* -> *delegation* -> *Mappers* -> *may_act enforce_claims*.
+. Edit the *Token Claim Value* to include the additional claim names, for example `["sub","iss","email"]`.
+. Ensure the corresponding claim is also added to `may_act` via a mapper (see <<_adding_additional_claims_to_may_act>>).
 
 [[_legacy-token-exchange]]
 == Legacy token exchange

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -46,6 +46,7 @@ import org.keycloak.protocol.oidc.mappers.AddressMapper;
 import org.keycloak.protocol.oidc.mappers.AllowedWebOriginsProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.AudienceResolveProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.FullNameMapper;
+import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
 import org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper;
 import org.keycloak.protocol.oidc.mappers.SubMapper;
 import org.keycloak.protocol.oidc.mappers.UserAttributeMapper;
@@ -54,12 +55,14 @@ import org.keycloak.protocol.oidc.mappers.UserPropertyMapper;
 import org.keycloak.protocol.oidc.mappers.UserRealmRoleMappingMapper;
 import org.keycloak.protocol.oidc.mappers.UserSessionNoteMapper;
 import org.keycloak.protocol.oidc.scope.DelegationScopeType;
+import org.keycloak.protocol.oidc.tokenexchange.TokenExchangeDelegationProvider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.representations.IDToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
 
@@ -112,6 +115,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     public static final String ALLOWED_WEB_ORIGINS = "allowed web origins";
     public static final String ACR = "acr loa level";
     public static final String DELEGATION_MAY_ACT_SUB = "may_act sub";
+    public static final String DELEGATION_ENFORCE_CLAIMS = "may_act enforce_claims";
     public static final String ORGANIZATION = "organization";
     // microprofile-jwt claims
     public static final String UPN = "upn";
@@ -279,6 +283,10 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             model = ParameterizedScopeUserPropertyMapper.create(
                     DELEGATION_MAY_ACT_SUB, "id", MAY_ACT + "." + SUBJECT, "String", true, true, true);
             builtins.put(DELEGATION_MAY_ACT_SUB, model);
+
+            model = HardcodedClaim.create(DELEGATION_ENFORCE_CLAIMS,
+                    MAY_ACT + "." + TokenExchangeDelegationProvider.ENFORCE_CLAIMS, toJsonString(TokenExchangeDelegationProvider.DEFAULT_ENFORCED_CLAIMS), "JSON", true, true, true);
+            builtins.put(DELEGATION_ENFORCE_CLAIMS, model);
         }
 
         model = UserSessionNoteMapper.createClaimMapper(IDToken.AUTH_TIME, AuthenticationManager.AUTH_TIME,
@@ -391,6 +399,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             delegationScope.setProtocol(getId());
             delegationScope.setConsentScreenText("${delegationScopeConsentText}");
             delegationScope.addProtocolMapper(builtins.get(DELEGATION_MAY_ACT_SUB));
+            delegationScope.addProtocolMapper(builtins.get(DELEGATION_ENFORCE_CLAIMS));
         }
     }
 
@@ -683,5 +692,13 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                     .defaultValue(OIDCProviderConfig.DEFAULT_ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN)
                     .add()
                 .build();
+    }
+
+    private static String toJsonString(Object value) {
+        try {
+            return JsonSerialization.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize value to JSON", e);
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/TokenExchangeDelegationProvider.java
@@ -18,8 +18,12 @@
  */
 package org.keycloak.protocol.oidc.tokenexchange;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 
@@ -39,15 +43,18 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.Urls;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.UserSessionManager;
+import org.keycloak.util.JsonSerialization;
 
 /**
  *
  * @author rmartinc
  */
 public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvider {
+
+    public static final String ENFORCE_CLAIMS = "enforce_claims";
+    public static final List<String> DEFAULT_ENFORCED_CLAIMS = List.of(JsonWebToken.SUBJECT, OIDCLoginProtocol.ISSUER);
 
     private AccessToken actorAccessToken;
     private AccessToken subjectAccessToken;
@@ -149,25 +156,49 @@ public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvid
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid may_act claim in the subject_token", Response.Status.BAD_REQUEST);
         }
 
-        Object issObject = mayActMap.get(OIDCLoginProtocol.ISSUER);
-        if (issObject != null && !issObject.equals(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()))) {
-            event.detail(Details.REASON, "Invalid issuer in the may_act claim of the subject_token");
+        if (!mayActMap.containsKey(JsonWebToken.SUBJECT)) {
+            event.detail(Details.REASON, "Missing mandatory 'sub' claim in may_act");
             event.error(Errors.INVALID_TOKEN);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid issuer in the may_act claim of the subject_token", Response.Status.BAD_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Missing mandatory 'sub' claim in may_act", Response.Status.BAD_REQUEST);
         }
 
-        Object subjectObject = mayActMap.get(JsonWebToken.SUBJECT);
-        if (!(subjectObject instanceof String subject)) {
-            event.detail(Details.REASON, "Invalid may_act claim in the subject_token");
+        Collection<String> enforcedClaims;
+        try {
+            enforcedClaims = getEnforcedClaims(mayActMap);
+        } catch (IllegalArgumentException e) {
+            event.detail(Details.REASON, e.getMessage());
             event.error(Errors.INVALID_TOKEN);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid may_act claim in the subject_token", Response.Status.BAD_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
         }
+        Map<String, Object> actorClaims = JsonSerialization.mapper.convertValue(actorAccessToken, Map.class);
+        for (String claimName : enforcedClaims) {
+            Object mayActValue = mayActMap.get(claimName);
+            if (mayActValue == null) {
+                continue;
+            }
+            Object actorValue = actorClaims.get(claimName);
+            if (!mayActValue.equals(actorValue)) {
+                String reason = String.format("Enforced claim '%s' in may_act does not match actor token claim '%s'", claimName, claimName);
+                event.detail(Details.REASON, reason);
+                event.error(Errors.INVALID_TOKEN);
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, reason, Response.Status.BAD_REQUEST);
+            }
+        }
+    }
 
-        if (!actorUser.getId().equals(subject)) {
-            event.detail(Details.REASON, "Actor user is not allowed by the may_act claim inside the subject_token");
-            event.error(Errors.INVALID_TOKEN);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Actor user is not allowed by the may_act claim inside the subject_token", Response.Status.BAD_REQUEST);
+    private Collection<String> getEnforcedClaims(Map<String, Object> mayActMap) {
+        Object enforceClaimsObj = mayActMap.get(ENFORCE_CLAIMS);
+        if (enforceClaimsObj instanceof Collection<?> list && !list.isEmpty()) {
+            Set<String> merged = new HashSet<>(DEFAULT_ENFORCED_CLAIMS);
+            for (Object item : list) {
+                if (!(item instanceof String s)) {
+                    throw new IllegalArgumentException("enforce_claims must contain only string values");
+                }
+                merged.add(s);
+            }
+            return merged;
         }
+        return DEFAULT_ENFORCED_CLAIMS;
     }
 
     @Override
@@ -176,6 +207,7 @@ public class TokenExchangeDelegationProvider extends StandardTokenExchangeProvid
 
         // add the "act" claim using the "may_act" claim sent in the subjectToken, chain current actor if present
         Map act = new HashMap((Map) subjectAccessToken.getOtherClaims().get(IDToken.MAY_ACT)); // should be present at this point
+        act.remove(ENFORCE_CLAIMS);
         Object prevAct = actorAccessToken.getOtherClaims().get(IDToken.ACT);
         if (prevAct != null) {
             act.put(IDToken.ACT, prevAct);

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
@@ -31,6 +31,7 @@ import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpoi
 import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper;
+import org.keycloak.protocol.oidc.tokenexchange.TokenExchangeDelegationProvider;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
@@ -409,7 +410,7 @@ public class TokenExchangeDelegationTest {
                 .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE)
                 .send();
         assertExchangeError(tokenExchangeRes, "otheruser", Errors.INVALID_TOKEN,
-                "Actor user is not allowed by the may_act claim inside the subject_token");
+                "Enforced claim 'sub' in may_act does not match actor token claim 'sub'");
 
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
@@ -459,11 +460,171 @@ public class TokenExchangeDelegationTest {
         AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
                 .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE)
                 .send();
-        assertExchangeError(tokenExchangeRes, Errors.INVALID_TOKEN, "Invalid issuer in the may_act claim of the subject_token");
+        assertExchangeError(tokenExchangeRes, Errors.INVALID_TOKEN,
+                "Enforced claim 'iss' in may_act does not match actor token claim 'iss'");
 
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
         Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void delegationWithCustomEnforcedClaims() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // add a preferred_username mapper to may_act
+        ProtocolMapperModel usernameMapper = ParameterizedScopeUserPropertyMapper.create(
+                "may_act preferred_username", "username",
+                MAY_ACT + "." + PREFERRED_USERNAME, "String",
+                true, true, true);
+        try (var response = realm.admin().clientScopes().get(delegationScopeId).getProtocolMappers()
+                .createMapper(ModelToRepresentation.toRepresentation(usernameMapper))) {
+            Assertions.assertEquals(201, response.getStatus());
+        }
+        realm.cleanup().add(r -> {
+            r.clientScopes().get(delegationScopeId).getProtocolMappers().getMappers().stream()
+                    .filter(m -> "may_act preferred_username".equals(m.getName()))
+                    .findFirst()
+                    .ifPresent(m -> r.clientScopes().get(delegationScopeId).getProtocolMappers().delete(m.getId()));
+        });
+
+        // update enforce_claims mapper to also include preferred_username
+        updateEnforceClaimsMapper(delegationScopeId, "[\"sub\",\"iss\",\"preferred_username\"]");
+
+        // login with delegation
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId(), null, administrator.getUsername());
+
+        // exchange with correct actor — all enforced claims match
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken(),
+                teToken -> assertActPresent(teToken, administrator.getId(), null, administrator.getUsername()));
+
+        // exchange with wrong actor — sub mismatch
+        String otherActorToken = getActorToken("otheruser", PASSWORD);
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(res.getAccessToken())
+                .actorToken(otherActorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE).send();
+        assertExchangeError(tokenExchangeRes, "otheruser", Errors.INVALID_TOKEN,
+                "Enforced claim 'sub' in may_act does not match actor token claim 'sub'");
+
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void delegationFallbackWithoutEnforceClaims() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // remove the enforce_claims mapper — provider should fall back to default sub/iss enforcement
+        removeDelegationMapper(delegationScopeId, OIDCLoginProtocolFactory.DELEGATION_ENFORCE_CLAIMS);
+
+        AccessTokenResponse res = loginWithDelegationScope();
+
+        // exchange with correct actor — default sub/iss enforcement applies and matches
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
+
+        // exchange with wrong actor — sub mismatch via default enforcement
+        tokenExchangeDelegationError(res.getAccessToken(), "otheruser", Errors.INVALID_TOKEN,
+                "Enforced claim 'sub' in may_act does not match actor token claim 'sub'");
+
+    }
+
+    @Test
+    public void delegationEnforcedClaimSkippedWhenAbsent() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // update enforce_claims to include email, but do NOT add an email mapper to may_act
+        // since may_act won't contain email, the enforcement for email should be silently skipped
+        updateEnforceClaimsMapper(delegationScopeId, "[\"sub\",\"iss\",\"email\"]");
+
+        AccessTokenResponse res = loginWithDelegationScope();
+
+        // exchange should succeed — email is not in may_act so the enforced claim is skipped
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
+
+    }
+
+    @Test
+    public void delegationEnforcedClaimMismatch() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // add a hardcoded email mapper with a wrong value to may_act
+        ProtocolMapperRepresentation emailMapper = new ProtocolMapperRepresentation();
+        emailMapper.setName("may_act email");
+        emailMapper.setProtocol("openid-connect");
+        emailMapper.setProtocolMapper("oidc-hardcoded-claim-mapper");
+        Map<String, String> emailConfig = new HashMap<>();
+        emailConfig.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, MAY_ACT + ".email");
+        emailConfig.put(HardcodedClaim.CLAIM_VALUE, "wrong@example.com");
+        emailConfig.put(OIDCAttributeMapperHelper.JSON_TYPE, "String");
+        emailConfig.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, Boolean.TRUE.toString());
+        emailMapper.setConfig(emailConfig);
+        String emailMapperId = ApiUtil.getCreatedId(
+                realm.admin().clientScopes().get(delegationScopeId).getProtocolMappers().createMapper(emailMapper));
+        realm.cleanup().add(r -> r.clientScopes().get(delegationScopeId).getProtocolMappers().delete(emailMapperId));
+
+        // update enforce_claims to include email
+        updateEnforceClaimsMapper(delegationScopeId, "[\"sub\",\"iss\",\"email\"]");
+
+        AccessTokenResponse res = loginWithDelegationScope();
+
+        // exchange with correct actor — sub/iss match but email mismatches
+        tokenExchangeDelegationError(res.getAccessToken(), Errors.INVALID_TOKEN,
+                "Enforced claim 'email' in may_act does not match actor token claim 'email'");
+
+    }
+
+    @Test
+    public void delegationEnforceClaimsAlwaysIncludesDefaults() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // set enforce_claims to only ["email"] — defaults (sub, iss) must still be enforced
+        updateEnforceClaimsMapper(delegationScopeId, "[\"email\"]");
+
+        AccessTokenResponse res = loginWithDelegationScope();
+
+        // exchange with wrong actor — sub must still be enforced even though it's not in the explicit list
+        tokenExchangeDelegationError(res.getAccessToken(), "otheruser", Errors.INVALID_TOKEN,
+                "Enforced claim 'sub' in may_act does not match actor token claim 'sub'");
+
+    }
+
+    @Test
+    public void delegationRejectsMissingSubInMayAct() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // remove the may_act sub mapper so may_act is present but without sub
+        removeDelegationMapper(delegationScopeId, OIDCLoginProtocolFactory.DELEGATION_MAY_ACT_SUB);
+
+        AccessTokenResponse res = loginWithDelegationScope();
+
+        // exchange must fail — may_act exists but has no sub
+        tokenExchangeDelegationError(res.getAccessToken(), Errors.INVALID_TOKEN,
+                "Missing mandatory 'sub' claim in may_act");
+
+    }
+
+    @Test
+    public void delegationRejectsNonStringEnforceClaims() {
+        addImpersonationToAdministrator();
+        String delegationScopeId = findDelegationScopeId();
+
+        // set enforce_claims to contain a non-string element
+        updateEnforceClaimsMapper(delegationScopeId, "[\"sub\", 1]");
+
+        AccessTokenResponse res = loginWithDelegationScope();
+
+        // exchange must fail — enforce_claims contains a non-string value
+        tokenExchangeDelegationError(res.getAccessToken(), Errors.INVALID_TOKEN,
+                "enforce_claims must contain only string values");
+
     }
 
     private void addImpersonationToAdministrator() {
@@ -472,6 +633,35 @@ public class TokenExchangeDelegationTest {
         final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
         administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
         administrator.cleanup().add(user -> user.roles().clientLevel(clientUUID).remove(List.of(impersonation)));
+    }
+
+    private AccessTokenResponse loginWithDelegationScope() {
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        return res;
+    }
+
+    private void tokenExchangeDelegationError(String subjectToken, String error, String reason) {
+        tokenExchangeDelegationError(subjectToken, administrator.getUsername(), error, reason);
+    }
+
+    private void tokenExchangeDelegationError(String subjectToken, String actorUsername, String error, String reason) {
+        String actorToken = getActorToken(actorUsername, PASSWORD);
+        AccessTokenResponse tokenExchangeRes = oauth.client("test-app", "test-secret").tokenExchangeRequest(subjectToken)
+                .actorToken(actorToken).actorTokenType(OAuth2Constants.ACCESS_TOKEN_TYPE).send();
+        assertExchangeError(tokenExchangeRes, actorUsername, error, reason);
+    }
+
+    private void removeDelegationMapper(String delegationScopeId, String mapperName) {
+        ProtocolMapperRepresentation mapper = realm.admin().clientScopes().get(delegationScopeId)
+                .getProtocolMappers().getMappers().stream()
+                .filter(m -> mapperName.equals(m.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(mapperName + " mapper not found"));
+        realm.admin().clientScopes().get(delegationScopeId).getProtocolMappers().delete(mapper.getId());
+        realm.cleanup().add(r -> r.clientScopes().get(delegationScopeId).getProtocolMappers()
+                .createMapper(mapper));
     }
 
     private void assertExchangeError(AccessTokenResponse tokenExchangeRes, String error, String reason) {
@@ -588,6 +778,7 @@ public class TokenExchangeDelegationTest {
     private static void assertActPresent(AccessToken token, String expectedActorId, String expectedIss, String expectedUsername) {
         Map<String, Object> act = (Map<String, Object>) token.getOtherClaims().get(ACT);
         Assertions.assertNotNull(act, "act claim should be present");
+        Assertions.assertFalse(act.containsKey(TokenExchangeDelegationProvider.ENFORCE_CLAIMS), "enforce_claims must not leak into act");
         Assertions.assertEquals(expectedActorId, act.get(SUBJECT), "act.sub should contain the actor user ID");
         if (expectedIss != null) {
             Assertions.assertEquals(expectedIss, act.get(OIDCLoginProtocol.ISSUER), "act.iss is not correct");
@@ -603,6 +794,22 @@ public class TokenExchangeDelegationTest {
 
     private static void assertMayActNotPresent(AccessToken token) {
         Assertions.assertNull(token.getOtherClaims().get(MAY_ACT), "may_act claim should not be present");
+    }
+
+    private void updateEnforceClaimsMapper(String delegationScopeId, String value) {
+        ClientScopeResource scopeResource = realm.admin().clientScopes().get(delegationScopeId);
+        ProtocolMapperRepresentation enforceMapper = scopeResource.getProtocolMappers().getMappers().stream()
+                .filter(m -> OIDCLoginProtocolFactory.DELEGATION_ENFORCE_CLAIMS.equals(m.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("enforce_claims mapper not found"));
+        String originalValue = enforceMapper.getConfig().get(HardcodedClaim.CLAIM_VALUE);
+        enforceMapper.getConfig().put(HardcodedClaim.CLAIM_VALUE, value);
+        scopeResource.getProtocolMappers().update(enforceMapper.getId(), enforceMapper);
+        realm.cleanup().add(r -> {
+            enforceMapper.getConfig().put(HardcodedClaim.CLAIM_VALUE, originalValue);
+            r.clientScopes().get(delegationScopeId).getProtocolMappers()
+                    .update(enforceMapper.getId(), enforceMapper);
+        });
     }
 
     private String findDelegationScopeId() {


### PR DESCRIPTION
- Closes #50979
- Replaces hardcoded `sub`/`iss` validation in `validateMayAct()` with a generic enforcement loop that compares any configured claim 1:1 between `may_act` and the actor token
- Enforced claims are controlled by a `HardcodedClaim` mapper (`may_act enforce_claims`) on the `delegation` client scope - admins configure enforcement by simply editing the mapper's JSON value (e.g. `["sub","iss","preferred_username"]`), no server restart or realm config needed
- Reuses the existing mapper infrastructure rather than introducing server-side configuration, keeping it lightweight
- Falls back to default `["sub","iss"]` enforcement when the mapper is removed or the list is empty
- Strips `enforce_claims` from the resulting `act` claim to prevent leaking into the delegation chain

@rmartinc @keycloak/core-authn Could you please check it? Thanks!