### PR TITLE
[26.7] Invalid redirect URI on logout from pages with sub-tab hash fragments

### DIFF
--- a/js/apps/admin-ui/src/authentication/policies/Policies.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/Policies.tsx
@@ -1,7 +1,7 @@
 import { Tab, Tabs, TabTitleText } from "@patternfly/react-core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { CibaPolicy } from "./CibaPolicy";
 import { OtpPolicy } from "./OtpPolicy";
@@ -18,8 +18,8 @@ const DEFAULT_TAB = PASSWORD_POLICY;
 
 export const Policies = () => {
   const { t } = useTranslation();
-  const { hash } = useLocation();
-  const initialTab = hash.replace("#", "") || DEFAULT_TAB;
+  const [searchParams] = useSearchParams();
+  const initialTab = searchParams.get("tab") || DEFAULT_TAB;
   const [subTab, setSubTab] = useState(initialTab);
   const { realmRepresentation: realm, refresh } = useRealm();
 

--- a/js/apps/admin-ui/src/realm-settings/LoginTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/LoginTab.tsx
@@ -167,7 +167,7 @@ export const RealmSettingsLoginTab = ({
                     realm: realmName,
                     tab: "policies",
                   }),
-                  hash: WEBAUTHN_PASSWORDLESS_POLICY,
+                  search: `?tab=${WEBAUTHN_PASSWORDLESS_POLICY}`,
                 }}
               />
             </FormGroup>


### PR DESCRIPTION
- Closes #51054

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit 36a87413a7e1cc94f345d603fa5a9aa533308a9a)
