### PR TITLE
Remove version override for `org.postgresql:postgresql` (#51140)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,12 +345,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Remove the override in https://github.com/keycloak/keycloak/issues/48990 -->
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${postgresql-jdbc.version}</version>
-            </dependency>
             <dependency>
                 <groupId>io.sundr</groupId>
                 <artifactId>builder-annotations</artifactId>


### PR DESCRIPTION
Closes #48990

---------

Co-authored-by: copilot-swe-agent[bot] <198982749+Copilot@users.noreply.github.com>
(cherry picked from commit da4fde79114db727f3b69f9196a873c663cf96cf)
