### PR TITLE
Identity provider details causes double API call

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -85,6 +85,7 @@ type HeaderProps = {
   value: boolean;
   save: () => void;
   toggleDeleteDialog: () => void;
+  provider?: IdentityProviderRepresentation;
 };
 
 type IdPWithMapperAttributes = IdentityProviderMapperRepresentation & {
@@ -95,12 +96,17 @@ type IdPWithMapperAttributes = IdentityProviderMapperRepresentation & {
   mapperId: string;
 };
 
-const Header = ({ onChange, value, save, toggleDeleteDialog }: HeaderProps) => {
+const Header = ({
+  onChange,
+  value,
+  save,
+  toggleDeleteDialog,
+  provider,
+}: HeaderProps) => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
   const { alias: displayName } = useParams<{ alias: string }>();
-  const [provider, setProvider] = useState<IdentityProviderRepresentation>();
   const { addAlert, addError } = useAlerts();
   const { setValue, formState, control } = useFormContext();
 
@@ -118,17 +124,6 @@ const Header = ({ onChange, value, save, toggleDeleteDialog }: HeaderProps) => {
     control,
     name: "config.metadataDescriptorUrl",
   });
-
-  useFetch(
-    () => adminClient.identityProviders.findOne({ alias: displayName }),
-    (fetchedProvider) => {
-      if (!fetchedProvider) {
-        throw new Error(t("notFound"));
-      }
-      setProvider(fetchedProvider);
-    },
-    [],
-  );
 
   const [toggleDisableDialog, DisableConfirm] = useConfirmDialog({
     titleKey: "disableProvider",
@@ -704,6 +699,7 @@ export default function DetailSettings() {
             onChange={field.onChange}
             save={save}
             toggleDeleteDialog={toggleDeleteDialog}
+            provider={provider}
           />
         )}
       />

--- a/js/apps/admin-ui/test/identity-providers/saml.ts
+++ b/js/apps/admin-ui/test/identity-providers/saml.ts
@@ -11,15 +11,18 @@ import {
 } from "./main.ts";
 
 export async function editSAMLSettings(page: Page, samlProviderName: string) {
+  const providerSwitch = page.getByTestId(`${samlProviderName}-switch`);
+
   // Toggle provider state
-  await switchOff(page, "#-switch");
+  await switchOff(page, providerSwitch);
   await confirmModal(page);
   await assertNotificationMessage(page, "Provider successfully updated");
   await goToIdentityProviders(page);
   await expect(page.getByText("Disabled")).toBeVisible();
 
   await clickTableRowItem(page, samlProviderName);
-  await switchOn(page, "#-switch");
+  await switchOn(page, providerSwitch);
+  await assertNotificationMessage(page, "Provider successfully updated");
 
   // Verify and configure settings
   await setUrl(page, "singleSignOnService", "invalid");


### PR DESCRIPTION
Closes #49721

Opening the identity provider details page sends two identical GET requests to `/admin/realms/{realm}/identity-provider/instances/{alias}` originating from `DetailSettings.tsx`. The Header component fetched the provider to build the page title and action menu while the parent DetailSettings component fetched the same provider to initialise the form.

This was noted by @RiyanJohnson in the original issue. 

This change passes the provider the parent already loaded down to Header as a prop and removes the second fetch along with the duplicated not found check and the SAML reload/import key actions in the header still work off the passed provider.

I tested this locally with a nightly server and the admin UI dev server. In dev mode the API call count on opening the details page decreases from 4 to 2, which is standard for React StrictMode as it mounts twice in dev, and matches the reported 2 to 1 in a production build. Also ran the admin-ui lint, unit tests, and tsc for safety too