### PR TITLE
[26.4] Mask vault password in show-config (#51013)

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/VaultPropertyMappers.java
@@ -25,6 +25,7 @@ final class VaultPropertyMappers implements PropertyMapperGrouping {
                 fromOption(VaultOptions.VAULT_PASS)
                         .to("kc.spi-vault--keystore--pass")
                         .paramLabel("pass")
+                        .isMasked(true)
                         .build(),
                 fromOption(VaultOptions.VAULT_TYPE)
                         .to("kc.spi-vault--keystore--type")

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ShowConfigCommandDistTest.java
@@ -98,6 +98,15 @@ public class ShowConfigCommandDistTest {
     }
 
     @Test
+    @Launch({ ShowConfig.NAME })
+    @WithEnvVars({"KC_VAULT_PASS", "vault-secret"})
+    void testShowConfigCommandHidesVaultPassword(LaunchResult result) {
+        String output = result.getOutput();
+        assertThat(output, containsString("kc.vault-pass =  " + PropertyMappers.VALUE_MASK));
+        assertThat(output, not(containsString("vault-secret")));
+    }
+
+    @Test
     @RawDistOnly(reason = "Containers are immutable")
     void testConfigSourceNames(KeycloakDistribution distribution) {
         CLIResult result = distribution.run("build");


### PR DESCRIPTION
* Mask vault password in show-config

Mark the vault password mapper as sensitive and ignore duplicate SmallRye environment aliases so the password is never shown in show-config output.

Closes #50844

Signed-off-by: Akash Kumar <meakash7902@gmail.com>

* removing the second class config logic / test

Signed-off-by: Steve Hawkins <shawkins@redhat.com>

---------

Signed-off-by: Akash Kumar <meakash7902@gmail.com>
Signed-off-by: Steve Hawkins <shawkins@redhat.com>
Co-authored-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit 39c424e92542439cecf2abfc9377ff7125b72ce6)
