### PR TITLE
[OID4VCI] Reject mismatched signature algorithms during SD-JWT verification

### DIFF
--- a/core/src/main/java/org/keycloak/sdjwt/JwsToken.java
+++ b/core/src/main/java/org/keycloak/sdjwt/JwsToken.java
@@ -78,7 +78,9 @@ public abstract class JwsToken {
 
     public void verifySignature(SignatureVerifierContext verifier) throws VerificationException {
         Objects.requireNonNull(verifier, "verifier must not be null");
-        String headerAlgorithm = jwsHeader == null ? null : jwsHeader.getRawAlgorithm();
+        String headerAlgorithm = jwsHeader == null || jwsHeader.getAlgorithm() == null
+                ? null
+                : jwsHeader.getRawAlgorithm();
         String verifierAlgorithm = verifier.getAlgorithm();
         if (headerAlgorithm == null || verifierAlgorithm == null || !headerAlgorithm.equals(verifierAlgorithm)) {
             throw new VerificationException(String.format(

--- a/core/src/main/java/org/keycloak/sdjwt/JwsToken.java
+++ b/core/src/main/java/org/keycloak/sdjwt/JwsToken.java
@@ -78,6 +78,13 @@ public abstract class JwsToken {
 
     public void verifySignature(SignatureVerifierContext verifier) throws VerificationException {
         Objects.requireNonNull(verifier, "verifier must not be null");
+        String headerAlgorithm = jwsHeader == null ? null : jwsHeader.getRawAlgorithm();
+        String verifierAlgorithm = verifier.getAlgorithm();
+        if (headerAlgorithm == null || verifierAlgorithm == null || !headerAlgorithm.equals(verifierAlgorithm)) {
+            throw new VerificationException(String.format(
+                    "JWS header algorithm '%s' does not match verifier algorithm '%s'",
+                    headerAlgorithm, verifierAlgorithm));
+        }
         try {
             if (!verifier.verify(jwsInput.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8),
                                  jwsInput.getSignature())) {

--- a/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
@@ -104,6 +104,26 @@ public abstract class SdJwtVerificationTest {
     }
 
     @Test
+    public void sdJwtVerificationShouldFail_WhenHeaderAlgorithmIsMissing() {
+        SdJwt signedSdJwt = SdJwt.builder()
+                .withIssuerSignedJwt(exampleFlatSdJwtV1().build())
+                .withIssuerSigningContext(testSettings.issuerSigContext)
+                .build();
+        String jwsWithoutAlgorithm = TestUtils.removeAlgorithmFromJwsHeader(
+                signedSdJwt.getIssuerSignedJWT().getJws());
+        SdJwt sdJwt = new SdJwt(new IssuerSignedJWT(jwsWithoutAlgorithm), null);
+
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> sdJwt.verify(
+                        defaultIssuerVerifyingKeys(),
+                        optionalTimeClaimVerificationOpts().build())
+        );
+
+        assertEquals("Invalid Issuer-Signed JWT: Signature could not be verified", exception.getMessage());
+    }
+
+    @Test
     public void testSdJwtVerification_EnforceIdempotence() throws VerificationException {
         IssuerSignedJWT issuerSignedJWT = exampleFlatSdJwtV1().build();
         SdJwt sdJwt = SdJwt.builder().withIssuerSignedJwt(issuerSignedJWT)

--- a/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import org.keycloak.OID4VCConstants;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.jose.jws.JWSHeader;
@@ -79,6 +80,27 @@ public abstract class SdJwtVerificationTest {
                 optionalTimeClaimVerificationOpts().build()
             );
         }
+    }
+
+    @Test
+    public void sdJwtVerificationShouldFail_WhenHeaderAlgorithmDiffersFromVerifierAlgorithm() {
+        SdJwt sdJwt = SdJwt.builder()
+                .withIssuerSignedJwt(exampleFlatSdJwtV1().build())
+                .withIssuerSigningContext(TestSettings.signerWithReportedAlgorithm(
+                        testSettings.issuerSigContext, Algorithm.ES384))
+                .build();
+
+        assertEquals(Algorithm.ES384, sdJwt.getIssuerSignedJWT().getJwsHeader().getRawAlgorithm());
+        assertEquals(Algorithm.ES256, testSettings.issuerVerifierContext.getAlgorithm());
+
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> sdJwt.verify(
+                        defaultIssuerVerifyingKeys(),
+                        optionalTimeClaimVerificationOpts().build())
+        );
+
+        assertEquals("Invalid Issuer-Signed JWT: Signature could not be verified", exception.getMessage());
     }
 
     @Test

--- a/core/src/test/java/org/keycloak/sdjwt/TestSettings.java
+++ b/core/src/test/java/org/keycloak/sdjwt/TestSettings.java
@@ -34,6 +34,7 @@ import org.keycloak.crypto.ECDSASignatureSignerContext;
 import org.keycloak.crypto.ECDSASignatureVerifierContext;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureException;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
 
@@ -77,6 +78,31 @@ public class TestSettings {
 
     public SignatureVerifierContext getHolderVerifierContext() {
         return holderVerifierContext;
+    }
+
+    public static SignatureSignerContext signerWithReportedAlgorithm(SignatureSignerContext delegate,
+                                                                      String reportedAlgorithm) {
+        return new SignatureSignerContext() {
+            @Override
+            public String getKid() {
+                return delegate.getKid();
+            }
+
+            @Override
+            public String getAlgorithm() {
+                return reportedAlgorithm;
+            }
+
+            @Override
+            public String getHashAlgorithm() {
+                return delegate.getHashAlgorithm();
+            }
+
+            @Override
+            public byte[] sign(byte[] data) throws SignatureException {
+                return delegate.sign(data);
+            }
+        };
     }
 
     // private constructor

--- a/core/src/test/java/org/keycloak/sdjwt/TestUtils.java
+++ b/core/src/test/java/org/keycloak/sdjwt/TestUtils.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Objects;
 
+import org.keycloak.common.util.Base64Url;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -59,6 +61,22 @@ public class TestUtils {
             result.append(input, i, end).append("\n");
         }
         return result.toString();
+    }
+
+    public static String removeAlgorithmFromJwsHeader(String jws) {
+        String[] parts = jws.split("\\.", -1);
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Expected a compact JWS with three parts");
+        }
+
+        try {
+            ObjectNode header = (ObjectNode) SdJwtUtils.mapper.readTree(Base64Url.decode(parts[0]));
+            header.remove("alg");
+            parts[0] = Base64Url.encode(SdJwtUtils.mapper.writeValueAsBytes(header));
+            return String.join(".", parts);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not rewrite JWS header", e);
+        }
     }
 
 }

--- a/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
@@ -212,6 +212,31 @@ public abstract class SdJwtVPVerificationTest {
     }
 
     @Test
+    public void testShouldFail_IfKeyBindingHeaderAlgorithmIsMissing() {
+        KeyBindingJWT keyBindingJWT = KeyBindingJWT.builder()
+                .withPayload(exampleKbPayload())
+                .withSignerContext(testSettings.holderSigContext)
+                .build();
+        String sdJwtVPString = TestUtils.readFileAsString(getClass(), "sdjwt/s20.1-sdjwt+kb.txt");
+        String sdJwtWithoutKb = sdJwtVPString.substring(
+                0, sdJwtVPString.lastIndexOf(OID4VCConstants.SDJWT_DELIMITER) + 1);
+        SdJwtVP sdJwtVP = SdJwtVP.of(sdJwtWithoutKb
+                + TestUtils.removeAlgorithmFromJwsHeader(keyBindingJWT.getJws()));
+
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> sdJwtVP.verify(
+                        defaultIssuerVerifyingKeys(),
+                        defaultIssuerSignedJwtVerificationOpts().build(),
+                        defaultKeyBindingJwtVerificationOpts().build())
+        );
+
+        assertEquals("Key binding JWT invalid", exception.getMessage());
+        assertEquals("JWS header algorithm 'null' does not match verifier algorithm 'ES256'",
+                exception.getCause().getMessage());
+    }
+
+    @Test
     public void testShouldFail_IfNoCnfClaim() {
         testShouldFailGeneric(
                 // This test vector has no cnf claim in Issuer-signed JWT

--- a/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/SdJwtVPVerificationTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.keycloak.OID4VCConstants;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.rule.CryptoInitRule;
 import org.keycloak.sdjwt.IssuerSignedJwtVerificationOpts;
@@ -185,6 +187,28 @@ public abstract class SdJwtVPVerificationTest {
                 "Key binding JWT invalid",
                 "VerificationException: Invalid jws signature"
         );
+    }
+
+    @Test
+    public void testShouldFail_IfKeyBindingHeaderAlgorithmDiffersFromVerifierAlgorithm() {
+        SignatureSignerContext signer = TestSettings.signerWithReportedAlgorithm(
+                testSettings.holderSigContext, Algorithm.ES384);
+        SdJwtVP sdJwtVP = exampleSdJwtWithCustomKbPayload(exampleKbPayload(), signer);
+
+        assertEquals(Algorithm.ES384,
+                sdJwtVP.getKeyBindingJWT().orElseThrow(AssertionError::new).getJwsHeader().getRawAlgorithm());
+
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> sdJwtVP.verify(
+                        defaultIssuerVerifyingKeys(),
+                        defaultIssuerSignedJwtVerificationOpts().build(),
+                        defaultKeyBindingJwtVerificationOpts().build())
+        );
+
+        assertEquals("Key binding JWT invalid", exception.getMessage());
+        assertEquals("JWS header algorithm 'ES384' does not match verifier algorithm 'ES256'",
+                exception.getCause().getMessage());
     }
 
     @Test
@@ -512,9 +536,14 @@ public abstract class SdJwtVPVerificationTest {
     }
 
     private SdJwtVP exampleSdJwtWithCustomKbPayload(ObjectNode kbPayloadSubstitute) {
+        return exampleSdJwtWithCustomKbPayload(kbPayloadSubstitute, testSettings.holderSigContext);
+    }
+
+    private SdJwtVP exampleSdJwtWithCustomKbPayload(ObjectNode kbPayloadSubstitute,
+                                                     SignatureSignerContext signerContext) {
         KeyBindingJWT keyBindingJWT = KeyBindingJWT.builder()
                 .withPayload(kbPayloadSubstitute)
-                .withSignerContext(testSettings.holderSigContext)
+                .withSignerContext(signerContext)
                 .build();
 
         String sdJwtVPString = TestUtils.readFileAsString(getClass(), "sdjwt/s20.1-sdjwt+kb.txt");


### PR DESCRIPTION
## Summary

SD-JWT signature verification now requires the algorithm declared in the protected JWS `alg` header to match the algorithm used by the `SignatureVerifierContext`.

The check is implemented in the shared `JwsToken.verifySignature` path, so it applies to both:
- issuer-signed JWTs
- key-binding JWTs

Missing algorithms and algorithm mismatches are rejected before the cryptographic verification operation is invoked. This also prevents profile-level algorithm policies from being bypassed: when a profile accepts the JOSE header algorithm, the verifier context is now guaranteed to use that same algorithm.

Closes #51109
