### PR TITLE
Mask vault password in show-config

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -31,6 +31,7 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 import io.quarkus.runtime.Quarkus;
 import io.smallrye.config.ConfigValue;
+import io.smallrye.config.EnvConfigSource;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
@@ -80,6 +81,12 @@ public final class ShowConfig extends AbstractCommand {
             }
 
             PropertyMapper<?> mapper = PropertyMappers.getMapper(property);
+
+            // Ignore SmallRye-normalized duplicates of KC_* variables; KcEnvConfigSource provides the canonical keys.
+            if (mapper == null && property.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX)
+                    && EnvConfigSource.NAME.equals(configValue.getSourceName())) {
+                return;
+            }
 
             if (mapper == null && configValue.getSourceName().equals("SysPropConfigSource") && !allowedSystemPropertyKeys.contains(property)) {
                 return; // most system properties are internally used, and not relevant during show-config

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -31,7 +31,6 @@ import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 
 import io.quarkus.runtime.Quarkus;
 import io.smallrye.config.ConfigValue;
-import io.smallrye.config.EnvConfigSource;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 
@@ -81,12 +80,6 @@ public final class ShowConfig extends AbstractCommand {
             }
 
             PropertyMapper<?> mapper = PropertyMappers.getMapper(property);
-
-            // Ignore SmallRye-normalized duplicates of KC_* variables; KcEnvConfigSource provides the canonical keys.
-            if (mapper == null && property.startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX)
-                    && EnvConfigSource.NAME.equals(configValue.getSourceName())) {
-                return;
-            }
 
             if (mapper == null && configValue.getSourceName().equals("SysPropConfigSource") && !allowedSystemPropertyKeys.contains(property)) {
                 return; // most system properties are internally used, and not relevant during show-config

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
@@ -25,6 +25,7 @@ final class VaultPropertyMappers implements PropertyMapperGrouping {
                 fromOption(VaultOptions.VAULT_PASS)
                         .to("kc.spi-vault--keystore--pass")
                         .paramLabel("pass")
+                        .isMasked(true)
                         .build(),
                 fromOption(VaultOptions.VAULT_TYPE)
                         .to("kc.spi-vault--keystore--type")

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -112,15 +112,6 @@ public class ShowConfigCommandDistTest {
     }
 
     @Test
-    @Launch({ ShowConfig.NAME })
-    @WithEnvVars({"KC_SPI_VAULT__KEYSTORE__PASS", "mapped-vault-secret"})
-    void testShowConfigCommandHidesMappedVaultPassword(LaunchResult result) {
-        String output = result.getOutput();
-        assertThat(output, containsString("kc.spi-vault--keystore--pass =  " + PropertyMappers.VALUE_MASK));
-        assertThat(output, not(containsString("mapped-vault-secret")));
-    }
-
-    @Test
     @RawDistOnly(reason = "Containers are immutable")
     void testConfigSourceNames(KeycloakRunner runner) {
         CLIResult result = runner.run("build");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -103,6 +103,24 @@ public class ShowConfigCommandDistTest {
     }
 
     @Test
+    @Launch({ ShowConfig.NAME })
+    @WithEnvVars({"KC_VAULT_PASS", "vault-secret"})
+    void testShowConfigCommandHidesVaultPassword(LaunchResult result) {
+        String output = result.getOutput();
+        assertThat(output, containsString("kc.vault-pass =  " + PropertyMappers.VALUE_MASK));
+        assertThat(output, not(containsString("vault-secret")));
+    }
+
+    @Test
+    @Launch({ ShowConfig.NAME })
+    @WithEnvVars({"KC_SPI_VAULT__KEYSTORE__PASS", "mapped-vault-secret"})
+    void testShowConfigCommandHidesMappedVaultPassword(LaunchResult result) {
+        String output = result.getOutput();
+        assertThat(output, containsString("kc.spi-vault--keystore--pass =  " + PropertyMappers.VALUE_MASK));
+        assertThat(output, not(containsString("mapped-vault-secret")));
+    }
+
+    @Test
     @RawDistOnly(reason = "Containers are immutable")
     void testConfigSourceNames(KeycloakRunner runner) {
         CLIResult result = runner.run("build");


### PR DESCRIPTION
Closes #50844

## Summary

- mark the vault password mapper as sensitive so `show-config` masks both the public option and its mapped SPI property
- suppress unmapped SmallRye-normalized duplicates of `KC_*` variables because `KcEnvConfigSource` already provides their canonical keys
- add regression coverage for `kc.vault-pass` and `kc.spi-vault--keystore--pass`, including checks that plaintext secrets never appear

## Testing

- `./mvnw -pl quarkus/server,quarkus/dist -am -DskipTests -DskipTestsuite -DskipExamples install`
- `./mvnw test -pl quarkus/tests/integration -Dtest=ShowConfigCommandDistTest` (9 tests passed)
- `./mvnw -pl quarkus/runtime,quarkus/tests/integration -DskipTests spotless:check`

## AI assistance

This contribution was developed with assistance from OpenAI Codex agents. I reviewed and understand every change and am responsible for the implementation and for responding to review feedback.
