### PR TITLE
[26.7] Upgrade to Quarkus 3.33.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.33.2.1</quarkus.version>
-        <quarkus.build.version>3.33.2.1</quarkus.build.version>
+        <quarkus.version>3.33.3.1</quarkus.version>
+        <quarkus.build.version>3.33.3.1</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>
@@ -154,10 +154,10 @@
         <cnpg.major-minor-version>1.29</cnpg.major-minor-version>
         <cnpg.patch-version>0</cnpg.patch-version>
         <cnpg.version>${cnpg.major-minor-version}.${cnpg.patch-version}</cnpg.version>
-        <postgresql-jdbc.version>42.7.11</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.13</postgresql-jdbc.version>
         <mariadb.version>11.8</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
-        <mariadb-jdbc.version>3.5.7</mariadb-jdbc.version>
+        <mariadb-jdbc.version>3.5.9</mariadb-jdbc.version>
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <mssql.collation>Latin1_General_100_CI_AS_SC_UTF8</mssql.collation>


### PR DESCRIPTION
Closes: #51344
Closes: #50955

~Note: log4j2-api 2.25.4 was bumped by Dependabot independently of the Quarkus BOM. I reverted it to 2.25.3 to stay aligned with Quarkus 3.33.3. Log4j is not used by Keycloak, it's only managed to avoid false positives from security scanners, see the discussion #50158.~
