### PR TITLE
Emit RISC account-disabled/account-enabled SSF events

### DIFF
--- a/docs/guides/securing-apps/ssf-support.adoc
+++ b/docs/guides/securing-apps/ssf-support.adoc
@@ -382,6 +382,10 @@ The {project_name} SSF Transmitter targets conformance with:
   `complex`).
 * https://openid.net/specs/openid-caep-interoperability-profile-1_0.html[CAEP Interoperability Profile 1.0 (draft)]
   -- `session-revoked` and `credential-change` event types.
+* https://openid.net/specs/openid-risc-1_0-final.html[RISC 1.0 (Final)]
+  -- `account-disabled` and `account-enabled` event types. Emitted when an admin toggles a
+  user's enabled state, and when brute-force protection permanently locks an account out
+  (`reason=disabled-by-bruteforce`).
 * Legacy SSE CAEP profile for Apple Business Manager interop (gated behind the `sse-caep-enabled` SPI flag).
 
 </@tmpl.guide>

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -54,6 +54,8 @@ public interface Details {
     String UPDATED_FIRST_NAME = PREF_UPDATED + "first_name";
     String PREVIOUS_LAST_NAME = PREF_PREVIOUS + "last_name";
     String UPDATED_LAST_NAME = PREF_UPDATED + "last_name";
+    String PREVIOUS_ENABLED = PREF_PREVIOUS + "enabled";
+    String UPDATED_ENABLED = PREF_UPDATED + "enabled";
     String REMEMBER_ME = "remember_me";
     String TOKEN_ID = "token_id";
     String TOKEN_TYPE = "token_type";

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -196,6 +196,7 @@ public class UserResource {
         auth.users().requireManage(user);
         try {
 
+            boolean wasEnabled = user.isEnabled();
             boolean wasPermanentlyLockedOut = false;
             if (rep.isEnabled() != null && rep.isEnabled()) {
                 if (!user.isEnabled() || session.getProvider(BruteForceProtector.class).isTemporarilyDisabled(session, realm, user)) {
@@ -236,6 +237,14 @@ public class UserResource {
                 session.getProvider(BruteForceProtector.class).cleanUpPermanentLockout(session, realm, user);
             }
 
+            if (rep.isEnabled() != null && rep.isEnabled() != wasEnabled) {
+                // Capture the enabled-state transition as admin event details — the
+                // representation only ever carries the new state, so without this a
+                // listener can't tell "account disabled" apart from any other profile
+                // update (see SSF RiscAccountDisabled / RiscAccountEnabled).
+                adminEvent.detail(Details.PREVIOUS_ENABLED, String.valueOf(wasEnabled))
+                        .detail(Details.UPDATED_ENABLED, String.valueOf(rep.isEnabled()));
+            }
             adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
 
             if (session.getTransactionManager().isActive()) {

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/DefaultSsfEventProviderFactory.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/DefaultSsfEventProviderFactory.java
@@ -66,13 +66,16 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
      * Every other built-in event in the map is contributed to the registry
      * only so the receiver-side parser can decode incoming SETs of that type.
      *
-     * <p>The two types here are use-cases enumerated by the OpenID CAEP
-     * Interoperability Profile 1.0: {@code session-revoked} and
-     * {@code credential-change}. The profile is opt-in per use-case
-     * ("Implementations MAY choose to support one or more …"), so supporting
-     * any one of them is enough to count as interoperable.
+     * <p>{@code session-revoked} and {@code credential-change} are the two
+     * use-cases enumerated by the OpenID CAEP Interoperability Profile 1.0.
+     * The profile is opt-in per use-case ("Implementations MAY choose to
+     * support one or more …"), so supporting any one of them is enough to
+     * count as interoperable. {@code account-disabled} and
+     * {@code account-enabled} are RISC 1.0 events, not part of that CAEP
+     * profile, added alongside it.
      *
      * @see <a href="https://openid.github.io/sharedsignals/openid-caep-interoperability-profile-1_0.html">OpenID CAEP Interoperability Profile 1.0</a>
+     * @see <a href="https://openid.net/specs/openid-risc-1_0-final.html">OpenID RISC 1.0 (Final)</a>
      */
     public static final Set<String> EMITTABLE_EVENT_TYPES = Set.of(
             CaepCredentialChange.TYPE,

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/DefaultSsfEventProviderFactory.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/DefaultSsfEventProviderFactory.java
@@ -12,6 +12,8 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.ssf.event.caep.CaepCredentialChange;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
+import org.keycloak.ssf.event.risc.RiscAccountDisabled;
+import org.keycloak.ssf.event.risc.RiscAccountEnabled;
 import org.keycloak.ssf.event.stream.SsfStreamUpdatedEvent;
 import org.keycloak.ssf.event.stream.SsfStreamVerificationEvent;
 
@@ -50,6 +52,10 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
         events.put(CaepCredentialChange.TYPE, CaepCredentialChange::new);
         events.put(CaepSessionRevoked.TYPE, CaepSessionRevoked::new);
 
+        // RISC events
+        events.put(RiscAccountDisabled.TYPE, RiscAccountDisabled::new);
+        events.put(RiscAccountEnabled.TYPE, RiscAccountEnabled::new);
+
         STANDARD_EVENT_FACTORIES = Map.copyOf(events);
     }
 
@@ -70,7 +76,9 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
      */
     public static final Set<String> EMITTABLE_EVENT_TYPES = Set.of(
             CaepCredentialChange.TYPE,
-            CaepSessionRevoked.TYPE);
+            CaepSessionRevoked.TYPE,
+            RiscAccountDisabled.TYPE,
+            RiscAccountEnabled.TYPE);
 
     /**
      * Subset of {@link #EMITTABLE_EVENT_TYPES} that {@code SecurityEventTokenMapper}
@@ -79,7 +87,9 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
      */
     public static final Set<String> NATIVELY_EMITTED_EVENT_TYPES = Set.of(
             CaepCredentialChange.TYPE,
-            CaepSessionRevoked.TYPE);
+            CaepSessionRevoked.TYPE,
+            RiscAccountDisabled.TYPE,
+            RiscAccountEnabled.TYPE);
 
     private volatile SsfEventRegistry registry;
 

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/InitiatingEntityAware.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/InitiatingEntityAware.java
@@ -1,0 +1,24 @@
+package org.keycloak.ssf.event;
+
+/**
+ * Implemented by event types that carry the {@code initiating_entity} claim.
+ *
+ * <p>The claim is defined by CAEP 1.0 as a profile-common optional claim, so
+ * {@link org.keycloak.ssf.event.caep.CaepEvent} declares it for the whole CAEP
+ * family. Individual events from other profiles may also carry it — Keycloak's
+ * RISC account-state events do, because the distinction between an
+ * administrator disabling an account and the brute-force policy engine doing so
+ * is information receivers act on. Those events declare the field themselves
+ * rather than inheriting it, since RISC does not define it profile-wide.
+ *
+ * <p>This interface exists so helpers that only need to stamp the claim (see
+ * {@code SecurityEventTokenMapper#applyInitiatingEntity}) can accept both
+ * families without widening {@link SsfEvent}, which deliberately carries only
+ * SET member semantics.
+ */
+public interface InitiatingEntityAware {
+
+    InitiatingEntity getInitiatingEntity();
+
+    void setInitiatingEntity(InitiatingEntity initiatingEntity);
+}

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/caep/CaepEvent.java
@@ -3,6 +3,7 @@ package org.keycloak.ssf.event.caep;
 import java.util.Map;
 
 import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.ssf.event.InitiatingEntityAware;
 import org.keycloak.ssf.event.SsfEvent;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.ssf.subject.SubjectIdJsonDeserializer;
@@ -15,7 +16,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  *
  * See: https://openid.net/specs/openid-caep-1_0-final.html
  */
-public abstract class CaepEvent extends SsfEvent {
+public abstract class CaepEvent extends SsfEvent implements InitiatingEntityAware {
 
     /**
      * See: https://openid.net/specs/openid-caep-1_0-final.html#section-3
@@ -82,10 +83,12 @@ public abstract class CaepEvent extends SsfEvent {
         this.eventTimestamp = eventTimestamp;
     }
 
+    @Override
     public InitiatingEntity getInitiatingEntity() {
         return initiatingEntity;
     }
 
+    @Override
     public void setInitiatingEntity(InitiatingEntity initiatingEntity) {
         this.initiatingEntity = initiatingEntity;
     }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountDisabled.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountDisabled.java
@@ -1,5 +1,10 @@
 package org.keycloak.ssf.event.risc;
 
+import java.util.Map;
+
+import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.ssf.event.InitiatingEntityAware;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -8,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * See: https://openid.net/specs/openid-risc-1_0-final.html
  */
-public class RiscAccountDisabled extends RiscEvent {
+public class RiscAccountDisabled extends RiscEvent implements InitiatingEntityAware {
 
     public static final String TYPE = "https://schemas.openid.net/secevent/risc/event-type/account-disabled";
 
@@ -28,6 +33,25 @@ public class RiscAccountDisabled extends RiscEvent {
     @JsonProperty("reason")
     protected String reason;
 
+    /**
+     * The time of the event (UNIX timestamp). RISC 1.0 lists no attributes for
+     * account-disabled, so this is a CAEP-defined claim carried as an extension —
+     * declared here rather than on {@link RiscEvent} because RISC does not define
+     * it profile-wide. Nullable so an absent timestamp is omitted from the wire
+     * JSON rather than serialized as {@code "event_timestamp": 0}.
+     */
+    @JsonProperty("event_timestamp")
+    protected Long eventTimestamp;
+
+    /**
+     * The entity that initiated the disablement. Distinguishes an administrator
+     * acting ({@link InitiatingEntity#ADMIN}) from Keycloak's own brute-force
+     * policy engine ({@link InitiatingEntity#POLICY}) — a distinction receivers
+     * act on, so it is emitted even though RISC does not define the claim.
+     */
+    @JsonProperty("initiating_entity")
+    protected InitiatingEntity initiatingEntity;
+
     public RiscAccountDisabled() {
         super(TYPE);
     }
@@ -40,10 +64,29 @@ public class RiscAccountDisabled extends RiscEvent {
         this.reason = reason;
     }
 
+    public Long getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(long eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+
     @Override
-    public String toString() {
-        return "AccountDisabled{" +
-               "reason='" + reason + '\'' +
-               '}';
+    public InitiatingEntity getInitiatingEntity() {
+        return initiatingEntity;
+    }
+
+    @Override
+    public void setInitiatingEntity(InitiatingEntity initiatingEntity) {
+        this.initiatingEntity = initiatingEntity;
+    }
+
+    @Override
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("reason", reason);
+        fields.put("eventTimestamp", eventTimestamp);
+        fields.put("initiatingEntity", initiatingEntity);
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountDisabled.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountDisabled.java
@@ -1,0 +1,49 @@
+package org.keycloak.ssf.event.risc;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The Account Disabled event indicates that an account has been deactivated, with an
+ * optional rationale.
+ *
+ * See: https://openid.net/specs/openid-risc-1_0-final.html
+ */
+public class RiscAccountDisabled extends RiscEvent {
+
+    public static final String TYPE = "https://schemas.openid.net/secevent/risc/event-type/account-disabled";
+
+    /**
+     * RISC enumerates {@code hijacking} and {@code bulk-account} as reasons. Keycloak
+     * additionally emits reasons describing its own native disablement triggers
+     * (administrator action, brute-force lockout, ...) that aren't part of the spec's
+     * list — mirroring how {@link org.keycloak.ssf.event.caep.CaepCredentialChange#getCredentialType()}
+     * accepts values beyond its documented set. Receivers that don't recognize a given
+     * reason should treat it as an opaque string.
+     */
+    public static final String REASON_HIJACKING = "hijacking";
+    public static final String REASON_BULK_ACCOUNT = "bulk-account";
+    public static final String REASON_ADMIN = "disabled-by-admin";
+    public static final String REASON_BRUTE_FORCE = "disabled-by-bruteforce";
+
+    @JsonProperty("reason")
+    protected String reason;
+
+    public RiscAccountDisabled() {
+        super(TYPE);
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public String toString() {
+        return "AccountDisabled{" +
+               "reason='" + reason + '\'' +
+               '}';
+    }
+}

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountEnabled.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountEnabled.java
@@ -1,0 +1,21 @@
+package org.keycloak.ssf.event.risc;
+
+/**
+ * The Account Enabled event signals that a previously disabled account has been
+ * reactivated.
+ *
+ * See: https://openid.net/specs/openid-risc-1_0-final.html
+ */
+public class RiscAccountEnabled extends RiscEvent {
+
+    public static final String TYPE = "https://schemas.openid.net/secevent/risc/event-type/account-enabled";
+
+    public RiscAccountEnabled() {
+        super(TYPE);
+    }
+
+    @Override
+    public String toString() {
+        return "AccountEnabled{}";
+    }
+}

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountEnabled.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountEnabled.java
@@ -1,21 +1,67 @@
 package org.keycloak.ssf.event.risc;
 
+import java.util.Map;
+
+import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.ssf.event.InitiatingEntityAware;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * The Account Enabled event signals that a previously disabled account has been
  * reactivated.
  *
  * See: https://openid.net/specs/openid-risc-1_0-final.html
  */
-public class RiscAccountEnabled extends RiscEvent {
+public class RiscAccountEnabled extends RiscEvent implements InitiatingEntityAware {
 
     public static final String TYPE = "https://schemas.openid.net/secevent/risc/event-type/account-enabled";
+
+    /**
+     * The time of the event (UNIX timestamp). RISC 1.0 lists no attributes for
+     * account-enabled, so this is a CAEP-defined claim carried as an extension —
+     * declared here rather than on {@link RiscEvent} because RISC does not define
+     * it profile-wide. Nullable so an absent timestamp is omitted from the wire
+     * JSON rather than serialized as {@code "event_timestamp": 0}.
+     */
+    @JsonProperty("event_timestamp")
+    protected Long eventTimestamp;
+
+    /**
+     * The entity that initiated the re-activation. Only the admin path emits this
+     * event today ({@link InitiatingEntity#ADMIN}); a future non-admin trigger
+     * would be an automated action rather than the user's own, hence
+     * {@link InitiatingEntity#SYSTEM} as its default.
+     */
+    @JsonProperty("initiating_entity")
+    protected InitiatingEntity initiatingEntity;
 
     public RiscAccountEnabled() {
         super(TYPE);
     }
 
+    public Long getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(long eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+
     @Override
-    public String toString() {
-        return "AccountEnabled{}";
+    public InitiatingEntity getInitiatingEntity() {
+        return initiatingEntity;
+    }
+
+    @Override
+    public void setInitiatingEntity(InitiatingEntity initiatingEntity) {
+        this.initiatingEntity = initiatingEntity;
+    }
+
+    @Override
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("eventTimestamp", eventTimestamp);
+        fields.put("initiatingEntity", initiatingEntity);
     }
 }

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscEvent.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscEvent.java
@@ -1,0 +1,15 @@
+package org.keycloak.ssf.event.risc;
+
+import org.keycloak.ssf.event.SsfEvent;
+
+/**
+ * Generic RiscEvent.
+ *
+ * See: https://openid.net/specs/openid-risc-1_0-final.html
+ */
+public abstract class RiscEvent extends SsfEvent {
+
+    public RiscEvent(String type) {
+        super(type);
+    }
+}

--- a/ssf/core/src/test/java/org/keycloak/ssf/event/risc/RiscAccountEventsTest.java
+++ b/ssf/core/src/test/java/org/keycloak/ssf/event/risc/RiscAccountEventsTest.java
@@ -1,0 +1,83 @@
+package org.keycloak.ssf.event.risc;
+
+import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Wire-format tests for the RISC account-state events.
+ *
+ * <p>{@code event_timestamp} and {@code initiating_entity} are CAEP-defined
+ * claims that these events carry as extensions — RISC 1.0 lists no attributes
+ * for account-disabled / account-enabled. They are declared on the concrete
+ * event classes rather than inherited, so these tests pin the serialized names
+ * and the omit-when-unset behaviour that the shared base class no longer
+ * provides.
+ */
+class RiscAccountEventsTest {
+
+    @Test
+    void accountDisabled_serializesReasonTimestampAndInitiatingEntity() throws Exception {
+        RiscAccountDisabled event = new RiscAccountDisabled();
+        event.setReason(RiscAccountDisabled.REASON_BRUTE_FORCE);
+        event.setEventTimestamp(1712345678L);
+        event.setInitiatingEntity(InitiatingEntity.POLICY);
+
+        JsonNode json = JsonSerialization.mapper.valueToTree(event);
+
+        assertEquals(RiscAccountDisabled.REASON_BRUTE_FORCE, json.path("reason").asText());
+        assertEquals(1712345678L, json.path("event_timestamp").asLong());
+        assertEquals("policy", json.path("initiating_entity").asText(),
+                "initiating_entity must serialize via the enum's @JsonValue code");
+    }
+
+    @Test
+    void accountEnabled_serializesTimestampAndInitiatingEntity() throws Exception {
+        RiscAccountEnabled event = new RiscAccountEnabled();
+        event.setEventTimestamp(1712345678L);
+        event.setInitiatingEntity(InitiatingEntity.ADMIN);
+
+        JsonNode json = JsonSerialization.mapper.valueToTree(event);
+
+        assertEquals(1712345678L, json.path("event_timestamp").asLong());
+        assertEquals("admin", json.path("initiating_entity").asText());
+    }
+
+    @Test
+    void unsetClaims_areOmittedFromWireJson() throws Exception {
+        JsonNode disabled = JsonSerialization.mapper.valueToTree(new RiscAccountDisabled());
+
+        // @JsonInclude(NON_NULL) on SsfEvent must still apply to the claims now
+        // declared on the concrete class — a primitive long would have emitted 0.
+        assertTrue(disabled.path("event_timestamp").isMissingNode(),
+                "unset event_timestamp must be omitted, not serialized as 0: " + disabled);
+        assertTrue(disabled.path("initiating_entity").isMissingNode(),
+                "unset initiating_entity must be omitted: " + disabled);
+        assertTrue(disabled.path("reason").isMissingNode(),
+                "unset reason must be omitted: " + disabled);
+    }
+
+    @Test
+    void toStringRendersDeclaredClaims() {
+        RiscAccountDisabled event = new RiscAccountDisabled();
+        event.setReason(RiscAccountDisabled.REASON_ADMIN);
+        event.setInitiatingEntity(InitiatingEntity.ADMIN);
+
+        String rendered = event.toString();
+
+        // The events override appendFields rather than toString, so the claims
+        // must appear without the base class knowing about them.
+        assertTrue(rendered.contains("reason='" + RiscAccountDisabled.REASON_ADMIN + "'"),
+                "declared String claims must render quoted: " + rendered);
+        assertTrue(rendered.contains("initiatingEntity=ADMIN"),
+                "declared claims must render: " + rendered);
+        assertFalse(rendered.contains("=null"),
+                "unset claims must be omitted, not rendered as null: " + rendered);
+    }
+}

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
@@ -1,0 +1,377 @@
+package org.keycloak.tests.ssf.transmitter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.common.Profile;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.ssf.Ssf;
+import org.keycloak.ssf.event.risc.RiscAccountDisabled;
+import org.keycloak.ssf.event.risc.RiscAccountEnabled;
+import org.keycloak.ssf.transmitter.DefaultSsfTransmitterProviderFactory;
+import org.keycloak.ssf.transmitter.SsfScopes;
+import org.keycloak.ssf.transmitter.SsfTransmitterConfig;
+import org.keycloak.ssf.transmitter.stream.StreamConfig;
+import org.keycloak.ssf.transmitter.stream.StreamDeliveryConfig;
+import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
+import org.keycloak.ssf.transmitter.support.SsfTransmitterUrls;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectHttpServer;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.server.DefaultKeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.util.HttpServerUtil;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests proving the RISC {@code account-disabled}/{@code account-enabled}
+ * wiring added on top of the Admin REST API actually reaches a receiver end to end —
+ * real {@code PUT /admin/realms/{realm}/users/{id}} calls, not the mapper-level unit
+ * tests in {@code SecurityEventTokenMapperTest}, which manufacture the admin-event
+ * details directly and so don't verify that {@code UserResource} actually produces
+ * them or that {@code SsfTransmitterEventListener} actually consumes them.
+ *
+ * <p>Also covers the {@code ssf.emitOnlyEvents} gate on the <em>admin</em>-event path
+ * ({@link org.keycloak.ssf.transmitter.event.SsfTransmitterEventListener#generateSecurityEventTokensForAdminEvent}),
+ * which previously had no coverage at all — {@code SsfTransmitterEmitOnlyEventsTests}
+ * only exercises the gate via native user events (LOGOUT/credential-update).
+ */
+@KeycloakIntegrationTest(config = SsfTransmitterAccountStateEventTests.AccountStateServerConfig.class)
+public class SsfTransmitterAccountStateEventTests {
+
+    static final String RECEIVER = "ssf-receiver-account-state";
+    static final String RECEIVER_SECRET = "receiver-account-state-secret";
+
+    static final String TEST_USER = "account-state-tester";
+    static final String TEST_PASSWORD = "test";
+
+    static final String PUSH_CONTEXT_PATH = "/ssf/push-account-state";
+    static final String MOCK_PUSH_ENDPOINT = "http://127.0.0.1:8500" + PUSH_CONTEXT_PATH;
+    static final String PUSH_AUTH_HEADER = "Bearer dummy-account-state-receiver";
+
+    static final long PUSH_WAIT_SECONDS = 5;
+    static final long NO_PUSH_WAIT_SECONDS = 3;
+
+    @InjectRealm(config = AccountStateRealm.class)
+    ManagedRealm realm;
+
+    @InjectSimpleHttp
+    SimpleHttp http;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectHttpServer
+    HttpServer mockReceiverServer;
+
+    private final BlockingQueue<String> pushes = new LinkedBlockingQueue<>();
+
+    private String testUserId;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        pushes.clear();
+
+        mockReceiverServer.createContext(PUSH_CONTEXT_PATH, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                try (InputStream is = exchange.getRequestBody()) {
+                    pushes.add(new String(is.readAllBytes(), StandardCharsets.UTF_8));
+                }
+                HttpServerUtil.sendResponse(exchange, 202, Map.of());
+            }
+        });
+
+        assignOptionalClientScopes(RECEIVER, SsfScopes.SCOPE_SSF_READ, SsfScopes.SCOPE_SSF_MANAGE);
+
+        testUserId = realm.admin().users().searchByUsername(TEST_USER, true).get(0).getId();
+        // Defensive: earlier test in the class may have left the user
+        // disabled or the receiver's emitOnlyEvents set — start every
+        // test from the same known state regardless of run order.
+        setUserEnabled(true);
+        setEmitOnlyEvents();
+
+        createPushStream(Set.of(RiscAccountDisabled.TYPE, RiscAccountEnabled.TYPE));
+    }
+
+    @AfterEach
+    public void cleanup() {
+        bestEffortDeleteStream();
+        setEmitOnlyEvents();
+        try {
+            mockReceiverServer.removeContext(PUSH_CONTEXT_PATH);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void adminDisablesUser_deliversAccountDisabledEvent() throws Exception {
+        setUserEnabled(false);
+
+        String push = pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertNotNull(push,
+                "admin disabling a user via the REST API must auto-emit RiscAccountDisabled");
+
+        JsonNode set = decodeSet(push);
+        Assertions.assertTrue(set.path("events").has(RiscAccountDisabled.TYPE),
+                "delivered SET should carry the account-disabled event type");
+        Assertions.assertEquals(RiscAccountDisabled.REASON_ADMIN,
+                set.path("events").path(RiscAccountDisabled.TYPE).path("reason").asText(),
+                "an admin-initiated disable must report reason=disabled-by-admin");
+        Assertions.assertEquals("admin",
+                set.path("events").path(RiscAccountDisabled.TYPE).path("initiating_entity").asText(),
+                "an admin-initiated disable must report initiating_entity=admin");
+    }
+
+    @Test
+    public void adminEnablesUser_deliversAccountEnabledEvent() throws Exception {
+        setUserEnabled(false);
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "setup disable should have produced a push before the re-enable under test");
+
+        setUserEnabled(true);
+
+        String push = pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertNotNull(push,
+                "admin re-enabling a user via the REST API must auto-emit RiscAccountEnabled");
+
+        JsonNode set = decodeSet(push);
+        Assertions.assertTrue(set.path("events").has(RiscAccountEnabled.TYPE),
+                "delivered SET should carry the account-enabled event type");
+    }
+
+    @Test
+    public void adminUpdatesUserWithoutEnabledChange_noPush() throws Exception {
+        UserResource userResource = realm.admin().users().get(testUserId);
+        UserRepresentation rep = userResource.toRepresentation();
+        rep.setFirstName("Changed" + System.nanoTime());
+        userResource.update(rep);
+
+        Assertions.assertNull(pushes.poll(NO_PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "a profile update that leaves 'enabled' untouched must not produce an account-state SET");
+    }
+
+    @Test
+    public void emitOnlyEvent_adminDisablesUser_skipsAutoEmit() throws Exception {
+        // Covers the admin-event path of the emitOnlyEvents gate fixed in
+        // SsfTransmitterEventListener.generateSecurityEventTokensForAdminEvent —
+        // previously untested, since the only existing emit-only coverage
+        // (SsfTransmitterEmitOnlyEventsTests) drives native user events.
+        setEmitOnlyEvents(RiscAccountDisabled.TYPE);
+
+        setUserEnabled(false);
+
+        Assertions.assertNull(pushes.poll(NO_PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "RiscAccountDisabled is in the receiver's emitOnlyEvents set — the admin-triggered "
+                        + "disable must not auto-emit, same as the native-event path");
+    }
+
+    // --- triggers ----------------------------------------------------------
+
+    protected void setUserEnabled(boolean enabled) {
+        UserResource userResource = realm.admin().users().get(testUserId);
+        UserRepresentation rep = userResource.toRepresentation();
+        rep.setEnabled(enabled);
+        userResource.update(rep);
+    }
+
+    protected void setEmitOnlyEvents(String... eventTypes) {
+        ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
+        ClientRepresentation rep = clientResource.toRepresentation();
+        rep.getAttributes().put(ClientStreamStore.SSF_EMIT_ONLY_EVENTS_KEY,
+                eventTypes.length == 0 ? null : String.join(",", eventTypes));
+        clientResource.update(rep);
+    }
+
+    // --- setup ---------------------------------------------------------------
+
+    protected void createPushStream(Set<String> eventsRequested) throws IOException {
+        StreamDeliveryConfig delivery = new StreamDeliveryConfig();
+        delivery.setMethod(Ssf.DELIVERY_METHOD_PUSH_URI);
+        delivery.setEndpointUrl(MOCK_PUSH_ENDPOINT);
+        delivery.setAuthorizationHeader(PUSH_AUTH_HEADER);
+
+        StreamConfig streamConfig = new StreamConfig();
+        streamConfig.setDelivery(delivery);
+        streamConfig.setEventsRequested(eventsRequested);
+        streamConfig.setDescription("Account state event integration test");
+
+        String token = obtainReceiverManageToken();
+        try (SimpleHttpResponse response = http.doPost(SsfTransmitterUrls.getStreamsEndpointUrl(realm.getBaseUrl()))
+                .json(streamConfig)
+                .auth(token)
+                .acceptJson()
+                .asResponse()) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    () -> "stream creation should succeed in test setup; body=" + safeBody(response));
+        }
+    }
+
+    protected String obtainReceiverManageToken() throws IOException {
+        String tokenUrl = realm.getBaseUrl() + "/protocol/openid-connect/token";
+        try (SimpleHttpResponse response = http.doPost(tokenUrl)
+                .authBasic(RECEIVER, RECEIVER_SECRET)
+                .param("grant_type", "client_credentials")
+                .param("scope", SsfScopes.SCOPE_SSF_MANAGE + " " + SsfScopes.SCOPE_SSF_READ)
+                .asResponse()) {
+            Assertions.assertEquals(200, response.getStatus(),
+                    "client_credentials grant should succeed for the receiver");
+            return response.asJson().get("access_token").asText();
+        }
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    protected JsonNode decodeSet(String encoded) throws Exception {
+        JWSInput jws = new JWSInput(encoded);
+        return JsonSerialization.readValue(jws.getContent(), JsonNode.class);
+    }
+
+    protected void assignOptionalClientScopes(String clientId, String... scopeNames) {
+        ClientRepresentation client = findClientByClientId(clientId);
+        Assertions.assertNotNull(client, () -> "expected client '" + clientId + "' to exist");
+        ClientResource clientResource = realm.admin().clients().get(client.getId());
+
+        Set<String> alreadyAssigned = clientResource.getOptionalClientScopes().stream()
+                .map(ClientScopeRepresentation::getName)
+                .collect(Collectors.toSet());
+
+        List<ClientScopeRepresentation> allScopes = realm.admin().clientScopes().findAll();
+        for (String scopeName : scopeNames) {
+            if (alreadyAssigned.contains(scopeName)) {
+                continue;
+            }
+            ClientScopeRepresentation scope = allScopes.stream()
+                    .filter(s -> scopeName.equals(s.getName()))
+                    .findFirst()
+                    .orElse(null);
+            Assertions.assertNotNull(scope,
+                    () -> "expected realm scope '" + scopeName + "' to exist");
+            clientResource.addOptionalClientScope(scope.getId());
+        }
+    }
+
+    protected ClientRepresentation findClientByClientId(String clientId) {
+        List<ClientRepresentation> clients = realm.admin().clients().findByClientId(clientId);
+        if (clients.isEmpty()) {
+            return null;
+        }
+        return clients.get(0);
+    }
+
+    protected void bestEffortDeleteStream() {
+        ClientRepresentation client = findClientByClientId(RECEIVER);
+        if (client == null) {
+            return;
+        }
+        String adminStreamUrl = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + client.getClientId() + "/stream";
+        try (SimpleHttpResponse ignored = http.doDelete(adminStreamUrl)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .asResponse()) {
+            // 204 / 404 both fine
+        } catch (IOException e) {
+            // best-effort
+        }
+    }
+
+    private String safeBody(SimpleHttpResponse response) {
+        try {
+            return response.asString();
+        } catch (Exception e) {
+            return "<no body: " + e.getMessage() + ">";
+        }
+    }
+
+    // --- config ----------------------------------------------------------
+
+    public static class AccountStateServerConfig extends DefaultKeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            KeycloakServerConfigBuilder configured = super.configure(config);
+            config.features(Profile.Feature.SSF);
+            config.log().categoryLevel("org.keycloak.ssf", "DEBUG");
+            config.spiOption("ssf-transmitter", "default",
+                    DefaultSsfTransmitterProviderFactory.CONFIG_OUTBOX_DRAINER_INTERVAL, "500ms");
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_MIN_VERIFICATION_INTERVAL_SECONDS, "0");
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_ALLOW_INSECURE_PUSH_TARGETS, "true");
+            return configured;
+        }
+    }
+
+    public static class AccountStateRealm implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.name("ssf-transmitter-account-state");
+            realm.attribute(Ssf.SSF_TRANSMITTER_ENABLED_KEY, "true");
+
+            realm.eventsEnabled(true);
+            realm.adminEventsEnabled(true);
+            realm.eventsListeners("jboss-logging", "ssf-events");
+
+            realm.users(
+                    UserBuilder.create(TEST_USER)
+                            .email(TEST_USER + "@local.test")
+                            .firstName("Ada")
+                            .lastName("StateTester")
+                            .enabled(true)
+                            .password(TEST_PASSWORD)
+                            .build()
+            );
+
+            realm.clients(
+                    ClientBuilder.create(RECEIVER)
+                            .secret(RECEIVER_SECRET)
+                            .serviceAccountsEnabled(true)
+                            .directAccessGrantsEnabled(false)
+                            .publicClient(false)
+                            .attribute(ClientStreamStore.SSF_ENABLED_KEY, "true")
+                            .attribute(ClientStreamStore.SSF_VALID_PUSH_URLS_KEY, "http://127.0.0.1:8500/*")
+                            .attribute(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "ALL")
+                            .build()
+            );
+
+            return realm;
+        }
+    }
+}

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
@@ -106,7 +106,7 @@ public class SsfTransmitterAccountStateEventTests {
     private String testUserId;
 
     @BeforeEach
-    public void setup() throws IOException {
+    public void setup() throws IOException, InterruptedException {
         pushes.clear();
 
         mockReceiverServer.createContext(PUSH_CONTEXT_PATH, new HttpHandler() {
@@ -138,8 +138,16 @@ public class SsfTransmitterAccountStateEventTests {
         // every other test in this class) succeeds reliably. Prime that path
         // once here with a throwaway disable/re-enable cycle so the real
         // per-test assertions below are never the first caller.
+        //
+        // Delivery is asynchronous (outbox drainer), so the warm-up's own
+        // pushes don't land immediately — actually wait for each one (or
+        // its absence) instead of clearing the queue right away, otherwise
+        // they arrive late and get consumed by the next real assertion
+        // instead of pushes.clear() below.
         setUserEnabled(false);
+        pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
         setUserEnabled(true);
+        pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
         pushes.clear();
     }
 

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
@@ -129,6 +129,18 @@ public class SsfTransmitterAccountStateEventTests {
         setEmitOnlyEvents();
 
         createPushStream(Set.of(RiscAccountDisabled.TYPE, RiscAccountEnabled.TYPE));
+
+        // Observed in CI: the very first admin-event-triggered SSF lookup
+        // (StreamService.findStreamsForSsfReceiverClients, via the admin-event
+        // path) against a freshly started per-class test server can transiently
+        // see no streams — likely a client-attribute-search cache/index warm-up
+        // race, since every subsequent call in the same server instance (i.e.
+        // every other test in this class) succeeds reliably. Prime that path
+        // once here with a throwaway disable/re-enable cycle so the real
+        // per-test assertions below are never the first caller.
+        setUserEnabled(false);
+        setUserEnabled(true);
+        pushes.clear();
     }
 
     @AfterEach

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountStateEventTests.java
@@ -106,7 +106,7 @@ public class SsfTransmitterAccountStateEventTests {
     private String testUserId;
 
     @BeforeEach
-    public void setup() throws IOException, InterruptedException {
+    public void setup() throws IOException {
         pushes.clear();
 
         mockReceiverServer.createContext(PUSH_CONTEXT_PATH, new HttpHandler() {
@@ -129,26 +129,6 @@ public class SsfTransmitterAccountStateEventTests {
         setEmitOnlyEvents();
 
         createPushStream(Set.of(RiscAccountDisabled.TYPE, RiscAccountEnabled.TYPE));
-
-        // Observed in CI: the very first admin-event-triggered SSF lookup
-        // (StreamService.findStreamsForSsfReceiverClients, via the admin-event
-        // path) against a freshly started per-class test server can transiently
-        // see no streams — likely a client-attribute-search cache/index warm-up
-        // race, since every subsequent call in the same server instance (i.e.
-        // every other test in this class) succeeds reliably. Prime that path
-        // once here with a throwaway disable/re-enable cycle so the real
-        // per-test assertions below are never the first caller.
-        //
-        // Delivery is asynchronous (outbox drainer), so the warm-up's own
-        // pushes don't land immediately — actually wait for each one (or
-        // its absence) instead of clearing the queue right away, otherwise
-        // they arrive late and get consumed by the next real assertion
-        // instead of pushes.clear() below.
-        setUserEnabled(false);
-        pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
-        setUserEnabled(true);
-        pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
-        pushes.clear();
     }
 
     @AfterEach
@@ -232,11 +212,21 @@ public class SsfTransmitterAccountStateEventTests {
         userResource.update(rep);
     }
 
+    /**
+     * Sets (or, with no arguments, clears) the receiver's
+     * {@code ssf.emitOnlyEvents} attribute.
+     *
+     * <p>Clearing writes an empty string rather than {@code null}: a
+     * null-valued attribute in the update representation is skipped rather
+     * than removed, so the previous value would survive and keep suppressing
+     * auto-emit in every subsequent test. {@code ClientStreamStore} treats
+     * blank the same as absent, so an empty string reliably means "no
+     * emit-only events".
+     */
     protected void setEmitOnlyEvents(String... eventTypes) {
         ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
         ClientRepresentation rep = clientResource.toRepresentation();
-        rep.getAttributes().put(ClientStreamStore.SSF_EMIT_ONLY_EVENTS_KEY,
-                eventTypes.length == 0 ? null : String.join(",", eventTypes));
+        rep.getAttributes().put(ClientStreamStore.SSF_EMIT_ONLY_EVENTS_KEY, String.join(",", eventTypes));
         clientResource.update(rep);
     }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -28,7 +28,7 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.ssf.SsfException;
 import org.keycloak.ssf.event.InitiatingEntity;
-import org.keycloak.ssf.event.SsfEvent;
+import org.keycloak.ssf.event.InitiatingEntityAware;
 import org.keycloak.ssf.event.caep.CaepCredentialChange;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
 import org.keycloak.ssf.event.risc.RiscAccountDisabled;
@@ -406,7 +406,7 @@ public class SecurityEventTokenMapper {
         credentialChangeEvent.setAttributeValue(KC_CREDENTIAL_USER_LABEL, kcUserLabel);
     }
 
-    protected void applyInitiatingEntity(Event userEvent, AdminEvent adminEvent, SsfEvent ssfEvent) {
+    protected void applyInitiatingEntity(Event userEvent, AdminEvent adminEvent, InitiatingEntityAware ssfEvent) {
         if (adminEvent != null) {
             ssfEvent.setInitiatingEntity(InitiatingEntity.ADMIN);
         } else {
@@ -415,7 +415,7 @@ public class SecurityEventTokenMapper {
     }
 
     /**
-     * Variant of {@link #applyInitiatingEntity(Event, AdminEvent, SsfEvent)} for
+     * Variant of {@link #applyInitiatingEntity(Event, AdminEvent, InitiatingEntityAware)} for
      * callers where "not admin-initiated" does not mean "user-initiated" —
      * e.g. brute-force lockout is Keycloak's own policy engine acting, not
      * an end-user choice, so defaulting to {@link InitiatingEntity#USER}
@@ -423,7 +423,7 @@ public class SecurityEventTokenMapper {
      * caller supply the correct value ({@link InitiatingEntity#POLICY} /
      * {@link InitiatingEntity#SYSTEM}) for its specific non-admin trigger(s).
      */
-    protected void applyInitiatingEntity(AdminEvent adminEvent, SsfEvent ssfEvent, InitiatingEntity nonAdminEntity) {
+    protected void applyInitiatingEntity(AdminEvent adminEvent, InitiatingEntityAware ssfEvent, InitiatingEntity nonAdminEntity) {
         ssfEvent.setInitiatingEntity(adminEvent != null ? InitiatingEntity.ADMIN : nonAdminEntity);
     }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -30,7 +30,6 @@ import org.keycloak.ssf.SsfException;
 import org.keycloak.ssf.event.InitiatingEntity;
 import org.keycloak.ssf.event.SsfEvent;
 import org.keycloak.ssf.event.caep.CaepCredentialChange;
-import org.keycloak.ssf.event.caep.CaepEvent;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
 import org.keycloak.ssf.event.risc.RiscAccountDisabled;
 import org.keycloak.ssf.event.risc.RiscAccountEnabled;

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -28,9 +28,12 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.ssf.SsfException;
 import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.ssf.event.SsfEvent;
 import org.keycloak.ssf.event.caep.CaepCredentialChange;
 import org.keycloak.ssf.event.caep.CaepEvent;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
+import org.keycloak.ssf.event.risc.RiscAccountDisabled;
+import org.keycloak.ssf.event.risc.RiscAccountEnabled;
 import org.keycloak.ssf.event.stream.SsfStreamUpdatedEvent;
 import org.keycloak.ssf.event.stream.SsfStreamVerificationEvent;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
@@ -63,6 +66,13 @@ public class SecurityEventTokenMapper {
     protected static final Pattern USER_RESET_PASSWORD_BY_ADMIN_PATH_PATTERN = Pattern.compile("^users/([^/]+)/reset-password$");
 
     protected static final Pattern USER_CREDENTIALS_CHANGED_BY_ADMIN_PATH_PATTERN = Pattern.compile("^users/([^/]+)/credentials/([^/]+)$");
+
+    // Bare "users/{id}" — the generic admin "update user" endpoint. Fires for
+    // every profile field change, so on its own it is not mapped by
+    // canConvert(AdminEvent); isEnabledStateChangeAdminEvent additionally
+    // requires the previous/updated "enabled" details UserResource attaches
+    // when that specific field changed.
+    protected static final Pattern USER_UPDATED_BY_ADMIN_PATH_PATTERN = Pattern.compile("^users/([^/]+)$");
 
     public static final String KC_CREDENTIAL_ID = "kc_credential_id";
 
@@ -304,6 +314,82 @@ public class SecurityEventTokenMapper {
         }
     }
 
+    /**
+     * Generates a RISC account-disabled event.
+     *
+     * @param userEvent the (possibly synthetic — see {@link #generateAccountStateChangeEventForAdminAction})
+     *                  user event carrying the affected user id
+     * @param adminEvent the admin event that triggered the disablement, or {@code null} for
+     *                   native triggers (currently only brute-force lockout) that aren't
+     *                   admin-initiated. Non-admin triggers are labeled
+     *                   {@link InitiatingEntity#POLICY} — brute-force lockout is Keycloak's
+     *                   own security policy engine acting, not an end-user choice, so it
+     *                   must not be reported to receivers as {@link InitiatingEntity#USER}.
+     * @param stream the receiving stream
+     * @param reason one of the {@code RiscAccountDisabled.REASON_*} constants, or another
+     *               value mutually understood by transmitter and receiver
+     */
+    public SsfSecurityEventToken generateAccountDisabledEvent(Event userEvent, AdminEvent adminEvent, StreamConfig stream, String reason) {
+        try {
+            String userId = userEvent.getUserId();
+
+            SsfSecurityEventToken eventToken = newSecurityEventToken(stream);
+            eventToken.setTxn(UUID.randomUUID().toString());
+            eventToken.setSubjectId(composeUserSubject(eventToken, userId, stream));
+
+            RiscAccountDisabled accountDisabledEvent = new RiscAccountDisabled();
+            accountDisabledEvent.setReason(reason);
+            accountDisabledEvent.setEventTimestamp(Time.currentTime());
+            applyInitiatingEntity(adminEvent, accountDisabledEvent, InitiatingEntity.POLICY);
+
+            Map<String, Object> events = new HashMap<>();
+            events.put(RiscAccountDisabled.TYPE, accountDisabledEvent);
+            eventToken.setEvents(events);
+
+            return eventToken;
+        } catch (Exception e) {
+            log.error("Error generating account disabled event", e);
+            return null;
+        }
+    }
+
+    /**
+     * Generates a RISC account-enabled event.
+     *
+     * @param userEvent the (possibly synthetic — see {@link #generateAccountStateChangeEventForAdminAction})
+     *                  user event carrying the affected user id
+     * @param adminEvent the admin event that triggered the re-activation, or {@code null} for
+     *                   native triggers that aren't admin-initiated. No such trigger exists yet
+     *                   (only the admin path calls this today), but a non-admin re-activation
+     *                   would be an automated/platform action rather than the user's own, so it
+     *                   is labeled {@link InitiatingEntity#SYSTEM} rather than
+     *                   {@link InitiatingEntity#USER} — update this if a future caller needs a
+     *                   more specific value.
+     * @param stream the receiving stream
+     */
+    public SsfSecurityEventToken generateAccountEnabledEvent(Event userEvent, AdminEvent adminEvent, StreamConfig stream) {
+        try {
+            String userId = userEvent.getUserId();
+
+            SsfSecurityEventToken eventToken = newSecurityEventToken(stream);
+            eventToken.setTxn(UUID.randomUUID().toString());
+            eventToken.setSubjectId(composeUserSubject(eventToken, userId, stream));
+
+            RiscAccountEnabled accountEnabledEvent = new RiscAccountEnabled();
+            accountEnabledEvent.setEventTimestamp(Time.currentTime());
+            applyInitiatingEntity(adminEvent, accountEnabledEvent, InitiatingEntity.SYSTEM);
+
+            Map<String, Object> events = new HashMap<>();
+            events.put(RiscAccountEnabled.TYPE, accountEnabledEvent);
+            eventToken.setEvents(events);
+
+            return eventToken;
+        } catch (Exception e) {
+            log.error("Error generating account enabled event", e);
+            return null;
+        }
+    }
+
     protected void applyCustomAttributes(Event userEvent, AdminEvent adminEvent, CaepCredentialChange credentialChangeEvent) {
         // Keycloak user events aren't required to carry a details map —
         // RESET_PASSWORD in particular doesn't populate it. Skip the
@@ -321,12 +407,25 @@ public class SecurityEventTokenMapper {
         credentialChangeEvent.setAttributeValue(KC_CREDENTIAL_USER_LABEL, kcUserLabel);
     }
 
-    protected void applyInitiatingEntity(Event userEvent, AdminEvent adminEvent, CaepEvent caepEvent) {
+    protected void applyInitiatingEntity(Event userEvent, AdminEvent adminEvent, SsfEvent ssfEvent) {
         if (adminEvent != null) {
-            caepEvent.setInitiatingEntity(InitiatingEntity.ADMIN);
+            ssfEvent.setInitiatingEntity(InitiatingEntity.ADMIN);
         } else {
-            caepEvent.setInitiatingEntity(InitiatingEntity.USER);
+            ssfEvent.setInitiatingEntity(InitiatingEntity.USER);
         }
+    }
+
+    /**
+     * Variant of {@link #applyInitiatingEntity(Event, AdminEvent, SsfEvent)} for
+     * callers where "not admin-initiated" does not mean "user-initiated" —
+     * e.g. brute-force lockout is Keycloak's own policy engine acting, not
+     * an end-user choice, so defaulting to {@link InitiatingEntity#USER}
+     * would misrepresent it to receivers. {@code nonAdminEntity} lets the
+     * caller supply the correct value ({@link InitiatingEntity#POLICY} /
+     * {@link InitiatingEntity#SYSTEM}) for its specific non-admin trigger(s).
+     */
+    protected void applyInitiatingEntity(AdminEvent adminEvent, SsfEvent ssfEvent, InitiatingEntity nonAdminEntity) {
+        ssfEvent.setInitiatingEntity(adminEvent != null ? InitiatingEntity.ADMIN : nonAdminEntity);
     }
 
     protected String narrowCaepCredentialType(String credentialType) {
@@ -601,6 +700,7 @@ public class SecurityEventTokenMapper {
             case UPDATE_CREDENTIAL,
                  REMOVE_CREDENTIAL,
                  RESET_PASSWORD -> !shouldIgnoreCredentialChange(event);
+            case USER_DISABLED_BY_PERMANENT_LOCKOUT -> true;
             default -> false;
         };
     }
@@ -608,10 +708,12 @@ public class SecurityEventTokenMapper {
     /**
      * Cheap predicate that returns {@code true} iff
      * {@link #toSecurityEventToken(AdminEvent, StreamConfig)} would produce a
-     * non-null SET for {@code adminEvent}. Currently the only mapped
-     * admin operation is the "log out all user sessions" path
-     * ({@code users/{userId}/logout}); everything else returns null and
-     * should short-circuit before any stream lookup happens.
+     * non-null SET for {@code adminEvent} — the admin paths mapped are
+     * "log out all user sessions" ({@code users/{userId}/logout}),
+     * admin-initiated password reset / credential management, and an
+     * enable/disable transition on the generic user update endpoint (see
+     * {@link #isEnabledStateChangeAdminEvent}); everything else returns
+     * null and should short-circuit before any stream lookup happens.
      */
     public boolean canConvert(AdminEvent adminEvent) {
         if (adminEvent == null) {
@@ -631,13 +733,41 @@ public class SecurityEventTokenMapper {
             }
         }
 
-        return false;
+        return isEnabledStateChangeAdminEvent(adminEvent);
     }
 
     protected List<Pattern> supportedAdminPathPatters() {
         return List.of(USER_LOGGED_OUT_BY_ADMIN_PATH_PATTERN,
                 USER_RESET_PASSWORD_BY_ADMIN_PATH_PATTERN,
                 USER_CREDENTIALS_CHANGED_BY_ADMIN_PATH_PATTERN);
+    }
+
+    /**
+     * True when {@code adminEvent} is a generic admin "update user" event
+     * (bare {@code users/{id}}, {@code OperationType.UPDATE}) that
+     * specifically flipped the {@code enabled} flag — i.e. the admin
+     * resource attached the {@link Details#PREVIOUS_ENABLED} /
+     * {@link Details#UPDATED_ENABLED} details with two different values.
+     * The bare update path is not in
+     * {@link #supportedAdminPathPatters()} because it fires for every user
+     * profile change, not just enable/disable — this predicate is the extra
+     * gate that narrows it down to the one transition RISC cares about.
+     */
+    protected boolean isEnabledStateChangeAdminEvent(AdminEvent adminEvent) {
+        if (adminEvent.getOperationType() != OperationType.UPDATE) {
+            return false;
+        }
+        String path = adminEvent.getResourcePath();
+        if (path == null || !USER_UPDATED_BY_ADMIN_PATH_PATTERN.matcher(path).matches()) {
+            return false;
+        }
+        Map<String, String> details = adminEvent.getDetails();
+        if (details == null) {
+            return false;
+        }
+        String previousEnabled = details.get(Details.PREVIOUS_ENABLED);
+        String updatedEnabled = details.get(Details.UPDATED_ENABLED);
+        return previousEnabled != null && updatedEnabled != null && !previousEnabled.equals(updatedEnabled);
     }
 
     protected boolean shouldIgnoreEvent(Event event) {
@@ -705,6 +835,10 @@ public class SecurityEventTokenMapper {
                 yield generateCredentialChangeEvent(event, adminEvent, stream,
                         CaepCredentialChange.ChangeType.UPDATE, "password");
             }
+
+            case USER_DISABLED_BY_PERMANENT_LOCKOUT ->
+                    generateAccountDisabledEvent(event, adminEvent, stream, RiscAccountDisabled.REASON_BRUTE_FORCE);
+
             // Add more event mappings here as needed.
             // Deliberately NOT mapped: UPDATE_PASSWORD / UPDATE_TOTP /
             // REMOVE_TOTP — these are deprecated event types Keycloak
@@ -769,7 +903,31 @@ public class SecurityEventTokenMapper {
             return generateCredentialChangeEventForAdminAction(userId, adminEvent, stream, changeType, credentialId, "credential_management");
         }
 
+        if (isEnabledStateChangeAdminEvent(adminEvent)) {
+            boolean nowEnabled = Boolean.parseBoolean(adminEvent.getDetails().get(Details.UPDATED_ENABLED));
+            return generateAccountStateChangeEventForAdminAction(userId, adminEvent, stream, nowEnabled);
+        }
+
         return null;
+    }
+
+    /**
+     * Builds a synthetic {@link Event} carrying just the user id — mirrors
+     * {@link #generateLogoutEventForAdminLogoutAllUserSessions} /
+     * {@link #generateCredentialChangeEventForAdminAction} — so the admin
+     * enable/disable path can reuse {@link #generateAccountDisabledEvent} /
+     * {@link #generateAccountEnabledEvent}, whose signature is shared with
+     * the natively-triggered (non-admin) paths.
+     */
+    protected SsfSecurityEventToken generateAccountStateChangeEventForAdminAction(String userId, AdminEvent adminEvent, StreamConfig stream, boolean nowEnabled) {
+
+        Event event = new Event();
+        event.setType(EventType.UPDATE_PROFILE);
+        event.setUserId(userId);
+
+        return nowEnabled
+                ? generateAccountEnabledEvent(event, adminEvent, stream)
+                : generateAccountDisabledEvent(event, adminEvent, stream, RiscAccountDisabled.REASON_ADMIN);
     }
 
     protected SsfSecurityEventToken generateCredentialChangeEventForAdminAction(String userId,

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -298,11 +298,14 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
     public void onEvent(AdminEvent adminEvent, boolean includeRepresentation) {
 
         if (shouldIgnoreEvent(adminEvent)) {
+            log.warnf("SSF-DIAG onEvent: shouldIgnoreEvent=true, dropping admin event id=%s realmId=%s resourcePath=%s",
+                    adminEvent.getId(), adminEvent.getRealmId(), adminEvent.getResourcePath());
             return;
         }
 
         SsfTransmitterProvider transmitter = session.getProvider(SsfTransmitterProvider.class);
         if (transmitter == null) {
+            log.warnf("SSF-DIAG onEvent: transmitter provider is null, dropping admin event id=%s", adminEvent.getId());
             return;
         }
 
@@ -314,12 +317,17 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         // triggered a stream lookup that the mapper would then ignore.
         // The canConvert predicate also handles the ResourceType=USER guard
         // the old code had inline.
-        if (!transmitter.securityEventTokenMapper().canConvert(adminEvent)) {
+        boolean canConvert = transmitter.securityEventTokenMapper().canConvert(adminEvent);
+        log.warnf("SSF-DIAG onEvent: canConvert=%s id=%s operationType=%s resourceType=%s resourcePath=%s details=%s",
+                canConvert, adminEvent.getId(), adminEvent.getOperationType(), adminEvent.getResourceType(),
+                adminEvent.getResourcePath(), adminEvent.getDetails());
+        if (!canConvert) {
             return;
         }
 
         var streamTokens = generateSecurityEventTokensForAdminEvent(adminEvent, transmitter);
         if (streamTokens == null || streamTokens.isEmpty()) {
+            log.warnf("SSF-DIAG onEvent: no streamTokens produced for admin event id=%s", adminEvent.getId());
             return;
         }
         dispatchSecurityEventTokens(streamTokens, transmitter);
@@ -343,6 +351,8 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
     protected List<Map.Entry<SsfSecurityEventToken, StreamConfig>> generateSecurityEventTokensForAdminEvent(AdminEvent adminEvent, SsfTransmitterProvider transmitter) {
 
         if (adminEvent.getResourceType() != ResourceType.USER) {
+            log.warnf("SSF-DIAG generateSecurityEventTokensForAdminEvent: resourceType=%s != USER, dropping id=%s",
+                    adminEvent.getResourceType(), adminEvent.getId());
             return List.of();
         }
 
@@ -354,8 +364,13 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         }
 
         RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
-        UserModel eventUser = session.users().getUserById(realm, SsfUtil.userIdFromAdminEventPath(adminEvent));
+        String eventUserId = SsfUtil.userIdFromAdminEventPath(adminEvent);
+        UserModel eventUser = session.users().getUserById(realm, eventUserId);
         if (eventUser == null) {
+            log.warnf("SSF-DIAG generateSecurityEventTokensForAdminEvent: eventUser not found. id=%s realm=%s(%s) "
+                            + "parsedUserId=%s resourcePath=%s",
+                    adminEvent.getId(), realm != null ? realm.getName() : null, adminEvent.getRealmId(),
+                    eventUserId, adminEvent.getResourcePath());
             return List.of();
         }
 
@@ -367,6 +382,9 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
                 // Avoids building a token for a stream the dispatcher
                 // would just filter out, and keeps logs honest for the
                 // multi-receiver case where only some streams deliver.
+                log.warnf("SSF-DIAG generateSecurityEventTokensForAdminEvent: shouldDispatchForUser=false. id=%s "
+                                + "userId=%s streamId=%s clientId=%s",
+                        adminEvent.getId(), eventUserId, stream.getStreamId(), stream.getClientClientId());
                 continue;
             }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -375,6 +375,12 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
                 log.debugf("Could not generate SSF Security Event Token for Admin Event. id=%s", adminEvent.getId());
                 continue;
             }
+            if (isAnyEventEmitOnlyForReceiver(securityEventToken, stream)) {
+                log.debugf("Skipping native auto-emit — event type is in receiver's emitOnlyEvents set. "
+                                + "streamId=%s clientId=%s jti=%s",
+                        stream.getStreamId(), stream.getClientClientId(), securityEventToken.getJti());
+                continue;
+            }
             log.debugf("Generated SSF Security Event Token for Admin Event. "
                             + "realm=%s clientId=%s streamId=%s operationType=%s resourceType=%s resourcePath=%s jti=%s",
                     session.getContext().getRealm().getName(),

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -298,14 +298,11 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
     public void onEvent(AdminEvent adminEvent, boolean includeRepresentation) {
 
         if (shouldIgnoreEvent(adminEvent)) {
-            log.warnf("SSF-DIAG onEvent: shouldIgnoreEvent=true, dropping admin event id=%s realmId=%s resourcePath=%s",
-                    adminEvent.getId(), adminEvent.getRealmId(), adminEvent.getResourcePath());
             return;
         }
 
         SsfTransmitterProvider transmitter = session.getProvider(SsfTransmitterProvider.class);
         if (transmitter == null) {
-            log.warnf("SSF-DIAG onEvent: transmitter provider is null, dropping admin event id=%s", adminEvent.getId());
             return;
         }
 
@@ -317,17 +314,12 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         // triggered a stream lookup that the mapper would then ignore.
         // The canConvert predicate also handles the ResourceType=USER guard
         // the old code had inline.
-        boolean canConvert = transmitter.securityEventTokenMapper().canConvert(adminEvent);
-        log.warnf("SSF-DIAG onEvent: canConvert=%s id=%s operationType=%s resourceType=%s resourcePath=%s details=%s",
-                canConvert, adminEvent.getId(), adminEvent.getOperationType(), adminEvent.getResourceType(),
-                adminEvent.getResourcePath(), adminEvent.getDetails());
-        if (!canConvert) {
+        if (!transmitter.securityEventTokenMapper().canConvert(adminEvent)) {
             return;
         }
 
         var streamTokens = generateSecurityEventTokensForAdminEvent(adminEvent, transmitter);
         if (streamTokens == null || streamTokens.isEmpty()) {
-            log.warnf("SSF-DIAG onEvent: no streamTokens produced for admin event id=%s", adminEvent.getId());
             return;
         }
         dispatchSecurityEventTokens(streamTokens, transmitter);
@@ -351,8 +343,6 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
     protected List<Map.Entry<SsfSecurityEventToken, StreamConfig>> generateSecurityEventTokensForAdminEvent(AdminEvent adminEvent, SsfTransmitterProvider transmitter) {
 
         if (adminEvent.getResourceType() != ResourceType.USER) {
-            log.warnf("SSF-DIAG generateSecurityEventTokensForAdminEvent: resourceType=%s != USER, dropping id=%s",
-                    adminEvent.getResourceType(), adminEvent.getId());
             return List.of();
         }
 
@@ -364,13 +354,8 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         }
 
         RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
-        String eventUserId = SsfUtil.userIdFromAdminEventPath(adminEvent);
-        UserModel eventUser = session.users().getUserById(realm, eventUserId);
+        UserModel eventUser = session.users().getUserById(realm, SsfUtil.userIdFromAdminEventPath(adminEvent));
         if (eventUser == null) {
-            log.warnf("SSF-DIAG generateSecurityEventTokensForAdminEvent: eventUser not found. id=%s realm=%s(%s) "
-                            + "parsedUserId=%s resourcePath=%s",
-                    adminEvent.getId(), realm != null ? realm.getName() : null, adminEvent.getRealmId(),
-                    eventUserId, adminEvent.getResourcePath());
             return List.of();
         }
 
@@ -382,9 +367,6 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
                 // Avoids building a token for a stream the dispatcher
                 // would just filter out, and keeps logs honest for the
                 // multi-receiver case where only some streams deliver.
-                log.warnf("SSF-DIAG generateSecurityEventTokensForAdminEvent: shouldDispatchForUser=false. id=%s "
-                                + "userId=%s streamId=%s clientId=%s",
-                        adminEvent.getId(), eventUserId, stream.getStreamId(), stream.getClientClientId());
                 continue;
             }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
@@ -347,8 +347,20 @@ public class ClientStreamStore implements SsfStreamStore {
     public List<StreamConfig> findStreamsForSsfReceiverClients() {
         RealmModel realm = session.getContext().getRealm();
         Map<String, String> attributes = Map.of(SSF_ENABLED_KEY, "true");
-        return session.clients()
+        // TEMPORARY DIAGNOSTIC — investigating an intermittent CI failure where
+        // this returns empty for a client whose stream was just created
+        // (keycloak/keycloak#51318). Remove once root-caused.
+        List<ClientModel> rawCandidates = session.clients()
                 .searchClientsByAttributes(realm, attributes, null, null)
+                .toList();
+        log.warnf("SSF-DIAG findStreamsForSsfReceiverClients: realm=%s(%s) rawCandidates=%s",
+                realm.getName(), realm.getId(),
+                rawCandidates.stream()
+                        .map(c -> c.getClientId() + "[enabled=" + c.isEnabled()
+                                + ",ssf.enabled=" + c.getAttribute(SSF_ENABLED_KEY)
+                                + ",streamId=" + c.getAttribute(SSF_STREAM_ID_KEY) + "]")
+                        .toList());
+        return rawCandidates.stream()
                 // The attribute search already matches ssf.enabled=true, but it
                 // cannot express the client on/off state — filter disabled
                 // receivers out here so the dispatcher and event listener never

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
@@ -347,20 +347,8 @@ public class ClientStreamStore implements SsfStreamStore {
     public List<StreamConfig> findStreamsForSsfReceiverClients() {
         RealmModel realm = session.getContext().getRealm();
         Map<String, String> attributes = Map.of(SSF_ENABLED_KEY, "true");
-        // TEMPORARY DIAGNOSTIC — investigating an intermittent CI failure where
-        // this returns empty for a client whose stream was just created
-        // (keycloak/keycloak#51318). Remove once root-caused.
-        List<ClientModel> rawCandidates = session.clients()
+        return session.clients()
                 .searchClientsByAttributes(realm, attributes, null, null)
-                .toList();
-        log.warnf("SSF-DIAG findStreamsForSsfReceiverClients: realm=%s(%s) rawCandidates=%s",
-                realm.getName(), realm.getId(),
-                rawCandidates.stream()
-                        .map(c -> c.getClientId() + "[enabled=" + c.isEnabled()
-                                + ",ssf.enabled=" + c.getAttribute(SSF_ENABLED_KEY)
-                                + ",streamId=" + c.getAttribute(SSF_STREAM_ID_KEY) + "]")
-                        .toList());
-        return rawCandidates.stream()
                 // The attribute search already matches ssf.enabled=true, but it
                 // cannot express the client on/off state — filter disabled
                 // receivers out here so the dispatcher and event listener never

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
@@ -1,0 +1,178 @@
+package org.keycloak.ssf.transmitter.event;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.events.Details;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.ssf.event.risc.RiscAccountDisabled;
+import org.keycloak.ssf.event.risc.RiscAccountEnabled;
+import org.keycloak.ssf.event.token.SsfSecurityEventToken;
+import org.keycloak.ssf.transmitter.stream.StreamConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the RISC {@code account-disabled} / {@code account-enabled}
+ * mapping added to {@link SecurityEventTokenMapper}: the brute-force
+ * permanent-lockout {@link Event} path and the admin "enable/disable a user"
+ * {@link AdminEvent} path (see {@link SecurityEventTokenMapper#isEnabledStateChangeAdminEvent}).
+ *
+ * <p>Session-independent methods only — subject resolution defaults to
+ * {@code iss_sub} (no organization/email lookups), so the mapper is
+ * constructed with a {@code null} session and a stub issuer, mirroring how
+ * {@link SsfTransmitterEventListenerTest} constructs the listener with a
+ * {@code null} session for predicates that don't touch it.
+ */
+class SecurityEventTokenMapperTest {
+
+    private static final String USER_ID = "user-123";
+
+    private final SecurityEventTokenMapper mapper =
+            new SecurityEventTokenMapper(null, null, session -> "https://issuer.example/realms/test");
+
+    // ----- brute-force permanent lockout (Event path) -----
+
+    @Test
+    void canConvert_permanentLockoutEvent_true() {
+        Event event = new Event();
+        event.setType(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT);
+        event.setUserId(USER_ID);
+
+        assertTrue(mapper.canConvert(event));
+    }
+
+    @Test
+    void toSecurityEventToken_permanentLockoutEvent_producesAccountDisabledWithBruteForceReason() {
+        Event event = new Event();
+        event.setType(EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT);
+        event.setUserId(USER_ID);
+
+        SsfSecurityEventToken token = mapper.toSecurityEventToken(event, streamConfig());
+
+        assertNotNull(token);
+        Object payload = token.getEvents().get(RiscAccountDisabled.TYPE);
+        assertTrue(payload instanceof RiscAccountDisabled);
+        RiscAccountDisabled accountDisabled = (RiscAccountDisabled) payload;
+        assertEquals(RiscAccountDisabled.REASON_BRUTE_FORCE, accountDisabled.getReason());
+        // No AdminEvent on this path, but brute-force lockout is Keycloak's own
+        // policy engine acting, not the user's choice — must not be USER.
+        assertEquals(InitiatingEntity.POLICY, accountDisabled.getInitiatingEntity());
+    }
+
+    // ----- admin-initiated enable/disable (AdminEvent path) -----
+
+    @Test
+    void canConvert_adminEnabledStateChange_true() {
+        AdminEvent adminEvent = adminUserUpdateEvent("true", "false");
+
+        assertTrue(mapper.canConvert(adminEvent));
+    }
+
+    @Test
+    void canConvert_adminUpdateWithoutEnabledChange_false() {
+        // Generic profile update (e.g. name/email) — no previous/updated
+        // enabled details attached, since the value didn't change.
+        AdminEvent adminEvent = adminUserUpdateEvent(null, null);
+
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
+    @Test
+    void canConvert_adminUpdateWithUnchangedEnabledDetail_false() {
+        // Defensive: if both details were ever attached with the same value,
+        // that is not a transition and must not be reported as one.
+        AdminEvent adminEvent = adminUserUpdateEvent("true", "true");
+
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
+    @Test
+    void canConvert_nonUpdateOperation_false() {
+        AdminEvent adminEvent = adminUserUpdateEvent("true", "false");
+        adminEvent.setOperationType(OperationType.DELETE);
+
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
+    @Test
+    void canConvert_subResourcePath_notPickedUpByEnabledStateGate() {
+        // Bare "users/{id}" is required — a sub-path must not be picked up
+        // by the enabled-state-change gate itself. Using ".../groups" here
+        // (rather than ".../logout") keeps this test isolated from the
+        // pre-existing "log out all sessions" pattern, which legitimately
+        // makes canConvert() return true for a ".../logout" path regardless
+        // of any enabled-state details.
+        AdminEvent adminEvent = adminUserUpdateEvent("true", "false");
+        adminEvent.setResourcePath("users/" + USER_ID + "/groups");
+
+        assertFalse(mapper.isEnabledStateChangeAdminEvent(adminEvent));
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
+    @Test
+    void toSecurityEventToken_adminDisablesUser_producesAccountDisabledWithAdminReason() {
+        AdminEvent adminEvent = adminUserUpdateEvent("true", "false");
+
+        SsfSecurityEventToken token = mapper.toSecurityEventToken(adminEvent, streamConfig());
+
+        assertNotNull(token);
+        Object payload = token.getEvents().get(RiscAccountDisabled.TYPE);
+        assertTrue(payload instanceof RiscAccountDisabled);
+        RiscAccountDisabled accountDisabled = (RiscAccountDisabled) payload;
+        assertEquals(RiscAccountDisabled.REASON_ADMIN, accountDisabled.getReason());
+        assertEquals(InitiatingEntity.ADMIN, accountDisabled.getInitiatingEntity());
+    }
+
+    @Test
+    void toSecurityEventToken_adminEnablesUser_producesAccountEnabled() {
+        AdminEvent adminEvent = adminUserUpdateEvent("false", "true");
+
+        SsfSecurityEventToken token = mapper.toSecurityEventToken(adminEvent, streamConfig());
+
+        assertNotNull(token);
+        Object payload = token.getEvents().get(RiscAccountEnabled.TYPE);
+        assertTrue(payload instanceof RiscAccountEnabled);
+        assertEquals(InitiatingEntity.ADMIN, ((RiscAccountEnabled) payload).getInitiatingEntity());
+    }
+
+    private StreamConfig streamConfig() {
+        return new StreamConfig();
+    }
+
+    /**
+     * Builds the {@link AdminEvent} shape {@code UserResource.updateUser}
+     * produces for {@code PUT /admin/realms/{realm}/users/{id}}: bare
+     * {@code users/{id}} resource path, {@code ResourceType.USER},
+     * {@code OperationType.UPDATE}, and — only when the enabled flag
+     * actually changed — the {@link Details#PREVIOUS_ENABLED} /
+     * {@link Details#UPDATED_ENABLED} detail pair.
+     */
+    private AdminEvent adminUserUpdateEvent(String previousEnabled, String updatedEnabled) {
+        AdminEvent adminEvent = new AdminEvent();
+        adminEvent.setResourceType(ResourceType.USER);
+        adminEvent.setOperationType(OperationType.UPDATE);
+        adminEvent.setResourcePath("users/" + USER_ID);
+
+        Map<String, String> details = new HashMap<>();
+        if (previousEnabled != null) {
+            details.put(Details.PREVIOUS_ENABLED, previousEnabled);
+        }
+        if (updatedEnabled != null) {
+            details.put(Details.UPDATED_ENABLED, updatedEnabled);
+        }
+        adminEvent.setDetails(details);
+
+        return adminEvent;
+    }
+}


### PR DESCRIPTION
Resolves  #48900

Adds RiscAccountDisabled/RiscAccountEnabled (ssf/core), wired into the SSF
transmitter for two triggers: an admin enabling/disabling a user via the
Admin REST API, and brute-force permanent lockout.

- UserResource.updateUser now captures the enabled-state transition and
  attaches it to the admin event as details (Details.PREVIOUS_ENABLED /
  UPDATED_ENABLED), which SecurityEventTokenMapper reads via the new
  isEnabledStateChangeAdminEvent gate on the generic "update user" path.
- USER_DISABLED_BY_PERMANENT_LOCKOUT is mapped directly to
  RiscAccountDisabled with reason=disabled-by-bruteforce.
- initiating_entity is POLICY for brute-force lockout and ADMIN for the
  admin path — not USER, since neither is an end-user action.
- Fixes a related pre-existing gap: admin-triggered SSF events (logout-all-
  sessions, credential-change-by-admin, and now these two) were bypassing
  the receiver's ssf.emitOnlyEvents gate, unlike the user-event path.
- New RiscEvent/RiscAccountDisabled/RiscAccountEnabled classes, registered
  as emittable + natively emitted in DefaultSsfEventProviderFactory.

Known gap, filed separately: SCIM `active` writes and AD federation sync
disable users by calling UserModel.setEnabled() directly, bypassing both
trigger points above, so they don't emit these events yet.  See https://github.com/keycloak/keycloak/issues/51317

Assisted-By: Claude Sonnet 5
