### PR TITLE
Align the HTTP/2 max header list size with the HTTP/1.1 max header size

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -62,6 +62,8 @@ quarkus.naming.enable-jndi=true
 # HTTP limits configuration - reverse-engineered from Wildfly
 quarkus.http.limits.max-initial-line-length=32779
 quarkus.http.limits.max-header-size=65535
+# Align the HTTP/2 header-list limit with max-header-size, instead of the much smaller Quarkus default
+quarkus.http.limits.max-header-list-size=65535
 
 # Default and non-production grade database vendor
 %dev.kc.db=dev-file

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -703,6 +703,15 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void testHttp2HeaderListSizeMatchesHttp1HeaderSizeDefault() {
+        ConfigArgsConfigSource.setCliArgs("");
+        SmallRyeConfig config = createConfig();
+        assertEquals(config.getConfigValue("quarkus.http.limits.max-header-size").getValue(),
+                config.getConfigValue("quarkus.http.limits.max-header-list-size").getValue());
+        assertEquals("65535", config.getConfigValue("quarkus.http.limits.max-header-list-size").getValue());
+    }
+
+    @Test
     public void testQuarkusPropertyTakesPrecedenceOverDefault() {
         putEnvVar("QUARKUS_HTTP_PORT", "9090");
         ConfigArgsConfigSource.setCliArgs("");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -41,6 +41,7 @@ import io.restassured.config.RedirectConfig;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
@@ -152,6 +153,54 @@ public class HttpDistTest {
                     req.authority(HostAndPort.create(authorityHost, authorityPort));
                     return req.send();
                 })
+                .map(HttpClientResponse::statusCode)
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @Launch({"start-dev"})
+    public void largeHeadersTest() throws Exception {
+        String largeValue = "a".repeat(32 * 1024);
+
+        Vertx vertx = Vertx.vertx();
+        try {
+            HttpClient http2Client = vertx.createHttpClient(new HttpClientOptions()
+                    .setSsl(true)
+                    .setTrustAll(true)
+                    .setVerifyHost(false)
+                    .setProtocolVersion(HttpVersion.HTTP_2)
+                    .setUseAlpn(true));
+            HttpClient http1Client = vertx.createHttpClient(new HttpClientOptions()
+                    .setSsl(true)
+                    .setTrustAll(true)
+                    .setVerifyHost(false));
+            try {
+                assertThat("Large headers under the limit are accepted over HTTP/2",
+                        largeHeaderRequest(http2Client, largeValue), Matchers.is(200));
+                assertThat("Large headers under the limit are accepted over HTTP/1.1",
+                        largeHeaderRequest(http1Client, largeValue), Matchers.is(200));
+            } finally {
+                http2Client.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+                http1Client.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+            }
+        } finally {
+            vertx.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static int largeHeaderRequest(HttpClient client, String headerValue) throws Exception {
+        RequestOptions options = new RequestOptions()
+                .setServer(SocketAddress.inetSocketAddress(8443, "localhost"))
+                .setPort(8443)
+                .setSsl(true)
+                .setURI("/realms/master")
+                .setMethod(HttpMethod.GET)
+                .putHeader("X-Large-Header", headerValue);
+
+        return client.request(options)
+                .compose(HttpClientRequest::send)
                 .map(HttpClientResponse::statusCode)
                 .toCompletionStage()
                 .toCompletableFuture()


### PR DESCRIPTION
Closes #51182

Keycloak configures `quarkus.http.limits.max-header-size=65535` for HTTP/1.1 in `application.properties` but never sets `max-header-list-size` so HTTP/2 requests were held to the much smaller Quarkus default which was noted by @shawkins in the original issue.

Any request with headers between the two limits succeeded over HTTP/1.1 but was rejected at the HTTP/2 codec so the server ends up sending `GOAWAY (PROTOCOL_ERROR)` with no HTTP response and logs nothing which a fronting proxy surfaces as a bare 500.

This aligns the HTTP/2 limit with the HTTP/1.1 limit and adds two tests. A unit test asserting the two defaults stay equal and a distribution level integration test `HttpDistTest#largeHeadersTest` that is sending a 20KB header over both HTTP/2 and HTTP/1.1 and asserting 200 on both. The HTTP/2 integration test case fails with the previous 8k default also.

Verified against a locally built dist with same binary, having limit flipped via env var:


| Request | limit 8192 (old default) | limit 65535 (this PR) |
| --- | --- | --- |
| normal HTTP/2 | 200 | 200 |
| 20KB headers, HTTP/2 | `GOAWAY error=1`, no response, nothing logged | 200 |
| 20KB headers, HTTP/1.1 | 200 | 200 |
| 70KB headers (over both limits) | — | HTTP/1.1: 431; HTTP/2: stream reset |


One thing of note is requests exceeding the now aligned limit still reset the HTTP/2 stream without a 431 unlike HTTP/1.1.
It seems that behaviour comes from the Vert.x layer upstream of this change. 