### PR TITLE
Wait for AUTH_RESPONSE page in MultipleTabsLoginTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
@@ -65,6 +65,7 @@ import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.util.BrowserTabUtil;
 import org.keycloak.testsuite.util.InfinispanTestTimeServiceRule;
 import org.keycloak.testsuite.util.MailServer;
+import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
@@ -341,7 +342,6 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
             multipleTabsParallelLogin(tabUtil);
 
             waitForAppPage(() -> loginPage.resetPassword());
-            WaitUtils.waitForPageToLoad();
             Assertions.assertTrue(oauth.parseLoginResponse().isError());
             events.skip(4);
             assertOnAppPageWithAlreadyLoggedInError(EventType.RESET_PASSWORD_ERROR);
@@ -426,9 +426,7 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
             tabUtil.closeTab(1);
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(1));
 
-            waitForAppPage(() -> {
-                driver.navigate().refresh();
-            });
+            waitForAppPage(() -> driver.navigate().refresh());
             Assertions.assertTrue(oauth.parseLoginResponse().isError());
             events.skip(6);
             assertOnAppPageWithAlreadyLoggedInError(EventType.LOGIN_ERROR);
@@ -1088,5 +1086,6 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
             // error and being redirected to client
             htmlUnitAction.run();
         }
+        UIUtils.currentTitleEquals("AUTH_RESPONSE");
     }
 }


### PR DESCRIPTION
Closes #51076
Closes #51075
Closes #51074
Closes #51073

Add a wait for the authentication response page. This was failing in several places in the `MultipleTabsLoginTest`. Don't know why this is happening now, probably some upgrade or similar. I have tested this locally and in the CI I executed both chrome and firefox 20 times each in https://github.com/rmartinc/keycloak/actions/runs/29931372085.
