### PR TITLE
Fix transient session start time validation

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -244,6 +244,7 @@ public final class Constants {
 
     // Note in transient userSession specifying that it was created from "persistent" user session for the temporary purpose. The values of this note could be "online" and "offline"
     public static final String CREATED_FROM_PERSISTENT = "created_from_persistent";
+    public static final String CREATED_FROM_PERSISTENT_STARTED = "created_from_persistent_started";
     public static final String CREATED_FROM_PERSISTENT_ONLINE = "online";
     public static final String CREATED_FROM_PERSISTENT_OFFLINE = "offline";
 

--- a/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
@@ -212,6 +212,18 @@ public class UserSessionUtil {
     }
 
     private static UserSessionModel createTransientSessionForClient(KeycloakSession session, UserSessionModel userSession, ClientModel client) {
+        String persistentSessionStarted = userSession.getNote(Constants.CREATED_FROM_PERSISTENT_STARTED);
+        if (persistentSessionStarted != null) {
+            int sessionStarted = Integer.parseInt(persistentSessionStarted);
+            return new UserSessionModelDelegate(userSession) {
+
+                @Override
+                public int getStarted() {
+                    return sessionStarted;
+                }
+            };
+        }
+
         UserSessionModel transientSession = createTransientUserSession(session, userSession);
         attachAuthenticationSession(session, transientSession, client);
         return transientSession;

--- a/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
@@ -215,6 +215,9 @@ public class UserSessionUtil {
         String persistentSessionStarted = userSession.getNote(Constants.CREATED_FROM_PERSISTENT_STARTED);
         if (persistentSessionStarted != null) {
             int sessionStarted = Integer.parseInt(persistentSessionStarted);
+            if (userSession.getAuthenticatedClientSessionByClient(client.getId()) == null) {
+                attachAuthenticationSession(session, userSession, client);
+            }
             return new UserSessionModelDelegate(userSession) {
 
                 @Override

--- a/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
@@ -178,6 +178,7 @@ public class UserSessionUtil {
 
         String noteValue = userSession.isOffline() ? Constants.CREATED_FROM_PERSISTENT_OFFLINE : Constants.CREATED_FROM_PERSISTENT_ONLINE;
         transientSession.setNote(Constants.CREATED_FROM_PERSISTENT, noteValue);
+        transientSession.setNote(Constants.CREATED_FROM_PERSISTENT_STARTED, String.valueOf(userSession.getStarted()));
 
         // Use "started" time from the original session
         return new UserSessionModelDelegate(transientSession) {
@@ -237,7 +238,9 @@ public class UserSessionUtil {
     }
 
     private static boolean checkTokenIssuedAt(AccessToken token, UserSessionModel userSession) {
-        if (token.isIssuedBeforeSessionStart(userSession.getStarted())) {
+        String persistentSessionStarted = userSession.getNote(Constants.CREATED_FROM_PERSISTENT_STARTED);
+        int sessionStarted = persistentSessionStarted == null ? userSession.getStarted() : Integer.parseInt(persistentSessionStarted);
+        if (token.isIssuedBeforeSessionStart(sessionStarted)) {
             logger.debug("Stale token for user session");
             return false;
         } else {

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/StandardBaseTokenExchangeV2Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/StandardBaseTokenExchangeV2Test.java
@@ -266,6 +266,7 @@ public class StandardBaseTokenExchangeV2Test extends AbstractBaseTokenExchangeTe
 
         // assert introspection and user-info works in 10s
         timeOffSet.set(10);
+        assertTrue(runOnServer.fetch(new TransientSessionValidationOnServer(realm.getName(), exchangedTokenString), Boolean.class));
         assertIntrospectSuccess(exchangedTokenString, "requester-client", "secret", john.getId());
         assertUserInfoSuccess(exchangedTokenString, "requester-client", "secret", john.getId());
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TransientSessionValidationOnServer.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TransientSessionValidationOnServer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oauth.tokenexchange;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.services.util.UserSessionUtil;
+import org.keycloak.testframework.remote.providers.runonserver.FetchOnServer;
+
+final class TransientSessionValidationOnServer implements FetchOnServer {
+
+    private final String realmName;
+    private final String tokenString;
+
+    TransientSessionValidationOnServer(String realmName, String tokenString) {
+        this.realmName = realmName;
+        this.tokenString = tokenString;
+    }
+
+    @Override
+    public Object run(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName(realmName);
+        ClientModel requester = session.clients().getClientByClientId(realm, "requester-client");
+        AccessToken token = session.tokens().decode(tokenString, AccessToken.class);
+
+        UserSessionUtil.UserSessionValidationResult first = UserSessionUtil.findValidSessionForAccessToken(
+                session, realm, token, requester, ignored -> {});
+        UserSessionUtil.UserSessionValidationResult second = UserSessionUtil.findValidSessionForAccessToken(
+                session, realm, token, requester, ignored -> {});
+
+        return first.getError() == null && second.getError() == null;
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TransientSessionValidationOnServer.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TransientSessionValidationOnServer.java
@@ -44,7 +44,9 @@ final class TransientSessionValidationOnServer implements FetchOnServer {
                 session, realm, token, requester, ignored -> {});
         UserSessionUtil.UserSessionValidationResult second = UserSessionUtil.findValidSessionForAccessToken(
                 session, realm, token, requester, ignored -> {});
+        UserSessionUtil.UserSessionValidationResult third = UserSessionUtil.findValidSessionForAccessToken(
+                session, realm, token, requester, ignored -> {});
 
-        return first.getError() == null && second.getError() == null;
+        return first.getError() == null && second.getError() == null && third.getError() == null;
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TransientSessionValidationOnServer.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TransientSessionValidationOnServer.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.tests.oauth.tokenexchange;
 
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -42,11 +43,22 @@ final class TransientSessionValidationOnServer implements FetchOnServer {
 
         UserSessionUtil.UserSessionValidationResult first = UserSessionUtil.findValidSessionForAccessToken(
                 session, realm, token, requester, ignored -> {});
+        if (first.getError() != null) {
+            return false;
+        }
+        AuthenticatedClientSessionModel clientSession = first.getUserSession().getAuthenticatedClientSessionByClient(requester.getId());
+        if (clientSession == null) {
+            return false;
+        }
+        clientSession.detachFromUserSession();
+
         UserSessionUtil.UserSessionValidationResult second = UserSessionUtil.findValidSessionForAccessToken(
                 session, realm, token, requester, ignored -> {});
         UserSessionUtil.UserSessionValidationResult third = UserSessionUtil.findValidSessionForAccessToken(
                 session, realm, token, requester, ignored -> {});
 
-        return first.getError() == null && second.getError() == null && third.getError() == null;
+        return second.getError() == null && third.getError() == null
+                && second.getUserSession().getAuthenticatedClientSessionByClient(requester.getId()) != null
+                && third.getUserSession().getAuthenticatedClientSessionByClient(requester.getId()) != null;
     }
 }


### PR DESCRIPTION
Closes #51250

When a persistent user session is converted into a transient session, the transient entity is created with the current start time. A second lookup in the same transaction can therefore treat a valid token as issued before the session started.

This change stores the original persistent session start time as an internal transient-session note and uses it during token-issued-at validation when the transient session is retrieved again.

A regression test verifies two consecutive validations of an `ONLINE_TRANSIENT_CLIENT` token within the same transaction.

### Testing

- Built the Keycloak server distribution successfully.
- Verified the regression test fails before the fix and passes after it.
- Ran all 25 tests in `StandardBaseTokenExchangeV2Test`: 25 passed, 0 failed.
- Ran test compilation and Spotless checks successfully.