### PR TITLE
Upgrade to Quarkus 3.37.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.33.2.1</quarkus.version>
-        <quarkus.build.version>3.33.2.1</quarkus.build.version>
+        <quarkus.version>3.37.4</quarkus.version>
+        <quarkus.build.version>3.37.4</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>
@@ -99,7 +99,7 @@
         <jboss-servlet-api_4.0_spec>2.0.0.Final</jboss-servlet-api_4.0_spec>
         <jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>2.0.1.Final</jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec.version>
         <jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>2.0.0.Final</jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec.version>
-        <log4j2-api.version>2.25.4</log4j2-api.version> <!-- Odd name needs to align with Quarkus -->
+        <log4j2-api.version>2.26.0</log4j2-api.version> <!-- Odd name needs to align with Quarkus -->
         <resteasy.version>6.2.16.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
         <owasp.html.sanitizer.version>20260101.1</owasp.html.sanitizer.version>
@@ -111,7 +111,7 @@
         <sun.activation.version>1.2.2</sun.activation.version>
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
         <undertow.version>2.3.24.Final</undertow.version>
-        <wildfly-elytron.version>2.8.4.Final</wildfly-elytron.version>
+        <wildfly-elytron.version>2.9.1.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
         <woodstox.version>6.0.3</woodstox.version>
         <wildfly.common.quarkus.aligned.version>1.5.4.Final-format-001</wildfly.common.quarkus.aligned.version>
@@ -146,7 +146,7 @@
         <tidb.container>mirror.gcr.io/pingcap/tidb:${tidb.version}</tidb.container>
         <mysql.version>8.4</mysql.version>
         <mysql.container>mirror.gcr.io/mysql:${mysql.version}</mysql.container>
-        <mysql-jdbc.version>9.6.0</mysql-jdbc.version>
+        <mysql-jdbc.version>9.7.0</mysql-jdbc.version>
         <postgresql.version>18</postgresql.version>
         <postgresql.container>mirror.gcr.io/postgres:${postgresql.version}</postgresql.container>
         <aurora-postgresql.version>17.5</aurora-postgresql.version>
@@ -154,19 +154,19 @@
         <cnpg.major-minor-version>1.29</cnpg.major-minor-version>
         <cnpg.patch-version>0</cnpg.patch-version>
         <cnpg.version>${cnpg.major-minor-version}.${cnpg.patch-version}</cnpg.version>
-        <postgresql-jdbc.version>42.7.11</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.13</postgresql-jdbc.version>
         <mariadb.version>11.8</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.7</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.9</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <mssql.collation>Latin1_General_100_CI_AS_SC_UTF8</mssql.collation>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->
-        <mssql-jdbc.version>13.2.1.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>13.4.0.jre11</mssql-jdbc.version>
         <oracledb.version>23.5</oracledb.version>
         <oracledb.container>mirror.gcr.io/gvenzl/oracle-free:${oracledb.version}-slim-faststart</oracledb.container>
         <!-- this is the oracle driver version also used in the Quarkus BOM -->
-        <oracle-jdbc.version>23.26.0.0.0</oracle-jdbc.version>
+        <oracle-jdbc.version>23.26.2.0.0</oracle-jdbc.version>
         <!-- Custom image, lives in test-framework/db-edb/container -->
         <edb.container>quay.io/keycloakqe/enterprisedb:${edb.version}</edb.container>
         <edb.version>18</edb.version>
@@ -180,7 +180,7 @@
         <junit.version>4.13.2</junit.version>
         <picketlink.version>2.7.0.Final</picketlink.version>
         <!-- Needs to be aligned with Quarkus, handled in quarkus/set-quarkus-version.sh script -->
-        <version.surefire.plugin>3.5.4</version.surefire.plugin>
+        <version.surefire.plugin>3.5.6</version.surefire.plugin>
         <xml-apis.version>1.4.01</xml-apis.version>
         <subethasmtp.version>3.1.7</subethasmtp.version>
         <assertj-core.version>3.22.0</assertj-core.version>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelHttpClientFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelHttpClientFactory.java
@@ -48,7 +48,7 @@ public class OTelHttpClientFactory extends DefaultHttpClientFactory implements E
     @Override
     protected HttpClientBuilder newHttpClientBuilder(KeycloakSession session) {
         var provider = (OTelTracingProvider) session.getProvider(TracingProvider.class);
-        return new HttpClientBuilder(ApacheHttpClientTelemetry.builder(provider.getOpenTelemetry()).build().newHttpClientBuilder());
+        return new HttpClientBuilder(ApacheHttpClientTelemetry.builder(provider.getOpenTelemetry()).build().createHttpClientBuilder());
     }
 
     @Override

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -381,7 +381,8 @@ public class LoggingDistTest {
         cliResult.assertStartedDevMode();
         cliResult.assertMessage("opentelemetry");
         cliResult.assertMessage("service.name=\"keycloak\"");
-        cliResult.assertMessage("Failed to export LogsRequestMarshaler.");
+        cliResult.assertMessage("Failed to export");
+        cliResult.assertMessage("error message: Connection refused");
     }
 
     @Test
@@ -438,10 +439,10 @@ public class LoggingDistTest {
 
         // Verify that sensitive cookie values are masked in the access log
         cliResult.assertMessage("[org.keycloak.http.access-log]");
-        cliResult.assertMessage("Authorization: Bearer ...");
-        cliResult.assertMessage("Authorization: DPoP ...");
+        cliResult.assertMessage("Authorization: Bearer <hidden>");
+        cliResult.assertMessage("Authorization: DPoP <hidden>");
         cliResult.assertMessage("Cookie: SOMETHING=something-not-sensitive");
         cliResult.assertMessage("Content-Language: cs");
-        HttpAccessLogOptions.DEFAULT_HIDDEN_COOKIES.forEach(cookie -> cliResult.assertMessage("Cookie: %s=...".formatted(cookie)));
+        HttpAccessLogOptions.DEFAULT_HIDDEN_COOKIES.forEach(cookie -> cliResult.assertMessage("Cookie: %s=<hidden>".formatted(cookie)));
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
-
 import static org.keycloak.tests.oid4vc.CredentialOfferStateUtils.getCredentialOfferStateRecord;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/tests/base/src/test/java/org/keycloak/tests/tracing/TracingProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/tracing/TracingProviderTest.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.ExceptionEventData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -84,7 +83,7 @@ public class TracingProviderTest {
 
                 var context = current.getSpanContext();
                 assertThat(context, is(span.getSpanContext()));
-                assertThat(context.getTraceFlags(), is(TraceFlags.getSampled()));
+                assertThat(context.getTraceFlags().isSampled(), is(true));
                 assertThat(current.isRecording(), is(true));
 
                 assertThat(current instanceof ReadableSpan, is(true));


### PR DESCRIPTION
Closes #51273

Apart from the version bumps, the PR contains cherry-picked quarkus-next fixes effective in <=3.37:
  - #48555 - TracingProviderTest OTel W3C random trace flag
  - #48475 - LoggingDistTest access log masking + OTel export
  - #47896 - OTel ApacheHttpClientTelemetry API adaptation

Once merged, I'll remove these commits from the quarkus-next branch to avoid conflicts.