### PR TITLE
Allow cross-client exchange of DPoP-bound tokens

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -22,6 +22,11 @@ When calling {project_name}'s experimental AuthZEN endpoints, the caller now nee
 
 The Admin REST API endpoints for listing client sessions (`GET /admin/realms/\{realm}/clients/\{id}/user-sessions` and `GET /admin/realms/\{realm}/clients/\{id}/offline-sessions`) now filter out sessions belonging to users that the caller does not have permission to view. Previously, any caller with the `view-clients` role could see all user sessions for a client, potentially exposing user identities to callers without the `view-users` role. After upgrading, callers without `view-users` permission will see fewer results from these endpoints.
 
+=== Cross-client Token Exchange with DPoP-bound tokens
+
+Standard Token Exchange now accepts a DPoP-bound `subject_token` issued to a different client when the requester is included in the token's `aud` claim and provides a valid DPoP proof for the token.
+The proof must be signed with the key identified by the token's `cnf.jkt` claim.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 
@@ -35,4 +40,3 @@ The following sections provide details on deprecated features.
 The following features have been removed from this release.
 
 === <TODO>
-

--- a/docs/guides/securing-apps/dpop.adoc
+++ b/docs/guides/securing-apps/dpop.adoc
@@ -184,8 +184,8 @@ For granular control, you can use the **dpop-bind-enforcer** executor within Cli
 
 Standard Token Exchange supports DPoP-bound tokens as `subject_token` under specific conditions:
 
-* The client performing the token exchange request *must be the same client* that the `subject_token` was issued for (the `azp` claim must match the requester client ID).
 * The client must include a valid DPoP proof in the exchange request, signed with the same key that was used to bind the original token. {project_name} verifies that the DPoP key thumbprint matches the `cnf.jkt` claim in the subject token.
+* If a different client performs the exchange, that client must be included in the `aud` claim of the `subject_token`.
 
 The exchanged token will also be DPoP-bound if a valid DPoP proof is included in the request.
 
@@ -197,5 +197,6 @@ Token exchange with DPoP is useful when:
 * You want to down-scope or change audiences while simultaneously adding DPoP binding
 * Your backend services require DPoP but the original token was issued as Bearer
 * You need to exchange a DPoP-bound token for a new one with different audiences or scopes while maintaining the DPoP binding
+* A gateway needs to exchange a DPoP-bound token issued to another client for a narrower-audience token
 
 </@tmpl.guide>

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -265,9 +265,9 @@ This use case can be replaced by refresh token grant.
 * The `subject_token` sent to the token exchange endpoint must have the requester client set as an audience in the `aud` claim. Otherwise, the request would be rejected. The only exception is, if client
 exchanges his own token, which was issued to it. Exchanging to itself might be useful to downscope/upscope the token or filter unneeded token audiences and so on.
 
-* Sender-constrained tokens (as defined in RFC 7800) can be used as `subject_token` only when the requesting client is the same client that the token was originally issued for.
-The client must also provide valid proof of possession: a DPoP proof for DPoP-bound tokens, or the matching client certificate for mTLS-bound tokens.
-If the client does not match or the proof is missing/invalid, the request is rejected. For more details on DPoP, see <@links.securingapps id="dpop" />.
+* Sender-constrained tokens (as defined in RFC 7800) can be used as `subject_token` when the requesting client provides valid proof of possession.
+For DPoP-bound tokens, the requesting client must provide a DPoP proof signed with the key to which the token is bound. A different client can exchange the token when it is included in the token's `aud` claim.
+X.509 certificate-bound tokens can only be exchanged by the client that the token was issued for, using the matching client certificate. If these requirements are not met, the request is rejected. For more details on DPoP, see <@links.securingapps id="dpop" />.
 
 * Consents - If the requester client has *Consent required* enabled, the token exchange is allowed only if the user is already granted consent to all requested scopes
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -157,8 +157,14 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
 
     protected void validateSenderConstrainedToken(AccessToken token) {
         if (isSenderConstrainedToken(token)) {
-            // Reject sender-constrained tokens (RFC 7800) as subject_token if client does not match the authorized parties claim
-            if (!token.getIssuedFor().equals(client.getClientId())) {
+            AccessToken.Confirmation cnf = token.getConfirmation();
+            boolean isDPoPBound = Profile.isFeatureEnabled(Profile.Feature.DPOP)
+                    && cnf.getKeyThumbprint() != null
+                    && (cnf.getJktType() == null || DPoPUtil.DPOP_JKT_TYPE.equals(cnf.getJktType()));
+
+            // DPoP-bound tokens can be exchanged by a different client after proof-of-possession validation below.
+            // Other sender-constrained tokens are restricted to the client identified by the authorized party claim.
+            if (!isDPoPBound && !token.getIssuedFor().equals(client.getClientId())) {
                 event.detail(Details.REASON, "Sender-constrained token exchange rejected as the token was not issued for the requesting client");
                 event.error(Errors.INVALID_REQUEST);
                 throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
@@ -166,7 +172,6 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
                       Response.Status.BAD_REQUEST);
             }
 
-            AccessToken.Confirmation cnf = token.getConfirmation();
             // Validate mTLS
             if (cnf.getCertThumbprint() != null) {
                 if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(token, session.getContext().getHttpRequest(), session)) {
@@ -174,7 +179,7 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
                 }
             }
             // Validate DPoP
-            if (Profile.isFeatureEnabled(Profile.Feature.DPOP) && cnf.getKeyThumbprint() != null) {
+            if (isDPoPBound) {
                 DPoP dPoP = session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE, DPoP.class);
                 if (dPoP == null) {
                     event.detail(Details.REASON, "DPoP proof is missing");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
@@ -1177,9 +1177,17 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void testDPoPTokenExchangeDifferentClient() throws Exception {
+        ProtocolMapperRepresentation audMapper = new ProtocolMapperRepresentation();
+        audMapper.setName("dpop-cross-client-audience-mapper");
+        audMapper.setProtocol("openid-connect");
+        audMapper.setProtocolMapper("oidc-audience-mapper");
+        audMapper.setConfig(Map.of("included.client.audience", "named-test-app", "access.token.claim", "true"));
+
         try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, "named-test-app")
                 .setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
-                .update()) {
+                .update();
+             ProtocolMappersUpdater ignoredMappers = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CONFIDENTIAL_CLIENT_ID)
+                .protocolMappers().add(audMapper).update()) {
             AccessTokenResponse tokenResponse = getDPoPBindAccessToken(rsaKeyPair);
             String dpopProof = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST,
                     oauth.getEndpoints().getToken(), (long) Time.currentTime(), Algorithm.PS256, jwsRsaHeader,
@@ -1189,9 +1197,10 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
                     .client("named-test-app", "password")
                     .dpopProof(dpopProof).send();
 
-            assertEquals(Status.BAD_REQUEST.getStatusCode(), exchangeResponse.getStatusCode());
-            assertEquals(OAuthErrorException.INVALID_REQUEST, exchangeResponse.getError());
-            assertTrue(exchangeResponse.getErrorDescription().contains("not issued for the requesting client"));
+            assertEquals(Status.OK.getStatusCode(), exchangeResponse.getStatusCode(), exchangeResponse.getErrorDescription());
+            assertEquals(TokenUtil.TOKEN_TYPE_DPOP, exchangeResponse.getTokenType());
+            AccessToken exchangedToken = oauth.verifyToken(exchangeResponse.getAccessToken());
+            assertEquals(jktRsa, exchangedToken.getConfirmation().getKeyThumbprint());
 
             oauth.doLogout(tokenResponse.getRefreshToken());
         }


### PR DESCRIPTION
## Summary

Permit a different authorized client to exchange a DPoP-bound subject token after validating proof of possession.

The requester must remain within the subject token’s audience, and the supplied DPoP proof must match the token’s `cnf.jkt` binding. Audience checks and restrictions for non-DPoP sender-constrained tokens remain unchanged.

## Testing

- Verified the services reactor compiles.
- Verified same-client and cross-client DPoP token exchange.
- Verified missing and mismatched DPoP proofs are rejected.
- Ran `spotless:check`.

Closes #51014