### PR TITLE
fix: removing the message about missing proactive closure

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/cdi/KeycloakBeanProducer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/cdi/KeycloakBeanProducer.java
@@ -27,14 +27,11 @@ import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.transaction.TransactionalSessionHandler;
 
 import io.quarkus.arc.Unremovable;
-import org.jboss.logging.Logger;
 
 @ApplicationScoped
 @Unremovable
 public class KeycloakBeanProducer implements TransactionalSessionHandler {
     
-    private static final Logger logger = Logger.getLogger(KeycloakBeanProducer.class);
-
     @Inject
     QuarkusKeycloakSessionFactory factory;
 
@@ -47,9 +44,7 @@ public class KeycloakBeanProducer implements TransactionalSessionHandler {
     }
 
     void dispose(@Disposes KeycloakSession session) {
-        if (!session.isClosed()) {
-            logger.warn("Proactive closing of the session was missed - refinements are needed to TransactionSessionHandler related logic");
-        }
+        // ensures the session is closed if the CloseSessionFilter did not run
         close(session);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/CloseSessionFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/CloseSessionFilter.java
@@ -34,7 +34,7 @@ import jakarta.ws.rs.ext.Provider;
 import org.keycloak.models.KeycloakSession;
 
 /**
- * Closing the session at the end of the request.
+ * Closing the session at the end of the request. Not guaranteed to run if the connection is already closed.
  * <p>
  * This ensures the tranaction is committed and data is written to the database and the caches before the response is closed.
  * Without this filter a request that runs shortly after the first request completed might return still stale data.


### PR DESCRIPTION
Opting for removal, rather than trying to further refine this. What additional refinements would entail:
- picking up quarkus 3.33.3 to get https://github.com/quarkusio/quarkus/issues/54889
- Adding the Cancellable annotation to CloseSessionFilter
- Add additional logic to account closure when there's Stream or StreamingOutput entities - as we expect those to be read / closed to proactively close the session. More than likely this would mean adding another flag to the session "pending closure" to track that the CloseSessionFilter had run, but that full closure had not happened yet.
- And finally detect in CloseSessionFilter that it's being run in a different thread than what started the transaction as what we're trying to truly detect / warn against are new or missing async scenarios that the TransactionalSessionHandler isn't handling. Ideally Keycloak maintainers shouldn't be adding new async endpoints, and we document that users shouldn't be doing that either. 

It doesn't seem like the additional complexity is warranted given this is already a corner case, and if we see a need for something like this in the future, it would be better to have quarkus provide us with a flag on the ResteasyReactiveRequestContext.

closes: #51131

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
