### PR TITLE
[26.6] Rotated client secret remains valid when the feature is disabled

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSecretConstants;
@@ -30,9 +32,11 @@ import static org.keycloak.models.ClientSecretConstants.CLIENT_SECRET_REMAINING_
  * @author <a href="mailto:masales@redhat.com">Marcelo Sales</a>
  */
 public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
+    private final boolean isRotationFeatureEnabled;
 
     private OIDCClientSecretConfigWrapper(ClientModel client, ClientRepresentation clientRep) {
         super(client, clientRep);
+        this.isRotationFeatureEnabled = Profile.isFeatureEnabled(Feature.CLIENT_SECRET_ROTATION);
     }
 
     public static OIDCClientSecretConfigWrapper fromClientModel(ClientModel client) {
@@ -82,7 +86,7 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
     }
 
     public void removeClientSecretRotated() {
-        if (hasRotatedSecret()) {
+        if (hasRotatedSecretAttributes()) {
             setAttribute(CLIENT_ROTATED_SECRET, null);
             setAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME, null);
             setAttribute(CLIENT_ROTATED_SECRET_EXPIRATION_TIME, null);
@@ -99,7 +103,12 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
     }
 
     public boolean hasRotatedSecret() {
-        return StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET)) && StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME));
+        return isRotationFeatureEnabled && hasRotatedSecretAttributes();
+    }
+
+    private boolean hasRotatedSecretAttributes() {
+        return StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET))
+                && StringUtil.isNotBlank(getAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -802,6 +802,8 @@ public class ClientResource {
 
             logger.debug("delete rotated secret");
 
+            // Always remove rotated secret attributes even when the feature is disabled,
+            // so stale secrets cannot become valid again if the feature is re-enabled.
             OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientModel(client);
 
             CredentialRepresentation rep = new CredentialRepresentation();

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthClient.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthClient.java
@@ -47,6 +47,10 @@ public class OAuthClient extends AbstractOAuthClient<OAuthClient> {
         return super.parseLoginResponse();
     }
 
+    public ClientResource clientResource() {
+        return clientResource;
+    }
+
     public ClientRegistration clientRegistration() {
         return ClientRegistration.create().httpClient(httpClient().get()).url(baseUrl, config.getRealm()).build();
     }

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientSecretRotationDisabledTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientSecretRotationDisabledTest.java
@@ -1,0 +1,82 @@
+package org.keycloak.tests.client;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.models.ClientSecretConstants;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.tests.common.TestRealmUserConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest
+public class ClientSecretRotationDisabledTest {
+
+    private static final String CLIENT_ID = "test-app";
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectUser(config = TestRealmUserConfig.class)
+    ManagedUser user;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    /**
+     * Verifies that rotated client secrets are not accepted when the CLIENT_SECRET_ROTATION
+     * feature is disabled, even if the rotated secret attributes remain in the database.
+     *
+     * @see <a href="https://github.com/keycloak/keycloak/issues/50855">Issue #50855</a>
+     */
+    @Test
+    public void rotatedSecretNotAcceptedWhenFeatureDisabled() {
+        String originalSecret = oauth.clientResource().getSecret().getValue();
+
+        // Verify the original secret works before rotating
+        oauth.client(CLIENT_ID, originalSecret);
+        oauth.doLogin(user.getUsername(), "password");
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
+        assertEquals(200, response.getStatusCode());
+        assertNotNull(response.getAccessToken());
+
+        String newSecret = oauth.clientResource().generateNewSecret().getValue();
+
+        // Set rotated secret attributes directly on the server-side model to bypass the admin
+        // API cleanup in ClientResource.update() which always removes rotation info when no
+        // rotation executor is active.
+        String creationTime = String.valueOf(Time.currentTime());
+        String expirationTime = String.valueOf(Time.currentTime() + 3600);
+        runOnServer.run(session -> {
+            var realmModel = session.getContext().getRealm();
+            var client = realmModel.getClientByClientId(CLIENT_ID);
+            client.setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET, originalSecret);
+            client.setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_CREATION_TIME, creationTime);
+            client.setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_EXPIRATION_TIME, expirationTime);
+        });
+
+        // Authentication with the rotated (original) secret must fail when feature is disabled
+        oauth.client(CLIENT_ID, originalSecret);
+        oauth.openLoginForm();
+        code = oauth.parseLoginResponse().getCode();
+        response = oauth.doAccessTokenRequest(code);
+        assertEquals(401, response.getStatusCode());
+
+        // Authentication with the current (new) secret must always work
+        oauth.client(CLIENT_ID, newSecret);
+        oauth.openLoginForm();
+        code = oauth.parseLoginResponse().getCode();
+        response = oauth.doAccessTokenRequest(code);
+        assertEquals(200, response.getStatusCode());
+        assertNotNull(response.getAccessToken());
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
@@ -18,7 +18,9 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientPoliciesPoliciesResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
+import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.common.profile.CommaSeparatedListProfileConfigResolver;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.models.AdminRoles;
@@ -56,6 +58,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -103,6 +106,11 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
             TimeUnit.MINUTES.toSeconds(10)).intValue();
     private static final int DEFAULT_REMAIN_EXPIRATION_PERIOD = Long.valueOf(
             TimeUnit.MINUTES.toSeconds(30)).intValue();
+
+    @BeforeClass
+    public static void beforeAll() {
+        Profile.configure(new CommaSeparatedListProfileConfigResolver(Feature.CLIENT_SECRET_ROTATION.getVersionedKey(), ""));
+    }
 
     @Rule
     public AssertEvents events = new AssertEvents(this);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthPostMethodTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthPostMethodTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.protocol.oidc.OIDCClientSecretConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -68,6 +69,7 @@ public class ClientAuthPostMethodTest extends AbstractKeycloakTest {
     public void addTestRealms(List<RealmRepresentation> testRealms) {
         RealmRepresentation realm = AbstractAdminTest.loadJson(getClass().getResourceAsStream("/testrealm.json"), RealmRepresentation.class);
         testRealms.add(realm);
+        Profile.configure();
     }
 
 


### PR DESCRIPTION
* Rotated client secret remains valid when the feature is disabled

Closes #50855

Signed-off-by: Martin Bartoš <mabartos@redhat.com>

* Simplify tests

Co-authored-by: Ricardo Martin <rmartinc@redhat.com>
Signed-off-by: Martin Bartoš <mabartos@redhat.com>

---------

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
Co-authored-by: Ricardo Martin <rmartinc@redhat.com>
(cherry picked from commit 12a37e4fc65acceb82177f3179a3ff4010ce6fab)

There might be conflicts with the https://github.com/keycloak/keycloak/pull/51301