### PR TITLE
Fix FreeMarkerLoginFormsProvider calling handleThemeResources twice per render (26.6)

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -503,7 +503,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
         if (realm != null) {
             RealmBean realmBean = new RealmBean(realm);
             attributes.put("realm", realmBean);
-            attributes.put("title", getMessage("loginTitle", realmBean.getDisplayName()));
+            attributes.put("title", formatMessage(new FormMessage(null, "loginTitle", realmBean.getDisplayName()), messagesBundle, locale));
 
             IdentityProviderBean idpBean = new IdentityProviderBean(session, realm, baseUriWithCodeAndClientId, context);
 


### PR DESCRIPTION
Closes #49718

PR:             https://github.com/keycloak/keycloak/pull/49719
Commit:         https://github.com/keycloak/keycloak/commit/7dd3fc87dfe7c134c61a62e81d79785da102e99b
PR branch:      backport-49719-26.6
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.6

Signed-off-by: maeberl <markus.eberl@eventim.de>
(cherry picked from commit 7dd3fc87dfe7c134c61a62e81d79785da102e99b)
