### PR TITLE
Patch 51315

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Adapters</name>

--- a/adapters/saml/core-public/pom.xml
+++ b/adapters/saml/core-public/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/saml/core/pom.xml
+++ b/adapters/saml/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/saml/pom.xml
+++ b/adapters/saml/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Keycloak SAML Client Adapter Modules</name>

--- a/adapters/saml/wildfly-elytron/pom.xml
+++ b/adapters/saml/wildfly-elytron/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/saml/wildfly/pom.xml
+++ b/adapters/saml/wildfly/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Keycloak SAML Wildfly Integration</name>

--- a/adapters/saml/wildfly/wildfly-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/adapters/spi/adapter-spi/pom.xml
+++ b/adapters/spi/adapter-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/spi/jboss-adapter-core/pom.xml
+++ b/adapters/spi/jboss-adapter-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/spi/pom.xml
+++ b/adapters/spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Keycloak Client Adapter SPI Modules</name>

--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz/policy/common/pom.xml
+++ b/authz/policy/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-provider-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz/policy/pom.xml
+++ b/authz/policy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz/pom.xml
+++ b/authz/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authzen/pom.xml
+++ b/authzen/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authzen/services/pom.xml
+++ b/authzen/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authzen/tests/authzen-client/pom.xml
+++ b/authzen/tests/authzen-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-authzen-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authzen/tests/base/pom.xml
+++ b/authzen/tests/base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-authzen-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authzen/tests/pom.xml
+++ b/authzen/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../tests/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/authzen/tests/providers/pom.xml
+++ b/authzen/tests/providers/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-authzen-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.keycloak.bom</groupId>
     <artifactId>keycloak-bom-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.7.0</version>
 
     <packaging>pom</packaging>
 

--- a/boms/spi/pom.xml
+++ b/boms/spi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.keycloak.bom</groupId>
         <artifactId>keycloak-bom-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <groupId>org.keycloak.bom</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/default/pom.xml
+++ b/crypto/default/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-crypto-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/elytron/pom.xml
+++ b/crypto/elytron/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-crypto-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/fips1402/pom.xml
+++ b/crypto/fips1402/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-crypto-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Crypto Parent</name>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/dependencies/server-all/pom.xml
+++ b/dependencies/server-all/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>keycloak-dependencies-parent</artifactId>
 		<groupId>org.keycloak</groupId>
-		<version>999.0.0-SNAPSHOT</version>
+		<version>26.7.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/dependencies/server-min/pom.xml
+++ b/dependencies/server-min/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>keycloak-dependencies-parent</artifactId>
 		<groupId>org.keycloak</groupId>
-		<version>999.0.0-SNAPSHOT</version>
+		<version>26.7.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-api-docs-dist</artifactId>

--- a/distribution/downloads/pom.xml
+++ b/distribution/downloads/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-dist-downloads</artifactId>

--- a/distribution/galleon-feature-packs/pom.xml
+++ b/distribution/galleon-feature-packs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <name>Galleon Feature Pack Builds</name>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>galleon-feature-packs-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>galleon-feature-packs-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/licenses-common/pom.xml
+++ b/distribution/licenses-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-distribution-licenses-common</artifactId>

--- a/distribution/maven-plugins/licenses-processor/pom.xml
+++ b/distribution/maven-plugins/licenses-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-maven-plugins-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-distribution-licenses-maven-plugin</artifactId>

--- a/distribution/maven-plugins/pom.xml
+++ b/distribution/maven-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-distribution-maven-plugins-parent</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/saml-adapters/pom.xml
+++ b/distribution/saml-adapters/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <name>SAML Adapters Distribution Parent</name>

--- a/distribution/saml-adapters/wildfly-adapter/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Keycloak Wildfly SAML Adapter</name>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/aggregation/pom.xml
+++ b/docs/documentation/aggregation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/api_documentation/pom.xml
+++ b/docs/documentation/api_documentation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/authorization_services/pom.xml
+++ b/docs/documentation/authorization_services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/dist/pom.xml
+++ b/docs/documentation/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/header-maven-plugin/pom.xml
+++ b/docs/documentation/header-maven-plugin/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>documentation-parent</artifactId>
         <groupId>org.keycloak.documentation</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>header-maven-plugin</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.7.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>header-maven-plugin</name>

--- a/docs/documentation/pom.xml
+++ b/docs/documentation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-docs-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
 
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.7.0</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/docs/documentation/release_notes/pom.xml
+++ b/docs/documentation/release_notes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/server_admin/pom.xml
+++ b/docs/documentation/server_admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/server_development/pom.xml
+++ b/docs/documentation/server_development/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/tests/pom.xml
+++ b/docs/documentation/tests/pom.xml
@@ -60,7 +60,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -2,10 +2,10 @@
 :project_name_full: Keycloak
 :project_community: true
 :project_product: false
-:project_version: DEV
-:project_versionMvn: 999.0.0-SNAPSHOT
-:project_versionNpm: 999.0.0-SNAPSHOT
-:project_versionDoc: DEV
+:project_version: 26.7.0
+:project_versionMvn: 26.7.0
+:project_versionNpm: 26.7.0
+:project_versionDoc: 26.7.0
 
 :jdk_version_latest: 25
 :jdk_version_container: 21

--- a/docs/documentation/upgrading/pom.xml
+++ b/docs/documentation/upgrading/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/guides/pom.xml
+++ b/docs/guides/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-docs-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/maven-plugin/pom.xml
+++ b/docs/maven-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-docs-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Docs Parent</name>

--- a/federation/ipatuura/pom.xml
+++ b/federation/ipatuura/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/kerberos/pom.xml
+++ b/federation/kerberos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/sssd/pom.xml
+++ b/federation/sssd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration/client-cli/admin-cli/pom.xml
+++ b/integration/client-cli/admin-cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-client-cli-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration/client-cli/client-cli-dist/pom.xml
+++ b/integration/client-cli/client-cli-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-client-cli-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-client-cli-dist</artifactId>

--- a/integration/client-cli/pom.xml
+++ b/integration/client-cli/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <name>Keycloak Client CLI</name>

--- a/integration/client-registration/pom.xml
+++ b/integration/client-registration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Integration</name>

--- a/js/apps/account-ui/package.json
+++ b/js/apps/account-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-account-ui",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.7.0",
   "type": "module",
   "main": "lib/keycloak-account-ui.js",
   "types": "./lib/keycloak-account-ui.d.ts",

--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-admin-ui",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.7.0",
   "type": "module",
   "main": "lib/keycloak-admin-ui.js",
   "types": "./lib/keycloak-admin-ui.d.ts",

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-admin-client",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.7.0",
   "description": "A client to interact with Keycloak's Administration API",
   "type": "module",
   "main": "lib/index.js",

--- a/js/libs/keycloak-admin-client/pom.xml
+++ b/js/libs/keycloak-admin-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/libs/ui-shared/package.json
+++ b/js/libs/ui-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-ui-shared",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.7.0",
   "type": "module",
   "main": "./dist/keycloak-ui-shared.js",
   "types": "./dist/keycloak-ui-shared.d.ts",

--- a/js/libs/ui-shared/pom.xml
+++ b/js/libs/ui-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/js/themes-vendor/pom.xml
+++ b/js/themes-vendor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/misc/db-compatibility-verifier/pom.xml
+++ b/misc/db-compatibility-verifier/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/misc/theme-verifier/pom.xml
+++ b/misc/theme-verifier/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/model/infinispan/proto.lock
+++ b/model/infinispan/proto.lock
@@ -1,6 +1,6 @@
 {
   "definitions" : [ {
-    "protopath" : "generated:/:KeycloakModelSchema.proto",
+    "protopath" : "proto:/:generated:/:KeycloakModelSchema.proto",
     "def" : {
       "enums" : [ {
         "name" : "State",
@@ -72,6 +72,10 @@
           "optional" : true
         } ]
       }, {
+        "name" : "CollectionToStreamMapper",
+        "type_id" : 65609,
+        "fields" : [ ]
+      }, {
         "name" : "GroupListPredicate",
         "type_id" : 65568,
         "fields" : [ {
@@ -80,6 +84,10 @@
           "type" : "string",
           "optional" : true
         } ]
+      }, {
+        "name" : "AuthClientSessionSetMapper",
+        "type_id" : 65608,
+        "fields" : [ ]
       }, {
         "name" : "RemoveUserSessionsEvent",
         "type_id" : 65564,
@@ -94,11 +102,6 @@
           "type" : "string",
           "optional" : true
         }, {
-          "id" : 3,
-          "name" : "resendingEvent",
-          "type" : "bool",
-          "optional" : true
-        }, {
           "id" : 4,
           "name" : "siteId",
           "type" : "string",
@@ -108,7 +111,9 @@
           "name" : "nodeId",
           "type" : "string",
           "optional" : true
-        } ]
+        } ],
+        "reserved_ids" : [ 3 ],
+        "reserved_names" : [ "resendingEvent" ]
       }, {
         "name" : "ResourceServerUpdatedEvent",
         "type_id" : 65550,
@@ -116,25 +121,6 @@
           "id" : 1,
           "name" : "id",
           "type" : "string",
-          "optional" : true
-        } ]
-      }, {
-        "name" : "InitializerState",
-        "type_id" : 65554,
-        "fields" : [ {
-          "id" : 1,
-          "name" : "realmId",
-          "type" : "string",
-          "optional" : true
-        }, {
-          "id" : 2,
-          "name" : "segmentsCount",
-          "type" : "int32",
-          "optional" : true
-        }, {
-          "id" : 3,
-          "name" : "segments",
-          "type" : "org.infinispan.protostream.commons.BitSet",
           "optional" : true
         } ]
       }, {
@@ -208,11 +194,6 @@
           "type" : "string",
           "optional" : true
         }, {
-          "id" : 3,
-          "name" : "resendingEvent",
-          "type" : "bool",
-          "optional" : true
-        }, {
           "id" : 4,
           "name" : "siteId",
           "type" : "string",
@@ -222,7 +203,9 @@
           "name" : "nodeId",
           "type" : "string",
           "optional" : true
-        } ]
+        } ],
+        "reserved_ids" : [ 3 ],
+        "reserved_names" : [ "resendingEvent" ]
       }, {
         "name" : "SessionData",
         "type_id" : 65558,
@@ -414,6 +397,11 @@
           "name" : "lastIPFailure",
           "type" : "string",
           "optional" : true
+        }, {
+          "id" : 8,
+          "name" : "numSecondaryAuthFailures",
+          "type" : "int32",
+          "optional" : true
         } ]
       }, {
         "name" : "AuthenticationSessionEntity",
@@ -498,6 +486,25 @@
           "optional" : true
         } ]
       }, {
+        "name" : "LoginFailuresLifespanUpdate",
+        "type_id" : 65620,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "maxDeltaTimeMillis",
+          "type" : "int64",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "maxTemporaryLockouts",
+          "type" : "int32",
+          "optional" : true
+        }, {
+          "id" : 3,
+          "name" : "permanentLockout",
+          "type" : "bool",
+          "optional" : true
+        } ]
+      }, {
         "name" : "ScopeRemovedEvent",
         "type_id" : 65553,
         "fields" : [ {
@@ -527,6 +534,45 @@
             "name" : "notes",
             "type" : "string"
           }
+        } ]
+      }, {
+        "name" : "PermissionTicketRemovedEvent",
+        "type_id" : 65613,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "id",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "owner",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 3,
+          "name" : "requester",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 4,
+          "name" : "resource",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 5,
+          "name" : "resourceName",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 6,
+          "name" : "scope",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 7,
+          "name" : "serverId",
+          "type" : "string",
+          "optional" : true
         } ]
       }, {
         "name" : "SessionPredicate",
@@ -663,6 +709,25 @@
           "optional" : true
         } ]
       }, {
+        "name" : "UserStorageProviderClusterEvent",
+        "type_id" : 65540,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "removed",
+          "type" : "bool",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "realmId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 3,
+          "name" : "storageProvider",
+          "type" : "UserStorageProviderModel",
+          "optional" : true
+        } ]
+      }, {
         "name" : "AuthenticatedClientSessionEntity",
         "type_id" : 65596,
         "fields" : [ {
@@ -691,9 +756,19 @@
           "type" : "string",
           "optional" : true
         }, {
-          "id" : 7,
-          "name" : "id",
-          "type" : "org.infinispan.protostream.commons.UUID",
+          "id" : 8,
+          "name" : "userSessionId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 9,
+          "name" : "clientId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 10,
+          "name" : "userId",
+          "type" : "string",
           "optional" : true
         } ],
         "maps" : [ {
@@ -703,7 +778,9 @@
             "name" : "notes",
             "type" : "string"
           }
-        } ]
+        } ],
+        "reserved_ids" : [ 7 ],
+        "reserved_names" : [ "id" ]
       }, {
         "name" : "LoginFailureKey",
         "type_id" : 65599,
@@ -716,25 +793,6 @@
           "id" : 2,
           "name" : "userId",
           "type" : "string",
-          "optional" : true
-        } ]
-      }, {
-        "name" : "UserStorageProviderClusterEvent",
-        "type_id" : 65540,
-        "fields" : [ {
-          "id" : 1,
-          "name" : "removed",
-          "type" : "bool",
-          "optional" : true
-        }, {
-          "id" : 2,
-          "name" : "realmId",
-          "type" : "string",
-          "optional" : true
-        }, {
-          "id" : 3,
-          "name" : "storageProvider",
-          "type" : "UserStorageProviderModel",
           "optional" : true
         } ]
       }, {
@@ -751,11 +809,6 @@
           "type" : "string",
           "optional" : true
         }, {
-          "id" : 3,
-          "name" : "resendingEvent",
-          "type" : "bool",
-          "optional" : true
-        }, {
           "id" : 4,
           "name" : "siteId",
           "type" : "string",
@@ -765,19 +818,9 @@
           "name" : "nodeId",
           "type" : "string",
           "optional" : true
-        } ]
-      }, {
-        "name" : "LastSessionRefreshEvent",
-        "type_id" : 65557,
-        "fields" : [ ],
-        "maps" : [ {
-          "key_type" : "string",
-          "field" : {
-            "id" : 1,
-            "name" : "lastSessionRefreshes",
-            "type" : "SessionData"
-          }
-        } ]
+        } ],
+        "reserved_ids" : [ 3 ],
+        "reserved_names" : [ "resendingEvent" ]
       }, {
         "name" : "ResourceUpdatedEvent",
         "type_id" : 65548,
@@ -840,6 +883,10 @@
           }
         } ]
       }, {
+        "name" : "ReloadCertificateFunction",
+        "type_id" : 65615,
+        "fields" : [ ]
+      }, {
         "name" : "GroupMovedEvent",
         "type_id" : 65581,
         "fields" : [ {
@@ -883,12 +930,45 @@
           "optional" : true
         } ]
       }, {
+        "name" : "RemoveKeyConsumer",
+        "type_id" : 65618,
+        "fields" : [ ]
+      }, {
         "name" : "InResourceServerPredicate",
         "type_id" : 65560,
         "fields" : [ {
           "id" : 1,
           "name" : "serverId",
           "type" : "string",
+          "optional" : true
+        } ]
+      }, {
+        "name" : "WorkflowScheduleClusterEvent",
+        "type_id" : 65621,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "realmId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "workflowId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 3,
+          "name" : "removed",
+          "type" : "bool",
+          "optional" : true
+        }, {
+          "id" : 4,
+          "name" : "intervalSecs",
+          "type" : "int32",
+          "optional" : true
+        }, {
+          "id" : 5,
+          "name" : "lastScheduleRun",
+          "type" : "int32",
           "optional" : true
         } ]
       }, {
@@ -920,6 +1000,24 @@
         "fields" : [ {
           "id" : 1,
           "name" : "id",
+          "type" : "string",
+          "optional" : true
+        } ]
+      }, {
+        "name" : "MapEntryToKeyMapper",
+        "type_id" : 65611,
+        "fields" : [ ]
+      }, {
+        "name" : "EmbeddedClientSessionKey",
+        "type_id" : 65616,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "userSessionId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "clientId",
           "type" : "string",
           "optional" : true
         } ]
@@ -971,6 +1069,54 @@
           "optional" : true
         } ]
       }, {
+        "name" : "PermissionTicketUpdatedEvent",
+        "type_id" : 65614,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "id",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "owner",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 3,
+          "name" : "requester",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 4,
+          "name" : "resource",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 5,
+          "name" : "resourceName",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 6,
+          "name" : "scope",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 7,
+          "name" : "serverId",
+          "type" : "string",
+          "optional" : true
+        } ]
+      }, {
+        "name" : "UserVerifiableCredentialsUpdatedEvent",
+        "type_id" : 65622,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "id",
+          "type" : "string",
+          "optional" : true
+        } ]
+      }, {
         "name" : "AuthenticatedClientSessionStore",
         "type_id" : 65595,
         "fields" : [ ],
@@ -981,6 +1127,20 @@
             "name" : "authenticatedClientSessionIds",
             "type" : "org.infinispan.protostream.commons.UUID"
           }
+        } ]
+      }, {
+        "name" : "ClientSessionFilterByUser",
+        "type_id" : 65617,
+        "fields" : [ {
+          "id" : 1,
+          "name" : "realmId",
+          "type" : "string",
+          "optional" : true
+        }, {
+          "id" : 2,
+          "name" : "userId",
+          "type" : "string",
+          "optional" : true
         } ]
       }, {
         "name" : "RoleUpdatedEvent",
@@ -1053,6 +1213,11 @@
           "name" : "containerId",
           "type" : "string",
           "optional" : true
+        }, {
+          "id" : 3,
+          "name" : "roleName",
+          "type" : "string",
+          "optional" : true
         } ]
       }, {
         "name" : "GroupAddedEvent",
@@ -1102,6 +1267,10 @@
           "type" : "string",
           "optional" : true
         } ]
+      }, {
+        "name" : "GroupAndCountCollectorSupplier",
+        "type_id" : 65610,
+        "fields" : [ ]
       }, {
         "name" : "ReplaceFunction",
         "type_id" : 65656,
@@ -1165,11 +1334,6 @@
           "type" : "int32",
           "optional" : true
         }, {
-          "id" : 11,
-          "name" : "authenticatedClientSessions",
-          "type" : "AuthenticatedClientSessionStore",
-          "optional" : true
-        }, {
           "id" : 12,
           "name" : "state",
           "type" : "State",
@@ -1184,6 +1348,11 @@
           "name" : "brokerUserId",
           "type" : "string",
           "optional" : true
+        }, {
+          "id" : 15,
+          "name" : "clientSessions",
+          "type" : "string",
+          "is_repeated" : true
         } ],
         "maps" : [ {
           "key_type" : "string",
@@ -1192,7 +1361,9 @@
             "name" : "notes",
             "type" : "string"
           }
-        } ]
+        } ],
+        "reserved_ids" : [ 11 ],
+        "reserved_names" : [ "authenticatedClientSessions" ]
       }, {
         "name" : "RealmRemovedEvent",
         "type_id" : 65585,
@@ -1268,6 +1439,10 @@
           "optional" : true
         } ]
       }, {
+        "name" : "SessionUnwrapMapper",
+        "type_id" : 65612,
+        "fields" : [ ]
+      }, {
         "name" : "InIdentityProviderPredicate",
         "type_id" : 65572,
         "fields" : [ {
@@ -1342,6 +1517,10 @@
           "type" : "string",
           "optional" : true
         } ]
+      }, {
+        "name" : "ValueIdentityBiFunction",
+        "type_id" : 65619,
+        "fields" : [ ]
       }, {
         "name" : "SessionEntityWrapper",
         "type_id" : 65555,

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/jpa/src/main/resources/META-INF/rolling-upgrades-supported-changes.json
+++ b/model/jpa/src/main/resources/META-INF/rolling-upgrades-supported-changes.json
@@ -1,0 +1,848 @@
+{
+  "changeSets" : [ {
+    "id" : "8.0.0-resource-tag-support",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-8.0.0.xml"
+  }, {
+    "id" : "1.0.0.Final-KEYCLOAK-5461",
+    "author" : "sthorger@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.0.0.Final-db2.xml"
+  }, {
+    "id" : "26.5.0-index-offline-css-by-client-storage-provider",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "1.6.1",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.6.1.xml"
+  }, {
+    "id" : "13.0.0-KEYCLOAK-16844",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "authz-3.4.0.CR1-resource-server-pk-change-part3-fixed-nodropindex",
+    "author" : "glavoie@gmail.com",
+    "filename" : "META-INF/jpa-changelog-authz-3.4.0.CR1.xml"
+  }, {
+    "id" : "26.7.0-login-failure-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.0.0-idps-for-login",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "3.2.0-fix",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-3.2.0.xml"
+  }, {
+    "id" : "2.5.0-unicode-other-dbs",
+    "author" : "hmlnarik@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.5.0.xml"
+  }, {
+    "id" : "1.2.0.RC1",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.2.0.CR1-db2.xml"
+  }, {
+    "id" : "25.0.0-28265-index-creation",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "1.6.1_from15",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.6.1.xml"
+  }, {
+    "id" : "3.2.0-fixed",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-3.2.0.xml"
+  }, {
+    "id" : "1.5.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.5.0.xml"
+  }, {
+    "id" : "26.6.0-44424-create-realm-in-client-session",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "1.2.0.RC1",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.2.0.CR1.xml"
+  }, {
+    "id" : "9.0.1-add-index-to-client.client_id",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.1.xml"
+  }, {
+    "id" : "4.2.0-KEYCLOAK-6313",
+    "author" : "wadahiro@gmail.com",
+    "filename" : "META-INF/jpa-changelog-4.2.0.xml"
+  }, {
+    "id" : "26.6.0-48716-create-mssql-idp-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "26.5.0-invitations-table-fixed2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "9.0.0-recreate-constraints-after-column-increase",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.0.xml"
+  }, {
+    "id" : "json-string-accomodation-fixed",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "22.0.5-24031",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-22.0.0.xml"
+  }, {
+    "id" : "26.7.0-9686-dynamic-scopes-consent",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "4.7.0-KEYCLOAK-1267",
+    "author" : "sguilhen@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.7.0.xml"
+  }, {
+    "id" : "client-attributes-string-accomodation-fixed-post-create-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-20.0.0.xml"
+  }, {
+    "id" : "23.0.0-12062",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-23.0.0.xml"
+  }, {
+    "id" : "2.5.0-unique-group-names",
+    "author" : "hmlnarik@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.5.0.xml"
+  }, {
+    "id" : "authz-2.0.0",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-2.0.0.xml"
+  }, {
+    "id" : "24.0.0-9758-2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.0.xml"
+  }, {
+    "id" : "client-attributes-string-accomodation-fixed",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-20.0.0.xml"
+  }, {
+    "id" : "21.1.0-19404",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-21.1.0.xml"
+  }, {
+    "id" : "26.2.6-40088-duplicate",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.2.6.xml"
+  }, {
+    "id" : "1.4.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.4.0-db2.xml"
+  }, {
+    "id" : "14.0.0-KEYCLOAK-18286-supported-dbs",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "2.5.0-duplicate-email-support",
+    "author" : "slawomir@dabek.name",
+    "filename" : "META-INF/jpa-changelog-2.5.0.xml"
+  }, {
+    "id" : "4.6.0-KEYCLOAK-8555",
+    "author" : "gideonray@gmail.com",
+    "filename" : "META-INF/jpa-changelog-4.6.0.xml"
+  }, {
+    "id" : "3.4.0-KEYCLOAK-5230",
+    "author" : "hmlnarik@redhat.com",
+    "filename" : "META-INF/jpa-changelog-3.4.0.xml"
+  }, {
+    "id" : "26.3.0-groups-description",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.3.0.xml"
+  }, {
+    "id" : "24.0.2-27967-reindex",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.2.xml"
+  }, {
+    "id" : "8.0.0-updating-credential-data-not-oracle-fixed",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-8.0.0.xml"
+  }, {
+    "id" : "26.5.0-drop-sess-refresh-idx",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "4.6.0-KEYCLOAK-8377",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-4.6.0.xml"
+  }, {
+    "id" : "26.7.0-persistent-auth-session-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "2.5.1",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.5.1.xml"
+  }, {
+    "id" : "1.9.0",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.9.0.xml"
+  }, {
+    "id" : "2.5.0-unicode-oracle",
+    "author" : "hmlnarik@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.5.0.xml"
+  }, {
+    "id" : "26.6.0-44424-idx-css-realm-and-clients",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "26.7.0-federated-verifiable-credentials-1",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "authn-3.4.0.CR1-refresh-token-max-reuse",
+    "author" : "glavoie@gmail.com",
+    "filename" : "META-INF/jpa-changelog-authz-3.4.0.CR1.xml"
+  }, {
+    "id" : "25.0.0-28265-index-2-mysql",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "24.0.0-9758",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.0.xml"
+  }, {
+    "id" : "25.0.0-28861-index-creation",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "26.5.0-add-sess-refresh-idx",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "9.0.0-drop-constraints-for-column-increase",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.0.xml"
+  }, {
+    "id" : "13.0.0-increase-column-size-federated",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "1.8.0",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.8.0-db2.xml"
+  }, {
+    "id" : "20.0.0-12964-unsupported-dbs",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-20.0.0.xml"
+  }, {
+    "id" : "25.0.0-org",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "1.3.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.3.0.xml"
+  }, {
+    "id" : "24.0.0-26618-edb-migration",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.0.xml"
+  }, {
+    "id" : "26.6.0-43829-user-created-timestamp-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "authz-3.4.0.CR1-resource-server-pk-change-part1",
+    "author" : "glavoie@gmail.com",
+    "filename" : "META-INF/jpa-changelog-authz-3.4.0.CR1.xml"
+  }, {
+    "id" : "14.0.0-KEYCLOAK-18286-revert",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "3.4.0",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-3.4.0.xml"
+  }, {
+    "id" : "26.0.0-org-indexes",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "4.3.0-KEYCLOAK-7984",
+    "author" : "wadahiro@gmail.com",
+    "filename" : "META-INF/jpa-changelog-4.3.0.xml"
+  }, {
+    "id" : "3.4.1",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-3.4.1.xml"
+  }, {
+    "id" : "26.6.0-45009-broker-link-user-id",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "24.0.2-27967-drop-index-if-present",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.2.xml"
+  }, {
+    "id" : "23.0.0-17258",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-23.0.0.xml"
+  }, {
+    "id" : "26.0.0-org-group-membership",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "9.0.0-always-display-client",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.0.xml"
+  }, {
+    "id" : "2.3.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.3.0.xml"
+  }, {
+    "id" : "14.0.0-KEYCLOAK-18286-unsupported-dbs",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "26.0.0-org-group",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "9.0.1-KEYCLOAK-12579-recreate-constraints",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.1.xml"
+  }, {
+    "id" : "21.0.2-17277",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-21.0.2.xml"
+  }, {
+    "id" : "25.0.0-28265-index-cleanup-css-preload",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "26.6.0-org-group-relationship",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "1.1.0.Final",
+    "author" : "sthorger@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.1.0.Final.xml"
+  }, {
+    "id" : "15.0.0-KEYCLOAK-18467",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-15.0.0.xml"
+  }, {
+    "id" : "26.7.0-persistent-auth-session-root-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.6.0-add-last-modified-timestamp-user",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "26.7.0-cluster-event",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "4.0.0-KEYCLOAK-5579-fixed",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.0.0.xml"
+  }, {
+    "id" : "map-remove-ri",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-12.0.0.xml"
+  }, {
+    "id" : "1.4.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.4.0.xml"
+  }, {
+    "id" : "1.9.2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-1.9.2.xml"
+  }, {
+    "id" : "2.2.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.2.0.xml"
+  }, {
+    "id" : "1.0.0.Final-KEYCLOAK-5461",
+    "author" : "sthorger@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.0.0.Final.xml"
+  }, {
+    "id" : "3.0.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-3.0.0.xml"
+  }, {
+    "id" : "25.0.0-28265-index-cleanup-uss-createdon",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "8.0.0-credential-cleanup-fixed",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-8.0.0.xml"
+  }, {
+    "id" : "4.0.0-KEYCLOAK-6228",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.0.0.xml"
+  }, {
+    "id" : "26.0.0-org-alias",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "25.0.0-28265-index-cleanup-uss-preload",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "21.1.0-19404-2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-21.1.0.xml"
+  }, {
+    "id" : "3.3.0",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-3.3.0.xml"
+  }, {
+    "id" : "31725-index-persist-revoked-access-tokens",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "26.2.6-40088-uk",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.2.6.xml"
+  }, {
+    "id" : "1.2.0.Beta1",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.2.0.Beta1-db2.xml"
+  }, {
+    "id" : "26.0.0.32582-remove-tables-user-session-user-session-note-and-client-session",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "26.7.0-45292-realm-display-name-remove-attribute",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "authz-7.0.0-KEYCLOAK-10443",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-7.0.0.xml"
+  }, {
+    "id" : "1.8.0-2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-1.8.0-db2.xml"
+  }, {
+    "id" : "authz-4.2.0.Final-KEYCLOAK-9944",
+    "author" : "hmlnarik@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-4.2.0.Final.xml"
+  }, {
+    "id" : "26.5.0-add-remember-me",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "26.2.6-39866-duplicate",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.2.6.xml"
+  }, {
+    "id" : "14.0.0-KEYCLOAK-18286",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "KEYCLOAK-17267-add-index-to-user-attributes",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "18.0.0-10625-IDX_ADMIN_EVENT_TIME",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-18.0.0.xml"
+  }, {
+    "id" : "1.9.1",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-1.9.1-db2.xml"
+  }, {
+    "id" : "29399-jdbc-ping-default",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.1.0.xml"
+  }, {
+    "id" : "26.6.0-add-timestamps-group",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "9.0.0-increase-column-size-federated-fk",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.0.xml"
+  }, {
+    "id" : "4.7.0-KEYCLOAK-7275",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-4.7.0.xml"
+  }, {
+    "id" : "2.5.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.5.0.xml"
+  }, {
+    "id" : "4.6.0-KEYCLOAK-7950",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.6.0.xml"
+  }, {
+    "id" : "26.7.0-jdbcping-timestamp",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.2.0-36750",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.2.0.xml"
+  }, {
+    "id" : "26.7.0-issued-ver-credential-expires-at-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "4.8.0-KEYCLOAK-8835",
+    "author" : "sguilhen@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.8.0.xml"
+  }, {
+    "id" : "26.5.0-add-sess-create-idx",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "4.0.0-KEYCLOAK-6335",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.0.0.xml"
+  }, {
+    "id" : "17.0.0-9562",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-17.0.0.xml"
+  }, {
+    "id" : "9.0.1-KEYCLOAK-12579-add-not-null-constraint",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.1.xml"
+  }, {
+    "id" : "26.7.0-verifiable-credential",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "20.0.0-12964-supported-dbs-edb-migration",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-20.0.0.xml"
+  }, {
+    "id" : "26.7.0-persistent-auth-session-root-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.2.0-26106",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.2.0.xml"
+  }, {
+    "id" : "26.7.0-add-timestamps-client",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.0.0-33201-org-redirect-url",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "2.4.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.4.0.xml"
+  }, {
+    "id" : "26.0.0-32583-drop-redundant-index-on-client-session",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "1.8.0-2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-1.8.0.xml"
+  }, {
+    "id" : "26.5.0-idp-config-allow-null-fixed-drop-mssql-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "client-attributes-string-accomodation-fixed-pre-drop-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-20.0.0.xml"
+  }, {
+    "id" : "40343-workflow-state-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.4.0.xml"
+  }, {
+    "id" : "authz-3.4.0.CR1-resource-server-pk-change-part2-KEYCLOAK-6095",
+    "author" : "hmlnarik@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-3.4.0.CR1.xml"
+  }, {
+    "id" : "18.0.15-30992-index-consent",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-18.0.15.xml"
+  }, {
+    "id" : "unique-consentuser",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "26.6.0-45009-broker-link-identity-provider",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "map-remove-ri-13.0.0",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "4.0.0-CLEANUP-UNUSED-TABLE",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-4.0.0.xml"
+  }, {
+    "id" : "authz-4.0.0.Beta3",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-4.0.0.Beta3.xml"
+  }, {
+    "id" : "1.2.0.Beta1",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.2.0.Beta1.xml"
+  }, {
+    "id" : "20.0.0-12964-supported-dbs",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-20.0.0.xml"
+  }, {
+    "id" : "3.4.2",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-3.4.2.xml"
+  }, {
+    "id" : "1.6.0",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.6.0.xml"
+  }, {
+    "id" : "3.4.2-KEYCLOAK-5172",
+    "author" : "mkanis@redhat.com",
+    "filename" : "META-INF/jpa-changelog-3.4.2.xml"
+  }, {
+    "id" : "26.7.0-single-use-object-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.5.0-idp-config-allow-null-fixed-create-mssql-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "authz-3.4.0.CR1-resource-server-pk-change-part3-fixed",
+    "author" : "glavoie@gmail.com",
+    "filename" : "META-INF/jpa-changelog-authz-3.4.0.CR1.xml"
+  }, {
+    "id" : "26.5.0-remove-workflow-provider-id-column",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "26.4.0-51321",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.4.0.xml"
+  }, {
+    "id" : "13.0.0-KEYCLOAK-17992-drop-constraints",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "25.0.0-28265-index-cleanup-uss-by-usersess",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "map-remove-ri",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-11.0.0.xml"
+  }, {
+    "id" : "8.0.0-updating-credential-data-oracle-fixed",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-8.0.0.xml"
+  }, {
+    "id" : "26.7.0-login-failure-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "2.1.0-KEYCLOAK-5461",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-2.1.0.xml"
+  }, {
+    "id" : "24.0.0-26618-drop-index-if-present",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.0.xml"
+  }, {
+    "id" : "26.7.0-outbox",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "unique-consentuser-edb-migration",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "31296-persist-revoked-access-tokens",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.0.0.xml"
+  }, {
+    "id" : "1.8.0",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.8.0.xml"
+  }, {
+    "id" : "1.9.1",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-1.9.1.xml"
+  }, {
+    "id" : "26.7.0-issued-ver-credential-vc-id-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "3.2.0-fix-with-keycloak-5416",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-3.2.0.xml"
+  }, {
+    "id" : "default-roles",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "9.0.1-KEYCLOAK-12579-drop-constraints",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.1.xml"
+  }, {
+    "id" : "26.4.0-40933-saml-encryption-attributes",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.4.0.xml"
+  }, {
+    "id" : "authz-4.2.0.Final",
+    "author" : "mhajas@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-4.2.0.Final.xml"
+  }, {
+    "id" : "1.7.0",
+    "author" : "bburke@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.7.0.xml"
+  }, {
+    "id" : "9.0.1-add-index-to-events",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-9.0.1.xml"
+  }, {
+    "id" : "26.1.0-34013",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.1.0.xml"
+  }, {
+    "id" : "26.5.0-idp-config-allow-null",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "22.0.0-17484-updated",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-22.0.0.xml"
+  }, {
+    "id" : "3.2.0-fix-offline-sessions",
+    "author" : "hmlnarik",
+    "filename" : "META-INF/jpa-changelog-3.2.0.xml"
+  }, {
+    "id" : "26.1.0-34380",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.1.0.xml"
+  }, {
+    "id" : "26.7.0-federated-issued-ver-credential",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.6.0-44424-index-css-user-session-and-offline",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "8.0.0-adding-credential-columns",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-8.0.0.xml"
+  }, {
+    "id" : "24.0.2-27228",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.2.xml"
+  }, {
+    "id" : "26.7.0-45292-realm-display-name-migrate-data",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "13.0.0-KEYCLOAK-17992-recreate-constraints",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "default-roles-cleanup",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-13.0.0.xml"
+  }, {
+    "id" : "1.2.0.Final",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-1.2.0.Final.xml"
+  }, {
+    "id" : "26.5.0-mysql-mariadb-default-charset-collation",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "26.7.0-single-use-object-index",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "26.6.0-44424-set-realm-in-client-session",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.6.0.xml"
+  }, {
+    "id" : "1.6.1_from16-pre",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.6.1.xml"
+  }, {
+    "id" : "1.6.1_from16",
+    "author" : "mposolda@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.6.1.xml"
+  }, {
+    "id" : "26.7.0-45292-realm-display-name-add-column",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "24.0.0-26618-reindex",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-24.0.0.xml"
+  }, {
+    "id" : "26.2.6-39866-uk",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.2.6.xml"
+  }, {
+    "id" : "14.0.0-KEYCLOAK-11019",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "26.7.0-46204-issued-ver-credential-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "authz-2.5.1",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-2.5.1.xml"
+  }, {
+    "id" : "26.7.0-add-last-modified-timestamp-client",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.7.0.xml"
+  }, {
+    "id" : "19.0.0-10135",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-19.0.0.xml"
+  }, {
+    "id" : "authz-4.0.0.CR1",
+    "author" : "psilva@redhat.com",
+    "filename" : "META-INF/jpa-changelog-authz-4.0.0.CR1.xml"
+  }, {
+    "id" : "unique-consentuser-mysql",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "12.1.0-add-realm-localization-table",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-12.0.0.xml"
+  }, {
+    "id" : "25.0.0-28265-index-2-not-mysql",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  }, {
+    "id" : "KEYCLOAK-18146-add-saml-art-binding-identifier",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-14.0.0.xml"
+  }, {
+    "id" : "1.1.0.Beta1",
+    "author" : "sthorger@redhat.com",
+    "filename" : "META-INF/jpa-changelog-1.1.0.Beta1.xml"
+  }, {
+    "id" : "26.5.0-index-offline-css-by-client",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-26.5.0.xml"
+  }, {
+    "id" : "25.0.0-28265-tables",
+    "author" : "keycloak",
+    "filename" : "META-INF/jpa-changelog-25.0.0.xml"
+  } ],
+  "migrations" : [ ]
+}

--- a/model/jpa/src/main/resources/META-INF/rolling-upgrades-unsupported-changes.json
+++ b/model/jpa/src/main/resources/META-INF/rolling-upgrades-unsupported-changes.json
@@ -1,0 +1,4 @@
+{
+  "changeSets" : [ ],
+  "migrations" : [ ]
+}

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Model Parent</name>

--- a/model/storage-private/pom.xml
+++ b/model/storage-private/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/storage-private/src/main/resources/META-INF/rolling-upgrades-supported-changes.json
+++ b/model/storage-private/src/main/resources/META-INF/rolling-upgrades-supported-changes.json
@@ -1,0 +1,100 @@
+{
+  "changeSets" : [ ],
+  "migrations" : [ {
+    "class" : "org.keycloak.migration.migrators.MigrateTo4_6_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo9_0_4"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo8_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo9_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo14_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo3_1_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo3_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo3_4_1"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo3_4_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo21_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo3_2_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_9_2"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo12_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_9_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_8_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo20_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo2_3_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo2_5_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo2_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo2_2_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo24_0_3"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo2_1_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo6_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo24_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_7_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_6_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_5_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo25_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_4_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.RealmMigration"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_3_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo1_2_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo23_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_7_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_6_1"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_4_3"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_6_2"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo3_4_2"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo8_0_2"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_1_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo4_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_2_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo18_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_3_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo4_2_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo22_0_0"
+  }, {
+    "class" : "org.keycloak.migration.migrators.MigrateTo26_4_0"
+  } ]
+}

--- a/model/storage-private/src/main/resources/META-INF/rolling-upgrades-unsupported-changes.json
+++ b/model/storage-private/src/main/resources/META-INF/rolling-upgrades-unsupported-changes.json
@@ -1,0 +1,4 @@
+{
+  "changeSets" : [ ],
+  "migrations" : [ ]
+}

--- a/model/storage-services/pom.xml
+++ b/model/storage-services/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/storage/pom.xml
+++ b/model/storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </description>
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.7.0</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -36,7 +36,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <maven.plugin-tools.version>3.15.1</maven.plugin-tools.version>
 
-        <project.version.npm>999.0.0-SNAPSHOT</project.version.npm>
+        <project.version.npm>26.7.0</project.version.npm>
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,8 @@
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <plugin.antrun.version>1.8</plugin.antrun.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
 
         <!-- Surefire Settings -->
         <surefire.memory.Xms>512m</surefire.memory.Xms>
@@ -1451,12 +1453,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <doclint>none</doclint>
                         <failOnError>false</failOnError>
                         <excludePackageNames>cx.*:org.freedesktop*:org.jvnet*</excludePackageNames>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.lazerycode.jmeter</groupId>
@@ -1717,6 +1724,34 @@
             <modules>
                 <module>distribution</module>
             </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>

--- a/quarkus/config-api/pom.xml
+++ b/quarkus/config-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/quarkus/dist/pom.xml
+++ b/quarkus/dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-quarkus-dist</artifactId>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Quarkus Parent</name>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>keycloak-quarkus-test-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>keycloak-quarkus-test-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quarkus/tests/pom.xml
+++ b/quarkus/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/rest/admin-ui-ext/pom.xml
+++ b/rest/admin-ui-ext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-rest-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-rest-admin-ui-ext</artifactId>

--- a/rest/admin-v2/api/pom.xml
+++ b/rest/admin-v2/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-v2-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-admin-v2-api</artifactId>

--- a/rest/admin-v2/pom.xml
+++ b/rest/admin-v2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-rest-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-admin-v2-parent</artifactId>

--- a/rest/admin-v2/services/pom.xml
+++ b/rest/admin-v2/services/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-v2-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-admin-v2-services</artifactId>

--- a/rest/admin-v2/tests/pom.xml
+++ b/rest/admin-v2/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-v2-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>keycloak-admin-v2-tests</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <name>Keycloak Administration UI</name>

--- a/saml-core-api/pom.xml
+++ b/saml-core-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/saml-core/pom.xml
+++ b/saml-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/client/pom.xml
+++ b/scim/client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/core/pom.xml
+++ b/scim/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/model/pom.xml
+++ b/scim/model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/pom.xml
+++ b/scim/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/services/pom.xml
+++ b/scim/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/tests/base/pom.xml
+++ b/scim/tests/base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-scim-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/tests/pom.xml
+++ b/scim/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../tests/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scim/tests/scim-client/pom.xml
+++ b/scim/tests/scim-client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-scim-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-spi/pom.xml
+++ b/server-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
@@ -255,6 +255,9 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
     }
 
     void verifyRedirectUri(String redirectUri, boolean isRedirectUriParam) throws ClientPolicyException {
+	if (redirectUri == null || redirectUri.trim().isEmpty()){
+		return;
+	}
         UriValidation validation;
 
         try {

--- a/ssf/core/pom.xml
+++ b/ssf/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ssf/pom.xml
+++ b/ssf/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ssf/services/pom.xml
+++ b/ssf/services/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ssf/tests/base/pom.xml
+++ b/ssf/tests/base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-ssf-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ssf/tests/pom.xml
+++ b/ssf/tests/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../tests/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/ssf/transmitter/pom.xml
+++ b/ssf/transmitter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/bom/pom.xml
+++ b/test-framework/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/builders/pom.xml
+++ b/test-framework/builders/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/clustering/pom.xml
+++ b/test-framework/clustering/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.testframework</groupId>
         <artifactId>keycloak-test-framework-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/core/pom.xml
+++ b/test-framework/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-edb/pom.xml
+++ b/test-framework/db-edb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-mariadb/pom.xml
+++ b/test-framework/db-mariadb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-mssql/pom.xml
+++ b/test-framework/db-mssql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-mysql/pom.xml
+++ b/test-framework/db-mysql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-oracle/pom.xml
+++ b/test-framework/db-oracle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-postgres/pom.xml
+++ b/test-framework/db-postgres/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-tidb/pom.xml
+++ b/test-framework/db-tidb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/email-server/pom.xml
+++ b/test-framework/email-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/infinispan-server/pom.xml
+++ b/test-framework/infinispan-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/junit5-config/pom.xml
+++ b/test-framework/junit5-config/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/oauth/pom.xml
+++ b/test-framework/oauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/remote-providers/pom.xml
+++ b/test-framework/remote-providers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/remote/pom.xml
+++ b/test-framework/remote/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/test-containers/pom.xml
+++ b/test-framework/test-containers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/test-providers/pom.xml
+++ b/test-framework/test-providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-framework/tests/pom.xml
+++ b/test-framework/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-framework/ui/pom.xml
+++ b/test-framework/ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/clustering/pom.xml
+++ b/tests/clustering/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.tests</groupId>
         <artifactId>keycloak-tests-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/conformance/pom.xml
+++ b/tests/conformance/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/custom-providers/pom.xml
+++ b/tests/custom-providers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/custom-scripts/pom.xml
+++ b/tests/custom-scripts/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/migration-util/pom.xml
+++ b/tests/migration-util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/utils-shared/pom.xml
+++ b/tests/utils-shared/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/utils/pom.xml
+++ b/tests/utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/webauthn/pom.xml
+++ b/tests/webauthn/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-testsuite-pom</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/testsuite/integration-arquillian/servers/app-server/app-server-spi/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/app-server-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/galleon/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/galleon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server-jboss</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server-jboss</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-servers-auth-server</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server-services</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>integration-arquillian-testsuite-providers-deployment</artifactId>

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server-services</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>integration-arquillian-testsuite-providers</artifactId>

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/infinispan/datagrid/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/infinispan/datagrid/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-infinispan</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/infinispan/infinispan/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/infinispan/infinispan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-infinispan</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/infinispan/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/infinispan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/testsuite/integration-arquillian/servers/cache-server/legacy/datagrid/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/legacy/datagrid/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-legacy</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/legacy/infinispan/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/legacy/infinispan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-legacy</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/legacy/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/legacy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/pom.xml
+++ b/testsuite/integration-arquillian/servers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/test-apps/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/test-apps/servlets/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-test-apps</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/tests/other/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-other</artifactId>

--- a/testsuite/integration-arquillian/tests/other/sssd/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/sssd/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-tests-other</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/testsuite/integration-arquillian/util/pom.xml
+++ b/testsuite/integration-arquillian/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-testsuite-pom</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-testsuite-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.7.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Fixes #51315.

When updating clients via the Admin UI, blank or empty string redirect URIs can be sent in the request payload. This causes `SecureRedirectUrisEnforcerExecutor` to throw an `Invalid URI Type` error when the `oauth-2-1-for-public-client` policy is active, preventing the client from being saved.

This PR skips validation for null or blank/empty redirect URIs before evaluating them.