### PR TITLE
fix: refining CLIResult asserts related to missing or repeated messages

### DIFF
--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jaxrs/filter/TestFilter.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jaxrs/filter/TestFilter.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.it.jaxrs.filter;
 
+import io.quarkus.vertx.http.runtime.filters.QuarkusRequestWrapper;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
 
@@ -62,6 +64,14 @@ public class TestFilter implements ContainerRequestFilter {
         } catch (RuntimeException e) {
             // should say something like Normal scoped producer method may not return null: org.keycloak.quarkus.runtime.integration.cdi.KeycloakBeanProducer.getKeycloakSession()
         }
+        
+        // add a handler that will run after the access logging
+        QuarkusRequestWrapper.get(request).addRequestDoneHandler(new Handler<Void>() {
+            @Override
+            public void handle(Void event) {
+                LOG.infof("TestFilter Request %s %s is done", method, path);
+            }
+        });
 
         LOG.infof("Request %s %s has context request %s has keycloaksession %s", method, path, address != null, s != null);
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -44,7 +44,7 @@ public class FipsDistTest {
             CLIResult cliResult = runner.run("start");
             cliResult.assertStarted();
             // Not shown as FIPS is not a preview anymore
-            cliResult.assertMessageWasShownExactlyNumberOfTimes("Preview features enabled: fips:v1", 0);
+            cliResult.assertNoStartupMessage("Preview features enabled: fips:v1");
             cliResult.assertMessage("FIPS1402Provider created: KC(" + BCFIPS_VERSION + ", FIPS-JVM: " + FIPS1402Provider.isSystemFipsEnabled() + ")");
         });
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JaxRsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JaxRsDistTest.java
@@ -17,8 +17,6 @@
 
 package org.keycloak.it.cli.dist;
 
-import java.util.concurrent.TimeUnit;
-
 import org.keycloak.it.jaxrs.filter.TestFilterTestProvider;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -27,7 +25,6 @@ import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.junit5.extension.StopServer.Mode;
 import org.keycloak.it.junit5.extension.TestProvider;
 
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +45,6 @@ public class JaxRsDistTest {
 
         assertEquals(200, when().get("/").getStatusCode());
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(
-                () -> cliResult.assertMessage("Request GET / has context request true has keycloaksession true"));
+        cliResult.assertMessage("Request GET / has context request true has keycloaksession true");
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -335,7 +335,7 @@ public class LoggingDistTest {
 
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);
-        cliResult.assertNoMessageGiven("Request GET /realms/master/clients/account/redirect has context request", "127.0.0.1 GET /realms/master/clients/account/redirect");
+        cliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/clients/account/redirect");
 
         // file
         CLIResult fileCliResult = runner.run("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-enabled=true", "--http-access-log-pattern='%A %{METHOD} %{REQUEST_URL} %{i,User-Agent}'", "--http-access-log-exclude=/realms/master/clients/.*");
@@ -345,9 +345,9 @@ public class LoggingDistTest {
 
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);
-        fileCliResult.assertNoMessageGiven("TestFilter GET Request /realms/master/clients/account/redirect is done", "[org.keycloak.http.access-log]");
-        fileCliResult.assertNoMessageGiven("TestFilter GET Request /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/.well-known/openid-configuration");
-        fileCliResult.assertNoMessageGiven("TestFilter GET Request /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/clients/account/redirect");
+        fileCliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "[org.keycloak.http.access-log]");
+        fileCliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/.well-known/openid-configuration");
+        fileCliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/clients/account/redirect");
 
         Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             String data = readHttpAccessLogFile(path, "keycloak-http-access.log");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -30,12 +30,14 @@ import org.keycloak.config.HttpAccessLogOptions;
 import org.keycloak.config.LoggingOptions;
 import org.keycloak.connections.httpclient.HttpClientBuilder;
 import org.keycloak.cookie.CookieType;
+import org.keycloak.it.jaxrs.filter.TestFilterTestProvider;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.KeycloakRunner;
 import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.junit5.extension.StopServer;
 import org.keycloak.it.junit5.extension.StopServer.Mode;
+import org.keycloak.it.junit5.extension.TestProvider;
 import org.keycloak.it.utils.RawDistRootPath;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
@@ -65,6 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DistributionTest(stopServer = Mode.MANUAL)
 @RawDistOnly(reason = "Too verbose for docker and enough to check raw dist")
 @Tag(DistributionTest.SLOW)
+@TestProvider(TestFilterTestProvider.class)
 public class LoggingDistTest {
 
     @Test
@@ -176,8 +179,8 @@ public class LoggingDistTest {
     @Test
     @Launch({"start-dev", "--log=syslog"})
     void syslogHandler(CLIResult cliResult) {
-        cliResult.assertNoMessage("org.keycloak");
-        cliResult.assertNoMessage("Listening on:");
+        cliResult.assertNoStartupMessage("org.keycloak");
+        cliResult.assertNoStartupMessage("Listening on:");
         cliResult.assertError("Error writing to TCP stream");
     }
 
@@ -332,19 +335,19 @@ public class LoggingDistTest {
 
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);
-        cliResult.assertNoMessage("127.0.0.1 GET /realms/master/clients/account/redirect");
+        cliResult.assertNoMessageGiven("Request GET /realms/master/clients/account/redirect has context request", "127.0.0.1 GET /realms/master/clients/account/redirect");
 
         // file
         CLIResult fileCliResult = runner.run("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-enabled=true", "--http-access-log-pattern='%A %{METHOD} %{REQUEST_URL} %{i,User-Agent}'", "--http-access-log-exclude=/realms/master/clients/.*");
         fileCliResult.assertStartedDevMode();
         when().get("http://127.0.0.1:8080/realms/master/.well-known/openid-configuration").then()
                 .statusCode(200);
-        fileCliResult.assertNoMessage("[org.keycloak.http.access-log]");
-        fileCliResult.assertNoMessage("127.0.0.1 GET /realms/master/.well-known/openid-configuration");
 
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);
-        fileCliResult.assertNoMessage("127.0.0.1 GET /realms/master/clients/account/redirect");
+        fileCliResult.assertNoMessageGiven("TestFilter GET Request /realms/master/clients/account/redirect is done", "[org.keycloak.http.access-log]");
+        fileCliResult.assertNoMessageGiven("TestFilter GET Request /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/.well-known/openid-configuration");
+        fileCliResult.assertNoMessageGiven("TestFilter GET Request /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/clients/account/redirect");
 
         Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             String data = readHttpAccessLogFile(path, "keycloak-http-access.log");
@@ -359,12 +362,12 @@ public class LoggingDistTest {
     void httpAccessLogFile(CLIResult cliResult, RawDistRootPath path) {
         when().get("http://127.0.0.1:8080/realms/master/.well-known/openid-configuration").then()
                 .statusCode(200);
-        cliResult.assertNoMessage("[org.keycloak.http.access-log]");
-        cliResult.assertNoMessage("127.0.0.1 GET /realms/master/.well-known/openid-configuration");
-
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);
-        cliResult.assertNoMessage("http://127.0.0.1:8080/realms/master/clients/account/redirect");
+        
+        cliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "[org.keycloak.http.access-log]");
+        cliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "127.0.0.1 GET /realms/master/.well-known/openid-configuration");
+        cliResult.assertNoMessageGiven("TestFilter Request GET /realms/master/clients/account/redirect is done", "http://127.0.0.1:8080/realms/master/clients/account/redirect");
 
         Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             String data = readHttpAccessLogFile(path, "my-custom-http-access.txt");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementDistTest.java
@@ -51,7 +51,7 @@ public class ManagementDistTest {
     @Launch({"start", "--hostname=hostname", "--http-enabled=false"})
     void testManagementNoHttps(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertNoMessage("Management interface listening on");
+        cliResult.assertNoStartupMessage("Management interface listening on");
         cliResult.assertError("Key material not provided to setup HTTPS.");
     }
 
@@ -60,7 +60,7 @@ public class ManagementDistTest {
     @Launch({"start-dev", "--legacy-observability-interface=true"})
     void testManagementDisabled(LaunchResult result, KeycloakRunner runner) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertNoMessage("Management interface listening on");
+        cliResult.assertNoStartupMessage("Management interface listening on");
 
         assertThrows(IOException.class, () -> when().get("/"), "Connection refused must be thrown");
         assertThrows(IOException.class, () -> when().get("/health"), "Connection refused must be thrown");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementOffDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManagementOffDistTest.java
@@ -38,7 +38,7 @@ public class ManagementOffDistTest {
     @Launch({"start-dev"})
     public void notOccupied(LaunchResult result) {
         CLIResult cliResult = (CLIResult) result;
-        cliResult.assertNoMessage("Management interface listening on");
+        cliResult.assertNoStartupMessage("Management interface listening on");
 
         assertThrows(IOException.class, () -> when().get("/"), "Connection refused must be thrown");
         assertThrows(IOException.class, () -> when().get("/health"), "Connection refused must be thrown");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/MetricsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/MetricsDistTest.java
@@ -62,7 +62,7 @@ public class MetricsDistTest {
     @Launch({ "start-dev", "--metrics-enabled=true" })
     void testMetricsEndpoint(CLIResult cliResult) {
         // See https://github.com/keycloak/keycloak/issues/36927
-        cliResult.assertNoMessage("A MeterFilter is being configured after a Meter has been registered to this registry.");
+        cliResult.assertNoStartupMessage("A MeterFilter is being configured after a Meter has been registered to this registry.");
 
         // Send one request to populate some of the HTTP metrics that are not available on an instance on startup
         when().get("/metrics").then()

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLIResult.java
@@ -82,7 +82,10 @@ public interface CLIResult extends LaunchResult {
         }
     }
     
-    private static void noOutput(String reason, String message, Supplier<String> supplier, CLIResult result) {
+    private static void noOutput(String reason, String message, Supplier<String> supplier, CLIResult result, boolean allowRunning) {
+        if (!allowRunning && result.exitCode() == -1) {
+            throw new AssertionError("This assertion should not be used against a server with manual stop mode");
+        }
         assertThat(reason, supplier.get(), not(containsString(message)));
     }
     
@@ -109,7 +112,7 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertNoError(String msg) {
-        noOutput("The error output contains: " + msg, msg, this::getErrorOutput, this);
+        noOutput("The error output contains: " + msg, msg, this::getErrorOutput, this, false);
     }
 
     default void assertWarning(String msg) {
@@ -125,10 +128,29 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertNoMessage(String message) {
-        noOutput("The standard output contains: " + message, message, this::getOutput, this);
+        noOutput("The standard output contains: " + message, message, this::getOutput, this, false);
+    }
+    
+    /**
+     * Used to check that a message has not been seen given that the expected message has been.
+     */
+    default void assertNoMessageGiven(String expected, String notExpected) {
+        assertMessage(expected);
+        noOutput("The standard output contains: " + notExpected, notExpected, this::getOutput, this, true);
+    }
+    
+    /**
+     * Used to check that message, which is nominally expected at startup, has not been seen.
+     * May be asserted against a running server because the run method blocks until the server is ready. 
+     */
+    default void assertNoStartupMessage(String message) {
+        noOutput("The standard output contains: " + message, message, this::getOutput, this, true);
     }
 
     default void assertMessageWasShownExactlyNumberOfTimes(String message, long numberOfShownTimes) {
+        if (exitCode() == -1) {
+            throw new AssertionError("This assertion should not be used against a server with manual stop mode");
+        }
         long msgCount = getOutput().lines().filter(oneMessage -> oneMessage.contains(message)).count();
         assertThat(msgCount, equalTo(numberOfShownTimes));
     }
@@ -138,7 +160,7 @@ public interface CLIResult extends LaunchResult {
     }
 
     default void assertNoBuild() {
-        assertNoMessage("Server configuration updated and persisted");
+        assertNoStartupMessage("Server configuration updated and persisted");
     }
 
     default boolean isClustered() {

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -428,12 +428,12 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
     }
 
     private CompletableFuture<Void> readOutput(Process process, OutputConsumer outputConsumer, Executor ex) {
-        var inputFuture = CompletableFuture.runAsync(() -> readOutput(process, process.inputReader(StandardCharsets.UTF_8), outputConsumer::onStdOut), ex);
-        var errorFuture = CompletableFuture.runAsync(() -> readOutput(process, process.errorReader(StandardCharsets.UTF_8), outputConsumer::onErrOut), ex);
+        var inputFuture = CompletableFuture.runAsync(() -> readOutput(process.inputReader(StandardCharsets.UTF_8), outputConsumer::onStdOut), ex);
+        var errorFuture = CompletableFuture.runAsync(() -> readOutput(process.errorReader(StandardCharsets.UTF_8), outputConsumer::onErrOut), ex);
         return CompletableFuture.allOf(inputFuture, errorFuture);
     }
 
-    private void readOutput(Process process, BufferedReader reader, Consumer<String> outputConsumer) {
+    private void readOutput(BufferedReader reader, Consumer<String> outputConsumer) {
         try (reader) {
             String line;
 

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -221,7 +221,9 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
             exitCode = keycloak.exitValue();
         }
 
-        shutdownOutputExecutor();
+        if (!shutdownOutputExecutor()) {
+            throw new AssertionError("Did not get complete output");
+        }
     }
 
     private void destroyDescendantsOnWindows(Process parent, boolean force) {
@@ -306,17 +308,18 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         readOutput(keycloak, outputConsumer, outputExecutor);
     }
 
-    private void shutdownOutputExecutor() {
+    private boolean shutdownOutputExecutor() {
         if (outputExecutor != null) {
             outputExecutor.shutdown();
             try {
-                outputExecutor.awaitTermination(30, TimeUnit.SECONDS);
+                return outputExecutor.awaitTermination(30, TimeUnit.SECONDS);
             } catch (InterruptedException cause) {
                 throw new RuntimeException("Failed to terminate output executor", cause);
             } finally {
                 outputExecutor = null;
             }
         }
+        return true;
     }
 
     private void resetForNextRun() {


### PR DESCRIPTION
These changes should keep the intention of the asserts, but avoid adding a baked in atLeast durations when checking for no messages.

closes: #51095

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
