### PR TITLE
[26.7] Rotated client secret remains valid when the feature is disabled

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSecretConstants;
@@ -32,9 +34,11 @@ import static org.keycloak.models.ClientSecretConstants.CLIENT_SECRET_REMAINING_
  * @author <a href="mailto:masales@redhat.com">Marcelo Sales</a>
  */
 public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
+    private final boolean isRotationFeatureEnabled;
 
     private OIDCClientSecretConfigWrapper(ClientModel client, ClientRepresentation clientRep) {
         super(client, clientRep);
+        this.isRotationFeatureEnabled = Profile.isFeatureEnabled(Feature.CLIENT_SECRET_ROTATION);
     }
 
     public static OIDCClientSecretConfigWrapper fromClientModel(ClientModel client) {
@@ -84,7 +88,7 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
     }
 
     public void removeClientSecretRotated() {
-        if (hasRotatedSecret()) {
+        if (hasRotatedSecretAttributes()) {
             setAttribute(CLIENT_ROTATED_SECRET, null);
             setAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME, null);
             setAttribute(CLIENT_ROTATED_SECRET_EXPIRATION_TIME, null);
@@ -101,7 +105,12 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
     }
 
     public boolean hasRotatedSecret() {
-        return StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET)) && StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME));
+        return isRotationFeatureEnabled && hasRotatedSecretAttributes();
+    }
+
+    private boolean hasRotatedSecretAttributes() {
+        return StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET))
+                && StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -794,6 +794,8 @@ public class ClientResource {
 
             logger.debug("delete rotated secret");
 
+            // Always remove rotated secret attributes even when the feature is disabled,
+            // so stale secrets cannot become valid again if the feature is re-enabled.
             OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientModel(client);
 
             CredentialRepresentation rep = new CredentialRepresentation();

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientSecretRotationDisabledTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientSecretRotationDisabledTest.java
@@ -1,0 +1,82 @@
+package org.keycloak.tests.client;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.models.ClientSecretConstants;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.tests.common.TestRealmUserConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest
+public class ClientSecretRotationDisabledTest {
+
+    private static final String CLIENT_ID = "test-app";
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectUser(config = TestRealmUserConfig.class)
+    ManagedUser user;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    /**
+     * Verifies that rotated client secrets are not accepted when the CLIENT_SECRET_ROTATION
+     * feature is disabled, even if the rotated secret attributes remain in the database.
+     *
+     * @see <a href="https://github.com/keycloak/keycloak/issues/50855">Issue #50855</a>
+     */
+    @Test
+    public void rotatedSecretNotAcceptedWhenFeatureDisabled() {
+        String originalSecret = oauth.clientResource().getSecret().getValue();
+
+        // Verify the original secret works before rotating
+        oauth.client(CLIENT_ID, originalSecret);
+        oauth.doLogin(user.getUsername(), "password");
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
+        assertEquals(200, response.getStatusCode());
+        assertNotNull(response.getAccessToken());
+
+        String newSecret = oauth.clientResource().generateNewSecret().getValue();
+
+        // Set rotated secret attributes directly on the server-side model to bypass the admin
+        // API cleanup in ClientResource.update() which always removes rotation info when no
+        // rotation executor is active.
+        String creationTime = String.valueOf(Time.currentTimeSeconds());
+        String expirationTime = String.valueOf(Time.currentTimeSeconds() + 3600);
+        runOnServer.run(session -> {
+            var realmModel = session.getContext().getRealm();
+            var client = realmModel.getClientByClientId(CLIENT_ID);
+            client.setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET, originalSecret);
+            client.setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_CREATION_TIME, creationTime);
+            client.setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_EXPIRATION_TIME, expirationTime);
+        });
+
+        // Authentication with the rotated (original) secret must fail when feature is disabled
+        oauth.client(CLIENT_ID, originalSecret);
+        oauth.openLoginForm();
+        code = oauth.parseLoginResponse().getCode();
+        response = oauth.doAccessTokenRequest(code);
+        assertEquals(401, response.getStatusCode());
+
+        // Authentication with the current (new) secret must always work
+        oauth.client(CLIENT_ID, newSecret);
+        oauth.openLoginForm();
+        code = oauth.parseLoginResponse().getCode();
+        response = oauth.doAccessTokenRequest(code);
+        assertEquals(200, response.getStatusCode());
+        assertNotNull(response.getAccessToken());
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
@@ -19,7 +19,9 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientPoliciesPoliciesResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
+import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.common.profile.CommaSeparatedListProfileConfigResolver;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
@@ -60,6 +62,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -107,6 +110,11 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
             TimeUnit.MINUTES.toSeconds(10)).intValue();
     private static final int DEFAULT_REMAIN_EXPIRATION_PERIOD = Long.valueOf(
             TimeUnit.MINUTES.toSeconds(30)).intValue();
+
+    @BeforeClass
+    public static void beforeAll() {
+        Profile.configure(new CommaSeparatedListProfileConfigResolver(Feature.CLIENT_SECRET_ROTATION.getVersionedKey(), ""));
+    }
 
     @Rule
     public AssertEvents events = new AssertEvents(this);


### PR DESCRIPTION
* Rotated client secret remains valid when the feature is disabled

Closes #50855

Signed-off-by: Martin Bartoš <mabartos@redhat.com>

* Simplify tests

Co-authored-by: Ricardo Martin <rmartinc@redhat.com>
Signed-off-by: Martin Bartoš <mabartos@redhat.com>

---------

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
Co-authored-by: Ricardo Martin <rmartinc@redhat.com>
(cherry picked from commit 12a37e4fc65acceb82177f3179a3ff4010ce6fab)


There might be conflicts with the https://github.com/keycloak/keycloak/pull/51300