### PR TITLE
[26.4] CVE-2026-45292: size-limiting baggage propagator wrapper

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagator.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagator.java
@@ -1,7 +1,6 @@
 package org.keycloak.quarkus.runtime.tracing;
 
 import java.util.Collection;
-import java.util.Iterator;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
@@ -53,28 +52,20 @@ public class SizeLimitedBaggagePropagator implements TextMapPropagator {
             return context;
         }
 
-        Iterator<String> headers = getter.getAll(carrier, BAGGAGE_HEADER);
-        if (headers == null || !headers.hasNext()) {
+        // Uses get() instead of getAll() (added in OTel 1.45.0) — equivalent protection since
+        // OTel 1.44.x propagator itself only reads a single header
+        String header = getter.get(carrier, BAGGAGE_HEADER);
+        if (header == null || header.isEmpty()) {
             return delegate.extract(context, carrier, getter);
         }
 
-        int totalBytes = 0;
-        int totalEntries = 0;
-        while (headers.hasNext()) {
-            String header = headers.next();
-            if (header == null || header.isEmpty()) {
-                continue;
-            }
-            totalBytes += header.length();
-            if (totalBytes > MAX_BAGGAGE_BYTES) {
-                log.debugf("Dropping oversized baggage headers (%d bytes cumulative, max %d)", totalBytes, MAX_BAGGAGE_BYTES);
-                return context;
-            }
-            totalEntries += countEntries(header);
-            if (totalEntries > MAX_BAGGAGE_ENTRIES) {
-                log.debugf("Dropping baggage headers with too many entries (%d cumulative, max %d)", totalEntries, MAX_BAGGAGE_ENTRIES);
-                return context;
-            }
+        if (header.length() > MAX_BAGGAGE_BYTES) {
+            log.debugf("Dropping oversized baggage header (%d bytes, max %d)", header.length(), MAX_BAGGAGE_BYTES);
+            return context;
+        }
+        if (countEntries(header) > MAX_BAGGAGE_ENTRIES) {
+            log.debugf("Dropping baggage header with too many entries (%d, max %d)", countEntries(header), MAX_BAGGAGE_ENTRIES);
+            return context;
         }
 
         return delegate.extract(context, carrier, getter);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagator.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagator.java
@@ -1,0 +1,92 @@
+package org.keycloak.quarkus.runtime.tracing;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import org.jboss.logging.Logger;
+
+/**
+ * Wraps a {@link TextMapPropagator} (typically {@code W3CBaggagePropagator}) and enforces
+ * W3C Baggage specification size limits before delegating extraction.
+ *
+ * <p>CVE-2026-45292: OTel SDK &le; 1.61.0 performs unbounded memory allocation when parsing
+ * oversized {@code baggage} headers. This wrapper short-circuits extraction when the header
+ * exceeds the spec limits, preventing the vulnerable code path from executing.
+ *
+ * @see <a href="https://github.com/advisories/GHSA-rcgg-9c38-7xpx">GHSA-rcgg-9c38-7xpx</a>
+ * @see <a href="https://www.w3.org/TR/baggage/#limits">W3C Baggage - Limits</a>
+ */
+public class SizeLimitedBaggagePropagator implements TextMapPropagator {
+
+    private static final Logger log = Logger.getLogger(SizeLimitedBaggagePropagator.class);
+
+    static final int MAX_BAGGAGE_BYTES = 8192;
+    static final int MAX_BAGGAGE_ENTRIES = 64;
+    private static final String BAGGAGE_HEADER = "baggage";
+
+    private final TextMapPropagator delegate;
+
+    public SizeLimitedBaggagePropagator(TextMapPropagator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Collection<String> fields() {
+        return delegate.fields();
+    }
+
+    @Override
+    public <C> void inject(Context context, C carrier, TextMapSetter<C> setter) {
+        delegate.inject(context, carrier, setter);
+    }
+
+    @Override
+    public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter) {
+        if (context == null) {
+            context = Context.root();
+        }
+        if (carrier == null || getter == null) {
+            return context;
+        }
+
+        Iterator<String> headers = getter.getAll(carrier, BAGGAGE_HEADER);
+        if (headers == null || !headers.hasNext()) {
+            return delegate.extract(context, carrier, getter);
+        }
+
+        int totalBytes = 0;
+        int totalEntries = 0;
+        while (headers.hasNext()) {
+            String header = headers.next();
+            if (header == null || header.isEmpty()) {
+                continue;
+            }
+            totalBytes += header.length();
+            if (totalBytes > MAX_BAGGAGE_BYTES) {
+                log.debugf("Dropping oversized baggage headers (%d bytes cumulative, max %d)", totalBytes, MAX_BAGGAGE_BYTES);
+                return context;
+            }
+            totalEntries += countEntries(header);
+            if (totalEntries > MAX_BAGGAGE_ENTRIES) {
+                log.debugf("Dropping baggage headers with too many entries (%d cumulative, max %d)", totalEntries, MAX_BAGGAGE_ENTRIES);
+                return context;
+            }
+        }
+
+        return delegate.extract(context, carrier, getter);
+    }
+
+    private static int countEntries(String baggage) {
+        int count = 1;
+        for (int i = 0, len = baggage.length(); i < len; i++) {
+            if (baggage.charAt(i) == ',') {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagatorCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagatorCustomizer.java
@@ -1,0 +1,31 @@
+package org.keycloak.quarkus.runtime.tracing;
+
+import jakarta.inject.Singleton;
+
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.quarkus.opentelemetry.runtime.propagation.TextMapPropagatorCustomizer;
+
+/**
+ * Wraps the {@link W3CBaggagePropagator} with a {@link SizeLimitedBaggagePropagator}
+ * that enforces W3C Baggage specification size limits before delegating extraction.
+ *
+ * <p>Workaround for CVE-2026-45292 on OTel SDK versions that lack built-in limits (&le; 1.61.0).
+ *
+ * // TODO: remove this workaround when Keycloak upgrades to a Quarkus version shipping OTel >= 1.62.0
+ * // see https://github.com/keycloak/keycloak/issues/49570
+ *
+ * @see SizeLimitedBaggagePropagator
+ */
+@Singleton
+public class SizeLimitedBaggagePropagatorCustomizer implements TextMapPropagatorCustomizer {
+
+    @Override
+    public TextMapPropagator customize(Context context) {
+        TextMapPropagator propagator = context.propagator();
+        if (propagator instanceof W3CBaggagePropagator) {
+            return new SizeLimitedBaggagePropagator(propagator);
+        }
+        return propagator;
+    }
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagatorTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagatorTest.java
@@ -1,0 +1,213 @@
+package org.keycloak.quarkus.runtime.tracing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that {@link SizeLimitedBaggagePropagator} enforces W3C Baggage limits,
+ * preventing CVE-2026-45292 regardless of the underlying OTel SDK version.
+ */
+public class SizeLimitedBaggagePropagatorTest {
+
+    private static final TextMapGetter<Map<String, String>> GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier) {
+            return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key) {
+            return carrier.get(key);
+        }
+
+        @Override
+        public Iterator<String> getAll(Map<String, String> carrier, String key) {
+            String value = carrier.get(key);
+            return value != null
+                    ? Collections.singletonList(value).iterator()
+                    : Collections.emptyIterator();
+        }
+    };
+
+    private final TextMapPropagator propagator =
+            new SizeLimitedBaggagePropagator(W3CBaggagePropagator.getInstance());
+
+    @Test
+    public void testExcessiveEntryCountIsBlocked() {
+        int attackEntryCount = 500;
+        StringBuilder header = new StringBuilder();
+        for (int i = 0; i < attackEntryCount; i++) {
+            if (i > 0) header.append(",");
+            header.append("key").append(i).append("=value").append(i);
+        }
+
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("baggage", header.toString());
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Oversized baggage (500 entries) must be dropped entirely", 0, baggage.size());
+    }
+
+    @Test
+    public void testOversizedBaggageHeaderIsBlocked() {
+        String longValue = "x".repeat(SizeLimitedBaggagePropagator.MAX_BAGGAGE_BYTES);
+        String header = "oversized-key=" + longValue;
+
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("baggage", header);
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Oversized baggage (>8192 bytes) must be dropped entirely", 0, baggage.size());
+    }
+
+    @Test
+    public void testNormalBaggagePassesThrough() {
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("baggage", "tenant=acme,request-id=abc-123,feature-flag=dark-mode");
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Normal baggage (3 entries) must be extracted", 3, baggage.size());
+        assertEquals("acme", baggage.getEntryValue("tenant"));
+        assertEquals("abc-123", baggage.getEntryValue("request-id"));
+        assertEquals("dark-mode", baggage.getEntryValue("feature-flag"));
+    }
+
+    @Test
+    public void testBaggageAtExactEntryLimitPassesThrough() {
+        StringBuilder header = new StringBuilder();
+        for (int i = 0; i < SizeLimitedBaggagePropagator.MAX_BAGGAGE_ENTRIES; i++) {
+            if (i > 0) header.append(",");
+            header.append("k").append(i).append("=v").append(i);
+        }
+
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("baggage", header.toString());
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Baggage at exactly the entry limit must be extracted",
+                SizeLimitedBaggagePropagator.MAX_BAGGAGE_ENTRIES, baggage.size());
+    }
+
+    @Test
+    public void testBaggageOneOverEntryLimitIsBlocked() {
+        int overLimit = SizeLimitedBaggagePropagator.MAX_BAGGAGE_ENTRIES + 1;
+        StringBuilder header = new StringBuilder();
+        for (int i = 0; i < overLimit; i++) {
+            if (i > 0) header.append(",");
+            header.append("k").append(i).append("=v").append(i);
+        }
+
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("baggage", header.toString());
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Baggage one over the entry limit must be dropped", 0, baggage.size());
+    }
+
+    @Test
+    public void testBaggageAtExactByteLimitPassesThrough() {
+        String key = "k";
+        String value = "x".repeat(SizeLimitedBaggagePropagator.MAX_BAGGAGE_BYTES - key.length() - 1);
+        String header = key + "=" + value;
+        assertEquals(SizeLimitedBaggagePropagator.MAX_BAGGAGE_BYTES, header.length());
+
+        Map<String, String> carrier = new HashMap<>();
+        carrier.put("baggage", header);
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Baggage at exactly the byte limit must be extracted", 1, baggage.size());
+    }
+
+    @Test
+    public void testMultipleHeadersCumulativeEntryCountIsBlocked() {
+        MultiValueCarrier carrier = new MultiValueCarrier();
+        for (int i = 0; i < 5; i++) {
+            StringBuilder header = new StringBuilder();
+            for (int j = 0; j < 20; j++) {
+                if (j > 0) header.append(",");
+                header.append("k").append(i * 20 + j).append("=v").append(i * 20 + j);
+            }
+            carrier.add("baggage", header.toString());
+        }
+
+        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Multiple headers with 100 cumulative entries must be dropped", 0, baggage.size());
+    }
+
+    @Test
+    public void testMultipleHeadersCumulativeBytesIsBlocked() {
+        MultiValueCarrier carrier = new MultiValueCarrier();
+        String chunk = "k=" + "x".repeat(5000);
+        carrier.add("baggage", chunk);
+        carrier.add("baggage", chunk);
+
+        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Multiple headers exceeding cumulative byte limit must be dropped", 0, baggage.size());
+    }
+
+    @Test
+    public void testNoBaggageHeaderPassesThrough() {
+        Map<String, String> carrier = new HashMap<>();
+
+        Context ctx = propagator.extract(Context.root(), carrier, GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("No baggage header must result in empty baggage", 0, baggage.size());
+    }
+
+    private static class MultiValueCarrier {
+        private final Map<String, List<String>> headers = new HashMap<>();
+
+        void add(String key, String value) {
+            headers.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+    }
+
+    private static final TextMapGetter<MultiValueCarrier> MULTI_GETTER = new TextMapGetter<>() {
+        @Override
+        public Iterable<String> keys(MultiValueCarrier carrier) {
+            return carrier.headers.keySet();
+        }
+
+        @Override
+        public String get(MultiValueCarrier carrier, String key) {
+            List<String> values = carrier.headers.get(key);
+            return values != null && !values.isEmpty() ? values.get(0) : null;
+        }
+
+        @Override
+        public Iterator<String> getAll(MultiValueCarrier carrier, String key) {
+            List<String> values = carrier.headers.get(key);
+            return values != null ? values.iterator() : Collections.emptyIterator();
+        }
+    };
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagatorTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/tracing/SizeLimitedBaggagePropagatorTest.java
@@ -1,9 +1,7 @@
 package org.keycloak.quarkus.runtime.tracing;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -31,14 +29,6 @@ public class SizeLimitedBaggagePropagatorTest {
         @Override
         public String get(Map<String, String> carrier, String key) {
             return carrier.get(key);
-        }
-
-        @Override
-        public Iterator<String> getAll(Map<String, String> carrier, String key) {
-            String value = carrier.get(key);
-            return value != null
-                    ? Collections.singletonList(value).iterator()
-                    : Collections.emptyIterator();
         }
     };
 
@@ -144,37 +134,6 @@ public class SizeLimitedBaggagePropagatorTest {
     }
 
     @Test
-    public void testMultipleHeadersCumulativeEntryCountIsBlocked() {
-        MultiValueCarrier carrier = new MultiValueCarrier();
-        for (int i = 0; i < 5; i++) {
-            StringBuilder header = new StringBuilder();
-            for (int j = 0; j < 20; j++) {
-                if (j > 0) header.append(",");
-                header.append("k").append(i * 20 + j).append("=v").append(i * 20 + j);
-            }
-            carrier.add("baggage", header.toString());
-        }
-
-        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
-        Baggage baggage = Baggage.fromContext(ctx);
-
-        assertEquals("Multiple headers with 100 cumulative entries must be dropped", 0, baggage.size());
-    }
-
-    @Test
-    public void testMultipleHeadersCumulativeBytesIsBlocked() {
-        MultiValueCarrier carrier = new MultiValueCarrier();
-        String chunk = "k=" + "x".repeat(5000);
-        carrier.add("baggage", chunk);
-        carrier.add("baggage", chunk);
-
-        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
-        Baggage baggage = Baggage.fromContext(ctx);
-
-        assertEquals("Multiple headers exceeding cumulative byte limit must be dropped", 0, baggage.size());
-    }
-
-    @Test
     public void testNoBaggageHeaderPassesThrough() {
         Map<String, String> carrier = new HashMap<>();
 
@@ -182,6 +141,48 @@ public class SizeLimitedBaggagePropagatorTest {
         Baggage baggage = Baggage.fromContext(ctx);
 
         assertEquals("No baggage header must result in empty baggage", 0, baggage.size());
+    }
+
+    // On OTel 1.44.x, get() returns only the first header - extra baggage headers are ignored by both the wrapper and the delegate propagator.
+
+    @Test
+    public void testMultipleHeadersOnlyFirstIsChecked() {
+        MultiValueCarrier carrier = new MultiValueCarrier();
+        carrier.add("baggage", "tenant=acme");
+        carrier.add("baggage", "extra=ignored");
+
+        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Only first baggage header must be extracted", 1, baggage.size());
+        assertEquals("acme", baggage.getEntryValue("tenant"));
+    }
+
+    @Test
+    public void testMultipleHeadersOversizedFirstIsBlocked() {
+        MultiValueCarrier carrier = new MultiValueCarrier();
+        String oversized = "k=" + "x".repeat(SizeLimitedBaggagePropagator.MAX_BAGGAGE_BYTES);
+        carrier.add("baggage", oversized);
+        carrier.add("baggage", "safe=value");
+
+        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Oversized first baggage header must be dropped", 0, baggage.size());
+    }
+
+    @Test
+    public void testMultipleHeadersOversizedSecondIsIgnored() {
+        MultiValueCarrier carrier = new MultiValueCarrier();
+        carrier.add("baggage", "tenant=acme");
+        String oversized = "k=" + "x".repeat(SizeLimitedBaggagePropagator.MAX_BAGGAGE_BYTES);
+        carrier.add("baggage", oversized);
+
+        Context ctx = propagator.extract(Context.root(), carrier, MULTI_GETTER);
+        Baggage baggage = Baggage.fromContext(ctx);
+
+        assertEquals("Oversized second baggage header must be ignored, first must be extracted", 1, baggage.size());
+        assertEquals("acme", baggage.getEntryValue("tenant"));
     }
 
     private static class MultiValueCarrier {
@@ -202,12 +203,6 @@ public class SizeLimitedBaggagePropagatorTest {
         public String get(MultiValueCarrier carrier, String key) {
             List<String> values = carrier.headers.get(key);
             return values != null && !values.isEmpty() ? values.get(0) : null;
-        }
-
-        @Override
-        public Iterator<String> getAll(MultiValueCarrier carrier, String key) {
-            List<String> values = carrier.headers.get(key);
-            return values != null ? values.iterator() : Collections.emptyIterator();
         }
     };
 }


### PR DESCRIPTION
Closes: #49570

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Cherry-picked from: https://github.com/keycloak/keycloak/commit/9bb7a957b57db1be7d3b9f14d61ed611a9ffd67b

Edit:
It needed to be adapted for OTel 1.44.x (Quarkus 3.27) that is used in 26.4. It uses `getter.get()` instead of `getAll()`, which is not available in that OTel version. This provides equivalent protection because OTel 1.44.x's `W3CBaggagePropagator` itself only reads a single header via `get()` (multi-header support was added in OTel 1.45.0). See the changes in the separate commit.