### PR TITLE
Handle missing refresh token in admin client

### DIFF
--- a/js/libs/keycloak-admin-client/src/client.ts
+++ b/js/libs/keycloak-admin-client/src/client.ts
@@ -145,9 +145,9 @@ export class KeycloakAdminClient {
     this.#accessTokenDecoded = decodeToken(token);
   }
 
-  public setRefreshToken(token: string) {
+  public setRefreshToken(token?: string) {
     this.refreshToken = token;
-    this.#refreshTokenDecoded = decodeToken(token);
+    this.#refreshTokenDecoded = token ? decodeToken(token) : undefined;
   }
 
   public async getAccessToken() {
@@ -183,7 +183,11 @@ export class KeycloakAdminClient {
     );
 
     this.setAccessToken(accessToken);
-    this.setRefreshToken(refreshToken);
+
+    // The current refresh token remains valid if the response does not carry a new one.
+    if (refreshToken) {
+      this.setRefreshToken(refreshToken);
+    }
   }
 
   public isTokenExpired(): boolean {

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -31,7 +31,7 @@ export interface TokenResponseRaw {
   access_token: string;
   expires_in: number;
   refresh_expires_in: number;
-  refresh_token: string;
+  refresh_token?: string;
   token_type: string;
   not_before_policy: number;
   session_state: string;
@@ -43,7 +43,7 @@ export interface TokenResponse {
   accessToken: string;
   expiresIn: number;
   refreshExpiresIn: number;
-  refreshToken: string;
+  refreshToken?: string;
   tokenType: string;
   notBeforePolicy: number;
   sessionState: string;

--- a/js/libs/keycloak-admin-client/test/client.spec.ts
+++ b/js/libs/keycloak-admin-client/test/client.spec.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { once } from "node:events";
+import { Server, createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { KeycloakAdminClient } from "../src/client.js";
+
+const credentials = {
+  grantType: "client_credentials",
+  clientId: "admin-cli",
+  clientSecret: "secret",
+} as const;
+
+const token = (secondsFromNow: number) => {
+  const payload = { exp: Math.ceil(Date.now() / 1000) + secondsFromNow };
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+};
+
+describe("Client", () => {
+  let server: Server;
+  let baseUrl: string;
+  let responses: object[];
+
+  before(async () => {
+    server = createServer((_req, res) => {
+      const response = responses.shift();
+      res.writeHead(response ? 200 : 500, {
+        "content-type": "application/json",
+      });
+      res.end(JSON.stringify(response ?? { error: "No response queued." }));
+    });
+    server.listen(0, "localhost");
+    await once(server, "listening");
+    baseUrl = `http://localhost:${(server.address() as AddressInfo).port}`;
+  });
+
+  after(async () => {
+    server.closeAllConnections();
+    server.close();
+    await once(server, "close");
+  });
+
+  // A client_credentials grant does not return a refresh token by default.
+  void it("authenticates when the token response has no refresh token", async () => {
+    responses = [{ access_token: token(60) }];
+
+    const client = new KeycloakAdminClient({ baseUrl });
+    await client.auth(credentials);
+
+    expect(client.refreshToken).to.be.undefined;
+    expect(client.isRefreshTokenExpired()).to.be.false;
+  });
+
+  void it("keeps the refresh token when the refreshed token response omits one", async () => {
+    const refreshToken = token(600);
+    const renewedAccessToken = token(60);
+    responses = [
+      { access_token: token(-60), refresh_token: refreshToken },
+      { access_token: renewedAccessToken },
+    ];
+
+    const client = new KeycloakAdminClient({ baseUrl });
+    await client.auth(credentials);
+
+    expect(await client.getAccessToken()).to.equal(renewedAccessToken);
+    expect(client.refreshToken).to.equal(refreshToken);
+  });
+});


### PR DESCRIPTION
Keycloak only issues a refresh token for the `client_credentials`
grant when the client is configured to, so `auth()` ended up passing
undefined to `decodeToken()` and threw a `TypeError`. The refresh
token is now optional in the token response types, and
`setRefreshToken()` clears the decoded token instead of trying to
decode nothing.

The same applies when refreshing: if the token endpoint leaves the
refresh token out of the response, the existing one is kept rather
than cleared.

Closes #50845
Relates to #46834

---

Generative AI Disclosure:

Claude Opus 5 was used in this pull request.