### PR TITLE
adding a linked pre-triage / linked issue check

### DIFF
--- a/.github/workflows/issue-closure.yml
+++ b/.github/workflows/issue-closure.yml
@@ -1,0 +1,158 @@
+name: Issue Closed or Reopened
+
+on:
+  issues:
+    types: [closed, reopened]
+
+concurrency:
+  group: issue-closed-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  handle-linked-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      ACTION: ${{ github.event.action }}
+    steps:
+      - name: Close, label, or restore linked pull requests
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          SKIP_LABEL="skip-issue-check"
+          EXPIRED_LABEL="status/expired-by-bot"
+          ISSUE_EXPIRED_PR_LABEL="status/issue-expired"
+
+          REPO_OWNER="${REPO%%/*}"
+          REPO_NAME="${REPO##*/}"
+
+          # Find open PRs that currently close this issue.
+          #
+          # timelineItems (CrossReferencedEvent) is NOT used here because the GitHub timeline is
+          # append-only: events are never removed when a PR description is edited to drop a reference.
+          # Instead we use a two-step approach that reflects live state:
+          #   1. Search API: find open PRs in this repo that mention the issue number (fast, may
+          #      over-fetch PRs that mention it without a closing keyword).
+          #   2. For each candidate, verify via closingIssuesReferences on the PR — this field is
+          #      re-derived from the current PR description on every request and is therefore
+          #      authoritative about whether the PR will actually close the issue when merged.
+
+          # Step 1: candidate PRs from search.
+          if ! CANDIDATE_PRS=$(
+            gh api graphql \
+              -F searchQuery="repo:${REPO} is:pr is:open #${ISSUE_NUMBER}" \
+              -f query='
+                query($searchQuery: String!) {
+                  search(query: $searchQuery, type: ISSUE, first: 50) {
+                    nodes {
+                      ... on PullRequest {
+                        number
+                        labels(first: 20) {
+                          nodes { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              ' 2>&1
+          ); then
+            echo "::error::Failed to search for linked pull requests for issue #$ISSUE_NUMBER: $CANDIDATE_PRS"
+            exit 1
+          fi
+
+          mapfile -t CANDIDATE_NUMBERS < <(
+            printf '%s\n' "$CANDIDATE_PRS" | jq -r '
+              .data.search.nodes[] | select(.number != null) | .number
+            ' 2>/dev/null | sort -u || true
+          )
+
+          # Step 2: confirm each candidate still closes this issue via closingIssuesReferences.
+          PR_NUMBERS=()
+          for CANDIDATE in "${CANDIDATE_NUMBERS[@]}"; do
+            [ -z "$CANDIDATE" ] && continue
+            if ! CLOSING_DATA=$(
+              gh api graphql \
+                -F owner="$REPO_OWNER" \
+                -F repo="$REPO_NAME" \
+                -F prNumber="$CANDIDATE" \
+                -f query='
+                  query($owner: String!, $repo: String!, $prNumber: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $prNumber) {
+                        closingIssuesReferences(first: 50) {
+                          nodes { number }
+                        }
+                      }
+                    }
+                  }
+                ' 2>&1
+            ); then
+              echo "::warning::Failed to verify closingIssuesReferences for PR #$CANDIDATE: $CLOSING_DATA — skipping."
+              continue
+            fi
+            if printf '%s\n' "$CLOSING_DATA" | jq -e \
+                --argjson n "$ISSUE_NUMBER" \
+                '.data.repository.pullRequest.closingIssuesReferences.nodes[] | select(.number == $n)' \
+                > /dev/null 2>&1; then
+              PR_NUMBERS+=("$CANDIDATE")
+            fi
+          done
+
+          if [ "${#PR_NUMBERS[@]}" -eq 0 ]; then
+            echo "No open pull requests currently closing issue #$ISSUE_NUMBER."
+            exit 0
+          fi
+
+          if [ "$ACTION" = "reopened" ]; then
+            # On reopen: remove status/issue-expired from every linked open PR.
+            for PR_NUMBER in "${PR_NUMBERS[@]}"; do
+              PR_LABELS=$(
+                printf '%s\n' "$CANDIDATE_PRS" | jq -r --argjson n "$PR_NUMBER" '
+                  .data.search.nodes[] | select(.number == $n) | .labels.nodes[].name
+                ' 2>/dev/null || true
+              )
+              if printf '%s\n' "$PR_LABELS" | grep -Fxq -- "$ISSUE_EXPIRED_PR_LABEL"; then
+                echo "Issue #$ISSUE_NUMBER reopened — removing '$ISSUE_EXPIRED_PR_LABEL' from PR #$PR_NUMBER."
+                gh pr edit "$PR_NUMBER" -R "$REPO" --remove-label "$ISSUE_EXPIRED_PR_LABEL"
+              else
+                echo "PR #$PR_NUMBER does not have '$ISSUE_EXPIRED_PR_LABEL' — nothing to remove."
+              fi
+            done
+            exit 0
+          fi
+
+          # On close: check whether the issue was expired by the bot.
+          ISSUE_LABELS=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/labels" --jq '.[].name' || true)
+          IS_EXPIRED_BY_BOT=0
+          if printf '%s\n' "$ISSUE_LABELS" | grep -Fxq -- "$EXPIRED_LABEL"; then
+            IS_EXPIRED_BY_BOT=1
+          fi
+
+          for PR_NUMBER in "${PR_NUMBERS[@]}"; do
+            # Check whether the PR carries the skip-issue-check label.
+            PR_LABELS=$(
+              printf '%s\n' "$CANDIDATE_PRS" | jq -r --argjson n "$PR_NUMBER" '
+                .data.search.nodes[] | select(.number == $n) | .labels.nodes[].name
+              ' 2>/dev/null || true
+            )
+
+            if printf '%s\n' "$PR_LABELS" | grep -Fxq -- "$SKIP_LABEL"; then
+              echo "PR #$PR_NUMBER has '$SKIP_LABEL' — skipping."
+              continue
+            fi
+
+            if [ "$IS_EXPIRED_BY_BOT" -eq 1 ]; then
+              echo "Issue #$ISSUE_NUMBER was expired by bot — adding '$ISSUE_EXPIRED_PR_LABEL' to PR #$PR_NUMBER."
+              gh pr edit "$PR_NUMBER" -R "$REPO" --add-label "$ISSUE_EXPIRED_PR_LABEL"
+            else
+              echo "Closing PR #$PR_NUMBER because linked issue #$ISSUE_NUMBER was closed."
+              gh pr close "$PR_NUMBER" -R "$REPO" \
+                --comment "Closing this pull request because the linked issue #$ISSUE_NUMBER has been closed."
+            fi
+          done

--- a/.github/workflows/pre-triage-pr.yml
+++ b/.github/workflows/pre-triage-pr.yml
@@ -1,0 +1,240 @@
+name: Pre-triage Pull Request
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled, ready_for_review]
+    branches:
+      - main 
+
+jobs:
+  pre-triage:
+    env:
+      GH_TOKEN: ${{ github.token }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check linked issues
+        id: check-linked-issues
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          FAILED=0
+          ERRORS=""
+          MARKER="<!-- pre-triage-linked-issues -->"
+          SKIP_LABEL="skip-issue-check"
+          
+          HAS_SKIP_LABEL=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --jq ".[] | select(.name == \"$SKIP_LABEL\") | .name" | head -1 || true)
+
+          # Append an error message to the ERRORS list and emit a CI annotation.
+          add_error() {
+            echo "::error::$1"
+            ERRORS="${ERRORS}"$'\n'"- $1"
+            FAILED=1
+          }
+          
+          # Remove HTML comments from markdown text so hidden examples/templates
+          # do not count as linked issues.
+          strip_html_comments() {
+            local text="$1"
+            perl -0pe 's/<!--.*?-->//gs' <<< "$text"
+          }
+
+          # Extract linked issue references from a block of text.
+          # Accepts all GitHub closing keywords (case-insensitive, with optional colon) followed by
+          # same-repo (#NNN), cross-repo (owner/repo#NNN), or URL references.
+          # Outputs one reference per line in the format "owner/repo#NNN".
+          extract_issues() {
+            local text="$1"
+            printf '%s\n' "$text" | perl -ne '
+              # Match GitHub closing keywords followed by a same-repo (#NNN),
+              # cross-repo (owner/repo#NNN), or URL issue reference.
+              while (/(?i:\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\b):?[ \t]+(?:(?:(?<cro>[\w-]+)\/(?<crr>[\w-]+)#)|#|(?:https:\/\/github\.com\/(?<urlo>[\w-]+)\/(?<urlr>[\w-]+)\/issues\/))(?<num>\d+)\b/g) {
+                my $owner = ($+{cro} // $+{urlo} // "");
+                my $repo  = ($+{crr} // $+{urlr} // "");
+                my $num   = $+{num};
+                if ($owner && $repo) {
+                  print "$owner/$repo#$num\n";
+                } else {
+                  print "'$REPO'#$num\n";
+                }
+              }
+            ' | sort -u || true
+          }
+          
+          # Collect all issue references mentioned across all commit messages in the PR.
+          # Returns one issue reference per line (may contain duplicates; caller can sort -u).
+          get_all_commit_issues() {
+            local all_commit_issues=""
+            local sha commit_msg issues
+
+            while IFS= read -r sha; do
+              if ! commit_msg=$(gh api "repos/$REPO/git/commits/$sha" --jq '.message' 2>&1); then
+                add_error "Failed to retrieve commit message for $sha: $commit_msg"
+                continue
+              fi
+
+              issues=$(extract_issues "$commit_msg")
+              all_commit_issues="${all_commit_issues}"$'\n'"${issues}"
+            done < <(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
+
+            printf '%s\n' "$all_commit_issues"
+          }
+
+          if [ -z "$HAS_SKIP_LABEL" ]; then
+            # --- Check PR description ---
+            PR_BODY_NO_COMMENTS=$(strip_html_comments "$PR_BODY")
+            PR_ISSUES=$(extract_issues "$PR_BODY_NO_COMMENTS")
+
+            if [ -z "$PR_ISSUES" ]; then
+              add_error "PR description must contain a linked issue (e.g. 'Closes #NNN')"
+            fi
+
+            ALL_COMMIT_ISSUES=$(get_all_commit_issues)
+            COMMIT_ISSUES=$(printf '%s\n' "$ALL_COMMIT_ISSUES" | sort -u | grep -v '^$' || true)
+            
+            # TODO: determine if there are potential timing issues with querying closingIssuesReferences
+            # - it's not clear that they will be updated prior to when the workflow runs
+            # TODO: there's no PR event for manually linking/unlinking issues, so this check can be out-of-sync after that
+            
+            # Parse GraphQL closingIssuesReferences into owner/repo#NNN format
+            parse_closing_refs() {
+              local json="$1"
+              printf '%s\n' "$json" | jq -r '
+                .data.repository.pullRequest.closingIssuesReferences.nodes[]
+                | "\(.repository.owner.login)/\(.repository.name)#\(.number)"
+              ' 2>/dev/null | sort -u || true
+            }
+            
+            # Parse GraphQL closingIssuesReferences into owner/repo#NNN<TAB>closed
+            parse_closing_refs_with_state() {
+              local json="$1"
+              printf '%s\n' "$json" | jq -r '
+                .data.repository.pullRequest.closingIssuesReferences.nodes[]
+                | "\(.repository.owner.login)/\(.repository.name)#\(.number)\t\(.closed)"
+              ' 2>/dev/null | sort -u || true
+            }
+
+            # Extract repo info from REPO (format: owner/repo)
+            REPO_OWNER="${REPO%%/*}"
+            REPO_NAME="${REPO##*/}"
+
+            # Query GitHub for closing issue references
+            CLOSING_ISSUES_REFERENCES_RAW=$(
+              gh api graphql \
+                -F owner="$REPO_OWNER" \
+                -F repo="$REPO_NAME" \
+                -F prNumber="$PR_NUMBER" \
+                -f query='
+                  query($owner: String!, $repo: String!, $prNumber: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $prNumber) {
+                        closingIssuesReferences(first: 50) {
+                          nodes {
+                            number
+                            closed
+                            repository {
+                              owner { login }
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                '
+            )
+
+            CLOSING_ISSUES_REFERENCES=$(parse_closing_refs "$CLOSING_ISSUES_REFERENCES_RAW")
+            CLOSING_ISSUES_WITH_STATE=$(parse_closing_refs_with_state "$CLOSING_ISSUES_REFERENCES_RAW")
+            
+            if [ "$FAILED" -eq 0 ]; then
+              while IFS= read -r ref; do
+                [ -z "$ref" ] && continue
+                issue_repo="${ref%%#*}"
+                if [ "$issue_repo" != "$REPO" ]; then
+                  # TODO: uncomment to disallow even manual links to other repos
+                  # add_error "Manually linked issue $ref is from a different repository, please remove it."
+                  continue
+                fi
+
+                # Find matching line: owner/repo#NNN<TAB>true|false
+                state_line=$(printf '%s\n' "$CLOSING_ISSUES_WITH_STATE" | grep -F -- "^$ref"$'\t' || true)
+
+                is_closed="${state_line##*$'\t'}"
+                if [ "$is_closed" = "true" ]; then
+                  add_error "Issue $ref is not open (current state: closed)"
+                  continue
+                fi
+                
+                if ! printf '%s\n' "$PR_ISSUES" | grep -Fxq -- "$ref"; then
+                  add_error "Issue $ref is a manually linked GitHub issue, but it's not in the PR description."
+                fi
+              done <<< "$CLOSING_ISSUES_REFERENCES"
+            fi  
+            
+            if [ "$FAILED" -eq 0 ]; then
+              while IFS= read -r ref; do
+                [ -z "$ref" ] && continue
+                issue_repo="${ref%%#*}"
+                if [ "$issue_repo" != "$REPO" ]; then
+                  add_error "Issue $ref in the PR description is from a different repository - do not use a closing keyword with it."
+                  continue
+                fi
+                if ! printf '%s\n' "$COMMIT_ISSUES" | grep -Fxq -- "$ref"; then
+                  add_error "Issue $ref is linked in the PR description but not in a commit message"
+                  continue
+                fi
+                if ! printf '%s\n' "$CLOSING_ISSUES_REFERENCES" | grep -Fxq -- "$ref"; then
+                  add_error "$ref is linked in the PR description but is not an issue - do not use a closing keyword with it."
+                fi
+              done <<< "$PR_ISSUES"
+            fi
+
+            if [ "$FAILED" -eq 0 ]; then
+              while IFS= read -r ref; do
+                [ -z "$ref" ] && continue
+                if ! printf '%s\n' "$PR_ISSUES" | grep -Fxq -- "$ref"; then
+                  issue_repo="${ref%%#*}"
+                  if [ "$issue_repo" != "$REPO" ]; then
+                    add_error "Issue $ref in the commit messages is from a different repository - do not use a closing keyword with it."
+                  else
+                    # TODO: could check if this is a valid issue - once added to the PR description, it will be validated though
+                    add_error "$ref is linked in the commit messages but not in the PR description."
+                  fi
+                fi
+              done <<< "$COMMIT_ISSUES"
+            fi
+          else
+            echo "skipping linked issue check"
+          fi
+
+          # --- Find last existing bot comment with our marker ---
+          EXISTING_COMMENT_ID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" | jq --arg marker "$MARKER" '.[] | select(.body | contains($marker)?) | .id' | tail -n1)
+          
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT_ID" -X DELETE
+          fi
+          
+          if [ "$FAILED" -ne 0 ]; then
+            COMMENT_BODY="${MARKER}
+          Thank you for contributing this PR. The following linked issue checks failed:
+          ${ERRORS}
+
+          Please refer to [CONTRIBUTING.md](https://github.com/${REPO}/blob/main/CONTRIBUTING.md) for requirements."
+
+            gh pr comment "$PR_NUMBER" -R "$REPO" --body "$COMMENT_BODY"
+            gh pr edit "${{ github.event.pull_request.number }}" -R "$GITHUB_REPOSITORY" --add-label "action/waiting-for-author"
+            exit 1
+          else
+            echo "All linked issue checks passed."
+            gh pr edit "${{ github.event.pull_request.number }}" -R "$GITHUB_REPOSITORY" --remove-label "action/waiting-for-author"
+          fi

--- a/.github/workflows/pre-triage-pr.yml
+++ b/.github/workflows/pre-triage-pr.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main 
 
+concurrency:
+  group: pre-triage-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pre-triage:
     env:
@@ -218,7 +222,7 @@ jobs:
           fi
 
           # --- Find last existing bot comment with our marker ---
-          EXISTING_COMMENT_ID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" | jq --arg marker "$MARKER" '.[] | select(.body | contains($marker)?) | .id' | tail -n1)
+          EXISTING_COMMENT_ID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" | jq --arg marker "$MARKER" '.[] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)?)) | .id' | tail -n1)
           
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT_ID" -X DELETE

--- a/.github/workflows/pre-triage-pr.yml
+++ b/.github/workflows/pre-triage-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize, labeled, unlabeled, ready_for_review]
     branches:
-      - main 
+      - main
 
 concurrency:
   group: pre-triage-pr-${{ github.event.pull_request.number }}
@@ -74,25 +74,6 @@ jobs:
             ' | sort -u || true
           }
           
-          # Collect all issue references mentioned across all commit messages in the PR.
-          # Returns one issue reference per line (may contain duplicates; caller can sort -u).
-          get_all_commit_issues() {
-            local all_commit_issues=""
-            local sha commit_msg issues
-
-            while IFS= read -r sha; do
-              if ! commit_msg=$(gh api "repos/$REPO/git/commits/$sha" --jq '.message' 2>&1); then
-                add_error "Failed to retrieve commit message for $sha: $commit_msg"
-                continue
-              fi
-
-              issues=$(extract_issues "$commit_msg")
-              all_commit_issues="${all_commit_issues}"$'\n'"${issues}"
-            done < <(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
-
-            printf '%s\n' "$all_commit_issues"
-          }
-
           if [ -z "$HAS_SKIP_LABEL" ]; then
             # --- Check PR description ---
             PR_BODY_NO_COMMENTS=$(strip_html_comments "$PR_BODY")
@@ -102,28 +83,30 @@ jobs:
               add_error "PR description must contain a linked issue (e.g. 'Closes #NNN')"
             fi
 
-            ALL_COMMIT_ISSUES=$(get_all_commit_issues)
+            # Collect issue references from every commit message in the current shell so
+            # that add_error failures are not lost inside a command-substitution subshell.
+            ALL_COMMIT_ISSUES=""
+            while IFS= read -r sha; do
+              if ! commit_msg=$(gh api "repos/$REPO/git/commits/$sha" --jq '.message' 2>&1); then
+                add_error "Failed to retrieve commit message for $sha: $commit_msg - the workflow will need to be rerun"
+                continue
+              fi
+              issues=$(extract_issues "$commit_msg")
+              ALL_COMMIT_ISSUES="${ALL_COMMIT_ISSUES}"$'\n'"${issues}"
+            done < <(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
             COMMIT_ISSUES=$(printf '%s\n' "$ALL_COMMIT_ISSUES" | sort -u | grep -v '^$' || true)
             
             # TODO: determine if there are potential timing issues with querying closingIssuesReferences
             # - it's not clear that they will be updated prior to when the workflow runs
             # TODO: there's no PR event for manually linking/unlinking issues, so this check can be out-of-sync after that
             
-            # Parse GraphQL closingIssuesReferences into owner/repo#NNN format
+            # Parse GraphQL closingIssuesReferences into owner/repo#NNN<TAB>closed<TAB>expired-by-bot.
+            # Derive the plain ref list with: parse_closing_refs ... | cut -f1
             parse_closing_refs() {
               local json="$1"
               printf '%s\n' "$json" | jq -r '
                 .data.repository.pullRequest.closingIssuesReferences.nodes[]
-                | "\(.repository.owner.login)/\(.repository.name)#\(.number)"
-              ' 2>/dev/null | sort -u || true
-            }
-            
-            # Parse GraphQL closingIssuesReferences into owner/repo#NNN<TAB>closed
-            parse_closing_refs_with_state() {
-              local json="$1"
-              printf '%s\n' "$json" | jq -r '
-                .data.repository.pullRequest.closingIssuesReferences.nodes[]
-                | "\(.repository.owner.login)/\(.repository.name)#\(.number)\t\(.closed)"
+                | "\(.repository.owner.login)/\(.repository.name)#\(.number)\t\(.closed)\t\(.labels.nodes | map(.name) | contains(["status/expired-by-bot"]))"
               ' 2>/dev/null | sort -u || true
             }
 
@@ -132,7 +115,9 @@ jobs:
             REPO_NAME="${REPO##*/}"
 
             # Query GitHub for closing issue references
-            CLOSING_ISSUES_REFERENCES_RAW=$(
+            CLOSING_ISSUES_WITH_STATE=""
+            CLOSING_ISSUES_REFERENCES=""
+            if ! CLOSING_ISSUES_REFERENCES_RAW=$(
               gh api graphql \
                 -F owner="$REPO_OWNER" \
                 -F repo="$REPO_NAME" \
@@ -145,6 +130,9 @@ jobs:
                           nodes {
                             number
                             closed
+                            labels(first: 50) {
+                              nodes { name }
+                            }
                             repository {
                               owner { login }
                               name
@@ -154,12 +142,15 @@ jobs:
                       }
                     }
                   }
-                '
-            )
-
-            CLOSING_ISSUES_REFERENCES=$(parse_closing_refs "$CLOSING_ISSUES_REFERENCES_RAW")
-            CLOSING_ISSUES_WITH_STATE=$(parse_closing_refs_with_state "$CLOSING_ISSUES_REFERENCES_RAW")
+                ' 2>&1
+            ); then
+              add_error "Failed to query closing issue references: $CLOSING_ISSUES_REFERENCES_RAW - the workflow will need to be rerun"
+            else
+              CLOSING_ISSUES_WITH_STATE=$(parse_closing_refs "$CLOSING_ISSUES_REFERENCES_RAW")
+              CLOSING_ISSUES_REFERENCES=$(printf '%s\n' "$CLOSING_ISSUES_WITH_STATE" | cut -f1)
+            fi
             
+            HAS_EXPIRED_ISSUE=0
             if [ "$FAILED" -eq 0 ]; then
               while IFS= read -r ref; do
                 [ -z "$ref" ] && continue
@@ -170,11 +161,15 @@ jobs:
                   continue
                 fi
 
-                # Find matching line: owner/repo#NNN<TAB>true|false
+                # Find matching line: owner/repo#NNN<TAB>closed<TAB>expired-by-bot
                 state_line=$(printf '%s\n' "$CLOSING_ISSUES_WITH_STATE" | grep -F -- "^$ref"$'\t' || true)
 
-                is_closed="${state_line##*$'\t'}"
-                if [ "$is_closed" = "true" ]; then
+                is_closed=$(printf '%s\n' "$state_line" | cut -f2)
+                is_expired=$(printf '%s\n' "$state_line" | cut -f3)
+                if [ "$is_expired" = "true" ]; then
+                  HAS_EXPIRED_ISSUE=1
+                fi
+                if [ "$is_closed" = "true" ] && [ "$is_expired" != "true" ]; then
                   add_error "Issue $ref is not open (current state: closed)"
                   continue
                 fi
@@ -183,7 +178,7 @@ jobs:
                   add_error "Issue $ref is a manually linked GitHub issue, but it's not in the PR description."
                 fi
               done <<< "$CLOSING_ISSUES_REFERENCES"
-            fi  
+            fi
             
             if [ "$FAILED" -eq 0 ]; then
               while IFS= read -r ref; do
@@ -193,13 +188,14 @@ jobs:
                   add_error "Issue $ref in the PR description is from a different repository - do not use a closing keyword with it."
                   continue
                 fi
+                if ! printf '%s\n' "$CLOSING_ISSUES_REFERENCES" | grep -Fxq -- "$ref"; then
+                  add_error "$ref is linked in the PR description but is not an issue - do not use a closing keyword with it."
+                  continue
+                fi
                 if ! printf '%s\n' "$COMMIT_ISSUES" | grep -Fxq -- "$ref"; then
                   add_error "Issue $ref is linked in the PR description but not in a commit message"
                   continue
-                fi
-                if ! printf '%s\n' "$CLOSING_ISSUES_REFERENCES" | grep -Fxq -- "$ref"; then
-                  add_error "$ref is linked in the PR description but is not an issue - do not use a closing keyword with it."
-                fi
+                fi                
               done <<< "$PR_ISSUES"
             fi
 
@@ -222,7 +218,10 @@ jobs:
           fi
 
           # --- Find last existing bot comment with our marker ---
-          EXISTING_COMMENT_ID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" | jq --arg marker "$MARKER" '.[] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)?)) | .id' | tail -n1)
+          # --paginate with --jq applies the filter per-page so all pages are searched.
+          EXISTING_COMMENT_ID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("'"$MARKER"'"))) | .id' \
+            | tail -n1)
           
           if [ -n "$EXISTING_COMMENT_ID" ]; then
             gh api "repos/$REPO/issues/comments/$EXISTING_COMMENT_ID" -X DELETE
@@ -241,4 +240,9 @@ jobs:
           else
             echo "All linked issue checks passed."
             gh pr edit "${{ github.event.pull_request.number }}" -R "$GITHUB_REPOSITORY" --remove-label "action/waiting-for-author"
+            if [ "${HAS_EXPIRED_ISSUE:-0}" -eq 1 ]; then
+              gh pr edit "${{ github.event.pull_request.number }}" -R "$GITHUB_REPOSITORY" --add-label "status/issue-expired"
+            else
+              gh pr edit "${{ github.event.pull_request.number }}" -R "$GITHUB_REPOSITORY" --remove-label "status/issue-expired"
+            fi
           fi


### PR DESCRIPTION
Refinement of the previous pre-triage check - based in part on https://github.com/keycloak/keycloak/pull/50075#pullrequestreview-4530483292

This removes:
- any interaction with the DCO check
- the usage of third-party github actions

As explained on https://github.com/keycloak/keycloak-ibm-team/issues/31#issuecomment-5004145360 this PR reflects the same understanding of issue linking (all closing keywords, optional colon, casing) that github has with the additional checks:
- the PR description must contain a linked issue
- the linked issues in the description, commits, and manually linked must all be the same and open issues.
- only manually linked issues, which can only be manipulated by contributors, may contain references to other repos - or that could be disallowed as well.

Violations to the above result in a comment on the PR highlighting what is wrong, a label is added to the PR, and the workflow fails. Alternatively a label can be added to skip this check.

See the comments in the script for some TODOs and other concerns - additional thoughts:
- the handling may need to be relaxed for forks
- could be changed to not run on a draft

From here if you want to be more strict about the number of linked issues, the syntax used, etc. that can be added - but I would avoid assigning special meaning to keywords.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
