### PR TITLE
Upgrade to Infinispan 16.0.14

### DIFF
--- a/docs/guides/high-availability/examples/generated/ispn-single.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-single.yaml
@@ -318,8 +318,8 @@ spec:
   expose:
     type: Route
   configMapName: "cluster-config"
-  image: quay.io/infinispan/server:16.0.12
-  version: 16.0.12
+  image: quay.io/infinispan/server:16.0.14
+  version: 16.0.14
   configListener:
     enabled: false
   container:

--- a/docs/guides/high-availability/examples/generated/ispn-site-a.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-site-a.yaml
@@ -348,8 +348,8 @@ spec:
   expose:
     type: Route
   configMapName: "cluster-config"
-  image: 
-  version: 16.0.12
+  image:
+  version: 16.0.14
   configListener:
     enabled: false
   container:

--- a/docs/guides/high-availability/examples/generated/ispn-site-b.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-site-b.yaml
@@ -348,8 +348,8 @@ spec:
   expose:
     type: Route
   configMapName: "cluster-config"
-  image: 
-  version: 16.0.12
+  image:
+  version: 16.0.14
   configListener:
     enabled: false
   container:

--- a/docs/guides/high-availability/examples/generated/ispn-volatile.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-volatile.yaml
@@ -520,8 +520,8 @@ spec:
   expose:
     type: Route
   configMapName: "cluster-config"
-  image: 
-  version: 16.0.12
+  image:
+  version: 16.0.14
   configListener:
     enabled: false
   container:

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
         <hibernate.c3p0.version>6.2.13.Final</hibernate.c3p0.version>
         <microprofile-metrics-api.version>5.1.2</microprofile-metrics-api.version>
-        <infinispan.version>16.0.12</infinispan.version>
+        <infinispan.version>16.0.14</infinispan.version>
         <protostream.version>6.0.7</protostream.version> <!-- For the annotation processor: keep in sync with the version shipped with Infinispan -->
         <protostream.plugin.version>${protostream.version}</protostream.plugin.version>
 


### PR DESCRIPTION
Backport of #51274 to release/26.7

This PR holds the changes needed to Upgrade to Infinispan 16.0.14

Closes #51037

Signed-off-by: Ruchika <ruchika.jha1@ibm.com>