### PR TITLE
Fix session-limit denial wrongly triggering brute force (#44474)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticatorFactory.java
@@ -19,6 +19,7 @@ public class UserSessionLimitsAuthenticatorFactory implements AuthenticatorFacto
     public static final String TERMINATE_OLDEST_SESSION = "Terminate oldest session";
     public static final String USER_SESSION_LIMITS = "user-session-limits";
     public static final String ERROR_MESSAGE = "errorMessage";
+    public static final String REFERENCE_CATEGORY = "not-brute-force-protected";
 
     private static AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
             AuthenticationExecutionModel.Requirement.REQUIRED,
@@ -32,7 +33,7 @@ public class UserSessionLimitsAuthenticatorFactory implements AuthenticatorFacto
 
     @Override
     public String getReferenceCategory() {
-        return null;
+        return REFERENCE_CATEGORY;
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/sessionlimits/UserSessionLimitsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/sessionlimits/UserSessionLimitsTest.java
@@ -18,6 +18,7 @@ package org.keycloak.tests.sessionlimits;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.mail.internet.MimeMessage;
 
@@ -77,6 +78,7 @@ import static org.keycloak.tests.sessionlimits.UserSessionLimitsUtil.assertClien
 import static org.keycloak.tests.sessionlimits.UserSessionLimitsUtil.assertSessionCount;
 import static org.keycloak.tests.sessionlimits.UserSessionLimitsUtil.configureSessionLimits;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -119,6 +121,7 @@ public class UserSessionLimitsTest {
     private static final String directGrant1 = "direct-grant-1";
     private static final String directGrant2 = "direct-grant-2";
     private static final int BRUTE_FORCE_FAILURE_FACTOR = 3;
+    private static final String testUsername2 = "test-user-2@localhost";
 
     @BeforeEach
     public void setup() {
@@ -840,6 +843,19 @@ public class UserSessionLimitsTest {
                 errorPage.assertCurrent();
                 assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
             }
+            String testUsername2UserId = managedRealm.admin().users().search(testUsername2).get(0).getId();
+            oauth.doPasswordGrantRequest(testUsername2, "wrong-password");
+
+            // Force one real failure for a different user and wait for it to be recorded.
+            // As Brute-force processing is async, so this confirms the queue has caught up
+            // with the LOGIN_ERROR events from the loop above before we check `userId`.
+            await().atMost(5, TimeUnit.SECONDS)
+                    .pollInterval(100, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> {
+                        Map<String, Object> markerStatus =
+                                managedRealm.admin().attackDetection().bruteForceUserStatus(testUsername2UserId);
+                        assertEquals(1, markerStatus.get("numFailures"), "Waiting for brute-force queue to drain");
+                    });
 
             // Check If the user got locked out or not.
             assertUserNotBruteForceLocked(userId);
@@ -923,6 +939,12 @@ public class UserSessionLimitsTest {
             realm.users(UserBuilder.create(username)
                     .email(username)
                     .name("Test", "User")
+                    .emailVerified(true)
+                    .password(password)
+                    .enabled(true));
+            realm.users(UserBuilder.create(testUsername2)
+                    .email(testUsername2)
+                    .name("Test", "User2")
                     .emailVerified(true)
                     .password(password)
                     .enabled(true));

--- a/tests/base/src/test/java/org/keycloak/tests/sessionlimits/UserSessionLimitsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/sessionlimits/UserSessionLimitsTest.java
@@ -17,6 +17,7 @@
 package org.keycloak.tests.sessionlimits;
 
 import java.util.List;
+import java.util.Map;
 
 import jakarta.mail.internet.MimeMessage;
 
@@ -36,6 +37,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -64,6 +66,7 @@ import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.tests.utils.MailUtils;
 import org.keycloak.testsuite.util.FlowUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.admin.client.resource.AttackDetectionResource;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,6 +118,7 @@ public class UserSessionLimitsTest {
     private static final String password = "password";
     private static final String directGrant1 = "direct-grant-1";
     private static final String directGrant2 = "direct-grant-2";
+    private static final int BRUTE_FORCE_FAILURE_FACTOR = 3;
 
     @BeforeEach
     public void setup() {
@@ -773,6 +777,101 @@ public class UserSessionLimitsTest {
     }
 
 
+    @Test
+    public void testSessionLimitDenialDoesNotTriggerBruteForceLockout() throws Exception {
+        RealmRepresentation realmClient = managedRealm.admin().toRepresentation();
+        boolean originalBruteForceEnabled = Boolean.TRUE.equals(realmClient.isBruteForceProtected());
+        Integer orginalFailureFactor = realmClient.getFailureFactor();
+
+        realmClient.setBruteForceProtected(true);
+        realmClient.setFailureFactor(BRUTE_FORCE_FAILURE_FACTOR);
+        realmClient.setMaxDeltaTimeSeconds(3600);
+        realmClient.setMaxFailureWaitSeconds(900);
+        realmClient.setWaitIncrementSeconds(60);
+        realmClient.setQuickLoginCheckMilliSeconds(1000L);
+
+        managedRealm.admin().update(realmClient);
+        managedRealm.admin().attackDetection().clearAllBruteForce();
+
+        String userId = managedRealm.admin().users().search(username).get(0).getId();
+
+        try{
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
+                    UserSessionLimitsAuthenticatorFactory.BEHAVIOR,
+                    UserSessionLimitsAuthenticatorFactory.DENY_NEW_SESSION);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
+                    UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT,
+                    "2");
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
+                    UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT,
+                    "0");
+
+            managedRealm.admin().users().get(userId).logout();
+            runOnServer.run(assertSessionCount(realmName, username, 0));
+            events.clear();
+
+            oauth.openLoginForm();
+            loginPage.fillLogin(username, password);
+            loginPage.submit();
+            EventRepresentation loginEvent = events.poll();
+            EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN);
+
+            deleteAllCookiesForRealm(driver);
+
+            oauth.openLoginForm();
+            loginPage.fillLogin(username, password);
+            loginPage.submit();
+            loginEvent = events.poll();
+            EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN);
+
+            // verifying session count is 2
+            runOnServer.run(assertSessionCount(realmName, username, 2));
+
+            for(int i=0; i <= BRUTE_FORCE_FAILURE_FACTOR+3; i++){
+                deleteAllCookiesForRealm(driver);
+                oauth.openLoginForm();
+                loginPage.fillLogin(username, password);
+                loginPage.submit();
+                EventRepresentation errorEvent = events.poll();
+                EventAssertion.assertError(errorEvent)
+                        .type(EventType.LOGIN_ERROR)
+                        .userId(null)
+                        .error(Errors.GENERIC_AUTHENTICATION_ERROR);
+                errorPage.assertCurrent();
+                assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
+            }
+
+            // Check If the user got locked out or not.
+            assertUserNotBruteForceLocked(userId);
+
+            // logout all session of test user
+            managedRealm.admin().users().get(userId).logout();
+            // Test login of the same user again
+            deleteAllCookiesForRealm(driver);
+            events.clear();
+
+            oauth.openLoginForm();
+            loginPage.fillLogin(username, password);
+            loginPage.submit();
+            loginEvent = events.poll();
+            EventAssertion.assertSuccess(loginEvent).type(EventType.LOGIN);
+        } finally {
+            managedRealm.admin().attackDetection().clearAllBruteForce();
+            realmClient.setBruteForceProtected(originalBruteForceEnabled);
+            realmClient.setFailureFactor(orginalFailureFactor);
+            managedRealm.admin().update(realmClient);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
+                    UserSessionLimitsAuthenticatorFactory.BEHAVIOR,
+                    UserSessionLimitsAuthenticatorFactory.DENY_NEW_SESSION);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
+                    UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT,
+                    "0");
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
+                    UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT,
+                    "1");
+        }
+    }
+
     private void restoreAndRemoveFlow(String realmName) {
         // Cleanup: restore original browser flow and remove custom flow
         String currentRealm = this.realmName;
@@ -803,6 +902,13 @@ public class UserSessionLimitsTest {
                 }
             }
         });
+    }
+
+    private void assertUserNotBruteForceLocked(String userId){
+        AttackDetectionResource detection = managedRealm.admin().attackDetection();
+        Map<String, Object> status = detection.bruteForceUserStatus(userId);
+        assertEquals(Boolean.FALSE, status.get("disabled"), "User should not be brute force locked out");
+        assertEquals(0, status.get("numFailures"), "No Failures should be recorded");
     }
 
     private void deleteAllCookiesForRealm(ManagedWebDriver driver) {

--- a/tests/base/src/test/java/org/keycloak/tests/sessionlimits/UserSessionLimitsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/sessionlimits/UserSessionLimitsTest.java
@@ -785,6 +785,10 @@ public class UserSessionLimitsTest {
         RealmRepresentation realmClient = managedRealm.admin().toRepresentation();
         boolean originalBruteForceEnabled = Boolean.TRUE.equals(realmClient.isBruteForceProtected());
         Integer orginalFailureFactor = realmClient.getFailureFactor();
+        Integer originalMaxDeltaTimeSeconds = realmClient.getMaxDeltaTimeSeconds();
+        Integer originalMaxFailureWaitSeconds = realmClient.getMaxFailureWaitSeconds();
+        Integer originalWaitIncrementSeconds = realmClient.getWaitIncrementSeconds();
+        Long originalQuickLoginCheckMilliSeconds = realmClient.getQuickLoginCheckMilliSeconds();
 
         realmClient.setBruteForceProtected(true);
         realmClient.setFailureFactor(BRUTE_FORCE_FAILURE_FACTOR);
@@ -875,6 +879,10 @@ public class UserSessionLimitsTest {
             managedRealm.admin().attackDetection().clearAllBruteForce();
             realmClient.setBruteForceProtected(originalBruteForceEnabled);
             realmClient.setFailureFactor(orginalFailureFactor);
+            realmClient.setMaxDeltaTimeSeconds(originalMaxDeltaTimeSeconds);
+            realmClient.setMaxFailureWaitSeconds(originalMaxFailureWaitSeconds);
+            realmClient.setWaitIncrementSeconds(originalWaitIncrementSeconds);
+            realmClient.setQuickLoginCheckMilliSeconds(originalQuickLoginCheckMilliSeconds);
             managedRealm.admin().update(realmClient);
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.BROWSER_FLOW,
                     UserSessionLimitsAuthenticatorFactory.BEHAVIOR,


### PR DESCRIPTION
Root Cause:

Users with valid credentials were being locked out when hitting session limits because the system treated session denials as authentication failures, incrementing the brute force protector counter.

Solution:

Following up on [feedback](https://github.com/keycloak/keycloak/pull/45541#issuecomment-4442065699)  from the previous PR #45541, this PR fixes the issue at its source by updating UserSessionLimitsAuthenticatorFactory:getReferenceCategory to return a non-null string that is distinct from the categories monitored by the brute force protector (e.g. "not-brute-force-protected").

Impact:

Session limit denials no longer increment brute force counters, preventing legitimate users from being locked out due to session limits.

Fixes #44474