### PR TITLE
Passkey icons use wrong color variant when realm disables dark mode

### DIFF
--- a/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/index.ftl
+++ b/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/index.ftl
@@ -155,6 +155,7 @@
         "resourceUrl": "${resourceUrl}",
         "logo": "${properties.logo!""}",
         "logoUrl": "${properties.logoUrl!""}",
+        "darkMode": ${darkMode?c},
         "baseUrl": "${baseUrl}",
         "locale": "${locale}",
         "referrerName": "${referrerName!""}",

--- a/js/apps/account-ui/src/account-security/SigningIn.tsx
+++ b/js/apps/account-ui/src/account-security/SigningIn.tsx
@@ -130,7 +130,7 @@ export const SigningIn = () => {
             >
               <div className="pf-v5-c-icon pf-m-xl">
                 <picture>
-                  {iconDarkSrc && (
+                  {context.environment.darkMode && iconDarkSrc && (
                     <source
                       srcSet={iconDarkSrc}
                       media="(prefers-color-scheme: dark)"

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/index.ftl
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/index.ftl
@@ -156,6 +156,7 @@
         "resourceUrl": "${resourceUrl}",
         "logo": "${properties.logo!""}",
         "logoUrl": "${properties.logoUrl!""}",
+        "darkMode": ${darkMode?c},
         "consoleBaseUrl": "${consoleBaseUrl}",
         "masterRealm": "${masterRealm}",
         "resourceVersion": "${resourceVersion}"

--- a/js/apps/create-keycloak-theme/templates/maven-resources/theme/my-account/account/index.ftl.mu
+++ b/js/apps/create-keycloak-theme/templates/maven-resources/theme/my-account/account/index.ftl.mu
@@ -126,6 +126,7 @@
         "resourceUrl": "${resourceUrl}",
         "logo": "${properties.logo!""}",
         "logoUrl": "${properties.logoUrl!""}",
+        "darkMode": ${darkMode?c},
         "baseUrl": "${baseUrl}",
         "locale": "${locale}",
         "referrerName": "${referrerName!""}",

--- a/js/libs/ui-shared/src/context/environment.ts
+++ b/js/libs/ui-shared/src/context/environment.ts
@@ -19,6 +19,8 @@ export type BaseEnvironment = {
   logo: string;
   /** The URL to be followed when the logo is clicked. */
   logoUrl: string;
+  /** Whether dark mode is enabled for the realm. */
+  darkMode: boolean;
   /** The scopes to be requested when sending authorization requests*/
   scope?: string;
 };

--- a/themes/src/main/resources/theme/keycloak.v2/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/webauthn-authenticate.ftl
@@ -38,7 +38,7 @@
                                             <div class="${properties.kcWebAuthnDefaultIcon!}">
                                             <#if authenticator.iconLight?? || authenticator.iconDark??>
                                                 <picture>
-                                                    <#if authenticator.iconDark??>
+                                                    <#if darkMode && authenticator.iconDark??>
                                                         <source srcset="${url.resourcesPath}/img/passkeys/${authenticator.iconDark}" media="(prefers-color-scheme: dark)">
                                                     </#if>
                                                     <img src="${url.resourcesPath}/img/passkeys/${authenticator.iconLight!authenticator.iconDark!''}" alt="" width="40" height="40">


### PR DESCRIPTION
- Closes #51087

Resolves the issue: 

https://github.com/user-attachments/assets/8e31d0e0-7f0b-4379-b987-c93f53ea308b


https://github.com/user-attachments/assets/7f855fc8-965c-43b1-8282-6715f30e7608


@edewit Could you please check it? I'd like to backport it to 26.7, and I mark the darkMode as required in the environment. I think it should be fine as users always uses the same server version and console versions, right? 
