### PR TITLE
Fix ArrayIndexOutOfBoundsException in Base64Url on padding-only input

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Base64Url.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64Url.java
@@ -44,7 +44,12 @@ public class Base64Url {
      * @return String in base64Url encoding
      */
     public static String encodeBase64ToBase64Url(String base64) {
-        String s = base64.split("=")[0]; // Remove any trailing '='s
+        // Remove any trailing '='s. String.split discards trailing empty strings,
+        // so a padding-only input (e.g. "=" or "==") produces an empty array whose
+        // first element cannot be accessed. Take the first segment only when the
+        // array is non-empty; otherwise there is no content before the padding.
+        String[] parts = base64.split("=");
+        String s = parts.length > 0 ? parts[0] : "";
         s = s.replace('+', '-'); // 62nd char of encoding
         s = s.replace('/', '_'); // 63rd char of encoding
         return s;

--- a/common/src/main/java/org/keycloak/common/util/Base64Url.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64Url.java
@@ -51,7 +51,7 @@ public class Base64Url {
         // input, so substring(0, 0) yields the empty string, which is correct
         // because there is no content before the padding.
         int idx = base64.indexOf('=');
-        String s = base64.replace("=", ""); // Remove any trailing '='s
+        String s = idx >= 0 ? base64.substring(0, idx) : base64;
         s = s.replace('+', '-'); // 62nd char of encoding
         s = s.replace('/', '_'); // 63rd char of encoding
         return s;

--- a/common/src/main/java/org/keycloak/common/util/Base64Url.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64Url.java
@@ -44,12 +44,13 @@ public class Base64Url {
      * @return String in base64Url encoding
      */
     public static String encodeBase64ToBase64Url(String base64) {
-        // Remove any trailing '='s. String.split discards trailing empty strings,
-        // so a padding-only input (e.g. "=" or "==") produces an empty array whose
-        // first element cannot be accessed. Take the first segment only when the
-        // array is non-empty; otherwise there is no content before the padding.
-        String[] parts = base64.split("=");
-        String s = parts.length > 0 ? parts[0] : "";
+        // Strip trailing Base64 padding ('=') by cutting at the first '='.
+        // indexOf avoids the regex + array allocation of String.split and also
+        // handles padding-only input (e.g. "=" or "==") without an
+        // ArrayIndexOutOfBoundsException — indexOf returns -1, so we keep the full string,
+        // which is empty after trimming when the input was all '=' characters.
+        int idx = base64.indexOf('=');
+        String s = idx >= 0 ? base64.substring(0, idx) : base64;
         s = s.replace('+', '-'); // 62nd char of encoding
         s = s.replace('/', '_'); // 63rd char of encoding
         return s;

--- a/common/src/main/java/org/keycloak/common/util/Base64Url.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64Url.java
@@ -51,7 +51,7 @@ public class Base64Url {
         // input, so substring(0, 0) yields the empty string, which is correct
         // because there is no content before the padding.
         int idx = base64.indexOf('=');
-        String s = idx >= 0 ? base64.substring(0, idx) : base64;
+        String s = base64.replace("=", ""); // Remove any trailing '='s
         s = s.replace('+', '-'); // 62nd char of encoding
         s = s.replace('/', '_'); // 63rd char of encoding
         return s;

--- a/common/src/main/java/org/keycloak/common/util/Base64Url.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64Url.java
@@ -47,8 +47,9 @@ public class Base64Url {
         // Strip trailing Base64 padding ('=') by cutting at the first '='.
         // indexOf avoids the regex + array allocation of String.split and also
         // handles padding-only input (e.g. "=" or "==") without an
-        // ArrayIndexOutOfBoundsException — indexOf returns -1, so we keep the full string,
-        // which is empty after trimming when the input was all '=' characters.
+        // ArrayIndexOutOfBoundsException — indexOf returns 0 for padding-only
+        // input, so substring(0, 0) yields the empty string, which is correct
+        // because there is no content before the padding.
         int idx = base64.indexOf('=');
         String s = idx >= 0 ? base64.substring(0, idx) : base64;
         s = s.replace('+', '-'); // 62nd char of encoding

--- a/common/src/test/java/org/keycloak/common/util/Base64UrlTest.java
+++ b/common/src/test/java/org/keycloak/common/util/Base64UrlTest.java
@@ -1,8 +1,8 @@
 package org.keycloak.common.util;
 
-import org.junit.jupiter.api.Test;
-
 import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,16 +41,13 @@ public class Base64UrlTest {
     }
 
     @Test
-    public void decode_normalInput() {
-        byte[] result = Base64Url.decode("dGVzdA");
-        assertThat(new String(result, StandardCharsets.UTF_8), equalTo("test"));
-    }
-
-    @Test
-    public void decode_base64WithPadding() {
+    public void decode_base64WithPaddingAndSpecialChars() {
         // decode() routes through encodeBase64ToBase64Url, so padded Base64
-        // input must still work.
+        // input with special chars must still work.
         byte[] result = Base64Url.decode("dGVzdA==");
         assertThat(new String(result, StandardCharsets.UTF_8), equalTo("test"));
+
+        // Input with '+' and '/' that must be converted before decoding
+        assertThat(Base64Url.encodeBase64ToBase64Url("AB+C/D=="), equalTo("AB-C_D"));
     }
 }

--- a/common/src/test/java/org/keycloak/common/util/Base64UrlTest.java
+++ b/common/src/test/java/org/keycloak/common/util/Base64UrlTest.java
@@ -1,0 +1,54 @@
+package org.keycloak.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for {@link Base64Url}.
+ */
+public class Base64UrlTest {
+
+    @Test
+    public void encodeBase64ToBase64Url_normalInput() {
+        // Standard Base64 with padding → Base64Url without padding, charset swapped.
+        assertThat(Base64Url.encodeBase64ToBase64Url("dGVzdA=="), equalTo("dGVzdA"));
+        assertThat(Base64Url.encodeBase64ToBase64Url("aGVsbG8="), equalTo("aGVsbG8"));
+    }
+
+    @Test
+    public void encodeBase64ToBase64Url_charsetConversion() {
+        // '+' → '-', '/' → '_'
+        assertThat(Base64Url.encodeBase64ToBase64Url("AB+C/D=="), equalTo("AB-C_D"));
+    }
+
+    @Test
+    public void encodeBase64ToBase64Url_paddingOnlyDoesNotThrow() {
+        // A padding-only input (e.g. "=" or "==") previously caused an
+        // ArrayIndexOutOfBoundsException because String.split("=") discards
+        // trailing empty strings and produces a zero-length array.
+        assertThat(Base64Url.encodeBase64ToBase64Url("="), equalTo(""));
+        assertThat(Base64Url.encodeBase64ToBase64Url("=="), equalTo(""));
+        assertThat(Base64Url.encodeBase64ToBase64Url("==="), equalTo(""));
+    }
+
+    @Test
+    public void encodeBase64ToBase64Url_emptyString() {
+        assertThat(Base64Url.encodeBase64ToBase64Url(""), equalTo(""));
+    }
+
+    @Test
+    public void decode_normalInput() {
+        byte[] result = Base64Url.decode("dGVzdA");
+        assertThat(new String(result), equalTo("test"));
+    }
+
+    @Test
+    public void decode_base64WithPadding() {
+        // decode() routes through encodeBase64ToBase64Url, so padded Base64
+        // input must still work.
+        byte[] result = Base64Url.decode("dGVzdA==");
+        assertThat(new String(result), equalTo("test"));
+    }
+}

--- a/common/src/test/java/org/keycloak/common/util/Base64UrlTest.java
+++ b/common/src/test/java/org/keycloak/common/util/Base64UrlTest.java
@@ -2,6 +2,8 @@ package org.keycloak.common.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -41,7 +43,7 @@ public class Base64UrlTest {
     @Test
     public void decode_normalInput() {
         byte[] result = Base64Url.decode("dGVzdA");
-        assertThat(new String(result), equalTo("test"));
+        assertThat(new String(result, StandardCharsets.UTF_8), equalTo("test"));
     }
 
     @Test
@@ -49,6 +51,6 @@ public class Base64UrlTest {
         // decode() routes through encodeBase64ToBase64Url, so padded Base64
         // input must still work.
         byte[] result = Base64Url.decode("dGVzdA==");
-        assertThat(new String(result), equalTo("test"));
+        assertThat(new String(result, StandardCharsets.UTF_8), equalTo("test"));
     }
 }


### PR DESCRIPTION
Base64Url.encodeBase64ToBase64Url strips trailing '=' padding with base64.split("=")[0]. When the input is entirely padding (e.g. "=" or "=="), String.split discards trailing empty strings and returns a zero-length array, so the [0] access throws ArrayIndexOutOfBoundsException. This surfaces through Base64Url.decode and JOSEParser.parse when processing malformed JOSE compact tokens that contain padding-only segments.

The fix guards the array access — the first segment is taken only when the array is non-empty, otherwise an empty string is returned, which is the correct Base64Url representation of content that was all padding.

Added Base64UrlTest covering normal inputs, charset conversion, the padding-only edge cases, empty strings, and the decode path.

Fixes #51212