### PR TITLE
Fix addManagedMember adding user as unmanaged when user is cache-wrapped

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -35,6 +35,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.MembershipMetadata;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.SubjectCredentialManager;
@@ -501,6 +502,17 @@ public class UserAdapter implements CachedUserModel {
         }
         getDelegateForUpdate();
         updated.joinGroup(group);
+
+    }
+
+    @Override
+    public void joinGroup(GroupModel group, MembershipMetadata metadata) {
+        // Only REALM groups are cached; organization groups always delegate to persistence
+        if (group.getType() == Type.REALM && updated == null && cached.getGroups(keycloakSession, modelSupplier).contains(group.getId())) {
+            return;
+        }
+        getDelegateForUpdate();
+        updated.joinGroup(group, metadata);
 
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/organization/cache/OrganizationCacheTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/cache/OrganizationCacheTest.java
@@ -131,6 +131,28 @@ public class OrganizationCacheTest extends AbstractOrganizationTest {
     }
 
     @Test
+    public void testAddManagedMemberWithCachedUser() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            UserModel member = session.users().addUser(realm, "member");
+            member.setEnabled(true);
+        });
+        runOnServer.run(session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel orga = orgProvider.getByDomainName("orga.org");
+            RealmModel realm = session.getContext().getRealm();
+            // Fetch through the standard cached user provider, as any real caller (e.g. a
+            // custom AdminRealmResourceProvider, or the registration/broker flows that call
+            // addManagedMember) would - this returns the infinispan cache-wrapped UserAdapter.
+            UserModel member = session.users().getUserByUsername(realm, "member");
+            boolean added = orgProvider.addManagedMember(orga, member);
+            assertTrue(added);
+            assertTrue(orgProvider.isManagedMember(orga, member),
+                    "user added via addManagedMember must be reported as a MANAGED member");
+        });
+    }
+
+    @Test
     public void testGetByMember() {
         runOnServer.run(session -> {
             OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);


### PR DESCRIPTION
## Problem
OrganizationProvider.addManagedMember is supposed to add a user to an
organization with MembershipType.MANAGED, but the user ends up UNMANAGED
instead whenever the UserModel passed in came from the standard cached
user provider (e.g. session.users().getUserById(...), as used by custom
AdminRealmResourceProviders and other real callers of addManagedMember).

## Root cause
JpaOrganizationProvider.addMember() calls user.joinGroup(group, metadata).
UserModel has a default implementation for that overload:

    default void joinGroup(GroupModel group, MembershipMetadata metadata) {
        joinGroup(group);
    }

The infinispan cache UserAdapter only overrides the single-arg
joinGroup(GroupModel), not the metadata-aware overload. So when user is
a cache-wrapped UserAdapter, the call falls through to the default
above, silently drops the MANAGED metadata, and ends up at the JPA
layer's joinGroup(group) -> joinGroup(group, null), which defaults the
membership type to UNMANAGED.

## Fix
Added the missing joinGroup(GroupModel, MembershipMetadata) override to
the infinispan UserAdapter, mirroring the existing joinGroup(GroupModel)
override exactly, so the metadata is passed through to the delegate
instead of being dropped.

## Testing
Added OrganizationCacheTest#testAddManagedMemberWithCachedUser, which
fetches a user through the normal cached user provider, calls
addManagedMember, and asserts isManagedMember is true.

- Verified the new test fails on the unfixed code
  (expected: <true> but was: <false>) and passes with the fix.
- Ran the broader organization/cache/member test suites
  (OrganizationCacheTest, OrganizationMemberTest,
  OrganizationMemberIdpLinkTest, OrganizationInternalGroupTest,
  OrganizationGroupMembershipTest) - 60 tests, all passing, no
  regressions.
- ./mvnw spotless:check passes on the changed modules.

Closes #43094