### PR TITLE
fix: moving waiting into the assertMessage method

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -297,8 +297,7 @@ public class LoggingDistTest {
 
         when().get("http://127.0.0.1:8080/realms/master/.well-known/openid-configuration").then()
                 .statusCode(200);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(
-                () -> assertThat(cliResult.getOutput(), containsString("{kc.realmName=master} DEBUG [org.keycloak.")));
+        cliResult.assertMessage("{kc.realmName=master} DEBUG [org.keycloak.");
         cliResult.assertStartedDevMode();
     }
 
@@ -328,10 +327,8 @@ public class LoggingDistTest {
     void httpAccessLogNotNamedPattern(CLIResult cliResult, KeycloakRunner runner, RawDistRootPath path) {
         when().get("http://127.0.0.1:8080/realms/master/.well-known/openid-configuration").then()
                 .statusCode(200);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(
-                () -> cliResult.assertMessage("[org.keycloak.http.access-log]"));
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(
-                () -> cliResult.assertMessage("127.0.0.1 GET /realms/master/.well-known/openid-configuration"));
+        cliResult.assertMessage("[org.keycloak.http.access-log]");
+        cliResult.assertMessage("127.0.0.1 GET /realms/master/.well-known/openid-configuration");
 
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -18,12 +18,15 @@
 package org.keycloak.it.junit5.extension;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.main.LaunchResult;
+import org.awaitility.Awaitility;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -44,8 +47,17 @@ public interface CLIResult extends LaunchResult {
             }
 
             @Override
+            public String getOutput() {
+                synchronized (outputStream) {
+                    return String.join("\n", outputStream);            
+                }
+            }
+
+            @Override
             public String getErrorOutput() {
-                return String.join("\n", errStream).replace("\r","");
+                synchronized (errStream) {
+                    return String.join("\n", errStream).replace("\r","");            
+                }
             }
 
             @Override
@@ -60,6 +72,20 @@ public interface CLIResult extends LaunchResult {
         };
     }
 
+    private static void awaitOutput(String reason, String message, Supplier<String> supplier, CLIResult result) {
+        if (result.exitCode() == -1) {
+            Awaitility.await(reason)
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(reason, supplier.get(), containsString(message)));
+        } else {
+            assertThat(reason, supplier.get(), containsString(message));
+        }
+    }
+    
+    private static void noOutput(String reason, String message, Supplier<String> supplier, CLIResult result) {
+        assertThat(reason, supplier.get(), not(containsString(message)));
+    }
+    
     default void assertStarted() {
         assertThat("The standard output should not contain a warning about log queue overrun.",
                 getOutput(), not(containsString("The delayed handler's queue was overrun and log record(s) were lost (Did you forget to configure logging?)")));
@@ -79,13 +105,11 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertError(String msg) {
-        assertThat("The error output does not contain: " + msg,
-                getErrorOutput(), containsString(msg));
+        awaitOutput("The error output does not contain: " + msg, msg, this::getErrorOutput, this);
     }
 
     default void assertNoError(String msg) {
-        assertThat("The error output contains: " + msg,
-                getErrorOutput(), not(containsString(msg)));
+        noOutput("The error output contains: " + msg, msg, this::getErrorOutput, this);
     }
 
     default void assertWarning(String msg) {
@@ -97,11 +121,11 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertMessage(String message) {
-        assertThat(getOutput(), containsString(message));
+        awaitOutput("The standard output does not contain: " + message, message, this::getOutput, this);
     }
 
     default void assertNoMessage(String message) {
-        assertThat(getOutput(), not(containsString(message)));
+        noOutput("The standard output contains: " + message, message, this::getOutput, this);
     }
 
     default void assertMessageWasShownExactlyNumberOfTimes(String message, long numberOfShownTimes) {

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -22,10 +22,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,11 +40,11 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -156,9 +156,19 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         Process proc = builder.start();
 
         DefaultOutputConsumer outputConsumer = new DefaultOutputConsumer();
-        readOutput(proc, outputConsumer);
-
-        int exitValue = proc.exitValue();
+        var executor = Executors.newCachedThreadPool();
+        int exitValue = -1;
+        try {
+            readOutput(proc, outputConsumer, executor).get();
+            exitValue = proc.waitFor();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        } finally {
+            executor.shutdownNow();
+        }
 
         return CLIResult.create(outputConsumer.getStdOut(), outputConsumer.getErrOut(), exitValue);
     }
@@ -292,8 +302,8 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
 
     private void asyncReadOutput() {
         shutdownOutputExecutor();
-        outputExecutor = Executors.newSingleThreadExecutor();
-        outputExecutor.execute(this::readOutput);
+        outputExecutor = Executors.newCachedThreadPool();
+        readOutput(keycloak, outputConsumer, outputExecutor);
     }
 
     private void shutdownOutputExecutor() {
@@ -414,36 +424,21 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         }
     }
 
-    private void readOutput() {
-        readOutput(keycloak, outputConsumer);
+    private CompletableFuture<Void> readOutput(Process process, OutputConsumer outputConsumer, Executor ex) {
+        var inputFuture = CompletableFuture.runAsync(() -> readOutput(process, process.inputReader(StandardCharsets.UTF_8), outputConsumer::onStdOut), ex);
+        var errorFuture = CompletableFuture.runAsync(() -> readOutput(process, process.errorReader(StandardCharsets.UTF_8), outputConsumer::onErrOut), ex);
+        return CompletableFuture.allOf(inputFuture, errorFuture);
     }
 
-    private void readOutput(Process process, OutputConsumer outputConsumer) {
-        try (
-                BufferedReader outStream = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                BufferedReader errStream = new BufferedReader(new InputStreamReader(process.getErrorStream()))
-        ) {
-            while (process.isAlive()) {
-                readStream(outStream, outputConsumer, false);
-                readStream(errStream, outputConsumer, true);
-                // a hint to temporarily disable the current thread in favor of the process where the distribution is running
-                // after some tests it shows effective to help starting the server faster
-                LockSupport.parkNanos(1L);
-            }
-        } catch (Throwable cause) {
-            throw new RuntimeException("Failed to read server output", cause);
-        }
-    }
+    private void readOutput(Process process, BufferedReader reader, Consumer<String> outputConsumer) {
+        try (reader) {
+            String line;
 
-    private void readStream(BufferedReader reader, OutputConsumer outputConsumer, boolean error) throws IOException {
-        String line;
-
-        while (reader.ready() && (line = reader.readLine()) != null) {
-            if (error) {
-                outputConsumer.onErrOut(line);
-            } else {
-                outputConsumer.onStdOut(line);
+            while ((line = reader.readLine()) != null) {
+                outputConsumer.accept(line);
             }
+        } catch (IOException cause) {
+            throw new UncheckedIOException(cause);
         }
     }
 


### PR DESCRIPTION
Awaitability was being used inconsistently around assertMessage calls, so it seems better to just embed the waiting in the CLIResult logic.

also making output reading more fool-proof

Based upon the copilot comments, it will also address flakyness such as https://github.com/keycloak/keycloak/actions/runs/29988894966/job/89147575751?pr=50324#step:5:3799

close: #51070

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
