### PR TITLE
[OID4VCI] Ensure credential configuration IDs are unique

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -1446,6 +1446,11 @@ public class RealmCacheSession implements CacheRealmProvider {
     }
 
     @Override
+    public Stream<ClientScopeModel> getClientScopesByProtocolForUpdate(RealmModel realm, String protocol) {
+        return getClientScopeDelegate().getClientScopesByProtocolForUpdate(realm, protocol);
+    }
+
+    @Override
     public Stream<ClientScopeModel> getClientScopesByAttributes(RealmModel realm, Map<String, String> searchMap,
                                                                 boolean useOr) {
         return getClientScopeDelegate().getClientScopesByAttributes(realm, searchMap, useOr);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -1289,6 +1289,21 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
                     .map(entity -> new ClientScopeAdapter(realm, em, session, entity));
     }
 
+    @Override
+    public Stream<ClientScopeModel> getClientScopesByProtocolForUpdate(RealmModel realm, String protocol) {
+        RealmEntity realmEntity = em.find(RealmEntity.class, realm.getId(), LockModeType.PESSIMISTIC_WRITE);
+        if (realmEntity == null) {
+            return Stream.empty();
+        }
+
+        TypedQuery<ClientScopeEntity> query = em.createNamedQuery("getClientScopesByProtocol", ClientScopeEntity.class)
+                .setParameter("realm", realm.getId())
+                .setParameter("protocol", protocol)
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE);
+        return query.getResultStream()
+                .map(entity -> new ClientScopeAdapter(realm, em, session, entity));
+    }
+
     /**
      * This method filters clientScopes by specific attributes. To do this, it will generate the sql-statement
      * dynamically based on the given search-parameters.<br />

--- a/model/storage-private/src/main/java/org/keycloak/storage/ClientScopeStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/ClientScopeStorageManager.java
@@ -82,6 +82,11 @@ public class ClientScopeStorageManager extends AbstractStorageManager<ClientScop
     }
 
     @Override
+    public Stream<ClientScopeModel> getClientScopesByProtocolForUpdate(RealmModel realm, String protocol) {
+        return localStorage().getClientScopesByProtocolForUpdate(realm, protocol);
+    }
+
+    @Override
     public Stream<ClientScopeModel> getClientScopesByAttributes(RealmModel realm, Map<String, String> searchMap,
                                                                 boolean useOr) {
         return localStorage().getClientScopesByAttributes(realm, searchMap, useOr);

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
@@ -88,6 +88,8 @@ import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.validation.OrganizationsValidation;
 import org.keycloak.partialimport.PartialImportResults;
+import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.LoginProtocolFactory;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.idm.ApplicationRepresentation;
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
@@ -375,9 +377,13 @@ public class DefaultExportImportManager implements ExportImportManager {
         importIdentityProviders(rep, newRealm, session);
         importIdentityProviderMappers(rep, session);
 
+        if (rep.isVerifiableCredentialsEnabled() != null) {
+            newRealm.setVerifiableCredentialsEnabled(rep.isVerifiableCredentialsEnabled());
+        }
+
         Map<String, ClientScopeModel> clientScopes = new HashMap<>();
         if (rep.getClientScopes() != null) {
-            clientScopes = createClientScopes(rep.getClientScopes(), newRealm);
+            clientScopes = createClientScopes(session, rep.getClientScopes(), newRealm);
         }
         if (rep.getDefaultDefaultClientScopes() != null) {
             for (String clientScopeName : rep.getDefaultDefaultClientScopes()) {
@@ -505,9 +511,6 @@ public class DefaultExportImportManager implements ExportImportManager {
         if (rep.isInternationalizationEnabled() != null) {
             newRealm.setInternationalizationEnabled(rep.isInternationalizationEnabled());
         }
-        if (rep.isVerifiableCredentialsEnabled() != null) {
-            newRealm.setVerifiableCredentialsEnabled(rep.isVerifiableCredentialsEnabled());
-        }
         if (rep.getSupportedLocales() != null) {
             newRealm.setSupportedLocales(new HashSet<String>(rep.getSupportedLocales()));
         }
@@ -612,9 +615,17 @@ public class DefaultExportImportManager implements ExportImportManager {
         return appMap;
     }
 
-    private static Map<String, ClientScopeModel> createClientScopes(List<ClientScopeRepresentation> clientScopes, RealmModel realm) {
+    private static Map<String, ClientScopeModel> createClientScopes(KeycloakSession session,
+                                                                    List<ClientScopeRepresentation> clientScopes,
+                                                                    RealmModel realm) {
         Map<String, ClientScopeModel> appMap = new HashMap<>();
         for (ClientScopeRepresentation resourceRep : clientScopes) {
+            LoginProtocolFactory loginProtocolFactory = (LoginProtocolFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(LoginProtocol.class, resourceRep.getProtocol());
+            if (loginProtocolFactory != null) {
+                loginProtocolFactory.validateClientScope(session, resourceRep);
+                loginProtocolFactory.addClientScopeDefaults(resourceRep);
+            }
             ClientScopeModel app = RepresentationToModel.createClientScope(realm, resourceRep);
             appMap.put(app.getName(), app);
         }

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -190,7 +190,7 @@ public class CredentialScopeModel implements ClientScopeModel {
     }
 
     public String getCredentialConfigurationId() {
-        return Optional.ofNullable(clientScope.getAttribute(VC_CONFIGURATION_ID)).orElse(clientScope.getName());
+        return clientScope.getAttribute(VC_CONFIGURATION_ID);
     }
 
     public void setCredentialConfigurationId(String credentialConfigurationId) {

--- a/server-spi/src/main/java/org/keycloak/models/ClientScopeProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientScopeProvider.java
@@ -85,6 +85,21 @@ public interface ClientScopeProvider extends Provider, ClientScopeLookupProvider
     Stream<ClientScopeModel> getClientScopesByProtocol(RealmModel realm, String protocol);
 
     /**
+     * Retrieves all client scopes of the given realm that use the given protocol while holding a realm-scoped
+     * transactional lock. Concurrent callers for the same realm must be serialized until the current transaction
+     * completes, including when no matching client scopes exist.
+     * The default implementation performs an unlocked query for compatibility; transactional persistence providers
+     * must override it to provide the locking guarantee.
+     *
+     * @param realm the realm to retrieve the client scopes from
+     * @param protocol the protocol expected from the client scopes
+     * @return stream of client scopes reflecting the latest committed state
+     */
+    default Stream<ClientScopeModel> getClientScopesByProtocolForUpdate(RealmModel realm, String protocol) {
+        return getClientScopesByProtocol(realm, protocol);
+    }
+
+    /**
      * Allows us to filter for scopes by specific attributes
      *
      * @param realm     Realm.

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import jakarta.ws.rs.core.Response;
 
@@ -55,6 +56,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
 
 import org.jboss.logging.Logger;
 
@@ -202,7 +204,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 
         clientScope.getAttributes().putIfAbsent(INCLUDE_IN_TOKEN_SCOPE, "true");
         clientScope.getAttributes().putIfAbsent(VC_INCLUDE_IN_METADATA, "true");
-        clientScope.getAttributes().putIfAbsent(VC_CONFIGURATION_ID, scopeName);
+        clientScope.getAttributes().put(VC_CONFIGURATION_ID, getEffectiveCredentialConfigurationId(clientScope));
         clientScope.getAttributes().putIfAbsent(VC_SUPPORTED_TYPES, credentialType);
         clientScope.getAttributes().putIfAbsent(VC_CONTEXTS, credentialType);
         clientScope.getAttributes().putIfAbsent(VCT, credentialType);
@@ -229,6 +231,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
         }
 
         validateOID4VCIRefreshInterval(clientScope);
+        validateCredentialConfigurationId(session, clientScope);
     }
 
     @Override
@@ -293,6 +296,40 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
     }
 
     // Private ---------------------------------------------------------------------------------------------------------
+
+    private void validateCredentialConfigurationId(KeycloakSession session, ClientScopeRepresentation clientScope) {
+        String credentialConfigurationId = getEffectiveCredentialConfigurationId(clientScope);
+        if (StringUtil.isBlank(credentialConfigurationId)) {
+            throw ErrorResponse.error("Credential configuration ID must not be blank", Response.Status.BAD_REQUEST);
+        }
+
+        session.getContext().getRealm().getClientScopesStream()
+                .filter(existingScope -> OID4VC_PROTOCOL.equals(existingScope.getProtocol()))
+                .filter(existingScope -> !Objects.equals(existingScope.getId(), clientScope.getId()))
+                .filter(existingScope -> credentialConfigurationId.equals(getEffectiveCredentialConfigurationId(existingScope)))
+                .findAny()
+                .ifPresent(existingScope -> {
+                    throw ErrorResponse.exists(String.format(
+                            "Credential configuration ID '%s' is already used by client scope '%s'",
+                            credentialConfigurationId, existingScope.getName()));
+                });
+    }
+
+    private static String getEffectiveCredentialConfigurationId(ClientScopeRepresentation clientScope) {
+        String configuredId = clientScope.getAttributes() == null
+                ? null
+                : clientScope.getAttributes().get(VC_CONFIGURATION_ID);
+        return getEffectiveCredentialConfigurationId(configuredId, clientScope.getName());
+    }
+
+    private static String getEffectiveCredentialConfigurationId(ClientScopeModel clientScope) {
+        return getEffectiveCredentialConfigurationId(clientScope.getAttribute(VC_CONFIGURATION_ID), clientScope.getName());
+    }
+
+    private static String getEffectiveCredentialConfigurationId(String configuredId, String scopeName) {
+        return StringUtil.isBlank(configuredId) ? scopeName : configuredId;
+    }
+
     /**
      * Validates that the refresh interval does not exceed the credential lifetime.
      *

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -303,8 +303,8 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
             throw ErrorResponse.error("Credential configuration ID must not be blank", Response.Status.BAD_REQUEST);
         }
 
-        session.getContext().getRealm().getClientScopesStream()
-                .filter(existingScope -> OID4VC_PROTOCOL.equals(existingScope.getProtocol()))
+        RealmModel realm = session.getContext().getRealm();
+        session.clientScopes().getClientScopesByProtocolForUpdate(realm, OID4VC_PROTOCOL)
                 .filter(existingScope -> !Objects.equals(existingScope.getId(), clientScope.getId()))
                 .filter(existingScope -> credentialConfigurationId.equals(getEffectiveCredentialConfigurationId(existingScope)))
                 .findAny()

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -104,7 +104,8 @@ public class SupportedCredentialConfiguration {
         SupportedCredentialConfiguration credentialConfiguration = new SupportedCredentialConfiguration();
 
         String credentialConfigurationId = Optional.ofNullable(credentialScope.getCredentialConfigurationId())
-                                                   .orElse(credentialScope.getName());
+                .orElseThrow(() -> new IllegalStateException("No credential configuration ID in client scope: "
+                        + credentialScope.getName()));
         credentialConfiguration.setId(credentialConfigurationId);
 
         credentialConfiguration.setScope(credentialScope.getName());

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -135,7 +135,7 @@ public class ClientScopeResource {
         try {
             LoginProtocolFactory loginProtocolFactory = //
                     (LoginProtocolFactory) session.getKeycloakSessionFactory().getProviderFactory(LoginProtocol.class,
-                                                                                                  clientScope.getProtocol());
+                                                                                                  rep.getProtocol());
             Optional.ofNullable(loginProtocolFactory).ifPresent(lp -> lp.addClientScopeDefaults(rep));
             RepresentationToModel.updateClientScope(rep, clientScope);
             adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -126,6 +126,10 @@ public class ClientScopeResource {
     })
     public Response update(final ClientScopeRepresentation rep) {
         auth.clients().requireManageClientScopes();
+        rep.setId(clientScope.getId());
+        if (rep.getProtocol() == null) {
+            rep.setProtocol(clientScope.getProtocol());
+        }
         ClientScopeResource.validateClientScope(session, rep);
         validateParameterizedScopeUpdate(rep);
         try {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -38,6 +38,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.DisplayObject;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -196,6 +197,33 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
                 clientScopes.get(secondScopeId).remove();
             }
             clientScopes.get(firstScopeId).remove();
+        }
+    }
+
+    @Test
+    public void testUpdatingProtocolToOID4VCAppliesOID4VCDefaults() {
+        ClientScopesResource clientScopes = testRealm.admin().clientScopes();
+        ClientScopeRepresentation scope = new ClientScopeRepresentation();
+        scope.setName("issue-51185-protocol-update");
+        scope.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+
+        String scopeId = null;
+        try (Response response = clientScopes.create(scope)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            scopeId = ApiUtil.getCreatedId(response);
+        }
+
+        try {
+            ClientScopeResource scopeResource = clientScopes.get(scopeId);
+            ClientScopeRepresentation update = scopeResource.toRepresentation();
+            update.setProtocol(OID4VC_PROTOCOL);
+            scopeResource.update(update);
+
+            ClientScopeRepresentation updatedScope = scopeResource.toRepresentation();
+            assertEquals(OID4VC_PROTOCOL, updatedScope.getProtocol());
+            assertEquals(updatedScope.getName(), updatedScope.getAttributes().get(VC_CONFIGURATION_ID));
+        } finally {
+            clientScopes.get(scopeId).remove();
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -26,12 +26,16 @@ import java.util.Map;
 import java.util.Set;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RealmsResource;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
@@ -78,6 +82,7 @@ import static org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory.NATURAL_PE
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,7 +100,9 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         clientScope.setName("test-client-scope");
         clientScope.setDescription("test-client-scope-description");
         clientScope.setProtocol(OID4VC_PROTOCOL);
-        clientScope.setAttributes(Map.of("test-attribute", "test-value"));
+        clientScope.setAttributes(Map.of(
+                "test-attribute", "test-value",
+                VC_CONFIGURATION_ID, "   "));
 
         String clientScopeId = null;
         ClientScopesResource clientScopes = testRealm.admin().clientScopes();
@@ -131,6 +138,74 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         } finally {
             assertNotNull(clientScopeId);
             clientScopes.get(clientScopeId).remove();
+        }
+    }
+
+    @Test
+    public void testCredentialConfigurationIdDoesNotFallbackToScopeName() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName(VCTestRealmConfig.TEST_REALM_NAME);
+            ClientScopeModel clientScope = realm.addClientScope("issue-51185-no-fallback");
+            clientScope.setProtocol(OID4VC_PROTOCOL);
+            try {
+                assertNull(new CredentialScopeModel(clientScope).getCredentialConfigurationId());
+            } finally {
+                realm.removeClientScope(clientScope.getId());
+            }
+        });
+    }
+
+    @Test
+    public void testCredentialConfigurationIdMustBeUnique() {
+        ClientScopesResource clientScopes = testRealm.admin().clientScopes();
+        String firstScopeId = createCredentialScope(clientScopes, "issue-51185-first", "issue-51185-shared-id");
+        String secondScopeId = null;
+
+        try {
+            CredentialScopeRepresentation explicitDuplicate = new CredentialScopeRepresentation("issue-51185-explicit-duplicate");
+            explicitDuplicate.setCredentialConfigurationId("issue-51185-shared-id");
+            try (Response response = clientScopes.create(explicitDuplicate)) {
+                assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+                assertTrue(response.readEntity(String.class).contains("issue-51185-shared-id"));
+            }
+
+            CredentialScopeRepresentation implicitDuplicate = new CredentialScopeRepresentation("issue-51185-shared-id");
+            implicitDuplicate.setCredentialConfigurationId(null);
+            try (Response response = clientScopes.create(implicitDuplicate)) {
+                assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+            }
+
+            secondScopeId = createCredentialScope(clientScopes, "issue-51185-second", "issue-51185-second-id");
+            ClientScopeResource secondScope = clientScopes.get(secondScopeId);
+            CredentialScopeRepresentation duplicateUpdate = new CredentialScopeRepresentation(secondScope.toRepresentation());
+            duplicateUpdate.setCredentialConfigurationId("issue-51185-shared-id");
+            duplicateUpdate.setProtocol(null);
+
+            WebApplicationException exception = assertThrows(WebApplicationException.class,
+                    () -> secondScope.update(duplicateUpdate));
+            assertEquals(Response.Status.CONFLICT.getStatusCode(), exception.getResponse().getStatus());
+
+            CredentialScopeRepresentation update = new CredentialScopeRepresentation(secondScope.toRepresentation());
+            update.setId(null);
+            update.setDescription("self update without representation ID");
+            secondScope.update(update);
+            assertEquals("issue-51185-second-id",
+                    secondScope.toRepresentation().getAttributes().get(VC_CONFIGURATION_ID));
+        } finally {
+            if (secondScopeId != null) {
+                clientScopes.get(secondScopeId).remove();
+            }
+            clientScopes.get(firstScopeId).remove();
+        }
+    }
+
+    private String createCredentialScope(ClientScopesResource clientScopes, String name,
+                                         String credentialConfigurationId) {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation(name);
+        scope.setCredentialConfigurationId(credentialConfigurationId);
+        try (Response response = clientScopes.create(scope)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            return ApiUtil.getCreatedId(response);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -350,6 +350,62 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         }
     }
 
+    @Test
+    public void testRealmImportAppliesCredentialScopeDefaults() {
+        RealmsResource realms = keycloak.realms();
+        String realmName = "issue-51185-import-defaults";
+        String scopeName = "issue-51185-imported-scope";
+
+        RealmRepresentation realmRep = new RealmRepresentation();
+        realmRep.setRealm(realmName);
+        realmRep.setEnabled(true);
+        realmRep.setVerifiableCredentialsEnabled(true);
+
+        ClientScopeRepresentation clientScope = new ClientScopeRepresentation();
+        clientScope.setName(scopeName);
+        clientScope.setProtocol(OID4VC_PROTOCOL);
+        realmRep.setClientScopes(List.of(clientScope));
+
+        try {
+            realms.create(realmRep);
+
+            ClientScopeRepresentation importedScope = realms.realm(realmName).clientScopes().findAll().stream()
+                    .filter(scope -> scopeName.equals(scope.getName()))
+                    .findFirst()
+                    .orElseThrow();
+            assertEquals(scopeName, importedScope.getAttributes().get(VC_CONFIGURATION_ID));
+        } finally {
+            realms.realm(realmName).remove();
+        }
+    }
+
+    @Test
+    public void testRealmImportRejectsDuplicateCredentialConfigurationIds() {
+        RealmsResource realms = keycloak.realms();
+        String realmName = "issue-51185-import-duplicate";
+        String credentialConfigurationId = "issue-51185-imported-shared-id";
+
+        RealmRepresentation realmRep = new RealmRepresentation();
+        realmRep.setRealm(realmName);
+        realmRep.setEnabled(true);
+        realmRep.setVerifiableCredentialsEnabled(true);
+
+        CredentialScopeRepresentation firstScope = new CredentialScopeRepresentation("issue-51185-imported-first");
+        firstScope.setCredentialConfigurationId(credentialConfigurationId);
+        CredentialScopeRepresentation secondScope = new CredentialScopeRepresentation("issue-51185-imported-second");
+        secondScope.setCredentialConfigurationId(credentialConfigurationId);
+        realmRep.setClientScopes(List.of(firstScope, secondScope));
+
+        try {
+            WebApplicationException exception = assertThrows(WebApplicationException.class, () -> realms.create(realmRep));
+            assertEquals(Response.Status.CONFLICT.getStatusCode(), exception.getResponse().getStatus());
+        } finally {
+            if (realms.findAll().stream().anyMatch(realm -> realmName.equals(realm.getRealm()))) {
+                realms.realm(realmName).remove();
+            }
+        }
+    }
+
     /**
      * Test that creating a client scope with invalid refresh interval is rejected
      */

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/clientscope/ClientScopeModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/clientscope/ClientScopeModelTest.java
@@ -18,6 +18,12 @@ package org.keycloak.testsuite.model.clientscope;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.keycloak.models.ClientModel;
@@ -26,12 +32,15 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientScopeProvider;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleProvider;
 import org.keycloak.models.cache.CacheRealmProvider;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.testsuite.model.KeycloakModelTest;
 import org.keycloak.testsuite.model.RequireProvider;
+import org.keycloak.testsuite.model.util.TransactionController;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -40,6 +49,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -124,6 +135,56 @@ public class ClientScopeModelTest extends KeycloakModelTest {
             return null;
         });
 
+    }
+
+    @Test
+    @RequireProvider(value=ClientScopeProvider.class, only="jpa")
+    public void testClientScopesByProtocolForUpdateSerializesRealmChanges() throws Exception {
+        String protocol = "client-scope-lock-test";
+        String clientScopeName = "client-scope-created-under-lock";
+        KeycloakSessionFactory sessionFactory = getFactory();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try (TransactionController firstTransaction = new TransactionController(sessionFactory)) {
+            boolean firstTransactionCompleted = false;
+            firstTransaction.begin();
+            try {
+                firstTransaction.runStep(session -> {
+                    RealmModel realm = session.realms().getRealm(realmId);
+                    session.getContext().setRealm(realm);
+                    assertThat(session.clientScopes().getClientScopesByProtocolForUpdate(realm, protocol)
+                            .collect(Collectors.toList()), empty());
+
+                    ClientScopeModel clientScope = session.clientScopes().addClientScope(realm, clientScopeName);
+                    clientScope.setProtocol(protocol);
+                    return null;
+                });
+
+                CountDownLatch secondTransactionStarted = new CountDownLatch(1);
+                Future<List<String>> secondTransaction = executor.submit(() ->
+                        KeycloakModelUtils.runJobInTransactionWithResult(sessionFactory, session -> {
+                            RealmModel realm = session.realms().getRealm(realmId);
+                            session.getContext().setRealm(realm);
+                            secondTransactionStarted.countDown();
+                            return session.clientScopes().getClientScopesByProtocolForUpdate(realm, protocol)
+                                    .map(ClientScopeModel::getName)
+                                    .collect(Collectors.toList());
+                        }));
+
+                assertTrue(secondTransactionStarted.await(5, TimeUnit.SECONDS));
+                assertThrows(TimeoutException.class, () -> secondTransaction.get(200, TimeUnit.MILLISECONDS));
+
+                firstTransaction.commit();
+                firstTransactionCompleted = true;
+                assertThat(secondTransaction.get(5, TimeUnit.SECONDS), containsInAnyOrder(clientScopeName));
+            } finally {
+                if (!firstTransactionCompleted) {
+                    firstTransaction.rollback();
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     private static void assertionsForClientScopesCaching(List<String> clientScopes, KeycloakSession session, RealmModel realm) {


### PR DESCRIPTION
## Summary

Enforces explicit and unique OID4VCI credential configuration IDs when client scopes are created, updated, or imported.

## Changes

- Remove the client-scope name fallback from `CredentialScopeModel.getCredentialConfigurationId()`.
- Default missing or blank credential configuration IDs to the client-scope name during creation, update, and realm import.
- Reject creation, update, or realm import when the effective credential configuration ID is already used by another OID4VCI client scope.
- Return HTTP 409 for duplicate credential configuration IDs.
- Serialize concurrent uniqueness checks using realm-scoped transactional locking.
- Ensure update validation cannot be bypassed by omitting the representation ID or protocol.
- Apply defaults using the target protocol when changing a client scope’s protocol.
- Apply protocol-specific validation and defaults when importing client scopes.
- Remove the additional scope-name fallback when generating issuer metadata.
- Add coverage for:
  - explicit and implicit duplicate IDs;
  - duplicate updates;
  - concurrent duplicate creation;
  - blank-ID defaulting;
  - updates with an omitted protocol or representation ID;
  - switching client scopes to OID4VCI;
  - realm-import defaulting and duplicate rejection;
  - removal of the model fallback.

Closes #51185