### PR TITLE
Don't offer or run non-CredentialValidator authenticators the user can't pass

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -251,6 +251,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
             <scope>test</scope>

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationSelectionResolver.java
@@ -29,6 +29,8 @@ import org.keycloak.credential.CredentialModel;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
 
 import org.jboss.logging.Logger;
 
@@ -176,11 +178,40 @@ class AuthenticationSelectionResolver {
 
         Authenticator localAuthenticator = processor.getSession().getProvider(Authenticator.class, execution.getAuthenticator());
         if (!(localAuthenticator instanceof CredentialValidator)) {
-            nonCredentialExecutions.add(execution);
+            if (isSelectableForCurrentUser(processor, execution, localAuthenticator)) {
+                nonCredentialExecutions.add(execution);
+            }
         } else {
             CredentialValidator<?> cv = (CredentialValidator<?>) localAuthenticator;
             typeAuthExecMap.put(cv.getType(processor.getSession()), execution);
         }
+    }
+
+    /**
+     * A non-CredentialValidator authenticator that requires a user should only be offered as a
+     * selectable alternative if it's actually usable by that user: either already configured for
+     * them, or the factory allows the user to configure it on the spot. Without this check,
+     * "Try another way" lists authenticators that throw CREDENTIAL_SETUP_REQUIRED the moment
+     * they're picked.
+     */
+    // package-private so AuthenticationSelectionResolverTest can exercise it directly
+    static boolean isSelectableForCurrentUser(AuthenticationProcessor processor, AuthenticationExecutionModel execution, Authenticator authenticator) {
+        if (!authenticator.requiresUser()) {
+            return true;
+        }
+
+        AuthenticationSessionModel authSession = processor.getAuthenticationSession();
+        UserModel authUser = authSession == null ? null : authSession.getAuthenticatedUser();
+        if (authUser == null) {
+            return true;
+        }
+
+        if (authenticator.configuredFor(processor.getSession(), processor.getRealm(), authUser)) {
+            return true;
+        }
+
+        AuthenticatorFactory factory = (AuthenticatorFactory) processor.getSession().getKeycloakSessionFactory().getProviderFactory(Authenticator.class, execution.getAuthenticator());
+        return factory != null && factory.isUserSetupAllowed();
     }
 
 

--- a/services/src/test/java/org/keycloak/authentication/AuthenticationSelectionResolverTest.java
+++ b/services/src/test/java/org/keycloak/authentication/AuthenticationSelectionResolverTest.java
@@ -1,0 +1,97 @@
+package org.keycloak.authentication;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link AuthenticationSelectionResolver#isSelectableForCurrentUser}, added so a
+ * non-CredentialValidator authenticator that requires a user is only offered as a selectable
+ * alternative ("Try another way") when it's actually usable by that user.
+ */
+class AuthenticationSelectionResolverTest {
+
+    private AuthenticationProcessor processor;
+    private AuthenticationExecutionModel execution;
+    private Authenticator authenticator;
+    private AuthenticatorFactory factory;
+    private KeycloakSession session;
+    private KeycloakSessionFactory sessionFactory;
+    private RealmModel realm;
+    private AuthenticationSessionModel authSession;
+    private UserModel user;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(KeycloakSession.class);
+        sessionFactory = mock(KeycloakSessionFactory.class);
+        realm = mock(RealmModel.class);
+        authSession = mock(AuthenticationSessionModel.class);
+        user = mock(UserModel.class);
+        execution = mock(AuthenticationExecutionModel.class);
+        authenticator = mock(Authenticator.class);
+        factory = mock(AuthenticatorFactory.class);
+
+        processor = mock(AuthenticationProcessor.class);
+        when(processor.getSession()).thenReturn(session);
+        when(processor.getRealm()).thenReturn(realm);
+        when(processor.getAuthenticationSession()).thenReturn(authSession);
+        when(session.getKeycloakSessionFactory()).thenReturn(sessionFactory);
+        when(execution.getAuthenticator()).thenReturn("custom-authenticator");
+        when(sessionFactory.getProviderFactory(Authenticator.class, "custom-authenticator")).thenReturn(factory);
+    }
+
+    @Test
+    void authenticatorNotRequiringUserIsAlwaysSelectable() {
+        when(authenticator.requiresUser()).thenReturn(false);
+
+        assertTrue(AuthenticationSelectionResolver.isSelectableForCurrentUser(processor, execution, authenticator));
+    }
+
+    @Test
+    void noAuthenticatedUserYetIsSelectable() {
+        when(authenticator.requiresUser()).thenReturn(true);
+        when(authSession.getAuthenticatedUser()).thenReturn(null);
+
+        assertTrue(AuthenticationSelectionResolver.isSelectableForCurrentUser(processor, execution, authenticator));
+    }
+
+    @Test
+    void configuredForCurrentUserIsSelectable() {
+        when(authenticator.requiresUser()).thenReturn(true);
+        when(authSession.getAuthenticatedUser()).thenReturn(user);
+        when(authenticator.configuredFor(session, realm, user)).thenReturn(true);
+
+        assertTrue(AuthenticationSelectionResolver.isSelectableForCurrentUser(processor, execution, authenticator));
+    }
+
+    @Test
+    void notConfiguredButUserSetupAllowedIsSelectable() {
+        when(authenticator.requiresUser()).thenReturn(true);
+        when(authSession.getAuthenticatedUser()).thenReturn(user);
+        when(authenticator.configuredFor(session, realm, user)).thenReturn(false);
+        when(factory.isUserSetupAllowed()).thenReturn(true);
+
+        assertTrue(AuthenticationSelectionResolver.isSelectableForCurrentUser(processor, execution, authenticator));
+    }
+
+    @Test
+    void notConfiguredAndUserSetupNotAllowedIsNotSelectable() {
+        when(authenticator.requiresUser()).thenReturn(true);
+        when(authSession.getAuthenticatedUser()).thenReturn(user);
+        when(authenticator.configuredFor(session, realm, user)).thenReturn(false);
+        when(factory.isUserSetupAllowed()).thenReturn(false);
+
+        assertFalse(AuthenticationSelectionResolver.isSelectableForCurrentUser(processor, execution, authenticator));
+    }
+}


### PR DESCRIPTION
Fixes #46481.

`addSimpleAuthenticationExecution` only checks `instanceof CredentialValidator` before adding
an execution to the selection list. Nothing evaluates `configuredFor()` or
`isUserSetupAllowed()` for anything else, so a non-CredentialValidator authenticator that
requires a user and isn't configured for them still shows up under "Try another way" - and
throws `CREDENTIAL_SETUP_REQUIRED` the moment it's picked.

This adds `isSelectableForCurrentUser`, called before the execution lands in
`nonCredentialExecutions`. Authenticators that don't require a user pass straight through.
The rest are only listed when `configuredFor()` returns true, or when the factory allows the
user to set them up on the spot. The factory lookup mirrors the one already used in this file.

Scope note: an earlier revision of this PR also dropped the `instanceof CredentialValidator`
guard in `DefaultAuthenticationFlow`. I backed that out. `AllowAccessAuthenticator` and
`DenyAccessAuthenticator` deliberately return `configuredFor() == false` and are meant to run
anyway, so removing the guard broke `AllowDenyAuthenticatorTest`. That restriction is there on
purpose. This PR is scoped to the selection list.

Nothing changes while no user has been identified. Those executions were previously added
unconditionally, so the new predicate is strictly narrower than the old behavior - it can't
hide an option that used to work.

`AuthenticationSelectionResolverTest` covers both branches, mocking the model objects the same
way the ssf/transmitter tests do. That needed `mockito-core` declared as a test dependency of
`services`; it's already managed by the parent BOM, so the entry carries no version.
