### PR TITLE
Gracefully handle disabled or removed IdP during logout

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -733,10 +733,18 @@ public class AuthenticationManager {
         String brokerId = userSession.getNote(Details.IDENTITY_PROVIDER);
         String initiatingIdp = logoutAuthSession.getAuthNote(AuthenticationManager.LOGOUT_INITIATING_IDP);
         if (brokerId != null && !brokerId.equals(initiatingIdp)) {
-            UserAuthenticationIdentityProvider<?> identityProvider = IdentityBrokerService.getIdentityProvider(session, brokerId);
-            Response response = identityProvider.keycloakInitiatedBrowserLogout(session, userSession, uriInfo, realm);
-            if (response != null) {
-                return response;
+            UserAuthenticationIdentityProvider<?> identityProvider = null;
+            try {
+                identityProvider = IdentityBrokerService.getIdentityProvider(session, brokerId);
+            } catch (IdentityBrokerException e) {
+                logger.warnf("Identity provider [%s] is no longer available, skipping Keycloak-initiated broker logout for user session [%s]", brokerId, userSession.getId());
+            }
+
+            if (identityProvider != null) {
+                Response response = identityProvider.keycloakInitiatedBrowserLogout(session, userSession, uriInfo, realm);
+                if (response != null) {
+                    return response;
+                }
             }
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -289,4 +289,39 @@ public class KcOidcBrokerLogoutTest extends AbstractKcOidcBrokerLogoutTest {
             identityProviderResource.update(representation);
         }
     }
+
+    @Test
+    public void logoutSucceedsWhenIdpIsDisabled() {
+        logInAsUserInIDPForFirstTime();
+        Assertions.assertTrue(oauth.parseLoginResponse().isSuccess());
+
+        // Disable the identity provider while the user session is still active
+        RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
+        IdentityProviderResource idpResource = consumerRealm.identityProviders().get(bc.getIDPAlias());
+        IdentityProviderRepresentation idpRep = idpResource.toRepresentation();
+        idpRep.setEnabled(false);
+        idpResource.update(idpRep);
+
+        try {
+            // Browser logout should complete gracefully even though the IdP is disabled
+            logoutFromRealm(
+                    getConsumerRoot(),
+                    bc.consumerRealmName(),
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            // Verify user is actually logged out
+            oauth.client("broker-app");
+            oauth.realm(bc.consumerRealmName());
+            oauth.openLoginForm();
+            waitForPage(driver, "sign in to", true);
+        } finally {
+            idpRep.setEnabled(true);
+            idpResource.update(idpRep);
+        }
+    }
+
 }


### PR DESCRIPTION
When a user logs in through an identity provider and that provider is later disabled or deleted, browserLogout throws an IdentityBrokerException that breaks the entire logout flow.

This wraps the identity provider lookup in a try-catch so that the logout completes locally even when the broker is no longer available, logging a warning instead of failing.

Closes #51123
