### PR TITLE
Preserve outer attribute path when evaluating nested SCIM value path filters

### DIFF
--- a/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateEvaluator.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateEvaluator.java
@@ -88,11 +88,12 @@ public class ScimJPAPredicateEvaluator extends ScimFilterParserBaseVisitor<JPAFi
 
     @Override
     public JPAFilterResult visitValuePath(ScimFilterParser.ValuePathContext ctx) {
-        parentPath = ctx.ATTRPATH().getText();
+        String previousPath = parentPath;
+        parentPath = resolveAttrPath(ctx.ATTRPATH().getText());
         try {
             return visit(ctx.expression());
         } finally {
-            parentPath = null;
+            parentPath = previousPath;
         }
     }
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -582,6 +582,27 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
+    public void testNestedValuePathDoesNotDropOuterAttributePath() {
+        createUser("bob", "Robert", "Anderson", "bob@keycloak.org", true);
+
+        // emails.name.familyName is not a valid attribute path, so the filter must not match anything;
+        // it must not be evaluated as if it were name[familyName eq "Anderson"]
+        String filter = "emails[name[familyName eq \"Anderson\"]]";
+        ListResponse<User> response = client.users().getAll(filter);
+        assertNoResults(response);
+    }
+
+    @Test
+    public void testNestedValuePathRestoresOuterAttributePath() {
+        User bob = createUser("bob", "Robert", "Anderson", "bob@keycloak.org", true);
+
+        // after the inner value path completes, familyName must still resolve to name.familyName
+        String filter = "name[bogus[value eq \"x\"] or familyName eq \"Anderson\"]";
+        ListResponse<User> response = client.users().getAll(filter);
+        assertSingleResult(response, bob.getUserName());
+    }
+
+    @Test
     public void testComplexAttributeCombinedWithRegularFilter() {
         User bob = createUser("bob", "Robert", "Anderson", "bob@keycloak.org", true);
         createUser("alice", "Alice", "Anderson", "alice@keycloak.org", false);


### PR DESCRIPTION
Ran into this while poking at the SCIM filter code: nested value paths resolve to the wrong attributes.

`visitValuePath()` tracks the current prefix in a single field and just sets it back to null when it's done. So with something like `a[b[c eq "x"] and d eq "y"]`, the inner `b[...]` stomps on the outer prefix (`c` becomes `b.c` instead of `a.b.c`), and once it finishes the prefix is wiped, so `d` gets resolved as a top-level attribute instead of `a.d`.

Process: save the old prefix, build the new one on top of it, put it back afterwards.

Fixes #51153