### PR TITLE
Configure OTP policy as default but with code reusable to true in BrowserFlowTest

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
@@ -102,6 +102,18 @@ public class BrowserFlowTest extends AbstractChangeImportedUserPasswordsTest {
     @Rule
     public AssertEvents events = new AssertEvents(this);
 
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+        super.configureTestRealm(testRealm);
+        testRealm.setOtpPolicyAlgorithm("HmacSHA1");
+        testRealm.setOtpPolicyDigits(6);
+        testRealm.setOtpPolicyInitialCounter(0);
+        testRealm.setOtpPolicyLookAheadWindow(1);
+        testRealm.setOtpPolicyPeriod(30);
+        testRealm.setOtpPolicyType("totp");
+        testRealm.setOtpPolicyCodeReusable(Boolean.TRUE);
+    }
+
     private void importTestRealm(Consumer<RealmRepresentation> realmUpdater) {
         if (testRealmReps == null) {
             testRealmReps = testContext.getTestRealmReps();


### PR DESCRIPTION
Closes #51064

The issue in the test is just that the OTP policy by default does not allow to re-use the same token in the same window (30s). There are two tests using the same user to login with OTP. Depending the order and how fast the two tests are executed they can be in the same 30s window and the login fails in the second test. Just adding the configuration to re-use OTP tokens.
