### PR TITLE
[UX] Close account console mobile nav after selecting a page

### DIFF
--- a/js/apps/account-ui/src/root/PageNav.tsx
+++ b/js/apps/account-ui/src/root/PageNav.tsx
@@ -4,6 +4,7 @@ import {
   NavExpandable,
   NavItem,
   NavList,
+  PageContext,
   PageSidebar,
   PageSidebarBody,
   Spinner,
@@ -12,6 +13,7 @@ import {
   PropsWithChildren,
   MouseEvent as ReactMouseEvent,
   Suspense,
+  useContext,
   useMemo,
   useState,
 } from "react";
@@ -137,6 +139,11 @@ type NavLinkProps = {
   isActive: boolean;
 };
 
+// Matches PatternFly's own "--pf-v5-global--breakpoint--xl" token, which is
+// the width below which its Page component switches the sidebar from a
+// persistent panel to a slide-over that must be closed after navigating.
+const PAGE_SIDEBAR_OVERLAY_BREAKPOINT_PX = 1200;
+
 export const NavLink = ({
   path,
   isActive,
@@ -146,16 +153,21 @@ export const NavLink = ({
   const menuItemPath = getFullUrl(path, environment.baseUrl) + location.search;
   const href = useHref(menuItemPath);
   const handleClick = useLinkClickHandler(menuItemPath);
+  const { isSidebarOpen, onSidebarToggle, width } = useContext(PageContext);
+  const isOverlayView = width < PAGE_SIDEBAR_OVERLAY_BREAKPOINT_PX;
 
   return (
     <NavItem
       data-testid={path}
       to={href}
       isActive={isActive}
-      onClick={(event) =>
+      onClick={(event) => {
         // PatternFly does not have the correct type for this event, so we need to cast it.
-        handleClick(event as unknown as ReactMouseEvent<HTMLAnchorElement>)
-      }
+        handleClick(event as unknown as ReactMouseEvent<HTMLAnchorElement>);
+        if (isOverlayView && isSidebarOpen) {
+          onSidebarToggle();
+        }
+      }}
     >
       {children}
     </NavItem>

--- a/js/apps/account-ui/test/mobile-nav.spec.ts
+++ b/js/apps/account-ui/test/mobile-nav.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { login } from "./support/actions.ts";
+import { createTestBed } from "./support/testbed.ts";
+
+const MOBILE_VIEWPORT = { width: 400, height: 800 };
+
+test.describe("Mobile nav", () => {
+  test("closes the overlay nav after selecting a page", async ({ page }) => {
+    await using testBed = await createTestBed();
+
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await login(page, testBed.realm);
+
+    await page.getByTestId("nav-toggle").click();
+    await expect(page.locator("#page-sidebar")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+
+    await page.getByTestId("accountSecurity").click();
+    await page.getByTestId("account-security/signing-in").click();
+
+    await expect(page.locator("#page-sidebar")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+    await expect(page.getByTestId("password/credential-list")).toBeVisible();
+  });
+
+  test("leaves the persistent nav open on desktop viewports", async ({
+    page,
+  }) => {
+    await using testBed = await createTestBed();
+
+    // Default project viewport is 1920x1080, above PatternFly's 1200px
+    // overlay breakpoint, so the sidebar is a persistent panel.
+    await login(page, testBed.realm);
+
+    await expect(page.locator("#page-sidebar")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+
+    await page.getByTestId("accountSecurity").click();
+    await page.getByTestId("account-security/signing-in").click();
+
+    await expect(page.locator("#page-sidebar")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+  });
+});

--- a/js/libs/ui-shared/src/masthead/Masthead.tsx
+++ b/js/libs/ui-shared/src/masthead/Masthead.tsx
@@ -96,7 +96,11 @@ const KeycloakMasthead = ({
   return (
     <Masthead {...rest}>
       <MastheadToggle>
-        <PageToggleButton variant="plain" aria-label={t("navigation")}>
+        <PageToggleButton
+          data-testid="nav-toggle"
+          variant="plain"
+          aria-label={t("navigation")}
+        >
           <BarsIcon />
         </PageToggleButton>
       </MastheadToggle>


### PR DESCRIPTION
If you have ever used Keycloak's Account Console on mobile, you probably noticed some UI/UX annoyances. For example, if you open the main menu, click on another category (e.g. Signing-in), the new page will be loaded in the background, but you don't immediately notice since the page is still overlayed by the main menu and you have to realize that you have to close it manually to continue.

This patch fixes that issue. It appeared onn narrow viewports (phones, or a desktop browser window resized below PatternFly's 1200px breakpoint).

This closes #51423

EDIT: Rebased to current `main`