### PR TITLE
Add tests for implicit flow in Token Exchange and delegation parameterized type

### DIFF
--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientBuilder.java
@@ -179,6 +179,11 @@ public class ClientBuilder extends Builder<ClientRepresentation> {
         return this;
     }
 
+    public ClientBuilder implicitFlowEnabled(Boolean enabled) {
+        rep.setImplicitFlowEnabled(enabled);
+        return this;
+    }
+
     public ClientBuilder webOrigins(String... webOrigins) {
         rep.setWebOrigins(combine(rep.getWebOrigins(), webOrigins));
         return this;

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientScopeBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientScopeBuilder.java
@@ -16,9 +16,12 @@
  */
 package org.keycloak.testframework.realm;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 
 /**
  * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
@@ -55,6 +58,14 @@ public class ClientScopeBuilder extends Builder<ClientScopeRepresentation> {
     public ClientScopeBuilder attribute(String key, String value) {
         rep.setAttributes(Builder.createIfNull(rep.getAttributes(), HashMap::new));
         rep.getAttributes().put(key, value);
+        return this;
+    }
+
+    public ClientScopeBuilder mappers(ProtocolMapperRepresentation... mappers) {
+        if (mappers != null) {
+            rep.setProtocolMappers(Builder.createIfNull(rep.getProtocolMappers(), LinkedList::new));
+            rep.getProtocolMappers().addAll(Arrays.asList(mappers));
+        }
         return this;
     }
 }

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ProtocolMapperBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ProtocolMapperBuilder.java
@@ -1,0 +1,46 @@
+package org.keycloak.testframework.realm;
+
+import java.util.HashMap;
+
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+
+/**
+ * Builder to help with protocol mappers in the test-suite.
+ *
+ * @author rmartinc
+ */
+public class ProtocolMapperBuilder extends Builder<ProtocolMapperRepresentation> {
+
+    private ProtocolMapperBuilder(ProtocolMapperRepresentation rep) {
+        super(rep);
+    }
+
+    public static ProtocolMapperBuilder create() {
+        return new ProtocolMapperBuilder(new ProtocolMapperRepresentation());
+    }
+
+    public static ProtocolMapperBuilder update(ProtocolMapperRepresentation rep) {
+        return new ProtocolMapperBuilder(rep);
+    }
+
+    public ProtocolMapperBuilder name(String name) {
+        rep.setName(name);
+        return this;
+    }
+
+    public ProtocolMapperBuilder protocol(String protocol) {
+        rep.setProtocol(protocol);
+        return this;
+    }
+
+    public ProtocolMapperBuilder protocolMapper(String protocolMapper) {
+        rep.setProtocolMapper(protocolMapper);
+        return this;
+    }
+
+    public ProtocolMapperBuilder config(String key, String value) {
+        rep.setConfig(Builder.createIfNull(rep.getConfig(), HashMap::new));
+        rep.getConfig().put(key, value);
+        return this;
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopeBuilder.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopeBuilder.java
@@ -3,6 +3,7 @@ package org.keycloak.tests.oauth;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.testframework.realm.ClientScopeBuilder;
 
 public class ParameterizedScopeBuilder {
@@ -52,6 +53,11 @@ public class ParameterizedScopeBuilder {
 
     public ParameterizedScopeBuilder regexp(String regexp) {
         builder.attribute(ClientScopeModel.PARAMETERIZED_SCOPE_REGEXP, regexp);
+        return this;
+    }
+
+    public ParameterizedScopeBuilder mappers(ProtocolMapperRepresentation... mappers) {
+        builder.mappers(mappers);
         return this;
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesOAuthGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesOAuthGrantTest.java
@@ -5,21 +5,28 @@ import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.grants.ciba.CibaGrantTypeFactory;
 import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
+import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.scope.ParameterizedScopeTypeProvider;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -35,6 +42,7 @@ import org.keycloak.testframework.realm.ClientBuilder;
 import org.keycloak.testframework.realm.ClientConfig;
 import org.keycloak.testframework.realm.ManagedClient;
 import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ProtocolMapperBuilder;
 import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
@@ -44,6 +52,7 @@ import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.OAuthGrantPage;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.suites.DatabaseTest;
+import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
@@ -65,6 +74,7 @@ public class ParameterizedScopesOAuthGrantTest {
 
     private static final String THIRD_PARTY_APP = "third-party";
     private static final String DEFAULT_USERNAME = "test-user@localhost";
+    private static final String DEFAULT_ADMIN_USERNAME = "administrator@localhost";
     private static final String DEFAULT_PASSWORD = "password";
 
     private static String PARAMETERIZED_SCOPE_ID;
@@ -106,6 +116,7 @@ public class ParameterizedScopesOAuthGrantTest {
         if (userConsents.stream().anyMatch(m -> THIRD_PARTY_APP.equals(m.get("clientId")))) {
             AccountHelper.revokeConsents(realm.admin(), DEFAULT_USERNAME, THIRD_PARTY_APP);
         }
+        oauth.responseType(OAuth2Constants.CODE);
     }
 
     @Test
@@ -673,6 +684,76 @@ public class ParameterizedScopesOAuthGrantTest {
         assertLongParameterRejected("length-scope");
     }
 
+    @Test
+    public void delegationScopeWithImplicitFlow() {
+        // create impersonation parameterized role with a hardcoded claim
+        createAndAssignOptionalScope(ParameterizedScopeBuilder.create("delegated-act")
+                .parameterizedScopeType("delegation")
+                .mappers(ProtocolMapperBuilder.create().name("Hardcoded Claim")
+                        .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                        .protocolMapper(HardcodedClaim.PROVIDER_ID)
+                        .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "matched_scope")
+                        .config(HardcodedClaim.CLAIM_VALUE, "implicit-delegation")
+                        .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, Boolean.TRUE.toString())
+                        .build())
+                .build());
+
+        // change the app to allow implicit flow and no consent required
+        ClientRepresentation rep = thirdParty.admin().toRepresentation();
+        rep.setConsentRequired(Boolean.FALSE);
+        rep.setImplicitFlowEnabled(Boolean.TRUE);
+        thirdParty.admin().update(rep);
+        realm.cleanup().add(r -> {
+            rep.setConsentRequired(Boolean.TRUE);
+            rep.setImplicitFlowEnabled(Boolean.FALSE);
+            r.clients().get(thirdParty.getId()).update(rep);
+        });
+
+        // add impersonation to the admin user
+        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
+        final String clientUUID = realmManagement.toRepresentation().getId();
+        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
+        AdminApiUtil.findUserByUsernameId(realm.admin(), DEFAULT_ADMIN_USERNAME).roles()
+                .clientLevel(clientUUID).add(List.of(impersonation));
+
+        // implicit flow login with the delegation scope granted
+        String requestedScope = "delegated-act:" + DEFAULT_ADMIN_USERNAME;
+        oauth.client(THIRD_PARTY_APP)
+                .responseType(OAuth2Constants.TOKEN)
+                .scope(requestedScope)
+                .openLoginForm();
+
+        oauth.fillLoginForm(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        AuthorizationEndpointResponse res = new AuthorizationEndpointResponse(oauth);
+
+        Assertions.assertTrue(res.isRedirected());
+        Assertions.assertNotNull(res.getAccessToken());
+
+        AccessToken token = oauth.verifyToken(res.getAccessToken());
+        MatcherAssert.assertThat(List.of(token.getScope().split(" ")), Matchers.hasItem(requestedScope));
+        Assertions.assertEquals("implicit-delegation", token.getOtherClaims().get("matched_scope"));
+
+        // logout and remove the permission
+        AccountHelper.logout(realm.admin(), DEFAULT_USERNAME);
+        AdminApiUtil.findUserByUsernameId(realm.admin(), DEFAULT_ADMIN_USERNAME).roles()
+                .clientLevel(clientUUID).remove(List.of(impersonation));
+
+        // implicit flow login with the delegation scope not granted
+        oauth.client(THIRD_PARTY_APP)
+                .responseType(OAuth2Constants.TOKEN)
+                .scope(requestedScope)
+                .openLoginForm();
+        oauth.fillLoginForm(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        res = new AuthorizationEndpointResponse(oauth);
+
+        Assertions.assertTrue(res.isRedirected());
+        Assertions.assertNotNull(res.getAccessToken());
+
+        token = oauth.verifyToken(res.getAccessToken());
+        MatcherAssert.assertThat(List.of(token.getScope().split(" ")), Matchers.not(Matchers.hasItem(requestedScope)));
+        Assertions.assertNull(token.getOtherClaims().get("matched_scope"));
+    }
+
     private String createAndAssignOptionalScope(ClientScopeRepresentation scope) {
         String scopeId = ApiUtil.getCreatedId(realm.admin().clientScopes().create(scope));
         thirdParty.admin().addOptionalClientScope(scopeId);
@@ -715,6 +796,12 @@ public class ParameterizedScopesOAuthGrantTest {
             realm.users(UserBuilder.create(DEFAULT_USERNAME)
                     .email(DEFAULT_USERNAME)
                     .name("Test", "User")
+                    .emailVerified(true)
+                    .password(DEFAULT_PASSWORD)
+                    .enabled(true),
+                    UserBuilder.create(DEFAULT_ADMIN_USERNAME)
+                    .email(DEFAULT_ADMIN_USERNAME)
+                    .name("Admin", "User")
                     .emailVerified(true)
                     .password(DEFAULT_PASSWORD)
                     .enabled(true));

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
@@ -34,6 +34,7 @@ import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
@@ -70,6 +71,7 @@ import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
 import org.keycloak.testsuite.util.oauth.LogoutResponse;
 import org.keycloak.testsuite.util.oauth.ciba.AuthenticationRequestAcknowledgement;
@@ -123,6 +125,7 @@ public class TokenExchangeDelegationTest {
         if (consents.stream().anyMatch(m -> oauth.getClientId().equals(m.get("clientId")))) {
             AccountHelper.revokeConsents(realm.admin(), USERNAME, oauth.getClientId());
         }
+        oauth.responseType(OAuth2Constants.CODE);
     }
 
     @Test
@@ -244,6 +247,59 @@ public class TokenExchangeDelegationTest {
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
         Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void delegationImplicit() {
+        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
+        final String clientUUID = realmManagement.toRepresentation().getId();
+        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
+        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
+
+        // enable implicit flow for the client
+        ClientRepresentation clientRep = oauth.clientResource().toRepresentation();
+        clientRep.setImplicitFlowEnabled(Boolean.TRUE);
+        oauth.clientResource().update(clientRep);
+        realm.cleanup().add(r -> {
+            clientRep.setImplicitFlowEnabled(Boolean.FALSE);
+            r.clients().get(clientRep.getId()).update(clientRep);
+        });
+
+        // request the delegation to administrator and accept the delegation using implicit
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        oauth.scope(scope).responseType(OAuth2Constants.TOKEN).openLoginForm();
+        oauth.fillLoginForm(USERNAME, PASSWORD);
+        grantPage.assertCurrent();
+        List<String> grants = grantPage.getDisplayedGrants();
+        MatcherAssert.assertThat(grants, Matchers.hasItem("Delegate token to administrator administrator?"));
+        grantPage.accept();
+
+        AuthorizationEndpointResponse res = new AuthorizationEndpointResponse(oauth);
+
+        Assertions.assertTrue(res.isRedirected());
+        Assertions.assertNotNull(res.getAccessToken());
+        AccessToken token = oauth.verifyToken(res.getAccessToken());
+        assertScopeContains(token.getScope(), scope);
+        assertMayActPresent(token, administrator.getId());
+
+        // logout
+        AdminApiUtil.findUserByUsernameId(realm.admin(), USERNAME).logout();
+
+        // remove the impersonation from the user and try again
+        administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
+
+        oauth.scope(scope).responseType(OAuth2Constants.TOKEN).openLoginForm();
+        oauth.fillLoginForm(USERNAME, PASSWORD);
+        res = new AuthorizationEndpointResponse(oauth);
+
+        Assertions.assertTrue(res.isRedirected());
+        Assertions.assertNotNull(res.getAccessToken());
+        token = oauth.verifyToken(res.getAccessToken());
+        assertScopeNotContains(token.getScope(), scope);
+        assertMayActNotPresent(token);
+
+        // logout
+        AdminApiUtil.findUserByUsernameId(realm.admin(), USERNAME).logout();
     }
 
     @Test


### PR DESCRIPTION
Closes #51152

Just adding implicit flow tests for TE Delegation and Parameterized scopes. We had no coverage for implicit in the Test Suite.

