### PR TITLE
GlaSSLess FIPS implementation

### DIFF
--- a/common/src/main/java/org/keycloak/common/crypto/CryptoIntegration.java
+++ b/common/src/main/java/org/keycloak/common/crypto/CryptoIntegration.java
@@ -6,6 +6,7 @@ import java.security.Security;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -27,10 +28,18 @@ public class CryptoIntegration {
     private static volatile CryptoProvider cryptoProvider;
 
     public static void init(ClassLoader classLoader) {
+        init(() -> detectProvider(classLoader));
+    }
+
+    public static void init(ClassLoader classLoader, String providerName, FipsMode fipsMode) {
+        init(() -> detectProvider(classLoader, providerName, fipsMode));
+    }
+
+    private static void init(Supplier<CryptoProvider> providerSupplier) {
         if (cryptoProvider == null) {
             synchronized (lock) {
                 if (cryptoProvider == null) {
-                    cryptoProvider = detectProvider(classLoader);
+                    cryptoProvider = providerSupplier.get();
                     logger.debugv("java security provider: {0}", BouncyIntegration.PROVIDER);
 
                 }
@@ -41,6 +50,27 @@ public class CryptoIntegration {
             logger.tracef(dumpJavaSecurityProviders());
             logger.tracef(dumpSecurityProperties());
         }
+    }
+
+    static CryptoProvider detectProvider(Iterable<CryptoProviderFactory> factories, String providerName, FipsMode fipsMode) {
+        List<CryptoProviderFactory> matchingFactories = StreamSupport.stream(factories.spliterator(), false)
+                .filter(factory -> providerName.equals(factory.getName()))
+                .collect(Collectors.toList());
+
+        if (matchingFactories.size() != 1) {
+            throw new IllegalStateException("Expected one crypto provider named '" + providerName + "', found " + matchingFactories.size());
+        }
+
+        CryptoProvider provider = matchingFactories.get(0).create(fipsMode);
+        if (provider == null) {
+            throw new IllegalStateException("Crypto provider factory '" + providerName + "' returned null");
+        }
+        logger.debugf("Detected crypto provider: %s", provider.getClass().getName());
+        return provider;
+    }
+
+    private static CryptoProvider detectProvider(ClassLoader classLoader, String providerName, FipsMode fipsMode) {
+        return detectProvider(ServiceLoader.load(CryptoProviderFactory.class, classLoader), providerName, fipsMode);
     }
 
     public static boolean isInitialised() {

--- a/common/src/main/java/org/keycloak/common/crypto/CryptoProviderFactory.java
+++ b/common/src/main/java/org/keycloak/common/crypto/CryptoProviderFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.crypto;
+
+public interface CryptoProviderFactory {
+
+    String getName();
+
+    CryptoProvider create(FipsMode fipsMode);
+}

--- a/common/src/main/java/org/keycloak/common/crypto/FipsProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/FipsProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.crypto;
+
+public enum FipsProvider {
+    AUTO("auto"),
+    BOUNCY_CASTLE("bouncycastle"),
+    GLASSLESS("glassless");
+
+    private static final String BOUNCY_CASTLE_FIPS_PROVIDER =
+            "org/bouncycastle/jcajce/provider/BouncyCastleFipsProvider.class";
+
+    private final String optionName;
+
+    FipsProvider(String optionName) {
+        this.optionName = optionName;
+    }
+
+    public static FipsProvider valueOfOption(String name) {
+        for (FipsProvider provider : values()) {
+            if (provider.optionName.equals(name)) {
+                return provider;
+            }
+        }
+        throw new IllegalArgumentException("Unknown FIPS provider: " + name);
+    }
+
+    public FipsProvider resolve(ClassLoader classLoader) {
+        if (this != AUTO) {
+            return this;
+        }
+        return classLoader.getResource(BOUNCY_CASTLE_FIPS_PROVIDER) == null ? GLASSLESS : BOUNCY_CASTLE;
+    }
+
+    @Override
+    public String toString() {
+        return optionName;
+    }
+}

--- a/common/src/test/java/org/keycloak/common/crypto/CryptoProviderFactoryTest.java
+++ b/common/src/test/java/org/keycloak/common/crypto/CryptoProviderFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.crypto;
+
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CryptoProviderFactoryTest {
+
+    @Test
+    public void shouldSelectFactoryByNameAndPassFipsMode() {
+        CryptoProvider expected = provider();
+        AtomicReference<FipsMode> selectedMode = new AtomicReference<>();
+        List<CryptoProviderFactory> factories = Arrays.asList(
+                factory("default", provider(), new AtomicReference<>()),
+                factory("glassless", expected, selectedMode));
+
+        CryptoProvider actual = CryptoIntegration.detectProvider(factories, "glassless", FipsMode.STRICT);
+
+        assertSame(expected, actual);
+        assertEquals(FipsMode.STRICT, selectedMode.get());
+    }
+
+    @Test
+    public void shouldRejectMissingFactory() {
+        IllegalStateException cause = assertThrows(IllegalStateException.class,
+                () -> CryptoIntegration.detectProvider(Collections.emptyList(), "glassless", FipsMode.STRICT));
+
+        assertEquals("Expected one crypto provider named 'glassless', found 0", cause.getMessage());
+    }
+
+    @Test
+    public void shouldRejectDuplicateFactories() {
+        List<CryptoProviderFactory> factories = Arrays.asList(
+                factory("glassless", provider(), new AtomicReference<>()),
+                factory("glassless", provider(), new AtomicReference<>()));
+
+        IllegalStateException cause = assertThrows(IllegalStateException.class,
+                () -> CryptoIntegration.detectProvider(factories, "glassless", FipsMode.STRICT));
+
+        assertEquals("Expected one crypto provider named 'glassless', found 2", cause.getMessage());
+    }
+
+    @Test
+    public void shouldRejectNullProvider() {
+        IllegalStateException cause = assertThrows(IllegalStateException.class,
+                () -> CryptoIntegration.detectProvider(
+                        Collections.singletonList(factory("glassless", null, new AtomicReference<>())), "glassless", FipsMode.STRICT));
+
+        assertEquals("Crypto provider factory 'glassless' returned null", cause.getMessage());
+    }
+
+    private static CryptoProviderFactory factory(String name, CryptoProvider provider, AtomicReference<FipsMode> selectedMode) {
+        return new CryptoProviderFactory() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public CryptoProvider create(FipsMode fipsMode) {
+                selectedMode.set(fipsMode);
+                return provider;
+            }
+        };
+    }
+
+    private static CryptoProvider provider() {
+        return (CryptoProvider) Proxy.newProxyInstance(CryptoProvider.class.getClassLoader(),
+                new Class<?>[] { CryptoProvider.class }, (proxy, method, args) -> null);
+    }
+}

--- a/common/src/test/java/org/keycloak/common/crypto/FipsProviderTest.java
+++ b/common/src/test/java/org/keycloak/common/crypto/FipsProviderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.common.crypto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FipsProviderTest {
+
+    @Test
+    public void shouldResolveProviderOptions() {
+        assertEquals(FipsProvider.AUTO, FipsProvider.valueOfOption("auto"));
+        assertEquals(FipsProvider.BOUNCY_CASTLE, FipsProvider.valueOfOption("bouncycastle"));
+        assertEquals(FipsProvider.GLASSLESS, FipsProvider.valueOfOption("glassless"));
+        assertEquals("auto", FipsProvider.AUTO.toString());
+        assertEquals("bouncycastle", FipsProvider.BOUNCY_CASTLE.toString());
+        assertEquals("glassless", FipsProvider.GLASSLESS.toString());
+        assertThrows(IllegalArgumentException.class, () -> FipsProvider.valueOfOption("unknown"));
+    }
+
+    @Test
+    public void shouldSelectGlasslessWhenBouncyCastleIsUnavailable() {
+        assertEquals(FipsProvider.GLASSLESS, FipsProvider.AUTO.resolve(new ClassLoader(null) {
+        }));
+    }
+
+    @Test
+    public void shouldSelectBouncyCastleWhenItsProviderClassIsAvailable() {
+        ClassLoader classLoader = new ClassLoader(null) {
+            @Override
+            public java.net.URL getResource(String name) {
+                return "org/bouncycastle/jcajce/provider/BouncyCastleFipsProvider.class".equals(name)
+                        ? FipsProviderTest.class.getResource("FipsProviderTest.class")
+                        : null;
+            }
+        };
+
+        assertEquals(FipsProvider.BOUNCY_CASTLE, FipsProvider.AUTO.resolve(classLoader));
+    }
+
+    @Test
+    public void shouldPreserveExplicitProviderSelection() {
+        ClassLoader classLoader = new ClassLoader(null) {
+            @Override
+            public java.net.URL getResource(String name) {
+                return FipsProviderTest.class.getResource("FipsProviderTest.class");
+            }
+        };
+
+        assertEquals(FipsProvider.GLASSLESS, FipsProvider.GLASSLESS.resolve(classLoader));
+        assertEquals(FipsProvider.BOUNCY_CASTLE, FipsProvider.BOUNCY_CASTLE.resolve(new ClassLoader(null) {
+        }));
+    }
+
+    @Test
+    public void shouldKeepExistingProviderClassNames() {
+        assertEquals("org.keycloak.crypto.fips.FIPS1402Provider", FipsMode.NON_STRICT.getProviderClassName());
+        assertEquals("org.keycloak.crypto.fips.Fips1402StrictCryptoProvider", FipsMode.STRICT.getProviderClassName());
+        assertEquals("org.keycloak.crypto.def.DefaultCryptoProvider", FipsMode.DISABLED.getProviderClassName());
+    }
+}

--- a/crypto/default/src/main/java/org/keycloak/crypto/def/DefaultCryptoProviderFactory.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/DefaultCryptoProviderFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.def;
+
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.common.crypto.CryptoProviderFactory;
+import org.keycloak.common.crypto.FipsMode;
+
+public class DefaultCryptoProviderFactory implements CryptoProviderFactory {
+
+    @Override
+    public String getName() {
+        return "default";
+    }
+
+    @Override
+    public CryptoProvider create(FipsMode fipsMode) {
+        if (fipsMode.isFipsEnabled()) {
+            throw new IllegalArgumentException("The default crypto provider does not support FIPS mode");
+        }
+        return new DefaultCryptoProvider();
+    }
+}

--- a/crypto/default/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProviderFactory
+++ b/crypto/default/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2026 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.crypto.def.DefaultCryptoProviderFactory

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/AesKeyWrapAlgorithmProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/AesKeyWrapAlgorithmProvider.java
@@ -22,7 +22,6 @@ import javax.crypto.Cipher;
 import org.keycloak.jose.jwe.JWEHeader;
 import org.keycloak.jose.jwe.JWEHeader.JWEHeaderBuilder;
 import org.keycloak.jose.jwe.JWEKeyStorage;
-import org.keycloak.jose.jwe.JWEKeyStorage.KeyUse;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 
@@ -34,15 +33,15 @@ public class AesKeyWrapAlgorithmProvider implements JWEAlgorithmProvider {
     @Override
     public byte[] decodeCek(byte[] encodedCek, Key encryptionKey, JWEHeader header, JWEEncryptionProvider encryptionProvider) throws Exception {
         Cipher cipher = Cipher.getInstance("AESWrap_128");
-        cipher.init(Cipher.UNWRAP_MODE, encryptionKey);
-        return cipher.unwrap(encodedCek, "AES", Cipher.SECRET_KEY).getEncoded();
+        cipher.init(Cipher.DECRYPT_MODE, encryptionKey);
+        return cipher.doFinal(encodedCek);
     }
 
     @Override
     public byte[] encodeCek(JWEEncryptionProvider encryptionProvider, JWEKeyStorage keyStorage, Key encryptionKey, JWEHeaderBuilder headerBuilder) throws Exception {
         Cipher cipher = Cipher.getInstance("AESWrap_128");
-        cipher.init(Cipher.WRAP_MODE, encryptionKey);
-        return cipher.wrap(keyStorage.getCEKKey(KeyUse.ENCRYPTION, false));
+        cipher.init(Cipher.ENCRYPT_MODE, encryptionKey);
+        return cipher.doFinal(keyStorage.getCekBytes());
     }
 
 

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronEcdhEsAlgorithmProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronEcdhEsAlgorithmProvider.java
@@ -77,8 +77,8 @@ public class ElytronEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
             return derivedKey;
         } else {
             Cipher cipher = Cipher.getInstance(getAesWrapAlgorithm(header.getAlgorithm()));
-            cipher.init(Cipher.UNWRAP_MODE, new SecretKeySpec(derivedKey, "AES"));
-            return cipher.unwrap(encodedCek, "AES", Cipher.SECRET_KEY).getEncoded();
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(derivedKey, "AES"));
+            return cipher.doFinal(encodedCek);
         }
     }
 
@@ -110,9 +110,8 @@ public class ElytronEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
             return new byte[0];
         } else {
             Cipher cipher = Cipher.getInstance(getAesWrapAlgorithm(header.getAlgorithm()));
-            cipher.init(Cipher.WRAP_MODE, new SecretKeySpec(derivedKey, "AES"));
-            byte[] cekBytes = keyStorage.getCekBytes();
-            return cipher.wrap(new SecretKeySpec(cekBytes, "AES"));
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(derivedKey, "AES"));
+            return cipher.doFinal(keyStorage.getCekBytes());
         }
     }
 

--- a/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronCryptoJWETest.java
+++ b/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronCryptoJWETest.java
@@ -33,11 +33,4 @@ public class ElytronCryptoJWETest extends JWETest {
 
         testDirectEncryptAndDecrypt(aesKey, hmacKey, JWEConstants.A256CBC_HS512, PAYLOAD, true);
     }
-
-    @Override
-    public void testAesKW_Aes128CbcHmacSha256() throws Exception {
-        // Skipping this test, this test fails when not using BC provider.
-
-    }
-
 }

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/Fips1402ProviderFactory.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/Fips1402ProviderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.fips;
+
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.common.crypto.CryptoProviderFactory;
+import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.common.crypto.FipsProvider;
+
+public class Fips1402ProviderFactory implements CryptoProviderFactory {
+
+    @Override
+    public String getName() {
+        return FipsProvider.BOUNCY_CASTLE.toString();
+    }
+
+    @Override
+    public CryptoProvider create(FipsMode fipsMode) {
+        return switch (fipsMode) {
+            case NON_STRICT -> new FIPS1402Provider();
+            case STRICT -> new Fips1402StrictCryptoProvider();
+            case DISABLED -> throw new IllegalArgumentException("The Bouncy Castle FIPS provider requires FIPS mode");
+        };
+    }
+}

--- a/crypto/fips1402/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProviderFactory
+++ b/crypto/fips1402/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2026 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.crypto.fips.Fips1402ProviderFactory

--- a/crypto/glassless/pom.xml
+++ b/crypto/glassless/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2026 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-crypto-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-crypto-glassless</artifactId>
+    <name>Keycloak Crypto Glassless Integration</name>
+    <description>Keycloak Crypto Glassless Integration</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-elytron</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.glassless</groupId>
+            <artifactId>glassless-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/crypto/glassless/src/main/java/org/keycloak/crypto/glassless/GlasslessCryptoProvider.java
+++ b/crypto/glassless/src/main/java/org/keycloak/crypto/glassless/GlasslessCryptoProvider.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.glassless;
+
+import java.lang.reflect.InvocationTargetException;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKeyFactory;
+
+import org.keycloak.crypto.JavaAlgorithm;
+import org.keycloak.crypto.elytron.WildFlyElytronProvider;
+
+import org.jboss.logging.Logger;
+
+public class GlasslessCryptoProvider extends WildFlyElytronProvider {
+
+    private static final Logger LOG = Logger.getLogger(GlasslessCryptoProvider.class);
+    private static final String PROVIDER_CLASS = "net.glassless.provider.GlaSSLessProvider";
+    private static final String FIPS_STATUS_CLASS = "net.glassless.provider.FIPSStatus";
+    private static final String OPENSSL_CRYPTO_CLASS = "net.glassless.provider.internal.OpenSSLCrypto";
+    private static final String PROVIDER_NAME = "GlaSSLess";
+
+    private final Provider glasslessProvider;
+
+    public GlasslessCryptoProvider() {
+        this(false);
+    }
+
+    protected GlasslessCryptoProvider(boolean requireFips) {
+        this(resolveProvider(), requireFips, null);
+    }
+
+    GlasslessCryptoProvider(Provider provider, boolean requireFips, GlasslessFipsStatus fipsStatus) {
+        glasslessProvider = provider;
+        boolean inserted = Security.getProvider(PROVIDER_NAME) == null;
+        if (inserted) {
+            Security.insertProviderAt(glasslessProvider, 1);
+        }
+
+        try {
+            GlasslessFipsStatus resolvedFipsStatus = fipsStatus == null ? resolveFipsStatus(glasslessProvider) : fipsStatus;
+            if (requireFips && !resolvedFipsStatus.isActive()) {
+                throw new IllegalStateException("Glassless strict mode requires an active OpenSSL FIPS provider");
+            }
+            if (requireFips && Security.getProviders()[0] != glasslessProvider) {
+                throw new IllegalStateException("Glassless must be the highest priority security provider in strict mode");
+            }
+            LOG.infof("GlasslessCryptoProvider created: KC(%s, FIPS mode: %s, FIPS provider available: %s, OpenSSL FIPS default properties: %s)",
+                    glasslessProvider, resolvedFipsStatus.fipsMode() ? "enabled" : "disabled",
+                    resolvedFipsStatus.fipsProviderAvailable(), resolvedFipsStatus.openSslFipsEnabled() ? "enabled" : "disabled");
+            LOG.info(formatProviderConfiguration(glasslessProvider));
+        } catch (RuntimeException cause) {
+            if (inserted) {
+                Security.removeProvider(PROVIDER_NAME);
+            }
+            throw cause;
+        }
+    }
+
+    record GlasslessFipsStatus(boolean fipsMode, boolean fipsProviderAvailable, boolean openSslFipsEnabled) {
+
+        boolean isActive() {
+            return fipsMode && fipsProviderAvailable && openSslFipsEnabled;
+        }
+    }
+
+    private static GlasslessFipsStatus resolveFipsStatus(Provider provider) {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return new GlasslessFipsStatus(
+                invokeBoolean(provider, "isFIPSMode"),
+                invokeStaticBoolean(classLoader, FIPS_STATUS_CLASS, "isFIPSProviderAvailable"),
+                isOpenSslDefaultContextFipsEnabled(classLoader));
+    }
+
+    /*
+     * Glassless 0.13.0 does not expose the OpenSSL default context FIPS property
+     * through its public API. FIPSStatus.isFIPSEnabled() is not sufficient for
+     * strict mode because it can also return true from glassless.fips.mode or
+     * the operating system crypto policy, even when OpenSSL is not constrained
+     * to the FIPS provider.
+     *
+     * Keep this temporary reflection in one function so it can be removed
+     * without changing the strict mode validation flow. A future Glassless API
+     * should expose a public, nonoverrideable method similar to:
+     *
+     *     FIPSStatus.isOpenSslDefaultContextFipsEnabled()
+     *
+     * The method should return the result of
+     * EVP_default_properties_is_fips_enabled(NULL) directly. It must not honor
+     * the Glassless system property or infer activation from the operating
+     * system policy. A richer API could return an immutable status object with
+     * separate values for configured policy, provider availability, and active
+     * OpenSSL default properties. Once that API exists, only this function
+     * should need to change.
+     */
+    static boolean isOpenSslDefaultContextFipsEnabled(ClassLoader classLoader) {
+        return invokeStaticBoolean(classLoader, OPENSSL_CRYPTO_CLASS, "isFIPSEnabled");
+    }
+
+    static String formatProviderConfiguration(Provider provider) {
+        Map<String, TreeSet<String>> servicesByType = new TreeMap<>();
+        for (Provider.Service service : provider.getServices()) {
+            servicesByType.computeIfAbsent(service.getType(), ignored -> new TreeSet<>()).add(service.getAlgorithm());
+        }
+
+        StringBuilder configuration = new StringBuilder("Glassless provider configuration:");
+        servicesByType.forEach((type, algorithms) -> {
+            configuration.append(System.lineSeparator())
+                    .append(type).append(" (").append(algorithms.size()).append("):");
+            algorithms.forEach(algorithm -> configuration.append(System.lineSeparator()).append("  ").append(algorithm));
+        });
+        return configuration.toString();
+    }
+
+    private static Provider resolveProvider() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Provider existingProvider = Security.getProvider(PROVIDER_NAME);
+        return existingProvider == null ? createProvider(classLoader) : existingProvider;
+    }
+
+    @Override
+    public Provider getBouncyCastleProvider() {
+        return glasslessProvider;
+    }
+
+    @Override
+    public ECParameterSpec createECParams(String curveName) {
+        try {
+            AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC", glasslessProvider);
+            parameters.init(new ECGenParameterSpec(curveName));
+            return parameters.getParameterSpec(ECParameterSpec.class);
+        } catch (Exception cause) {
+            throw new RuntimeException("Failed to generate EC parameter spec", cause);
+        }
+    }
+
+    @Override
+    public KeyPairGenerator getKeyPairGen(String algorithm) throws NoSuchAlgorithmException {
+        return KeyPairGenerator.getInstance(algorithm, glasslessProvider);
+    }
+
+    @Override
+    public KeyFactory getKeyFactory(String algorithm) throws NoSuchAlgorithmException {
+        if ("ECDSA".equals(algorithm)) {
+            algorithm = "EC";
+        }
+        return KeyFactory.getInstance(algorithm, glasslessProvider);
+    }
+
+    @Override
+    public Cipher getAesGcmCipher() throws NoSuchAlgorithmException, NoSuchPaddingException {
+        return Cipher.getInstance("AES/GCM/NoPadding", glasslessProvider);
+    }
+
+    @Override
+    public SecretKeyFactory getSecretKeyFact(String keyAlgorithm) throws NoSuchAlgorithmException {
+        return SecretKeyFactory.getInstance(keyAlgorithm, glasslessProvider);
+    }
+
+    @Override
+    public Signature getSignature(String sigAlgName) throws NoSuchAlgorithmException {
+        return Signature.getInstance(JavaAlgorithm.getJavaAlgorithm(sigAlgName), glasslessProvider);
+    }
+
+    private static Provider createProvider(ClassLoader classLoader) {
+        try {
+            Object provider = Class.forName(PROVIDER_CLASS, true, classLoader).getDeclaredConstructor().newInstance();
+            if (provider instanceof Provider securityProvider) {
+                return securityProvider;
+            }
+            throw new IllegalStateException(PROVIDER_CLASS + " is not a Java security provider");
+        } catch (InvocationTargetException cause) {
+            throw new IllegalStateException("Failed to initialize Glassless", cause.getCause());
+        } catch (ReflectiveOperationException | LinkageError cause) {
+            throw new IllegalStateException("Glassless 0.13.0 or later and Java 25 or later are required", cause);
+        }
+    }
+
+    private static boolean invokeBoolean(Object target, String method) {
+        try {
+            return (boolean) target.getClass().getMethod(method).invoke(target);
+        } catch (ReflectiveOperationException cause) {
+            throw new IllegalStateException("Glassless 0.13.0 or later is required", cause);
+        }
+    }
+
+    private static boolean invokeStaticBoolean(ClassLoader classLoader, String className, String method) {
+        try {
+            return (boolean) Class.forName(className, true, classLoader).getMethod(method).invoke(null);
+        } catch (ReflectiveOperationException | LinkageError cause) {
+            throw new IllegalStateException("Glassless 0.13.0 or later is required", cause);
+        }
+    }
+}

--- a/crypto/glassless/src/main/java/org/keycloak/crypto/glassless/GlasslessCryptoProviderFactory.java
+++ b/crypto/glassless/src/main/java/org/keycloak/crypto/glassless/GlasslessCryptoProviderFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.glassless;
+
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.common.crypto.CryptoProviderFactory;
+import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.common.crypto.FipsProvider;
+
+public class GlasslessCryptoProviderFactory implements CryptoProviderFactory {
+
+    @Override
+    public String getName() {
+        return FipsProvider.GLASSLESS.toString();
+    }
+
+    @Override
+    public CryptoProvider create(FipsMode fipsMode) {
+        return switch (fipsMode) {
+            case NON_STRICT -> new GlasslessCryptoProvider();
+            case STRICT -> new GlasslessStrictCryptoProvider();
+            case DISABLED -> throw new IllegalArgumentException("The Glassless provider requires FIPS mode");
+        };
+    }
+}

--- a/crypto/glassless/src/main/java/org/keycloak/crypto/glassless/GlasslessStrictCryptoProvider.java
+++ b/crypto/glassless/src/main/java/org/keycloak/crypto/glassless/GlasslessStrictCryptoProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.glassless;
+
+public class GlasslessStrictCryptoProvider extends GlasslessCryptoProvider {
+
+    public GlasslessStrictCryptoProvider() {
+        super(true);
+    }
+
+    @Override
+    public String[] getSupportedRsaKeySizes() {
+        return new String[] { "2048", "3072", "4096" };
+    }
+}

--- a/crypto/glassless/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProviderFactory
+++ b/crypto/glassless/src/main/resources/META-INF/services/org.keycloak.common.crypto.CryptoProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2026 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.crypto.glassless.GlasslessCryptoProviderFactory

--- a/crypto/glassless/src/test/java/org/keycloak/crypto/glassless/GlasslessCryptoProviderActualTest.java
+++ b/crypto/glassless/src/test/java/org/keycloak/crypto/glassless/GlasslessCryptoProviderActualTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.glassless;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.jose.jwe.JWE;
+import org.keycloak.jose.jwe.JWEConstants;
+import org.keycloak.jose.jwe.JWEHeader;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class GlasslessCryptoProviderActualTest {
+
+    private static final byte[] DATA = "Keycloak Glassless integration".getBytes(StandardCharsets.UTF_8);
+
+    @After
+    public void cleanup() {
+        CryptoIntegration.setProvider(null);
+        Security.removeProvider("GlaSSLess");
+    }
+
+    @Test
+    public void shouldPerformKeycloakCryptographicOperations() throws Exception {
+        assumeGlasslessAvailable();
+
+        CryptoIntegration.init(Thread.currentThread().getContextClassLoader(), "glassless", FipsMode.NON_STRICT);
+        GlasslessCryptoProvider provider = (GlasslessCryptoProvider) CryptoIntegration.getProvider();
+        Provider glassless = provider.getBouncyCastleProvider();
+        assertEquals("GlaSSLess", glassless.getName());
+        assertEquals(glassless, Security.getProviders()[0]);
+
+        KeyPairGenerator keyPairGenerator = provider.getKeyPairGen("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        assertEquals(glassless, keyPairGenerator.getProvider());
+
+        assertSignature(provider, keyPair, "RS256");
+        assertSignature(provider, keyPair, "PS256");
+
+        SecretKeySpec key = new SecretKeySpec(new byte[16], "AES");
+        IvParameterSpec iv = new IvParameterSpec(new byte[16]);
+        Cipher encrypt = provider.getAesCbcCipher();
+        encrypt.init(Cipher.ENCRYPT_MODE, key, iv);
+        byte[] encrypted = encrypt.doFinal(DATA);
+        Cipher decrypt = provider.getAesCbcCipher();
+        decrypt.init(Cipher.DECRYPT_MODE, key, iv);
+        assertArrayEquals(DATA, decrypt.doFinal(encrypted));
+        assertEquals(glassless, encrypt.getProvider());
+
+        Cipher keyWrap = Cipher.getInstance("AESWrap_128", glassless);
+        keyWrap.init(Cipher.ENCRYPT_MODE, key);
+        byte[] keyMaterial = new byte[32];
+        byte[] wrappedKey = keyWrap.doFinal(keyMaterial);
+        Cipher keyUnwrap = Cipher.getInstance("AESWrap_128", glassless);
+        keyUnwrap.init(Cipher.DECRYPT_MODE, key);
+        assertArrayEquals(keyMaterial, keyUnwrap.doFinal(wrappedKey));
+
+        SecretKeySpec hmacKey = new SecretKeySpec(new byte[16], "HmacSHA256");
+        Mac glasslessMac = Mac.getInstance("HmacSHA256", glassless);
+        glasslessMac.init(hmacKey);
+        byte[] glasslessTag = glasslessMac.doFinal(DATA);
+        Mac referenceMac = Mac.getInstance("HmacSHA256", "SunJCE");
+        referenceMac.init(hmacKey);
+        assertArrayEquals(referenceMac.doFinal(DATA), glasslessTag);
+
+        SecretKeyFactory secretKeyFactory = provider.getSecretKeyFact("PBKDF2WithHmacSHA256");
+        assertEquals(glassless, secretKeyFactory.getProvider());
+        assertEquals(32, secretKeyFactory.generateSecret(
+                new PBEKeySpec("glassless-keycloak-password".toCharArray(), new byte[16], 1_000, 256)).getEncoded().length);
+
+        assertTrue(provider.createECParams("secp256r1").getOrder().bitLength() >= 256);
+
+        JWE jwe = new JWE()
+                .header(new JWEHeader(JWEConstants.A128KW, JWEConstants.A128CBC_HS256, null))
+                .content(DATA);
+        jwe.getKeyStorage().setEncryptionKey(key);
+        String encoded = jwe.encodeJwe();
+        JWE decoded = new JWE();
+        decoded.getKeyStorage().setDecryptionKey(key);
+        decoded.verifyAndDecodeJwe(encoded);
+        assertArrayEquals(DATA, decoded.getContent());
+    }
+
+    @Test
+    public void shouldRequireOpenSslFipsForStrictMode() throws Exception {
+        assumeGlasslessAvailable();
+
+        GlasslessCryptoProvider provider = new GlasslessCryptoProvider();
+        boolean fipsMode = (boolean) provider.getBouncyCastleProvider().getClass().getMethod("isFIPSMode")
+                .invoke(provider.getBouncyCastleProvider());
+        Class<?> status = Class.forName("net.glassless.provider.FIPSStatus");
+        boolean fipsProviderAvailable = (boolean) status.getMethod("isFIPSProviderAvailable").invoke(null);
+        boolean openSslFipsEnabled = GlasslessCryptoProvider.isOpenSslDefaultContextFipsEnabled(
+                Thread.currentThread().getContextClassLoader());
+
+        if (fipsMode && fipsProviderAvailable && openSslFipsEnabled) {
+            assertArrayEquals(new String[] { "2048", "3072", "4096" },
+                    new GlasslessStrictCryptoProvider().getSupportedRsaKeySizes());
+        } else {
+            assertThrows(IllegalStateException.class, GlasslessStrictCryptoProvider::new);
+        }
+    }
+
+    private static void assertSignature(GlasslessCryptoProvider provider, KeyPair keyPair, String algorithm) throws Exception {
+        Signature signer = provider.getSignature(algorithm);
+        signer.initSign(keyPair.getPrivate());
+        signer.update(DATA);
+        byte[] signature = signer.sign();
+
+        Signature verifier = provider.getSignature(algorithm);
+        verifier.initVerify(keyPair.getPublic());
+        verifier.update(DATA);
+        assertTrue(verifier.verify(signature));
+        assertEquals("GlaSSLess", signer.getProvider().getName());
+    }
+
+    private static void assumeGlasslessAvailable() {
+        assumeTrue("Glassless requires Java 25", Runtime.version().feature() >= 25);
+        try {
+            Class.forName("net.glassless.provider.GlaSSLessProvider");
+        } catch (ClassNotFoundException cause) {
+            assumeTrue("Glassless test dependency is not available", false);
+        }
+    }
+}

--- a/crypto/glassless/src/test/java/org/keycloak/crypto/glassless/GlasslessCryptoProviderTest.java
+++ b/crypto/glassless/src/test/java/org/keycloak/crypto/glassless/GlasslessCryptoProviderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.crypto.glassless;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.keycloak.crypto.glassless.GlasslessCryptoProvider.GlasslessFipsStatus;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GlasslessCryptoProviderTest {
+
+    @After
+    public void cleanup() {
+        Security.removeProvider("GlaSSLess");
+    }
+
+    @Test
+    public void shouldRegisterGlasslessAtHighestPriority() {
+        GlasslessCryptoProvider provider = new GlasslessCryptoProvider(new TestProvider(), false, status(false, false, false));
+
+        assertEquals("GlaSSLess", provider.getBouncyCastleProvider().getName());
+        assertEquals("GlaSSLess", Security.getProviders()[0].getName());
+    }
+
+    @Test
+    public void shouldRejectStrictModeWhenFipsModeIsDisabled() {
+        IllegalStateException cause = assertThrows(IllegalStateException.class,
+                () -> new GlasslessCryptoProvider(new TestProvider(), true, status(false, true, true)));
+
+        assertTrue(cause.getMessage().contains("active OpenSSL FIPS provider"));
+        assertEquals(null, Security.getProvider("GlaSSLess"));
+    }
+
+    @Test
+    public void shouldRejectStrictModeWhenFipsProviderIsUnavailable() {
+        IllegalStateException cause = assertThrows(IllegalStateException.class,
+                () -> new GlasslessCryptoProvider(new TestProvider(), true, status(true, false, true)));
+
+        assertTrue(cause.getMessage().contains("active OpenSSL FIPS provider"));
+        assertEquals(null, Security.getProvider("GlaSSLess"));
+    }
+
+    @Test
+    public void shouldRejectStrictModeWhenOpenSslFipsDefaultPropertiesAreDisabled() {
+        IllegalStateException cause = assertThrows(IllegalStateException.class,
+                () -> new GlasslessCryptoProvider(new TestProvider(), true, status(true, true, false)));
+
+        assertTrue(cause.getMessage().contains("active OpenSSL FIPS provider"));
+        assertEquals(null, Security.getProvider("GlaSSLess"));
+    }
+
+    @Test
+    public void shouldEnableStrictModeWithOpenSslFips() {
+        GlasslessCryptoProvider provider = new GlasslessCryptoProvider(new TestProvider(), true, status(true, true, true));
+
+        assertEquals("GlaSSLess", Security.getProviders()[0].getName());
+    }
+
+    @Test
+    public void shouldFormatProviderConfiguration() {
+        assertEquals(String.join(System.lineSeparator(),
+                "Glassless provider configuration:",
+                "Cipher (2):",
+                "  AES/GCM/NoPadding",
+                "  RSA/ECB/OAEPPadding",
+                "Signature (1):",
+                "  SHA256withRSA"), GlasslessCryptoProvider.formatProviderConfiguration(new TestProvider()));
+    }
+
+    private static GlasslessFipsStatus status(boolean fipsMode, boolean fipsProviderAvailable, boolean openSslFipsEnabled) {
+        return new GlasslessFipsStatus(fipsMode, fipsProviderAvailable, openSslFipsEnabled);
+    }
+
+    private static class TestProvider extends Provider {
+
+        private TestProvider() {
+            super("GlaSSLess", "test", "Test Glassless provider");
+            putService(new Service(this, "Signature", "SHA256withRSA", TestProvider.class.getName(), null, null));
+            putService(new Service(this, "Cipher", "RSA/ECB/OAEPPadding", TestProvider.class.getName(), null, null));
+            putService(new Service(this, "Cipher", "AES/GCM/NoPadding", TestProvider.class.getName(), null, null));
+        }
+    }
+}

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -33,6 +33,7 @@
     <modules>
         <module>default</module>
         <module>fips1402</module>
+        <module>glassless</module>
         <module>elytron</module>
     </modules>
 </project>

--- a/docs/guides/server/fips.adoc
+++ b/docs/guides/server/fips.adoc
@@ -9,8 +9,8 @@ includedOptions="">
 
 The Federal Information Processing Standard Publication 140-2, (FIPS 140-2), is a U.S. government computer security standard used to approve cryptographic modules. {project_name} supports running in FIPS 140-2 compliant mode. In this case, {project_name} will use only FIPS approved cryptography algorithms for its functionality.
 
-NOTE: {project_name} FIPS 140-2 integration is tested with OpenJDK 25, however the underlying BouncyCastle
-FIPS library is not officially validated with OpenJDK 25. Hence for FIPS 140-2 compliance, it is still recommended to use
+NOTE: The Bouncy Castle FIPS integration is tested with OpenJDK 25. However, the underlying Bouncy Castle
+FIPS library is not officially validated with OpenJDK 25. Therefore, for FIPS 140-2 compliance, it is still recommended to use
 {project_name} on OpenJDK 21.
 
 To run in FIPS 140-2, {project_name} should run on a FIPS 140-2 enabled system. This requirement usually assumes RHEL or Fedora where FIPS was enabled during installation.
@@ -32,6 +32,124 @@ If the system is not in FIPS mode, you can enable it with the following command,
 fips-mode-setup --enable
 ----
 
+== Choosing the cryptographic provider
+
+Glassless is included in the {project_name} distribution and is selected by default when the `fips` feature is enabled.
+
+The `fips-provider` build option defaults to `auto`. In this mode, {project_name} checks whether the Bouncy Castle FIPS provider class is available. If it is available, {project_name} selects Bouncy Castle. Otherwise, {project_name} selects Glassless. Therefore, adding the supported Bouncy Castle FIPS JAR files to the `KEYCLOAK_HOME/providers` directory before building the server is enough to switch to Bouncy Castle.
+
+You can override automatic selection with one of the following values:
+
+`bouncycastle`:: Uses the Bouncy Castle FIPS libraries. Add all the supported Bouncy Castle FIPS JAR files before building the server.
+
+`glassless`:: Uses Glassless to make OpenSSL cryptographic algorithms available through the Java Cryptography Architecture.
+
+Automatic selection avoids requiring a provider option in the normal case. Use an explicit value only when you need to override the provider detected from the available libraries.
+
+=== Configuring Glassless
+
+Glassless delegates cryptographic operations to OpenSSL. When you select Glassless, {project_name} registers it as the highest priority Java security provider.
+
+Glassless is a bridge to OpenSSL, not the validated cryptographic module. The FIPS validation and certificate come from the OpenSSL FIPS module supplied by your operating system vendor. Verify that this module meets the compliance requirements for your deployment.
+
+In `non-strict` mode, {project_name} does not require an OpenSSL FIPS provider. In `strict` mode, {project_name} starts only when Glassless reports that FIPS mode is enabled and an OpenSSL FIPS provider is available. This validation does not enable FIPS mode on the operating system or configure OpenSSL.
+
+Glassless ${properties["glassless.version"]} requires Java 25 or later, OpenSSL 3 or later, and native access to the Foreign Function and Memory API.
+
+[#installing-glassless]
+==== Installing Glassless
+
+. Configure and activate the OpenSSL FIPS provider for your operating system.
++
+If your OpenSSL installation does not already activate the FIPS provider, create an OpenSSL configuration such as the following example:
++
+[source]
+----
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+alg_section = algorithm_sect
+
+[provider_sect]
+base = base_sect
+fips = fips_sect
+
+[base_sect]
+activate = 1
+
+[fips_sect]
+activate = 1
+
+[algorithm_sect]
+default_properties = fips=yes
+----
++
+The OpenSSL module location and any additional configuration are specific to your operating system. Use the FIPS module and configuration supplied by the operating system vendor.
+
+. Set `OPENSSL_CONF` if the configuration is not in the default OpenSSL location:
++
+[source,bash]
+----
+export OPENSSL_CONF=/path/to/openssl-fips.cnf
+----
+
+. Enable native access for both the build and start commands:
++
+[source,bash]
+----
+export JAVA_OPTS_APPEND="--enable-native-access=ALL-UNNAMED"
+----
++
+When using Glassless ${properties["glassless.version"]} with OpenSSL 3.5, also configure a finite field TLS group:
++
+[source,bash]
+----
+export JAVA_OPTS_APPEND="--enable-native-access=ALL-UNNAMED -Djdk.tls.namedGroups=ffdhe2048"
+----
++
+This setting avoids an EC ephemeral key generation limitation in this Glassless and OpenSSL combination. It does not change the keystore format or the server certificate algorithm.
+
+. Build an optimized server with Glassless in strict mode:
++
+[source,bash]
+----
+$KEYCLOAK_HOME/bin/kc.sh build --features=fips --fips-mode=strict
+----
+
+. Start the optimized server. The FIPS options must match the optimized build:
++
+<@kc.start parameters="--optimized --features=fips --fips-mode=strict"/>
+
+For information about configuring a container, see <<fips-containers,Running {project_name} in FIPS mode in containers>>.
+
+==== Verifying the Glassless configuration
+
+Before starting {project_name}, you can run the Glassless provider JAR to check the OpenSSL FIPS status:
+
+[source,bash]
+----
+java --enable-native-access=ALL-UNNAMED -jar $KEYCLOAK_HOME/lib/lib/main/net.glassless.glassless-provider-${properties["glassless.version"]}.jar
+----
+
+For strict mode, verify that the command reports the following values:
+
+[source]
+----
+FIPS Mode: ENABLED
+FIPS Provider Available: true
+OpenSSL FIPS Enabled: true
+----
+
+After {project_name} starts, verify that the startup log contains an entry similar to the following example:
+
+[source]
+----
+GlasslessCryptoProvider created: KC(GlaSSLess version ${properties["glassless.version"]} [..., FIPS], FIPS mode: enabled, FIPS provider available: true)
+----
+
+For more information about activating and verifying the provider, see the https://glassless.net/fips/[Glassless FIPS documentation].
+
 == BouncyCastle library
 
 {project_name} internally uses the BouncyCastle library for many cryptography utilities. Please note that the default version of the BouncyCastle library that shipped with {project_name} is not FIPS compliant;
@@ -49,27 +167,42 @@ BouncyCastle FIPS can be downloaded from the https://www.bouncycastle.org/downlo
 * bcpkix-fips version ${properties["bouncycastle.pkixfips.version"]}.
 * bcutil-fips version ${properties["bouncycastle.bcutilfips.version"]}.
 
+When these JAR files are present, {project_name} automatically selects Bouncy Castle during the next build. You can also set `--fips-provider=bouncycastle` to require Bouncy Castle explicitly. An explicit selection fails at startup if the required libraries are not available.
+
 == Generating keystore
 
-You can create either `pkcs12` or `bcfks` keystore to be used for the {project_name} server SSL.
+The keystore type depends on the selected cryptographic provider. Use a `pkcs12` keystore with Glassless. With Bouncy Castle, use a `bcfks` keystore in strict mode. You can also use a `pkcs12` keystore with Bouncy Castle in non-strict mode.
 
 === PKCS12 keystore
 
-The `p12` (or `pkcs12`) keystore (and/or truststore) works well in BCFIPS non-approved mode.
+The `p12` or `pkcs12` keystore and truststore work with Glassless. They also work in BCFIPS non-approved mode.
 
-PKCS12 keystore can be generated with OpenJDK 21 Java on RHEL 9 in the standard way. For instance, the following command can be used to generate the keystore:
+Generate a PKCS12 keystore with the Java version required by the selected cryptographic provider. Use Java 25 or later with Glassless. For example:
 
 [source,bash]
 ----
-keytool -genkeypair -sigalg SHA512withRSA -keyalg RSA -storepass passwordpassword \
-  -keystore $KEYCLOAK_HOME/conf/server.keystore \
+keytool -genkeypair -storetype PKCS12 -keyalg RSA -keysize 2048 \
+  -sigalg SHA512withRSA -storepass passwordpassword \
+  -keystore $KEYCLOAK_HOME/conf/server.p12 \
   -alias localhost \
   -dname CN=localhost -keypass passwordpassword
 ----
 
-The `pkcs12` keystores in FIPS mode *do not* manage secret (symmetric) keys. This limitation is imposed by the `BCFIPS` provider which does not allow this type of keys inside the `pkcs12` keystore type.
+When using BCFIPS, `pkcs12` keystores in FIPS mode *do not* manage secret (symmetric) keys. This limitation is imposed by the `BCFIPS` provider, which does not allow this type of key in a `pkcs12` keystore.
 
 When the system is in FIPS mode, the default `java.security` file is changed in order to use FIPS enabled security providers, so no additional configuration is needed. Additionally, in the PKCS12 keystore, you can store PBE (password-based encryption) keys simply by using the keytool command, which makes it ideal for using it with {project_name} KeyStore Vault and/or to store configuration properties in the KeyStore Config Source. For more details, see the <@links.server id="configuration"/> and the <@links.server id="vault"/>.
+
+==== Why PKCS12 can be used with Glassless
+
+BCFKS is a keystore implementation supplied by Bouncy Castle. BCFKS is required with the Bouncy Castle provider in strict mode because BCFIPS approved mode does not support JKS or PKCS12 keystores. This restriction is specific to BCFIPS. It is not a general requirement of FIPS strict mode.
+
+Glassless does not provide the BCFKS keystore implementation. PKCS12 is the default and recommended JDK keystore format, and Glassless can use the keys stored in it. Therefore, PKCS12 is a suitable interoperable format when the security policy for your deployment permits it.
+
+The Java 25 `keytool` command in the previous section uses PBES2 with PBKDF2, HMAC SHA-256, and AES-256 to encrypt the private key and certificate contents. Glassless provides the PBES2 operations when it is the highest priority provider. Do not reuse a legacy PKCS12 file that is protected with algorithms such as Triple DES, RC2, or SHA-1. Recreate the keystore with a current Java version instead.
+
+WARNING: Using the PKCS12 format does not by itself establish FIPS compliance. The JDK provider implements the PKCS12 parser and, with the standard Java 25 provider configuration, SunJCE performs the whole file integrity MAC. This operation is outside the Glassless and OpenSSL FIPS module boundary. RHEL 9 also documents PKCS12 processing as not FIPS compliant because the KDF used for this MAC is not FIPS approved. If your policy requires every key protection operation to occur inside a validated cryptographic module, use a keystore or external key management solution approved by your platform vendor instead of PKCS12.
+
+Glassless remains the highest priority provider for the cryptographic algorithms that it supports and for TLS operations that use the loaded key. Verify the keystore protection requirements against the security policy and certificate of the OpenSSL FIPS module supplied by your operating system vendor. For the RHEL limitation, see the https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening[RHEL security hardening guide].
 
 === BCFKS keystore
 
@@ -102,7 +235,7 @@ WARNING: Using self-signed certificates is for demonstration purposes only, so r
 
 Similar options are needed when you are doing any other manipulation with keystore/truststore of `bcfks` type.
 
-== Running the server.
+== Running the server
 
 To run the server with BCFIPS in non-approved mode, enter the following command::
 
@@ -115,14 +248,16 @@ NOTE: You can disable logging in production if everything works as expected.
 
 == Strict mode
 
-There is the `fips-mode` option, which is automatically set to `non-strict` when the `fips` feature is enabled. This means to run BCFIPS in the "non-approved mode".
-The more secure alternative is to use `--features=fips --fips-mode=strict` in which case BouncyCastle FIPS will use "approved mode".
-Using that option results in stricter security requirements on cryptography and security algorithms.
+The `fips-mode` option defaults to `non-strict` when the `fips` feature is enabled. With Bouncy Castle, `non-strict` uses BCFIPS non-approved mode and `strict` uses BCFIPS approved mode. With Glassless, `non-strict` does not require an OpenSSL FIPS provider. Glassless strict mode requires an active OpenSSL FIPS provider.
 
-NOTE: In strict mode, the default keystore type (as well as default truststore type) is BCFKS. If you want to use a different keystore type
+Use `--features=fips --fips-mode=strict` to enable the stricter security requirements for the selected provider.
+
+NOTE: In strict mode with the Bouncy Castle provider, the default keystore type (as well as default truststore type) is BCFKS. If you want to use a different keystore type
 it is required to use the option `--https-key-store-type` with appropriate type. A similar command might be needed for the truststore as well if you want to use it.
 
-When starting the server, you can check that the startup log contains `KC` provider with the note about `Approved Mode` such as the following:
+NOTE: Glassless does not use BCFKS as the default keystore type. Use a `pkcs12` keystore and specify `--https-key-store-type=pkcs12` when {project_name} cannot detect the type from the file extension.
+
+When using Bouncy Castle, verify that the startup log contains the `KC` provider with the `Approved Mode` note, such as the following:
 
 [source]
 ----
@@ -131,10 +266,9 @@ FIPS1402Provider created: KC(BCFIPS version 2.0102 Approved Mode, FIPS-JVM: enab
 
 === Cryptography restrictions in strict mode
 
-* As mentioned in the previous section, strict mode may not work with `pkcs12` keystore. It is required to use another keystore (like `bcfks`) as mentioned earlier. Also `jks` and `pkcs12` keystores are not
-supported in {project_name} when using strict mode. Some examples are importing or generating a keystore of an OIDC or SAML client in the Admin Console or for a `java-keystore` provider in the realm keys.
+* When using Bouncy Castle, strict mode does not support `jks` and `pkcs12` keystores. Use a `bcfks` keystore instead. This restriction applies, for example, when importing or generating an OIDC or SAML client keystore in the Admin Console or when configuring a `java-keystore` realm key provider. This BCFKS requirement does not apply when using Glassless.
 
-* User passwords must be 14 characters or longer. {project_name} uses PBKDF2 based password encoding by default. BCFIPS approved mode requires passwords to be at least 112 bits
+* When using Bouncy Castle, user passwords must be 14 characters or longer. {project_name} uses PBKDF2 based password encoding by default. BCFIPS approved mode requires passwords to be at least 112 bits
 (effectively 14 characters) with PBKDF2 algorithm. If you want to allow a shorter password, set the property `max-padding-length` of provider `pbkdf2-sha512` of SPI `password-hashing`
 to 14 to provide additional padding when verifying a hash created by this algorithm. This setting is also backwards compatible with previously stored passwords.
 For example, if the user's database is in a non-FIPS environment and you have shorter passwords and you want to verify them now with {project_name} using BCFIPS in approved mode, the passwords should work.
@@ -158,7 +292,7 @@ the older `pbkdf2-sha256` can log in because their passwords may be shorter than
 the OIDC notation), then your client secrets should be at least 14 characters long. Note that for good security, it is recommended to use client secrets generated by the {project_name} server, which
 always fulfils this requirement.
 
-* The bc-fips version 1.0.2.4 deals with the end of the transition period for PKCS 1.5 RSA encryption. Therefore JSON Web Encryption (JWE) with algorithm `RSA1_5` is not allowed in strict mode by default (BC provides the system property `-Dorg.bouncycastle.rsa.allow_pkcs15_enc=true` as backward compatibility option for the moment). `RSA-OAEP` and `RSA-OAEP-256` are still available as before.
+* When using Bouncy Castle, the bc-fips version 1.0.2.4 deals with the end of the transition period for PKCS 1.5 RSA encryption. Therefore JSON Web Encryption (JWE) with algorithm `RSA1_5` is not allowed in strict mode by default (BC provides the system property `-Dorg.bouncycastle.rsa.allow_pkcs15_enc=true` as backward compatibility option for the moment). `RSA-OAEP` and `RSA-OAEP-256` are still available as before.
 
 == Other restrictions
 
@@ -192,10 +326,10 @@ For Kerberos/SPNEGO, the security provider `SunJGSS` is not yet fully FIPS compl
 if you want to be FIPS compliant. The `KERBEROS` feature is disabled by default in {project_name} when it is executed on FIPS platform and when security provider is not
 available. Details are in the https://bugzilla.redhat.com/show_bug.cgi?id=2051628[bugzilla].
 
-== Run the CLI on the FIPS host
+== Running the CLI on the FIPS host
 
-If you want to run Client Registration CLI (`kcreg.sh|bat` script) or Admin CLI (`kcadm.sh|bat` script),
- the CLI must also use the BouncyCastle FIPS dependencies instead of plain BouncyCastle dependencies. To achieve this, you may copy the
+The `fips-provider` option configures the server. When using Bouncy Castle, the Client Registration CLI (`kcreg.sh|bat` script) and Admin CLI (`kcadm.sh|bat` script)
+must also use the Bouncy Castle FIPS dependencies instead of plain Bouncy Castle dependencies. To achieve this, you may copy the
 jars to the CLI library folder and that is enough. CLI tool will automatically use BCFIPS dependencies instead of plain BC when
 it detects that corresponding BCFIPS jars are present (see above for the versions used). For example, use command such as the following before running the CLI:
 
@@ -216,17 +350,22 @@ fips.keystore.type=bcfks" > /tmp/kcadm.java.security
 export KC_OPTS="-Djava.security.properties=/tmp/kcadm.java.security"
 ----
 
-== {project_name} server in FIPS mode in containers
+[#fips-containers]
+== Running {project_name} in FIPS mode in containers
 
 When you want {project_name} in FIPS mode to be executed inside a container, your "host" must be using FIPS mode as well. The container
 will then "inherit" FIPS mode from the parent host.
 See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening#enabling-fips-mode-in-a-container_using-the-system-wide-cryptographic-policies[this section]
 in the RHEL documentation for the details.
 
-The {project_name} container image will automatically be in fips mode when executed from the host in FIPS mode.
-However, make sure that the {project_name} container also uses BCFIPS jars (instead of BC jars) and proper options when started.
+The {project_name} container image will automatically be in FIPS mode when executed from the host in FIPS mode.
+The container must also include the libraries and runtime required by the selected cryptographic provider.
 
-Regarding this, it is best to build your own container image as described in the <@links.server id="containers"/> and tweak it to use BCFIPS etc.
+=== Using Bouncy Castle in a container
+
+Make sure that the container uses the BCFIPS JAR files instead of the non-FIPS Bouncy Castle JAR files and that the proper options are used when starting {project_name}.
+
+Build your own container image as described in the <@links.server id="containers"/> and add the BCFIPS configuration to that image.
 
 For example in the current directory, you can create sub-directory `files` and add:
 
@@ -258,6 +397,36 @@ ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
 
 Then build FIPS as an optimized Docker image and start it as described in the <@links.server id="containers"/>. These steps require that you use arguments as described above when starting the image.
 
+=== Using Glassless in a container
+
+A container that uses Glassless must provide Java 25 or later, OpenSSL 3 or later, and an OpenSSL FIPS provider. Use a base image that meets these requirements when building the custom image.
+
+Before running the {project_name} build command in the container image, complete the following steps:
+
+. Install Java, OpenSSL, and the OpenSSL FIPS module in the image.
+. Set `JAVA_OPTS_APPEND=--enable-native-access=ALL-UNNAMED`. When the image uses OpenSSL 3.5, also add `-Djdk.tls.namedGroups=ffdhe2048` as described in <<installing-glassless,Installing Glassless>>.
+. Configure OpenSSL to activate the FIPS provider. If you use a custom OpenSSL configuration, set `OPENSSL_CONF` to its location.
+. Build the optimized server:
++
+[source,dockerfile]
+----
+RUN /opt/keycloak/bin/kc.sh build --features=fips --fips-mode=strict
+----
+
+Keep `JAVA_OPTS_APPEND` and `OPENSSL_CONF` in the final image because Glassless uses them at runtime.
+
+Start the image with the same FIPS build options:
+
+[source,bash]
+----
+podman|docker run --name mykeycloak <IMAGE> \
+  start --optimized \
+  --features=fips \
+  --fips-mode=strict
+----
+
+Glassless is bundled, so no provider JAR or `fips-provider` option is needed. If Bouncy Castle FIPS JAR files are added to `/opt/keycloak/providers` before the build, {project_name} selects Bouncy Castle instead. If the OpenSSL FIPS provider is missing or inactive, {project_name} fails to start in strict Glassless mode.
+
 == Migration from non-fips environment
 
 If you previously used {project_name} in a non-fips environment, it is possible to migrate it to a FIPS environment including its data. However, restrictions and considerations exist as
@@ -268,7 +437,7 @@ with `argon2`, they will not be able to login after switch to the FIPS environme
 Password policy for your realm from the beginning (before any users are created) and override the default algorithm for example to `pbkdf2-sha512`, which is FIPS compliant. This strategy helps to make the
 migration to the FIPS environment to be smooth. Otherwise, if your users are already on `argon2` passwords, simply ask users to reset the password after migrating to the FIPS
 environment.  For instance, ask users to use "Forget password" or send the email for reset-password to all users.
-* Make sure all the {project_name} functionality relying on keystores uses only supported keystore types. This differs based on whether strict or non-strict mode is used.
+* Make sure all the {project_name} functionality relying on keystores uses only the types supported by the selected cryptographic provider and FIPS mode.
 * Kerberos authentication may not work. If your authentication flow uses `Kerberos` authenticator, this authenticator will be automatically switched to `DISABLED` when migrated to FIPS
 environment. It is recommended to remove any `Kerberos` user storage providers from your realm and disable `Kerberos` related functionality in LDAP providers before switching to FIPS environment.
 

--- a/glassless_report.md
+++ b/glassless_report.md
@@ -458,6 +458,29 @@ BUILD SUCCESS
 
 The complete 55 module distribution reactor was additionally built with OpenJDK 21. This proves that bundling the Java 25 Glassless artifact does not prevent a normal Java 21 Keycloak distribution build. On Java 21, users enabling FIPS must provide Bouncy Castle FIPS JAR files because Glassless itself requires Java 25.
 
+### Current pull request CI remediation
+
+The Ubuntu and Windows Quarkus unit test jobs from workflow run `29988221565` failed for the same Glassless related reason. The Quarkus runtime exposed `GlasslessCryptoProviderFactory` to `ServiceLoader`, but its wildcard dependency exclusions removed `keycloak-crypto-elytron`. Loading the Glassless factory therefore failed with `NoClassDefFoundError: org/keycloak/crypto/elytron/WildFlyElytronProvider` before the default provider could be selected. The failing aggregate Keycloak CI status was only a consequence of those two jobs.
+
+The Quarkus runtime now declares its Elytron crypto dependency directly. The Glassless dependency can continue excluding all transitives, which keeps the Java 25 Glassless provider JAR out of consumers that only need the Keycloak runtime module, while every classpath that exposes the Glassless factory also contains its Keycloak base implementation.
+
+The exact Quarkus unit test command from CI was rerun:
+
+```text
+./mvnw test -f quarkus/pom.xml -pl '!tests,!tests/junit5,!tests/integration,!dist'
+Reactor modules: 5
+Failures: 0
+Errors: 0
+BUILD SUCCESS
+```
+
+The two classes that failed on both CI platforms now pass:
+
+```text
+KeycloakMetricsConfigurationTest: 2 tests, 0 failures, 0 errors
+KeycloakPathConfigurationTest: 5 tests, 0 failures, 0 errors
+```
+
 ## Container construction
 
 ### Container contents

--- a/glassless_report.md
+++ b/glassless_report.md
@@ -1,0 +1,652 @@
+# Keycloak Glassless FIPS integration report
+
+Date: 23 July 2026
+
+Status: implemented, rebuilt, tested, containerized, pushed, and remotely verified
+
+## Executive summary
+
+This change ships Glassless as the default FIPS cryptographic provider for Keycloak while preserving Bouncy Castle compatibility. The default `fips-provider=auto` mode selects Bouncy Castle when its FIPS provider class is available and selects the bundled Glassless provider otherwise. Provider implementations are discovered through `ServiceLoader` factories. Selection uses a direct class resource check instead of cascading exception probes.
+
+The resulting container is available at:
+
+```text
+quay.io/sebastian_laskawiec/keycloak:glassless
+```
+
+The immutable remote digest is:
+
+```text
+quay.io/sebastian_laskawiec/keycloak@sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc
+```
+
+The tag is anonymously readable. It was verified without using the local Quay credentials.
+
+Quay page: https://quay.io/repository/sebastian_laskawiec/keycloak?tab=tags
+
+## Quick Docker manual
+
+This is the shortest way to try the image locally. It uses HTTP and the embedded development database, so it is intended for evaluation only.
+
+### 1. Pull the image
+
+```bash
+docker pull quay.io/sebastian_laskawiec/keycloak:glassless
+```
+
+For a reproducible pull, use the immutable digest:
+
+```bash
+docker pull quay.io/sebastian_laskawiec/keycloak@sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc
+```
+
+To keep the complete demonstration immutable, replace the tagged image coordinate in the start command with this digest coordinate.
+
+### 2. Start Keycloak
+
+The bootstrap password below is deliberately long enough for strict FIPS mode.
+
+```bash
+CONTAINER_ID=$(docker run --detach \
+  --publish 8080:8080 \
+  --env KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  --env KC_BOOTSTRAP_ADMIN_PASSWORD=glasslessAdminPassword25 \
+  quay.io/sebastian_laskawiec/keycloak:glassless \
+  start --optimized \
+  --features=fips \
+  --fips-mode=strict \
+  --http-enabled=true \
+  --hostname-strict=false)
+
+echo "$CONTAINER_ID"
+```
+
+The image is already optimized with these FIPS settings. The command intentionally shows `--features=fips` and `--fips-mode=strict`, but does not specify `--fips-provider`. Keycloak automatically selects the bundled Glassless provider because no Bouncy Castle FIPS provider class is present.
+
+### 3. Wait for readiness
+
+```bash
+docker logs --follow "$CONTAINER_ID"
+```
+
+The important messages are:
+
+```text
+Automatically selected FIPS provider: glassless
+GlasslessCryptoProvider created: KC(GlaSSLess version 0.13.0 [..., FIPS], FIPS mode: enabled, FIPS provider available: true, OpenSSL FIPS default properties: enabled)
+Keycloak 999.0.0-SNAPSHOT on JVM ... started
+```
+
+Press `Ctrl+C` after the startup message. Then verify OpenID discovery:
+
+```bash
+curl --fail --silent --output /dev/null --write-out 'HTTP %{http_code}\n' \
+  http://127.0.0.1:8080/realms/master/.well-known/openid-configuration
+```
+
+Expected result:
+
+```text
+HTTP 200
+```
+
+The administration console is available at http://127.0.0.1:8080/admin/ using `admin` and `glasslessAdminPassword25`.
+
+### 4. Request a token
+
+```bash
+curl --fail --silent \
+  --request POST \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data client_id=admin-cli \
+  --data username=admin \
+  --data password=glasslessAdminPassword25 \
+  --data grant_type=password \
+  http://127.0.0.1:8080/realms/master/protocol/openid-connect/token
+```
+
+A successful response contains a three segment JWT `access_token` and `"token_type":"Bearer"`.
+
+### 5. Verify Glassless and OpenSSL FIPS status
+
+```bash
+docker exec "$CONTAINER_ID" \
+  java --enable-native-access=ALL-UNNAMED \
+  -jar /opt/keycloak/lib/lib/main/net.glassless.glassless-provider-0.13.0.jar
+```
+
+Expected result:
+
+```text
+Provider: GlaSSLess v0.13.0
+FIPS Mode: ENABLED
+FIPS Provider Available: true
+OpenSSL FIPS Enabled: true
+Hybrid Mode: DISABLED
+```
+
+Verify the persisted Keycloak configuration:
+
+```bash
+docker exec "$CONTAINER_ID" /opt/keycloak/bin/kc.sh show-config
+```
+
+Expected configuration includes:
+
+```text
+kc.features = fips (Persisted)
+kc.optimized = true (Persisted)
+```
+
+The default `auto` provider value is not printed by `show-config`. The `Automatically selected FIPS provider: glassless` startup message is the authoritative selection evidence.
+
+### 6. Stop and remove the demonstration container
+
+```bash
+docker rm --force "$CONTAINER_ID"
+```
+
+## User facing configuration
+
+The build option accepts:
+
+```text
+--fips-provider=auto
+--fips-provider=bouncycastle
+--fips-provider=glassless
+```
+
+`auto` is the default. It selects Bouncy Castle when `org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider` is available and selects Glassless otherwise. A normal Glassless build therefore needs no provider option:
+
+```bash
+bin/kc.sh build \
+  --features=fips \
+  --fips-mode=strict
+```
+
+Glassless 0.13.0 requires a 64 bit Java 25 runtime, OpenSSL 3, and native access:
+
+```bash
+export JAVA_OPTS_APPEND='--enable-native-access=ALL-UNNAMED'
+```
+
+Glassless is bundled in the standard Keycloak distribution at `lib/lib/main/net.glassless.glassless-provider-0.13.0.jar`. Users do not need to download or copy it. To use Bouncy Castle instead, copy all supported Bouncy Castle FIPS JAR files into `KEYCLOAK_HOME/providers` before building. Explicit `glassless` and `bouncycastle` values remain available as overrides.
+
+The implementation and container configuration follow the Glassless documentation:
+
+1. https://glassless.net/
+2. https://glassless.net/fips/
+3. https://central.sonatype.com/artifact/net.glassless/glassless-provider/0.13.0
+
+## Provider selection architecture
+
+### Automatic provider model
+
+`FipsProvider` defines the supported provider option values:
+
+```text
+AUTO -> auto
+BOUNCY_CASTLE -> bouncycastle
+GLASSLESS -> glassless
+```
+
+`SecurityOptions.FIPS_PROVIDER` exposes the build time option. Its default is `auto`.
+
+`FipsProvider.resolve(ClassLoader)` checks for the Bouncy Castle FIPS provider class as a class loader resource. A present resource selects Bouncy Castle. An absent resource selects Glassless. Explicit provider values return themselves. This provides deterministic detection without loading provider classes, triggering static initialization, or using exception control flow.
+
+### ServiceLoader registry
+
+`CryptoProviderFactory` is a small provider factory contract:
+
+```java
+public interface CryptoProviderFactory {
+    String getName();
+    CryptoProvider create(FipsMode fipsMode);
+}
+```
+
+Keycloak loads all factories with `ServiceLoader`, filters them by the configured provider name, and requires exactly one match. Missing and duplicate factories fail with deterministic errors. A factory returning `null` is also rejected.
+
+The following factories are registered:
+
+1. `DefaultCryptoProviderFactory`, provider name `default`
+2. `Fips1402ProviderFactory`, provider name `bouncycastle`
+3. `GlasslessCryptoProviderFactory`, provider name `glassless`
+
+The existing `CryptoIntegration.init(ClassLoader)` entry point remains available for clients and existing test code. Keycloak server startup uses the new named factory entry point.
+
+This keeps selection separate from provider construction and eliminates cascading exception blocks.
+
+## Glassless provider implementation
+
+The new `crypto/glassless` module contains:
+
+1. `GlasslessCryptoProvider`
+2. `GlasslessStrictCryptoProvider`
+3. `GlasslessCryptoProviderFactory`
+4. Unit tests using a controlled provider
+5. Tests using the real Glassless 0.13.0 provider on Java 25
+
+The implementation builds on the existing Elytron based Keycloak crypto provider. This reuses Keycloak certificate, PEM, OCSP, identity extraction, ECDSA, and JWE integration code instead of duplicating it.
+
+Glassless is inserted at Java security provider priority one. Critical operations explicitly request the Glassless provider where the Keycloak crypto interface allows it. Covered operations include RSA key generation, RSA and EC key factories, RSA and RSA PSS signatures, EC parameters, AES GCM, and PBKDF2. AES CBC reuses the inherited Keycloak cipher implementation and resolves to Glassless through its priority one registration. The real provider test verifies that resolution.
+
+### Bootstrap provider inventory
+
+Every Glassless initialization logs the complete provider service inventory at info level. Services are grouped by type, types and algorithms are sorted for deterministic output, and each group includes its algorithm count. The output includes all registered ciphers, signatures, key generators, key factories, message digests, MACs, and other Java security services.
+
+The distribution test verifies the inventory header, the cipher group, and `AES/GCM/NoPadding`. A controlled unit test verifies the complete deterministic format.
+
+### Strict mode validation
+
+Strict mode requires all of the following:
+
+1. Glassless is installed and can initialize on Java 25 or later
+2. Glassless reports that FIPS mode is enabled
+3. Glassless reports that an OpenSSL FIPS provider is available
+4. The OpenSSL default context reports that its FIPS properties are enabled
+5. Glassless is the highest priority Java security provider
+
+Startup fails if any strict mode requirement is not met. If initialization fails after Glassless was inserted, the provider is removed to avoid leaving partial global security state.
+
+Glassless 0.13.0 does not expose requirement four through its public API. Keycloak temporarily isolates one reflective call to the internal `OpenSSLCrypto.isFIPSEnabled()` method. This method reads `EVP_default_properties_is_fips_enabled(NULL)` directly, so a `glassless.fips.mode=true` override or an operating system policy file cannot satisfy strict mode by itself. The workaround is encapsulated in `isOpenSslDefaultContextFipsEnabled` and can be replaced in one place when Glassless exposes the equivalent public API.
+
+The strict provider retains the existing Keycloak FIPS RSA key size policy of 2048, 3072, and 4096 bits.
+
+## Compatibility work
+
+### Bouncy Castle compatibility
+
+Bouncy Castle remains fully supported. Automatic mode selects it when the Bouncy Castle FIPS provider class is present. Its error message, strict and nonstrict modes, approved mode behavior, and explicit `--fips-provider=bouncycastle` override are preserved.
+
+When the FIPS feature is disabled, the Glassless provider, both FIPS integrations, and their supporting artifacts are excluded from the optimized distribution. When the FIPS feature is enabled, both FIPS integrations are retained so automatic detection and explicit overrides work after user supplied provider JAR files are installed. The non FIPS Bouncy Castle artifacts and the default Keycloak crypto provider remain excluded.
+
+### Keystore behavior
+
+Strict Bouncy Castle mode continues to default HTTPS keystores and truststores to BCFKS.
+
+Strict Glassless mode does not force BCFKS. BCFKS is a Bouncy Castle keystore implementation, so Glassless uses standard Java keystore implementations instead. PKCS12 is the default JDK keystore format and is the interoperable choice for deployments whose security policy permits it.
+
+The HTTPS store type mapper resolves `auto` with the same provider detector. It defaults to BCFKS only when strict mode resolves to Bouncy Castle. Automatic Glassless mode leaves the type unset so file extension detection can select PKCS12.
+
+#### Why PKCS12 works
+
+The keystore format and the provider used for cryptographic operations are separate JCA concepts. Java 25 supplies the PKCS12 parser through the `SUN` provider. After the key is loaded, Glassless remains the highest priority provider and performs the supported cryptographic operations with OpenSSL. The strict Glassless container loaded a Java 25 PKCS12 keystore, started HTTPS, and returned HTTP 200 from OpenID discovery.
+
+The tested Java 25 `keytool` output protected the private key and certificate contents with:
+
+```text
+PBES2
+PBKDF2
+HMAC SHA256
+AES 256 CBC
+10000 iterations
+```
+
+This avoids the legacy Triple DES, RC2, and SHA1 protection algorithms found in older PKCS12 files. Existing files must be inspected or recreated with the current Java runtime rather than assumed to use these settings.
+
+#### Compliance boundary
+
+PKCS12 working in strict Glassless mode is not, by itself, proof that every keystore protection operation is inside the OpenSSL FIPS module boundary. Provider tracing on the tested image established the following boundary:
+
+```text
+KeyStore.PKCS12                              SUN
+Cipher.PBEWithHmacSHA256AndAES_256           GlaSSLess
+Mac.HmacPBESHA256                            SunJCE
+TLS operations after loading the private key GlaSSLess
+```
+
+The PKCS12 whole file MAC is the important qualification. Glassless 0.13.0 does not register `HmacPBESHA256`, so the standard Java 25 provider configuration resolves that operation to SunJCE. It does not run in Glassless or the OpenSSL FIPS module. RHEL 9 separately states that PKCS12 file processing is not FIPS compliant because the KDF used for the whole file HMAC is not approved.
+
+The precise conclusion is therefore:
+
+1. PKCS12 is functionally correct for strict Glassless Keycloak and was proven with HTTPS.
+2. The BCFKS requirement is specific to BCFIPS and must not be imposed on Glassless.
+3. PKCS12 is acceptable only when the deployment security policy permits this external container and its integrity mechanism.
+4. A deployment that requires every key protection operation inside a validated module must use a platform approved keystore or external key management solution instead.
+
+The applicable operating system policy and the validated OpenSSL module security policy remain authoritative. The RHEL qualification is documented at https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening.
+
+### AES key wrapping
+
+Glassless supports AES key wrapping through encrypt and decrypt operations, but does not support the Java `Cipher.wrap` and `Cipher.unwrap` SPI operations used by the existing Elytron implementation.
+
+The focused compatibility change uses `ENCRYPT_MODE`, `DECRYPT_MODE`, and `doFinal` for AES key wrapping. The complete content encryption key is wrapped, which also fixes the previously skipped AES key wrap plus AES CBC HMAC JWE regression case.
+
+The same compatible operation is used for ECDH ES with AES key wrapping.
+
+## Main source changes
+
+The main integration points are:
+
+1. `common/src/main/java/org/keycloak/common/crypto/CryptoProviderFactory.java`
+2. `common/src/main/java/org/keycloak/common/crypto/FipsProvider.java`
+3. `common/src/main/java/org/keycloak/common/crypto/CryptoIntegration.java`
+4. `crypto/default/src/main/java/org/keycloak/crypto/def/DefaultCryptoProviderFactory.java`
+5. `crypto/fips1402/src/main/java/org/keycloak/crypto/fips/Fips1402ProviderFactory.java`
+6. `crypto/glassless`
+7. `quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java`
+8. `quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java`
+9. `quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java`
+10. `quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java`
+11. `quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java`
+12. `crypto/elytron/src/main/java/org/keycloak/crypto/elytron/AesKeyWrapAlgorithmProvider.java`
+13. `crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronEcdhEsAlgorithmProvider.java`
+14. `docs/guides/server/fips.adoc`
+15. `pom.xml` and `crypto/glassless/pom.xml` for the bundled provider dependency
+16. `quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/GlasslessFipsDistTest.java`
+
+## Test coverage
+
+### Clean distribution rebuild
+
+The complete dependency reactor required for the Keycloak distribution was rebuilt from clean targets:
+
+```bash
+./mvnw -pl quarkus/dist -am -DskipTests -DskipExamples clean install
+```
+
+Result:
+
+```text
+Reactor modules: 55
+Failures: 0
+BUILD SUCCESS
+```
+
+Tests were deliberately run separately so their individual results remained visible.
+
+### Focused unit and regression suites
+
+The following suites were rerun after the clean build:
+
+| Suite | Tests | Failures | Errors | Skipped |
+| --- | ---: | ---: | ---: | ---: |
+| `CryptoProviderFactoryTest` | 4 | 0 | 0 | 0 |
+| `FipsProviderTest` | 5 | 0 | 0 | 0 |
+| `GlasslessCryptoProviderTest` | 6 | 0 | 0 | 0 |
+| `GlasslessCryptoProviderActualTest` | 2 | 0 | 0 | 0 |
+| `ElytronCryptoJWETest` | 14 | 0 | 0 | 2 |
+| `ConfigurationTest` | 73 | 0 | 0 | 0 |
+| `IgnoredArtifactsTest` | 16 | 0 | 0 | 0 |
+| Total | 120 | 0 | 0 | 2 |
+
+The complete Elytron crypto module suite was also run during implementation:
+
+```text
+Tests: 173
+Failures: 0
+Errors: 0
+Skipped: 2
+```
+
+### Real Glassless cryptography
+
+The real provider test uses Glassless 0.13.0, not a provider mock. It covers:
+
+1. ServiceLoader factory discovery
+2. Provider priority
+3. RSA key pair generation
+4. RS256 signing and verification
+5. PS256 signing and verification
+6. AES CBC encryption and decryption
+7. AES key wrapping of a 32 byte key
+8. HMAC SHA 256 compared with the reference SunJCE output
+9. PBKDF2 with HMAC SHA 256
+10. EC parameter creation
+11. End to end A128KW plus A128CBC HS256 JWE encoding and decoding
+12. Strict mode rejection when OpenSSL FIPS is unavailable or not selected by the default context
+13. Strict mode acceptance against a real active OpenSSL FIPS default context
+
+### Distribution integration tests
+
+`FipsDistTest` was run against the freshly built distribution:
+
+```text
+Tests: 10
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+This suite covers existing Bouncy Castle behavior, automatic Bouncy Castle selection, missing provider failures, strict and nonstrict modes, and keystore compatibility.
+
+`GlasslessFipsDistTest` runs in a separate provider specific distribution lifecycle:
+
+```text
+Tests: 1
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+It proves that the bundled provider is selected automatically without `--fips-provider`, starts a real Glassless nonstrict server, logs the complete provider inventory including the cipher group and AES GCM, checks OpenID discovery, and obtains an access token. The dedicated class keeps the Bouncy Castle and Glassless distribution augmentation lifecycles independent.
+
+`HelpCommandDistTest` verifies all command line help approval snapshots:
+
+```text
+Tests: 23
+Failures: 0
+Errors: 0
+Skipped: 0
+```
+
+The generated help contains:
+
+```text
+--fips-provider <provider>
+The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+uses Bouncy Castle when its FIPS provider classes are available, otherwise
+it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+Default: auto.
+```
+
+The complete Keycloak guide build also passed after the FIPS guide update:
+
+```text
+./mvnw -pl docs/guides -DskipTests package
+BUILD SUCCESS
+```
+
+The exact formatting check used by the Keycloak CI also passed:
+
+```text
+./mvnw -Pdocs,distribution,operator spotless:check
+Reactor modules: 163
+BUILD SUCCESS
+```
+
+The complete 55 module distribution reactor was additionally built with OpenJDK 21. This proves that bundling the Java 25 Glassless artifact does not prevent a normal Java 21 Keycloak distribution build. On Java 21, users enabling FIPS must provide Bouncy Castle FIPS JAR files because Glassless itself requires Java 25.
+
+## Container construction
+
+### Container contents
+
+| Component | Value |
+| --- | --- |
+| Base | Red Hat Universal Base Image 10 |
+| Architecture | `linux/amd64` |
+| Java | OpenJDK 25.0.4 |
+| OpenSSL | 3.5.5 |
+| OpenSSL FIPS provider | Red Hat Enterprise Linux 9 OpenSSL FIPS Provider, 3.0.7 based module |
+| Glassless | 0.13.0 |
+| Keycloak | 999.0.0 SNAPSHOT from the current working tree |
+| Local image size | 1,103,426,103 bytes |
+| Local image ID | `sha256:913af873187a172ff799ca7e5a3712781632948097b79aa0043b91021ca7767e` |
+| Remote manifest digest | `sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc` |
+
+The image is prebuilt with:
+
+```text
+--features=fips
+--fips-mode=strict
+```
+
+No provider option is persisted. Automatic selection happens at startup and selects the bundled Glassless provider unless Bouncy Castle FIPS classes are supplied.
+
+It also persists:
+
+```text
+JAVA_OPTS_APPEND=--enable-native-access=ALL-UNNAMED
+OPENSSL_CONF=/etc/pki/tls/openssl-glassless-fips.cnf
+```
+
+The OpenSSL configuration activates the base and FIPS providers and sets the default property query to `fips=yes`.
+
+Image inspection found Glassless only in the bundled runtime library directory:
+
+```text
+/opt/keycloak/lib/lib/main/org.keycloak.keycloak-crypto-glassless-999.0.0-SNAPSHOT.jar
+/opt/keycloak/lib/lib/main/net.glassless.glassless-provider-0.13.0.jar
+```
+
+No Glassless JAR was copied into `/opt/keycloak/providers`.
+
+### Input integrity
+
+The rebuilt Keycloak distribution archive was:
+
+```text
+SHA256 bac0f887eef845995ba2fd90d30af51f3f161daf8632ca90e84204fee200057f
+Size 185716280 bytes
+quarkus/dist/target/keycloak-999.0.0-SNAPSHOT.tar.gz
+```
+
+The Glassless provider JAR was verified during the image build:
+
+```text
+SHA256 5b815a1f81ba01d8c0470e879f9b46d7b081bc05c2561cd99be4c76a0fb855b8
+glassless-provider-0.13.0.jar
+```
+
+### Build command
+
+The final image was built without Docker layer cache:
+
+```bash
+docker build --no-cache \
+  --progress=plain \
+  --file /tmp/keycloak-glassless-image/Containerfile \
+  --tag quay.io/sebastian_laskawiec/keycloak:glassless \
+  /tmp/keycloak-glassless-image
+```
+
+The build itself verified the Glassless JAR checksum, active OpenSSL providers, Glassless FIPS status, and successful Keycloak strict mode augmentation before producing the image.
+
+## Container verification evidence
+
+### Image build evidence
+
+```text
+/opt/keycloak/lib/lib/main/net.glassless.glassless-provider-0.13.0.jar: OK
+FIPS
+Providers:
+  base
+    name: OpenSSL Base Provider
+    version: 3.5.5
+    status: active
+  fips
+    name: Red Hat Enterprise Linux 9 - OpenSSL FIPS Provider
+    version: 3.0.7-cda111b5812c30d4
+    status: active
+
+Provider: GlaSSLess v0.13.0
+OpenSSL: OpenSSL 3.5.5 27 Jan 2026
+FIPS Mode: ENABLED
+FIPS Provider Available: true
+OpenSSL FIPS Enabled: true
+Hybrid Mode: DISABLED
+
+Quarkus augmentation completed
+Server configuration updated and persisted
+```
+
+### Running container evidence
+
+Docker reported the exact container command:
+
+```text
+command=["start","--optimized","--features=fips","--fips-mode=strict","--http-enabled=true","--hostname-strict=false"]
+```
+
+There is no `fips-provider` argument. The startup log then proves the automatic decision:
+
+```text
+Automatically selected FIPS provider: glassless
+GlasslessCryptoProvider created: KC(GlaSSLess version 0.13.0 [OpenSSL 3.5.5 27 Jan 2026, FIPS], FIPS mode: enabled, FIPS provider available: true, OpenSSL FIPS default properties: enabled)
+Created temporary admin user with username admin
+Keycloak 999.0.0-SNAPSHOT on JVM started in 5.543s
+Listening on: http://0.0.0.0:8080
+Profile prod activated
+```
+
+Functional requests returned:
+
+```text
+discovery_http=200
+issuer=http://127.0.0.1:18081/realms/master
+token_http=200
+token_type=Bearer
+access_token_segments=3
+```
+
+### Push and remote verification evidence
+
+```text
+The push refers to repository [quay.io/sebastian_laskawiec/keycloak]
+glassless: digest: sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc size: 1587
+```
+
+Anonymous remote manifest inspection returned:
+
+```text
+Name:      quay.io/sebastian_laskawiec/keycloak:glassless
+MediaType: application/vnd.docker.distribution.manifest.v2+json
+Digest:    sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc
+```
+
+An anonymous pull using an empty Docker credential configuration also succeeded:
+
+```text
+quay.io/sebastian_laskawiec/keycloak@sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc: Pulling from sebastian_laskawiec/keycloak
+Digest: sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc
+Status: Image is up to date for quay.io/sebastian_laskawiec/keycloak@sha256:a8b1e5942ad02d4f46336503c0f04565ed0188f2dc48e5e1f27687977cda8dfc
+```
+
+## Production guidance
+
+The quick manual intentionally enables HTTP and uses the embedded database. A production deployment must additionally configure at least:
+
+1. TLS or a correctly configured trusted reverse proxy
+2. A supported external database
+3. Persistent storage and backup policies
+4. Production bootstrap and credential management
+5. Hostname and proxy settings
+6. Resource limits and health checks
+7. A tested upgrade and rollback process
+8. Image digest pinning rather than a mutable tag
+
+Use PKCS12 for Glassless keystores only when the deployment security policy permits its integrity mechanism. Otherwise, use a platform approved keystore or external key management solution.
+
+## FIPS compliance boundary
+
+The container proves that Glassless reports FIPS mode enabled, that the OpenSSL FIPS provider is active and available, and that Keycloak strict mode accepts and uses that provider.
+
+The UBI tooling also emits this important warning:
+
+```text
+Using update-crypto-policies --set FIPS is not sufficient for FIPS compliance.
+The kernel must be started with fips=1 for FIPS compliance.
+```
+
+Therefore, the container result must not be interpreted as certification of an arbitrary host. Formal compliance depends on the complete deployment boundary, including the host kernel, validated OpenSSL module, platform configuration, operational controls, and the requirements of the applicable certification program.
+
+## Build provenance
+
+The image was produced from branch `glassless`, based on commit:
+
+```text
+42f8e0ee84973df358a862bb8e06972e8628edb9
+```
+
+The automatic selection, bundled dependency, tests, and documentation were present as working tree changes on top of that commit when the distribution and container were built. The remote image digest is the authoritative identifier for the exact published container content.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <bouncycastle.bcfips.version>2.1.2</bouncycastle.bcfips.version>
         <bouncycastle.bctls-fips.version>2.1.22</bouncycastle.bctls-fips.version>
         <bouncycastle.bcutilfips.version>2.1.5</bouncycastle.bcutilfips.version>
-
+        <glassless.version>0.13.0</glassless.version>
         <dom4j.version>2.1.3</dom4j.version>
         <h2.version>2.4.240</h2.version>
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
@@ -444,6 +444,11 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcutil-fips</artifactId>
                 <version>${bouncycastle.bcutilfips.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.glassless</groupId>
+                <artifactId>glassless-provider</artifactId>
+                <version>${glassless.version}</version>
             </dependency>
 
             <dependency>
@@ -1213,6 +1218,11 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-crypto-elytron</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-crypto-glassless</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -97,7 +97,7 @@ public class HttpOptions {
             .category(OptionCategory.HTTP)
             .description("The type of the key store file. " +
                     "If not given, the type is automatically detected based on the file extension. " +
-                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
+                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "', Bouncy Castle is selected as the FIPS provider, and no value is set, it defaults to 'BCFKS'.")
             .build();
 
     public static final Option<File> HTTPS_TRUST_STORE_FILE = new OptionBuilder<>("https-trust-store-file", File.class)
@@ -114,7 +114,7 @@ public class HttpOptions {
             .category(OptionCategory.HTTP)
             .description("The type of the trust store file. " +
                     "If not given, the type is automatically detected based on the file extension. " +
-                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "' and no value is set, it defaults to 'BCFKS'.")
+                    "If '" + SecurityOptions.FIPS_MODE.getKey() + "' is set to '" + FipsMode.STRICT + "', Bouncy Castle is selected as the FIPS provider, and no value is set, it defaults to 'BCFKS'.")
             .build();
 
     public static final Option<Integer> HTTP_MAX_QUEUED_REQUESTS = new OptionBuilder<>("http-max-queued-requests", Integer.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/SecurityOptions.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.common.crypto.FipsProvider;
 
 public class SecurityOptions {
 
@@ -16,6 +17,14 @@ public class SecurityOptions {
                     + "This option defaults to '" + FipsMode.DISABLED + "' when '" + Profile.Feature.FIPS.getKey() + "' feature is disabled, which is by default. "
                     + "This option defaults to '" + FipsMode.NON_STRICT + "' when '" + Profile.Feature.FIPS.getKey() + "' feature is enabled.")
             .defaultValue(FipsMode.DISABLED)
+            .build();
+
+    public static final Option<FipsProvider> FIPS_PROVIDER = new OptionBuilder<>("fips-provider", FipsProvider.class)
+            .category(OptionCategory.SECURITY)
+            .expectedValues(FipsProvider.values())
+            .buildTime(true)
+            .description("The cryptographic provider used when FIPS mode is enabled. The 'auto' value uses Bouncy Castle when its FIPS provider classes are available, otherwise it uses Glassless.")
+            .defaultValue(FipsProvider.AUTO)
             .build();
 
     private static List<String> getFipsModeValues() {

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -57,6 +57,7 @@ import org.keycloak.authorization.policy.provider.PolicySpi;
 import org.keycloak.authorization.policy.provider.js.DeployedScriptPolicyFactory;
 import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.common.crypto.FipsProvider;
 import org.keycloak.common.util.MultiSiteUtils;
 import org.keycloak.common.util.StreamUtil;
 import org.keycloak.config.DatabaseOptions;
@@ -921,7 +922,10 @@ class KeycloakProcessor {
             throw new RuntimeException("FIPS mode cannot be enabled without enabling the FIPS feature --features=fips");
         }
 
-        recorder.setCryptoProvider(fipsMode);
+        FipsProvider fipsProvider = getOptionalValue(NS_KEYCLOAK_PREFIX + SecurityOptions.FIPS_PROVIDER.getKey())
+                .map(FipsProvider::valueOfOption)
+                .orElse(FipsProvider.AUTO);
+        recorder.setCryptoProvider(fipsMode, fipsProvider);
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -217,6 +217,10 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-elytron</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
             <exclusions>
                 <exclusion>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -207,6 +207,16 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-glassless</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
             <exclusions>
                 <exclusion>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -34,8 +34,8 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Enablement;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.common.crypto.FipsProvider;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.HealthOptions;
 import org.keycloak.config.HttpAccessLogOptions;
@@ -70,9 +70,12 @@ import liquibase.Scope;
 import liquibase.servicelocator.ServiceLocator;
 import org.hibernate.cfg.AvailableSettings;
 import org.infinispan.protostream.SerializationContextInitializer;
+import org.jboss.logging.Logger;
 
 @Recorder
 public class KeycloakRecorder {
+
+    private static final Logger LOG = Logger.getLogger(KeycloakRecorder.class);
 
     public void initConfig() {
         Config.init(new MicroProfileConfigProvider());
@@ -199,19 +202,25 @@ public class KeycloakRecorder {
         return propertyCollector -> propertyCollector.accept(AvailableSettings.DEFAULT_SCHEMA, Configuration.getConfigValue(DatabaseOptions.DB_SCHEMA).getValue());
     }
 
-    public void setCryptoProvider(FipsMode fipsMode) {
-        String cryptoProvider = fipsMode.getProviderClassName();
+    public void setCryptoProvider(FipsMode fipsMode, FipsProvider fipsProvider) {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        FipsProvider resolvedProvider = fipsProvider.resolve(classLoader);
+        String providerName = fipsMode.isFipsEnabled() ? resolvedProvider.toString() : "default";
+
+        if (fipsMode.isFipsEnabled() && fipsProvider == FipsProvider.AUTO) {
+            LOG.infof("Automatically selected FIPS provider: %s", resolvedProvider);
+        }
 
         try {
-            CryptoIntegration.setProvider(
-                    (CryptoProvider) Thread.currentThread().getContextClassLoader().loadClass(cryptoProvider).getDeclaredConstructor().newInstance());
-        } catch (ClassNotFoundException | NoClassDefFoundError cause) {
+            CryptoIntegration.init(classLoader, providerName, fipsMode);
+        } catch (RuntimeException | LinkageError cause) {
             if (fipsMode.isFipsEnabled()) {
-                throw new RuntimeException("Failed to configure FIPS. Make sure you have added the Bouncy Castle FIPS dependencies to the 'providers' directory.");
+                if (resolvedProvider == FipsProvider.BOUNCY_CASTLE) {
+                    throw new RuntimeException("Failed to configure FIPS. Make sure you have added the Bouncy Castle FIPS dependencies to the 'providers' directory.", cause);
+                }
+                throw new RuntimeException("Failed to configure Glassless. Java 25 or later is required.", cause);
             }
-            throw new RuntimeException("Unexpected error when configuring the crypto provider: " + cryptoProvider, cause);
-        } catch (Exception cause) {
-            throw new RuntimeException("Unexpected error when configuring the crypto provider: " + cryptoProvider, cause);
+            throw new RuntimeException("Unexpected error when configuring the crypto provider: " + providerName, cause);
         }
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -66,7 +66,10 @@ public class IgnoredArtifacts {
             "org.bouncycastle:bc-fips",
             "org.bouncycastle:bctls-fips",
             "org.bouncycastle:bcpkix-fips",
-            "org.bouncycastle:bcutil-fips"
+            "org.bouncycastle:bcutil-fips",
+            "net.glassless:glassless-provider",
+            "org.keycloak:keycloak-crypto-glassless",
+            "org.keycloak:keycloak-crypto-elytron"
     );
 
     private static Set<String> fips() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.common.crypto.FipsProvider;
 import org.keycloak.config.HttpOptions;
 import org.keycloak.config.ManagementOptions;
 import org.keycloak.config.Option;
@@ -31,6 +32,7 @@ import io.smallrye.config.ConfigSourceInterceptorContext;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isSet;
+import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromFeature;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
@@ -312,10 +314,14 @@ public final class HttpPropertyMappers implements PropertyMapperGrouping {
 
     private static String resolveKeyStoreType(String value,
             ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        if (FipsMode.STRICT.toString().equals(value)) {
-            return "BCFKS";
+        if (!FipsMode.STRICT.toString().equals(value)) {
+            return null;
         }
-        return null;
+
+        var provider = configSourceInterceptorContext.restart(NS_KEYCLOAK_PREFIX + SecurityOptions.FIPS_PROVIDER.getKey());
+        FipsProvider resolvedProvider = provider == null ? FipsProvider.AUTO : FipsProvider.valueOfOption(provider.getValue());
+        resolvedProvider = resolvedProvider.resolve(Thread.currentThread().getContextClassLoader());
+        return resolvedProvider == FipsProvider.BOUNCY_CASTLE ? "BCFKS" : null;
     }
 
     private static String resolveMaxThreads(String value,

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/SecurityPropertyMappers.java
@@ -19,6 +19,9 @@ final class SecurityPropertyMappers implements PropertyMapperGrouping {
         return List.of(
                 fromOption(SecurityOptions.FIPS_MODE).transformer(SecurityPropertyMappers::resolveFipsMode)
                         .paramLabel("mode")
+                        .build(),
+                fromOption(SecurityOptions.FIPS_PROVIDER)
+                        .paramLabel("provider")
                         .build()
         );
     }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -635,7 +635,13 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void testHttpTrustStoreType() {
         ConfigArgsConfigSource.setCliArgs("--fips-mode=strict");
+        assertNull(createConfig().getConfigValue(HttpPropertyMappers.QUARKUS_HTTPS_TRUST_STORE_FILE_TYPE).getValue());
+
+        ConfigArgsConfigSource.setCliArgs("--fips-mode=strict", "--fips-provider=bouncycastle");
         assertEquals("BCFKS", createConfig().getConfigValue(HttpPropertyMappers.QUARKUS_HTTPS_TRUST_STORE_FILE_TYPE).getValue());
+
+        ConfigArgsConfigSource.setCliArgs("--fips-mode=strict", "--fips-provider=glassless");
+        assertNull(createConfig().getConfigValue(HttpPropertyMappers.QUARKUS_HTTPS_TRUST_STORE_FILE_TYPE).getValue());
 
         ConfigArgsConfigSource.setCliArgs("--https-trust-store-type=jks");
         assertEquals("jks", createConfig().getConfigValue(HttpPropertyMappers.QUARKUS_HTTPS_TRUST_STORE_FILE_TYPE).getValue());

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifactsTest.java
@@ -69,6 +69,25 @@ public class IgnoredArtifactsTest extends AbstractConfigurationTest {
 
         var ignoredArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
         assertThat(ignoredArtifacts.containsAll(IgnoredArtifacts.FIPS_ENABLED), is(true));
+        assertThat(ignoredArtifacts.contains("org.keycloak:keycloak-crypto-glassless"), is(false));
+        assertThat(ignoredArtifacts.contains("org.keycloak:keycloak-crypto-elytron"), is(false));
+        assertThat(ignoredArtifacts.contains("org.keycloak:keycloak-crypto-fips1402"), is(false));
+        assertThat(ignoredArtifacts.contains("net.glassless:glassless-provider"), is(false));
+    }
+
+    @Test
+    public void explicitProviderKeepsAutomaticSelectionArtifacts() {
+        var profile = getProfileWithEnabledFeature(Profile.Feature.FIPS);
+        assertThat(profile.isFeatureEnabled(Profile.Feature.FIPS), is(true));
+
+        setSystemProperty(NS_KEYCLOAK_PREFIX + "fips-provider", "bouncycastle", () -> {
+            var ignoredArtifacts = IgnoredArtifacts.getDefaultIgnoredArtifacts();
+            assertThat(ignoredArtifacts.containsAll(IgnoredArtifacts.FIPS_ENABLED), is(true));
+            assertThat(ignoredArtifacts.contains("org.keycloak:keycloak-crypto-glassless"), is(false));
+            assertThat(ignoredArtifacts.contains("org.keycloak:keycloak-crypto-elytron"), is(false));
+            assertThat(ignoredArtifacts.contains("org.keycloak:keycloak-crypto-fips1402"), is(false));
+            assertThat(ignoredArtifacts.contains("net.glassless:glassless-provider"), is(false));
+        });
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ManagementConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ManagementConfigurationTest.java
@@ -320,9 +320,12 @@ public class ManagementConfigurationTest extends AbstractConfigurationTest {
     }
 
     @Test
-    public void fipsKeystoreType(){
+    public void bouncyCastleFipsKeystoreType() {
         makeInterfaceOccupied();
-        putEnvVar("KC_FIPS_MODE", "strict");
+        putEnvVars(Map.of(
+                "KC_FIPS_MODE", "strict",
+                "KC_FIPS_PROVIDER", "bouncycastle"
+        ));
 
         initConfig();
 
@@ -330,6 +333,21 @@ public class ManagementConfigurationTest extends AbstractConfigurationTest {
                 "https-key-store-type", "BCFKS",
                 "https-management-key-store-type", "BCFKS"
         ));
+        assertManagementEnabled(true);
+    }
+
+    @Test
+    public void glasslessFipsKeystoreType() {
+        makeInterfaceOccupied();
+        putEnvVars(Map.of(
+                "KC_FIPS_MODE", "strict",
+                "KC_FIPS_PROVIDER", "glassless"
+        ));
+
+        initConfig();
+
+        assertConfigNull("https-key-store-type");
+        assertConfigNull("https-management-key-store-type");
         assertManagementEnabled(true);
     }
 

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -21,6 +21,16 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-quarkus-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.glassless</groupId>
+            <artifactId>glassless-provider</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-elytron</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Only necessary for proper Maven build order - if explicitly added, deployment JARs will not be part of /lib/deployment folder -->
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -45,6 +45,7 @@ public class FipsDistTest {
             cliResult.assertStarted();
             // Not shown as FIPS is not a preview anymore
             cliResult.assertMessageWasShownExactlyNumberOfTimes("Preview features enabled: fips:v1", 0);
+            cliResult.assertMessage("Automatically selected FIPS provider: bouncycastle");
             cliResult.assertMessage("FIPS1402Provider created: KC(" + BCFIPS_VERSION + ", FIPS-JVM: " + FIPS1402Provider.isSystemFipsEnabled() + ")");
         });
     }
@@ -67,7 +68,7 @@ public class FipsDistTest {
     }
 
     @Test
-    @Launch({ "start", "--fips-mode=non-strict" })
+    @Launch({ "start", "--fips-mode=non-strict", "--fips-provider=bouncycastle" })
     void failStartDueToMissingFipsDependencies(CLIResult cliResult) {
         cliResult.assertError("Failed to configure FIPS. Make sure you have added the Bouncy Castle FIPS dependencies to the 'providers' directory.");
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/GlasslessFipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/GlasslessFipsDistTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.KeycloakRunner;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.StopServer.Mode;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+@DistributionTest(stopServer = Mode.MANUAL, defaultOptions = { "--db=dev-file", "--features=fips", "--http-enabled=true", "--hostname-strict=false" })
+@RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SLOW)
+public class GlasslessFipsDistTest {
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_25)
+    void testBundledGlasslessIsSelectedAutomatically(KeycloakRunner runner) {
+        runner.setEnvVar("JAVA_OPTS_APPEND", "--enable-native-access=ALL-UNNAMED");
+        runner.setEnvVar("KC_BOOTSTRAP_ADMIN_USERNAME", "admin");
+        runner.setEnvVar("KC_BOOTSTRAP_ADMIN_PASSWORD", "glasslessAdminPassword25");
+
+        CLIResult cliResult = runner.run("start", "--fips-mode=non-strict");
+        cliResult.assertStarted();
+        cliResult.assertMessage("Automatically selected FIPS provider: glassless");
+        cliResult.assertMessage("GlasslessCryptoProvider created: KC(GlaSSLess version 0.13.0");
+        cliResult.assertMessage("Glassless provider configuration:");
+        cliResult.assertMessage("Cipher (");
+        cliResult.assertMessage("AES/GCM/NoPadding");
+
+        when().get("/realms/master/.well-known/openid-configuration").then().statusCode(200);
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("client_id", "admin-cli")
+                .formParam("username", "admin")
+                .formParam("password", "glasslessAdminPassword25")
+                .formParam("grant_type", "password")
+                .when().post("/realms/master/protocol/openid-connect/token")
+                .then().statusCode(200)
+                .body("token_type", equalTo("Bearer"))
+                .body("access_token", not(emptyString()));
+    }
+}

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
@@ -120,6 +120,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 Examples:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -335,8 +335,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -349,8 +350,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -580,6 +582,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 Server configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -414,8 +414,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -428,8 +429,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -979,6 +981,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 OpenAPI configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -383,8 +383,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -397,8 +398,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -628,6 +630,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 Server configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -415,8 +415,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -429,8 +430,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -980,6 +982,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 OpenAPI configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -347,8 +347,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -361,8 +362,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -379,8 +379,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -393,8 +394,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -382,8 +382,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -396,8 +397,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -627,6 +629,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 Server configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -414,8 +414,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -428,8 +429,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -979,6 +981,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 OpenAPI configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -380,8 +380,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -394,8 +395,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -625,6 +627,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 Server configuration:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -412,8 +412,9 @@ HTTP(S):
                      The password of the key store file. Default: password.
 --https-key-store-type <type>
                      The type of the key store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
                      The list of protocols to explicitly enable. If a value is not supported by the
@@ -426,8 +427,9 @@ HTTP(S):
                      The password of the trust store file.
 --https-trust-store-type <type>
                      The type of the trust store file. If not given, the type is automatically
-                       detected based on the file extension. If 'fips-mode' is set to 'strict' and
-                       no value is set, it defaults to 'BCFKS'.
+                       detected based on the file extension. If 'fips-mode' is set to 'strict',
+                       Bouncy Castle is selected as the FIPS provider, and no value is set, it
+                       defaults to 'BCFKS'.
 --shutdown-delay <delay>
                      Length of the pre-shutdown phase during which the server prepares for
                        shutdown. May be an ISO 8601 duration value, an integer number of seconds,
@@ -977,6 +979,11 @@ Security:
                        which is by default. This option defaults to 'non-strict' when 'fips'
                        feature is enabled. Possible values are: non-strict, strict. Default:
                        disabled.
+--fips-provider <provider>
+                     The cryptographic provider used when FIPS mode is enabled. The 'auto' value
+                       uses Bouncy Castle when its FIPS provider classes are available, otherwise
+                       it uses Glassless. Possible values are: auto, bouncycastle, glassless.
+                       Default: auto.
 
 OpenAPI configuration:
 


### PR DESCRIPTION
## Summary

This Pull Request contains a prototype for introducing [GlaSSLess](https://glassless.net/) FIPS provider into Keycloak codebase. 

The `glassless_report.md` file contains detailed information how GlaSSLess is integrated.

## How to play with it?

The easiest way to test this out is to use a pre-built Docker container and foloowing the guide below.

### 1. Pull the image

```bash
docker pull quay.io/sebastian_laskawiec/keycloak:glassless
```

### 2. Start Keycloak

The bootstrap password below is deliberately long enough for strict FIPS mode.

```bash
CONTAINER_ID=$(docker run --detach \
  --publish 8080:8080 \
  --env KC_BOOTSTRAP_ADMIN_USERNAME=admin \
  --env KC_BOOTSTRAP_ADMIN_PASSWORD=glasslessAdminPassword25 \
  quay.io/sebastian_laskawiec/keycloak:glassless \
  start --optimized \
  --features=fips \
  --fips-mode=strict \
  --fips-provider=glassless \
  --http-enabled=true \
  --hostname-strict=false)

echo "$CONTAINER_ID"
```

The image is already optimized with these FIPS settings. Supplying them explicitly at startup makes the selected mode and provider visible and verifies that the invocation matches the optimized image.

### 3. Wait for readiness

```bash
docker logs --follow "$CONTAINER_ID"
```

The important messages are:

```text
GlasslessCryptoProvider created: KC(GlaSSLess version 0.13.0 [..., FIPS], FIPS mode: enabled, FIPS provider available: true)
Keycloak 999.0.0-SNAPSHOT on JVM ... started
```

Press `Ctrl+C` after the startup message. Then verify OpenID discovery:

```bash
curl --fail --silent --output /dev/null --write-out 'HTTP %{http_code}\n' \
  http://127.0.0.1:8080/realms/master/.well-known/openid-configuration
```

Expected result:

```text
HTTP 200
```

The administration console is available at http://127.0.0.1:8080/admin/ using `admin` and `glasslessAdminPassword25`.

### 4. Request a token

```bash
curl --fail --silent \
  --request POST \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --data client_id=admin-cli \
  --data username=admin \
  --data password=glasslessAdminPassword25 \
  --data grant_type=password \
  http://127.0.0.1:8080/realms/master/protocol/openid-connect/token
```

A successful response contains a three segment JWT `access_token` and `"token_type":"Bearer"`.

### 5. Verify Glassless and OpenSSL FIPS status

```bash
docker exec "$CONTAINER_ID" \
  java --enable-native-access=ALL-UNNAMED \
  -jar /opt/keycloak/providers/glassless-provider-0.13.0.jar
```

Expected result:

```text
Provider: GlaSSLess v0.13.0
FIPS Mode: ENABLED
FIPS Provider Available: true
OpenSSL FIPS Enabled: true
Hybrid Mode: DISABLED
```

Verify the persisted Keycloak provider selection:

```bash
docker exec "$CONTAINER_ID" /opt/keycloak/bin/kc.sh show-config
```

Expected configuration includes:

```text
kc.fips-provider = glassless (Persisted)
kc.features = fips (Persisted)
kc.optimized = true (Persisted)
```