### PR TITLE
Clarify error when multiple export targets are configured

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
@@ -96,6 +96,10 @@ public final class ExportPropertyMappers implements PropertyMapperGrouping {
     @Override
     public void validateConfig(Picocli picocli) {
         if (picocli.getParsedCommand().orElse(null) instanceof Export && getOptionalValue(EXPORTER_PROPERTY).isEmpty() && System.getProperty(PROVIDER) == null) {
+            if (!isBlank(ExportOptions.FILE) && !isBlank(ExportOptions.DIR)) {
+                throw new PropertyException("Only one of the --dir or --file options can be specified.");
+            }
+
             throw new PropertyException("Must specify either --dir or --file options.");
         }
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -58,6 +58,9 @@ public class ExportDistTest {
         cliResult = runner.run("export", "--dir=some-dir", "--users=skip");
         cliResult.assertMessage("Realm 'master' - data exported");
 
+        runner.setEnvVar("KC_DIR", "configured-dir");
+        cliResult = runner.run("export", "--file=some-file");
+        cliResult.assertError("Only one of the --dir or --file options can be specified.");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- distinguish export commands with both directory and file targets from commands with neither
- report that only one export target can be configured
- add distribution-level coverage for `KC_DIR` combined with `--file`

## Motivation

`KC_DIR` is treated as an export directory. When it is combined with `--file`, exporter selection intentionally rejects the two targets, but validation previously emitted the missing-target message.

This changes only the diagnostic and does not change import/export option semantics.

## Testing

- `./mvnw -pl quarkus/server,quarkus/dist -am -DskipTests -DskipTestsuite -DskipExamples install`
- `./mvnw -pl quarkus/tests/junit5 -am -DskipTests -DskipTestsuite -DskipExamples install`
- `./mvnw test -pl quarkus/tests/integration -Dtest=ExportDistTest#testExport`
- `./mvnw -pl quarkus/runtime,quarkus/tests/integration -DskipTests spotless:check`

Closes #50700

## AI disclosure

I used OpenAI Codex to assist with repository analysis and the implementation and test for this change. I reviewed, understand, and can explain all submitted changes.
