### PR TITLE
Hydrate group listings with a single query instead of one lookup per group

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -185,10 +185,10 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
     @Override
     public Stream<GroupModel> getSubGroupsStream(String search, Boolean exact, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
-        CriteriaQuery<String> queryBuilder = builder.createQuery(String.class);
+        CriteriaQuery<GroupEntity> queryBuilder = builder.createQuery(GroupEntity.class);
         Root<GroupEntity> root = queryBuilder.from(GroupEntity.class);
 
-        queryBuilder.select(root.get("id"));
+        queryBuilder.select(root);
 
         List<Predicate> predicates = new ArrayList<>();
 
@@ -216,6 +216,9 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
         queryBuilder.orderBy(builder.asc(root.get("name")));
 
         return closing(paginateQuery(em.createQuery(queryBuilder), firstResult, maxResults).getResultStream()
+                // The selected entities are managed by the persistence context, so the by-id lookup is served
+                // from it (or the group cache) without issuing one additional query per group.
+                .map(GroupEntity::getId)
                 .map(realm::getGroupById)
                 // In concurrent tests, the group might be deleted in another thread, therefore, skip those null values.
                 .filter(Objects::nonNull)

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -781,10 +781,10 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     @Override
     public Stream<GroupModel> getTopLevelGroupsStream(RealmModel realm, String search, Boolean exact, Integer firstResult, Integer maxResults) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
-        CriteriaQuery<String> queryBuilder = builder.createQuery(String.class);
+        CriteriaQuery<GroupEntity> queryBuilder = builder.createQuery(GroupEntity.class);
         Root<GroupEntity> root = queryBuilder.from(GroupEntity.class);
 
-        queryBuilder.select(root.get("id"));
+        queryBuilder.select(root);
 
         List<Predicate> predicates = new ArrayList<>();
 
@@ -804,6 +804,9 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         queryBuilder.orderBy(builder.asc(root.get("name")));
 
         return closing(paginateQuery(em.createQuery(queryBuilder), firstResult, maxResults).getResultStream()
+            // The selected entities are managed by the persistence context, so the by-id lookup is served
+            // from it (or the group cache) without issuing one additional query per group.
+            .map(GroupEntity::getId)
             .map(realm::getGroupById)
             // In concurrent tests, the group might be deleted in another thread, therefore, skip those null values.
             .filter(Objects::nonNull)
@@ -1422,10 +1425,10 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     @Override
     public Stream<GroupModel> searchForGroupByNameStream(RealmModel realm, String search, Boolean exact, Integer first, Integer max) {
         CriteriaBuilder builder = em.getCriteriaBuilder();
-        CriteriaQuery<String> queryBuilder = builder.createQuery(String.class);
+        CriteriaQuery<GroupEntity> queryBuilder = builder.createQuery(GroupEntity.class);
         Root<GroupEntity> root = queryBuilder.from(GroupEntity.class);
 
-        queryBuilder.select(root.get("id"));
+        queryBuilder.select(root);
 
         List<Predicate> predicates = new ArrayList<>();
 
@@ -1445,6 +1448,9 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         queryBuilder.orderBy(builder.asc(root.get("name")));
 
         return closing(paginateQuery(em.createQuery(queryBuilder), first, max).getResultStream()
+                // The selected entities are managed by the persistence context, so the by-id lookup is served
+                // from it (or the group cache) without issuing one additional query per group.
+                .map(GroupEntity::getId)
                 .map(id -> session.groups().getGroupById(realm, id))
                 .filter(Objects::nonNull)
                 .distinct());

--- a/tests/base/src/test/java/org/keycloak/tests/model/GroupListingQueryCountTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/GroupListingQueryCountTest.java
@@ -1,0 +1,119 @@
+package org.keycloak.tests.model;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.cache.CacheRealmProvider;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.remote.annotations.TestOnServer;
+
+import org.hibernate.Session;
+import org.hibernate.SessionEventListener;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KeycloakIntegrationTest
+public class GroupListingQueryCountTest {
+
+    private static final int GROUP_COUNT = 25;
+    private static final int PAGE_SIZE = 20;
+
+    @InjectRealm(config = GroupListingRealmConfig.class)
+    ManagedRealm realm;
+
+    @TestOnServer
+    public void topLevelGroupsPageIsHydratedByASingleQuery(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        long count = countColdPageQueries(session, () ->
+                session.groups().getTopLevelGroupsStream(realm, 0, PAGE_SIZE).collect(Collectors.toList()));
+        // The page of groups is selected as entities in one query; hydrating the models must not
+        // issue one additional lookup per group.
+        assertThat(count, is(1L));
+    }
+
+    @TestOnServer
+    public void searchByNamePageIsHydratedByASingleQuery(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        long count = countColdPageQueries(session, () ->
+                session.groups().searchForGroupByNameStream(realm, "grp", false, GROUP_COUNT - PAGE_SIZE, PAGE_SIZE)
+                        .collect(Collectors.toList()));
+        assertThat(count, is(1L));
+    }
+
+    @TestOnServer
+    public void subGroupsPageIsHydratedByASingleQuery(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        GroupModel parent = session.groups().searchForGroupByNameStream(realm, "sub-parent", true, 0, 1)
+                .findFirst().orElseGet(() -> session.groups().createGroup(realm, "sub-parent"));
+        Set<String> existing = parent.getSubGroupsStream().map(GroupModel::getName).collect(Collectors.toSet());
+        for (int i = 0; i < GROUP_COUNT; i++) {
+            String name = String.format("sub-%02d", i);
+            if (!existing.contains(name)) {
+                session.groups().createGroup(realm, name, parent);
+            }
+        }
+        long count = countColdPageQueries(session, () ->
+                parent.getSubGroupsStream(null, false, 0, PAGE_SIZE).collect(Collectors.toList()));
+        assertThat(count, is(1L));
+    }
+
+    /**
+     * Measures the statements needed to load a page of groups when the group cache cannot serve them,
+     * as after an eviction or on another cluster node. The warmup run collects the ids of the page,
+     * registering an invalidation for each id forces the by-id resolution to the store, and clearing
+     * the persistence context makes sure the warmup run cannot satisfy those lookups either.
+     * ({@code CacheRealmProvider.clear()} is a cluster notification that does not take effect within
+     * the running session, so the miss path is forced per group instead.)
+     */
+    private static long countColdPageQueries(KeycloakSession session, Supplier<List<GroupModel>> loadPage) {
+        List<GroupModel> warmup = loadPage.get();
+        assertThat(warmup.size(), is(PAGE_SIZE));
+
+        CacheRealmProvider cache = session.getProvider(CacheRealmProvider.class);
+        warmup.forEach(group -> cache.registerGroupInvalidation(group.getId()));
+        session.getProvider(JpaConnectionProvider.class).getEntityManager().clear();
+
+        return countQueries(session, () -> assertThat(loadPage.get().size(), is(PAGE_SIZE)));
+    }
+
+    private static long countQueries(KeycloakSession session, Runnable walk) {
+        // Counted through a listener on this Hibernate session rather than the SessionFactory-wide
+        // Statistics, so statements issued concurrently by other threads sharing the factory cannot
+        // skew the result.
+        AtomicLong prepared = new AtomicLong();
+        session.getProvider(JpaConnectionProvider.class)
+                .getEntityManager()
+                .unwrap(Session.class)
+                .addEventListeners(new SessionEventListener() {
+                    @Override
+                    public void jdbcPrepareStatementStart() {
+                        prepared.incrementAndGet();
+                    }
+                });
+        walk.run();
+        return prepared.get();
+    }
+
+    private static class GroupListingRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder r) {
+            r.name("group-listing-query-count-realm");
+            for (int i = 0; i < GROUP_COUNT; i++) {
+                r.groups(String.format("grp-%02d", i));
+            }
+            return r;
+        }
+    }
+}


### PR DESCRIPTION
Closes #51125

## Problem

Listing groups (`GET /admin/realms/{realm}/groups` with and without `search`, and `GET .../groups/{id}/children`) issues one SQL statement per group whenever the group cache cannot serve it: a cold cache, and — permanently — realms larger than the bounded cache. Reproduction and end-to-end numbers are in the issue.

## Cause

`JpaRealmProvider#getTopLevelGroupsStream`, `JpaRealmProvider#searchForGroupByNameStream` and the JPA `GroupAdapter#getSubGroupsStream` select only group ids and resolve each row through `getGroupById(...)`; every cache miss becomes an `em.find` round trip — an N+1.

## Fix

Select the `GroupEntity` rows themselves — the query keeps the same predicates, ordering, pagination and fine-grained-authz filters and changes only its SELECT list; the stream then maps each entity to its id before the existing by-id resolution. The selected entities are managed by the persistence context, so the unchanged per-id resolution through `getGroupById(...)` is served without any additional statement per group. The per-id hop is deliberately kept (rather than mapping entities straight to adapters as `searchGroupsByAttributes` does) so the group cache is still populated and all adapter and invalidation semantics stay as they are.

## Testing

`GroupListingQueryCountTest` (tests/base, same pattern as `CompositeRoleExpansionQueryCountTest`): a page of 20 groups must be hydrated by exactly 1 prepared statement for the top-level listing, the name search, and the subgroups listing — previously 21 each. The test forces the cache-miss path deterministically via per-group invalidations and clearing the persistence context after a warmup pass.

## AI disclosure

Per CONTRIBUTING.md: this change was developed with the assistance of an AI agent (code audit, patch drafting, test drafting, and benchmarking); it was reviewed and is understood and maintained by the submitter.
