### PR TITLE
Localize WebAuthn registration verification errors

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -49,6 +49,7 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
+import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -87,12 +88,16 @@ import com.webauthn4j.verifier.attestation.statement.tpm.TPMAttestationStatement
 import com.webauthn4j.verifier.attestation.statement.u2f.FIDOU2FAttestationStatementVerifier;
 import com.webauthn4j.verifier.attestation.trustworthiness.certpath.CertPathTrustworthinessVerifier;
 import com.webauthn4j.verifier.attestation.trustworthiness.self.DefaultSelfAttestationTrustworthinessVerifier;
+import com.webauthn4j.verifier.exception.UserNotPresentException;
+import com.webauthn4j.verifier.exception.UserNotVerifiedException;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.WebAuthnConstants.REG_ERR_DETAIL_LABEL;
 import static org.keycloak.WebAuthnConstants.REG_ERR_LABEL;
 import static org.keycloak.services.messages.Messages.WEBAUTHN_ERROR_REGISTER_VERIFICATION;
 import static org.keycloak.services.messages.Messages.WEBAUTHN_ERROR_REGISTRATION;
+import static org.keycloak.services.messages.Messages.WEBAUTHN_ERROR_USER_NOT_PRESENT;
+import static org.keycloak.services.messages.Messages.WEBAUTHN_ERROR_USER_NOT_VERIFIED;
 import static org.keycloak.services.messages.Messages.WEBAUTHN_REGISTER_TITLE;
 
 /**
@@ -319,7 +324,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
             context.success();
         } catch (WebAuthnException wae) {
             if (logger.isDebugEnabled()) logger.debug(wae.getMessage(), wae);
-            setErrorResponse(context, WEBAUTHN_ERROR_REGISTRATION, wae.getMessage(), originalEventType);
+            setErrorResponse(context, WEBAUTHN_ERROR_REGISTRATION, wae.getMessage(), getWebAuthnErrorMessageKey(wae), originalEventType);
             return;
         } catch (Exception e) {
             if (logger.isDebugEnabled()) logger.debug(e.getMessage(), e);
@@ -451,7 +456,25 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
         // NOP
     }
 
+    private static String getWebAuthnErrorMessageKey(WebAuthnException exception) {
+        // Only map exceptions that represent a single failure reason in WebAuthn4J. Other exception types can
+        // represent multiple reasons and cannot be translated to one accurate user-facing message.
+        if (exception instanceof UserNotPresentException) {
+            return WEBAUTHN_ERROR_USER_NOT_PRESENT;
+        } else if (exception instanceof UserNotVerifiedException) {
+            return WEBAUTHN_ERROR_USER_NOT_VERIFIED;
+        }
+        return null;
+    }
+
     private void setErrorResponse(RequiredActionContext context, final String errorCase, final String errorMessage, @Deprecated final EventType originalEventType) {
+        setErrorResponse(context, errorCase, errorMessage, null, originalEventType);
+    }
+
+    private void setErrorResponse(RequiredActionContext context, final String errorCase, final String errorMessage, final String userFacingErrorMessageKey,
+                                  @Deprecated final EventType originalEventType) {
+        LoginFormsProvider form = context.form();
+        String userFacingErrorMessage = userFacingErrorMessageKey == null ? errorMessage : form.getMessage(userFacingErrorMessageKey);
         Response errorResponse = null;
         switch (errorCase) {
         case WEBAUTHN_ERROR_REGISTER_VERIFICATION:
@@ -462,7 +485,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
             EventBuilder deprecatedRegisterVerificationEvent = registerVerificationEvent.clone().event(originalEventType);
             registerVerificationEvent.error(Errors.INVALID_USER_CREDENTIALS);
             deprecatedRegisterVerificationEvent.error(Errors.INVALID_USER_CREDENTIALS);
-            errorResponse = context.form()
+            errorResponse = form
                 .setError(errorCase, errorMessage)
                 .setAttribute(WEB_AUTHN_TITLE_ATTR, WEBAUTHN_REGISTER_TITLE)
                 .createWebAuthnErrorPage();
@@ -476,8 +499,8 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
             EventBuilder deprecatedRegistrationEvent = registrationEvent.clone().event(originalEventType);
             deprecatedRegistrationEvent.error(Errors.INVALID_REGISTRATION);
             registrationEvent.error(Errors.INVALID_REGISTRATION);
-            errorResponse = context.form()
-                .setError(errorCase, errorMessage)
+            errorResponse = form
+                .setError(errorCase, userFacingErrorMessage)
                 .setAttribute(WEB_AUTHN_TITLE_ATTR, WEBAUTHN_REGISTER_TITLE)
                 .createWebAuthnErrorPage();
             context.challenge(errorResponse);

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -335,6 +335,8 @@ public class Messages {
     public static final String WEBAUTHN_ERROR_AUTH_VERIFICATION = "webauthn-error-auth-verification";
     public static final String WEBAUTHN_ERROR_REGISTER_VERIFICATION = "webauthn-error-register-verification";
     public static final String WEBAUTHN_ERROR_USER_NOT_FOUND = "webauthn-error-user-not-found";
+    public static final String WEBAUTHN_ERROR_USER_NOT_PRESENT = "webauthn-error-user-not-present";
+    public static final String WEBAUTHN_ERROR_USER_NOT_VERIFIED = "webauthn-error-user-not-verified";
 
     // Conditions in Conditional Flow
     public static final String ACCESS_DENIED = "access-denied";

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
@@ -1,17 +1,25 @@
 package org.keycloak.tests.webauthn;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 
+import com.webauthn4j.converter.AttestationObjectConverter;
+import com.webauthn4j.converter.util.ObjectConverter;
+import com.webauthn4j.data.attestation.AttestationObject;
+import com.webauthn4j.data.attestation.authenticator.AuthenticatorData;
+import com.webauthn4j.data.extension.authenticator.RegistrationExtensionAuthenticatorOutput;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.keycloak.WebAuthnConstants.AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Tests that WebAuthn registration enforces realm policy server-side.
@@ -78,6 +86,45 @@ public class WebAuthnPolicyComplianceTest extends AbstractWebAuthnVirtualTest {
                         "opts.publicKey.authenticatorSelection = opts.publicKey.authenticatorSelection || {};" +
                         "opts.publicKey.authenticatorSelection.userVerification = 'discouraged';"),
                 "User verification is required.");
+    }
+
+    @Test
+    public void tamperedUserPresence() {
+        String testId = "up-tamper";
+        String username = "policy-" + testId;
+        String email = "policy-" + testId + "@email";
+
+        managedRealm.updateWithCleanup(r -> r
+                .webAuthnPolicyAttestationConveyancePreference("none"));
+
+        oAuthClient.openRegistrationForm();
+        registerPage.assertCurrent();
+        registerPage.register("firstName", "lastName", email, username, PASSWORD);
+
+        webAuthnRegisterPage.assertCurrent();
+
+        ((JavascriptExecutor) driver.driver()).executeScript(
+                "document.getElementById('register').addEventListener('submit', function(event) {" +
+                "  event.preventDefault();" +
+                "}, { once: true });");
+
+        webAuthnRegisterPage.clickRegister();
+        webAuthnRegisterPage.registerWebAuthnCredential(SecretGenerator.getInstance().randomString(24));
+
+        String encodedAttestationObject = new WebDriverWait(driver.driver(), Duration.ofSeconds(10)).until(webDriver -> {
+            String value = (String) ((JavascriptExecutor) webDriver).executeScript(
+                    "return document.getElementById('attestationObject').value;");
+            return value.isEmpty() ? null : value;
+        });
+        String tamperedAttestationObject = clearUserPresenceFlag(encodedAttestationObject);
+
+        ((JavascriptExecutor) driver.driver()).executeScript(
+                "document.getElementById('attestationObject').value = arguments[0];" +
+                "document.getElementById('register').requestSubmit();",
+                tamperedAttestationObject);
+
+        webAuthnErrorPage.assertCurrent();
+        assertThat(webAuthnErrorPage.getError(), containsString("User presence is required."));
     }
 
     @Test
@@ -180,5 +227,23 @@ public class WebAuthnPolicyComplianceTest extends AbstractWebAuthnVirtualTest {
                 "  " + body +
                 "  return origCreate(opts);" +
                 "};";
+    }
+
+    private static String clearUserPresenceFlag(String encodedAttestationObject) {
+        AttestationObjectConverter converter = new AttestationObjectConverter(new ObjectConverter());
+        AttestationObject attestationObject = converter.convert(encodedAttestationObject);
+        AuthenticatorData<RegistrationExtensionAuthenticatorOutput> authenticatorData = attestationObject.getAuthenticatorData();
+        assertThat("Test credential must initially have user presence", authenticatorData.isFlagUP(), is(true));
+
+        AuthenticatorData<RegistrationExtensionAuthenticatorOutput> tamperedAuthenticatorData = new AuthenticatorData<>(
+                authenticatorData.getRpIdHash(),
+                (byte) (authenticatorData.getFlags() & ~AuthenticatorData.BIT_UP),
+                authenticatorData.getSignCount(),
+                authenticatorData.getAttestedCredentialData(),
+                authenticatorData.getExtensions());
+
+        return converter.convertToBase64urlString(new AttestationObject(
+                tamperedAuthenticatorData,
+                attestationObject.getAttestationStatement()));
     }
 }

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnPolicyComplianceTest.java
@@ -77,7 +77,7 @@ public class WebAuthnPolicyComplianceTest extends AbstractWebAuthnVirtualTest {
                 tamperCreateOptions(
                         "opts.publicKey.authenticatorSelection = opts.publicKey.authenticatorSelection || {};" +
                         "opts.publicKey.authenticatorSelection.userVerification = 'discouraged';"),
-                "Verifier is configured to check user verified, but UV flag in authenticatorData is not set.");
+                "User verification is required.");
     }
 
     @Test

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -510,6 +510,8 @@ webauthn-error-different-user=First authenticated user is not the one authentica
 webauthn-error-auth-verification=Passkey authentication result is invalid. {0}
 webauthn-error-register-verification=Passkey registration result is invalid. {0}
 webauthn-error-user-not-found=Unknown user authenticated by the Passkey.
+webauthn-error-user-not-present=User presence is required.
+webauthn-error-user-not-verified=User verification is required.
 
 # Passkey
 passkey-login-title=Passkey login


### PR DESCRIPTION
## Summary

- map WebAuthn4J user-presence and user-verification registration exceptions to Keycloak login-theme message keys
- retain the original WebAuthn4J details in debug logs and event details
- add English source messages and full-stack integration coverage for the reported user-verification path and the user-presence mapping

## Motivation

When user verification is required but the authenticator does not verify the user, Keycloak currently renders a localized registration-error prefix followed by WebAuthn4J's English developer-facing exception text. This resolves a Keycloak message key for the user-facing detail while preserving the original diagnostic for operators.

Only WebAuthn4J exception types that represent a single failure reason are mapped. Other WebAuthn exception types, browser-originated registration errors, and the authentication path are unchanged.

## Testing

**Automated:**

- `./mvnw test -f tests/webauthn/pom.xml -Dtest=WebAuthnPolicyComplianceTest#tamperedUserPresence` — 1 test passed
- `./mvnw test -f tests/webauthn/pom.xml -Dtest=WebAuthnPolicyComplianceTest#tamperedUserVerification` — 1 test passed
- `./mvnw test -f tests/webauthn/pom.xml -Dtest=WebAuthnPolicyComplianceTest` — 9 tests passed
- `./mvnw -pl quarkus/dist -am -DskipTests -DskipTestsuite -DskipExamples package` — 53-module reactor passed
- `./mvnw -pl services,themes,tests/webauthn -DskipTests spotless:check`
- `git diff --check`

**Manual:**

- Built the runnable distribution from `45554ad0`, started it with a disposable H2 realm, and drove registration with a standalone headless Chrome client. A valid credential was accepted; after clearing the UP flag from a browser-generated credential before submission, Keycloak rendered “Failed to register your Passkey. User presence is required.”

## Documentation

Not applicable; this changes an existing error diagnostic and introduces no configuration or workflow change.

## AI disclosure

I used OpenAI Codex agents to assist with repository analysis, implementation, tests, and review of this change. I reviewed, understand, and can explain and revise every submitted change.

Closes #44963
