### PR TITLE
fix(admin/api): verify role belongs to master realm when checking for protected admin roles

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/RolePermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/RolePermissions.java
@@ -684,6 +684,10 @@ class RolePermissions implements RolePermissionEvaluator, RolePermissionManageme
         return resourceServer;
     }
     private boolean isRealmAdminRole(RoleModel role) {
-        return role.getContainer() instanceof RealmModel && List.of(AdminRoles.ADMIN, AdminRoles.CREATE_REALM).contains(role.getName());
+        if (!(role.getContainer() instanceof RealmModel)) {
+            return false;
+        }
+        RealmModel roleRealm = (RealmModel) role.getContainer();
+        return roleRealm.getName().equals(Config.getAdminRealm()) && List.of(AdminRoles.ADMIN, AdminRoles.CREATE_REALM).contains(role.getName());
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/rbac/InternalClientManagementTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/rbac/InternalClientManagementTest.java
@@ -96,6 +96,30 @@ public class InternalClientManagementTest extends AbstractAdminRBACTest {
     }
 
     @Test
+    public void testNonMasterRealmManageRealmAdminCanRenameAdminRealmRole() {
+        createRealm(adminClient, "myrealm");
+
+        // create admin and create-realm roles in myrealm
+        adminClient.realm("myrealm").roles().create(new RoleRepresentation(AdminRoles.ADMIN, null, false));
+        adminClient.realm("myrealm").roles().create(new RoleRepresentation(AdminRoles.CREATE_REALM, null, false));
+
+        // Grant manage-realm for "myrealm" to a master user
+        grantMasterRealmManagementRole("myrealm", masterUser.getUsername(), AdminRoles.MANAGE_REALM);
+
+        runAs(masterRealm.getName(), masterUser.getUsername(), client -> {
+            for (String name : Set.of(AdminRoles.ADMIN, AdminRoles.CREATE_REALM)) {
+                RoleRepresentation role = client.realm("myrealm").roles().get(name).toRepresentation();
+                // Should not throw ForbiddenException
+                client.realm("myrealm").roles().get(name).update(renamed(role));
+
+                // Verify the role was renamed
+                RoleRepresentation updatedRole = client.realm("myrealm").roles().get(renamed(role).getName()).toRepresentation();
+                assertEquals(renamed(role).getName(), updatedRole.getName());
+            }
+        });
+    }
+
+    @Test
     public void testMasterRealmManageRealmAdminCannotRenameAdminRealmRoleViaNameBasedEndpoint() {
         grantMasterRealmManagementRole(Config.getAdminRealm(), masterUser.getUsername(), AdminRoles.MANAGE_REALM);
 
@@ -169,7 +193,7 @@ public class InternalClientManagementTest extends AbstractAdminRBACTest {
     private RoleRepresentation renamed(RoleRepresentation original) {
         RoleRepresentation renamed = new RoleRepresentation();
         renamed.setId(original.getId());
-        renamed.setName(TEMP_ROLE_NAME);
+        renamed.setName(original.getName() + "_renamed");
         renamed.setDescription(original.getDescription());
         return renamed;
     }


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #51323

Custom realm-level roles named `admin` in non-master realms were being incorrectly blocked from updates with `HTTP 403 Forbidden`. The recent security fix in PR #49624 relied on `isRealmAdminRole()`, which checked the role name but did not verify if the role belonged to the protected `master` admin realm.

## Short description of the changes
- Updated `RolePermissions.isRealmAdminRole()` to explicitly check that the role belongs to the master realm (`Config.getAdminRealm()`) before blocking it.
- This ensures that ordinary application realms can freely use and manage custom roles named `admin` or `create-realm` without being incorrectly flagged as protected server-administration roles.

(Note: AI was used in autocomplete mode)
