### PR TITLE
Upgrade to Quarkus 3.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.37.4</quarkus.version>
-        <quarkus.build.version>3.37.4</quarkus.build.version>
+        <quarkus.version>3.38.0</quarkus.version>
+        <quarkus.build.version>3.38.0</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>
@@ -111,7 +111,7 @@
         <sun.activation.version>1.2.2</sun.activation.version>
         <org.glassfish.jaxb.xsom.version>2.3.3-b02</org.glassfish.jaxb.xsom.version>
         <undertow.version>2.3.24.Final</undertow.version>
-        <wildfly-elytron.version>2.9.1.Final</wildfly-elytron.version>
+        <wildfly-elytron.version>2.9.2.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
         <woodstox.version>6.0.3</woodstox.version>
         <wildfly.common.quarkus.aligned.version>1.5.4.Final-format-001</wildfly.common.quarkus.aligned.version>

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -63,6 +63,9 @@ quarkus.naming.enable-jndi=true
 quarkus.http.limits.max-initial-line-length=32779
 quarkus.http.limits.max-header-size=65535
 
+# Keycloak has its own hostname validation
+quarkus.http.host-validation.require-localhost=false
+
 # Default and non-production grade database vendor
 %dev.kc.db=dev-file
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -546,7 +546,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog", "--log-syslog-max-length=wrong");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getErrString(), containsString(
-                "Invalid value for option '--log-syslog-max-length': value wrong not in correct format (regular expression): [0-9]+[BbKkMmGgTtPpEeZzYy]?"));
+                "Invalid value for option '--log-syslog-max-length': No digits in memory size string"));
     }
 
     @Test

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -210,6 +210,18 @@
                 <artifactId>keycloak-rest-admin-ui-ext</artifactId>
             </dependency>
 
+            <!-- Pin aesh versions for WildFly CLI compatibility, see https://github.com/keycloak/keycloak/issues/50220 -->
+            <dependency>
+                <groupId>org.aesh</groupId>
+                <artifactId>readline</artifactId>
+                <version>2.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aesh</groupId>
+                <artifactId>aesh</artifactId>
+                <version>2.8.4</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
     


### PR DESCRIPTION
Closes #51310

Apart from the version bumps, the PR contains cherry-picked quarkus-next fixes effective in 3.38:

- #50019 - Update error message for invalid syslog max length option in PicocliTest
- #50485 - Pin Aesh versions for WildFly CLI compatibility
- #51032 - Disable Quarkus HTTP Host header validation filter