### PR TITLE
fix(oid4vc): account for realm optional client scopes in credential scope resolution

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/clientpolicy/CredentialClientPolicyExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/clientpolicy/CredentialClientPolicyExecutor.java
@@ -69,7 +69,7 @@ public class CredentialClientPolicyExecutor implements ClientPolicyExecutorProvi
         // Get the list of requested credential scopes that are associated with this client
         //
         AuthorizationEndpointRequest request = context.getAuthorizationEndpointRequest();
-        List<CredentialScopeModel> credScopes = CredentialScopeUtils.getCredentialScopesForAuthorization(client, request);
+        List<CredentialScopeModel> credScopes = CredentialScopeUtils.getCredentialScopesForAuthorization(session, client, request);
 
         // Proceed when there are requested credential scopes
         //

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationCheckProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationCheckProvider.java
@@ -39,7 +39,7 @@ public class OID4VCAuthorizationCheckProvider implements AuthorizationEndpointCh
 
         // Get the list of requested credential scopes that are associated with this client
         //
-        List<CredentialScopeModel> credScopes = CredentialScopeUtils.getCredentialScopesForAuthorization(client, request);
+        List<CredentialScopeModel> credScopes = CredentialScopeUtils.getCredentialScopesForAuthorization(session, client, request);
 
         // Proceed when there are requested credential scopes
         //

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/CredentialScopeUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/CredentialScopeUtils.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.models.ClientModel;
@@ -70,25 +72,46 @@ public class CredentialScopeUtils {
         return !credScopes.isEmpty() ? credScopes.get(0) : null;
     }
 
-    /**
+/**
      * Get the list of credential scopes associated by the given and requested by the given authorization request
      */
     public static List<CredentialScopeModel> getCredentialScopesForAuthorization(ClientModel client, AuthorizationEndpointRequest request) {
+        if (client == null || request == null) {
+            return List.of();
+        }
 
         List<String> requestScopes = Optional.ofNullable(request.getScope())
                 .map(it -> it.split("\\s"))
                 .map(Arrays::asList)
                 .orElse(List.of());
 
-        // Get the list of requested credential scopes that are associated with this client
-        //
-        Map<String, ClientScopeModel> clientScopes = client.getClientScopes(false);
-        List<CredentialScopeModel> credScopes = requestScopes.stream()
-                .filter(clientScopes::containsKey)
-                .map(clientScopes::get)
-                .filter(it -> OID4VC_PROTOCOL.equals(it.getProtocol()))
-                .map(CredentialScopeModel::new)
-                .toList();
+        // Derive realm directly from the client model
+        RealmModel realm = client.getRealm();
+
+        // Combine client scopes (default & optional) with realm optional client scopes
+        // Note: getDefaultClientScopesStream(false) retrieves Realm Optional Client Scopes
+        Map<String, ClientScopeModel> clientScopes = Stream.of(
+                        client.getClientScopes(true).values().stream(),
+                        client.getClientScopes(false).values().stream(),
+                        realm.getDefaultClientScopesStream(false)
+                )
+                .flatMap(Function.identity())
+                .collect(Collectors.toMap(
+                        ClientScopeModel::getName,
+                        Function.identity(),
+                        (existing, replacement) -> existing // Preserve client-level override priority
+                ));
+
+        List<CredentialScopeModel> credScopes = new ArrayList<>();
+        for (String scopeName : requestScopes) {
+            ClientScopeModel scopeModel = clientScopes.get(scopeName);
+            if (scopeModel != null) {
+                CredentialScopeModel credModel = parseCredentialScopeModel(scopeModel);
+                if (credModel != null) {
+                    credScopes.add(credModel);
+                }
+            }
+        }
 
         return credScopes;
     }


### PR DESCRIPTION
Closes #51187

### Summary
Updates OID4VCI scope evaluation in `CredentialScopeUtils`, `OID4VCAuthorizationCheckProvider`, and `CredentialClientPolicyExecutor` to properly recognize and account for requested scopes configured as Realm Optional Client Scopes.