### PR TITLE
Ignore unknown properties when parsing Client ID Metadata Documents

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
@@ -35,7 +35,10 @@ import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 
 /**
@@ -86,7 +89,8 @@ import org.jboss.logging.Logger;
  * According to the CIMD specification, the client metadata format is the same as for Dynamic Client Registration except for {@code client_id} property.
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7591>OAuth 2.0 Dynamic Client Registration Protocol [RFC 7591]</a>
  * Therefore, {@link OIDCClientRepresentation} is used for the client metadata format.
- * The CIMD specification allows the use of additional properties (MAY requirement level), but the class does not treat them.
+ * The CIMD specification allows the use of additional properties (MAY requirement level).
+ * The class ignores such the properties when parsing a client metadata document, but it does not treat them.
  *
  * <p>Client Metadata Augmentation in {@code OIDCClientRepresentation}:
  * To successfully convert a fetched client metadata to {@code ClientRepresentation}, intentionally augment it.
@@ -415,6 +419,15 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
     // Implementation
     // Fetch Client Metadata
     public static final String ERR_METADATA_FETCH_FAILED = "Client Metadata fetch failed";
+    public static final String ERR_METADATA_PARSE_FAILED = "Invalid Client Metadata: cannot be parsed as a client metadata document.";
+
+    // The CIMD specification (Section 4.1) allows a client metadata document to define additional properties,
+    // and RFC 7591 (Section 2) requires ignoring any client metadata the authorization server does not understand.
+    // Therefore, a client metadata document is parsed leniently, ignoring unknown properties.
+    // The lenient parsing is intentionally scoped to fetched client metadata documents so that
+    // other consumers of OIDCClientRepresentation (e.g. Dynamic Client Registration) keep their current behavior.
+    private static final ObjectMapper clientMetadataObjectMapper = JsonSerialization.createObjectMapperWithDefaults()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /**
      * Verifies an authorization request to check if the request includes required parameters and follows the expected format.
@@ -591,7 +604,7 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
                 }
             }
 
-            clientOIDC = response.asJson(OIDCClientRepresentation.class);
+            clientOIDC = parseClientMetadata(response.asString());
 
             // to successfully convert it to Client Representation, intentionally augment it.
             augmentClientOIDC(clientOIDC);
@@ -600,6 +613,23 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
         } catch (IOException e) {
             getLogger().warnv("HTTP connection failure: {0}", e);
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, ERR_METADATA_FETCH_FAILED);
+        }
+    }
+
+    /**
+     * Parse a fetched client metadata document leniently, ignoring unknown properties as required by
+     * the CIMD specification (Section 4.1) and RFC 7591 (Section 2).
+     *
+     * @param clientMetadataDocument a fetched client metadata document as a JSON string
+     * @return {@code OIDCClientRepresentation} a parsed client metadata
+     * @throws ClientPolicyException when the document cannot be parsed as a client metadata document.
+     */
+    protected OIDCClientRepresentation parseClientMetadata(final String clientMetadataDocument) throws ClientPolicyException {
+        try {
+            return clientMetadataObjectMapper.readValue(clientMetadataDocument, OIDCClientRepresentation.class);
+        } catch (JsonProcessingException e) {
+            getLogger().warnv("failed to parse client metadata document: {0}", e.getMessage());
+            throw invalidClientIdMetadata(ERR_METADATA_PARSE_FAILED);
         }
     }
 

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/CimdProvider.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/CimdProvider.java
@@ -4,12 +4,14 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
 import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -27,6 +29,8 @@ public class CimdProvider implements Closeable {
     private final OIDCClientRepresentation client;
     private Status responseStatus;
     private String cacheControlHeader;
+    private Map<String, Object> additionalProperties;
+    private String rawMetadata;
 
     public CimdProvider(HttpServer httpServer, OIDCClientRepresentation client) {
         this.httpServer = httpServer;
@@ -47,6 +51,23 @@ public class CimdProvider implements Closeable {
         this.cacheControlHeader = cacheControlHeader;
     }
 
+    /**
+     * Sets additional properties to be merged into the served client metadata document.
+     * Useful for testing documents that contain properties beyond the ones defined in
+     * {@link OIDCClientRepresentation}, which the CIMD specification permits.
+     */
+    public void setAdditionalProperties(Map<String, Object> additionalProperties) {
+        this.additionalProperties = additionalProperties;
+    }
+
+    /**
+     * Sets a raw response body to be served verbatim instead of the serialized client representation.
+     * Useful for testing malformed client metadata documents.
+     */
+    public void setRawMetadata(String rawMetadata) {
+        this.rawMetadata = rawMetadata;
+    }
+
     @Override
     public void close() {
         httpServer.removeContext(CONTEXT);
@@ -59,7 +80,12 @@ public class CimdProvider implements Closeable {
             try (exchange) {
                 switch (responseStatus) {
                     case OK -> {
-                        String metadata = JsonSerialization.writeValueAsString(client);
+                        String metadata = rawMetadata != null ? rawMetadata : JsonSerialization.writeValueAsString(client);
+                        if (rawMetadata == null && additionalProperties != null && !additionalProperties.isEmpty()) {
+                            ObjectNode node = (ObjectNode) JsonSerialization.mapper.readTree(metadata);
+                            additionalProperties.forEach((name, value) -> node.set(name, JsonSerialization.mapper.valueToTree(value)));
+                            metadata = JsonSerialization.writeValueAsString(node);
+                        }
                         exchange.getResponseHeaders().add("Content-Type", "application/json");
                         if (cacheControlHeader != null) {
                             exchange.getResponseHeaders().add("Cache-Control", cacheControlHeader);

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientIdMetadataDocumentTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientIdMetadataDocumentTest.java
@@ -565,6 +565,49 @@ public class ClientIdMetadataDocumentTest {
         assertLoginAndError(AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_FETCH_FAILED);
     }
 
+    @Test
+    public void testClientIdMetadataDocumentExecutorIgnoresUnknownProperties() throws Exception {
+        // register profiles
+        updatePolicy(createDefaultConditionConfig(), createDefaultExecutorConfig());
+
+        // public client whose client metadata document contains additional, non-registered properties.
+        // The CIMD specification (Section 4.1) allows a client metadata document to define additional properties,
+        // and RFC 7591 (Section 2) requires ignoring any client metadata the authorization server does not understand.
+        // "code_challenge_methods_used" is a non-registered property served by real-world MCP clients.
+        setCimdPublicClient();
+        cimd.setAdditionalProperties(Map.of(
+                "code_challenge_methods_used", List.of("S256"),
+                "x_unknown_property", "arbitrary-value"));
+
+        // send an authorization request - success
+        String code = loginUserAndGetCode(true);
+
+        // get an access token
+        AccessTokenResponse tokenResponse = oauth.client(CLIENT_ID).accessTokenRequest(code).send();
+        Assertions.assertEquals(200, tokenResponse.getStatusCode());
+        AccessToken accessToken = oauth.verifyToken(tokenResponse.getAccessToken());
+        Assertions.assertEquals(CLIENT_ID, accessToken.getIssuedFor());
+
+        // the unknown properties are ignored: the recognized metadata is registered as usual
+        ClientRepresentation clientRepresentation = findByClientIdByAdmin();
+        Assertions.assertTrue(clientRepresentation.isPublicClient());
+
+        // delete the persisted client
+        logoutAndDelete(clientRepresentation.getId(), tokenResponse.getIdToken());
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorParseClientMetadataFailed() throws Exception {
+        // register profiles
+        updatePolicy(createDefaultConditionConfig(), createDefaultExecutorConfig());
+
+        // 200 OK but the response body is not a valid JSON document
+        cimd.setRawMetadata("{\"client_id\": \"" + CLIENT_ID + "\", \"redirect_uris\": \"not-json");
+
+        // send an authorization request - fail
+        assertLoginAndError(AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_PARSE_FAILED);
+    }
+
     private void testClientIdMetadataDocumentExecutorCacheControl(String cacheControlHeaderValue, int expectedExpiry) {
         // set Client Metadata
         cimd.getRepresentation().setLogoUri("https://www.example.com");


### PR DESCRIPTION
Closes #51236

The CIMD executor parsed fetched client metadata documents with the default strict ObjectMapper, so any property not defined in OIDCClientRepresentation raised UnrecognizedPropertyException and the authorization request was rejected as 'Client Metadata fetch failed'.

Both the CIMD specification (Section 4.1: the document MAY define additional properties) and RFC 7591 (Section 2: the authorization server MUST ignore client metadata it does not understand) require tolerating unknown properties. 

Real-world MCP clients such as Lovable publish documents with non-registered properties
(code_challenge_methods_used) and could not authorize at all.

Client metadata documents are now parsed leniently, scoped to the CIMD code path so Dynamic Client Registration keeps its strict behavior, and JSON mapping failures are reported distinctly from transport failures.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

