### PR TITLE
[OID4VCI] Omit blank key attestation values from OID4VCI metadata

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -401,7 +401,11 @@ public class CredentialScopeModel implements ClientScopeModel {
 
     public List<String> getRequiredKeyAttestationKeyStorage() {
         return Optional.ofNullable(clientScope.getAttribute(VC_KEY_ATTESTATION_REQUIRED_KEY_STORAGE))
-                       .map(s -> Arrays.asList(s.split(",")))
+                       .map(s -> Arrays.stream(s.split(","))
+                                        .map(String::trim)
+                                        .filter(value -> !value.isEmpty())
+                                        .toList())
+                       .filter(values -> !values.isEmpty())
                        // it is important to return null here instead of an empty list:
                        // If both key_storage and user_authentication parameters are absent, the
                        // key_attestations_required parameter may be empty, indicating a key attestation is needed
@@ -411,12 +415,16 @@ public class CredentialScopeModel implements ClientScopeModel {
 
     public void setRequiredKeyAttestationKeyStorage(List<String> keyStorage) {
         clientScope.setAttribute(VC_KEY_ATTESTATION_REQUIRED_KEY_STORAGE, Optional.ofNullable(keyStorage)
-                .map(list -> String.join(",")).orElse(null));
+                .map(list -> String.join(",", list)).orElse(null));
     }
 
     public List<String> getRequiredKeyAttestationUserAuthentication() {
         return Optional.ofNullable(clientScope.getAttribute(VC_KEY_ATTESTATION_REQUIRED_USER_AUTH))
-                       .map(s -> Arrays.asList(s.split(",")))
+                       .map(s -> Arrays.stream(s.split(","))
+                                        .map(String::trim)
+                                        .filter(value -> !value.isEmpty())
+                                        .toList())
+                       .filter(values -> !values.isEmpty())
                        // it is important to return null here instead of an empty list:
                        // If both key_storage and user_authentication parameters are absent, the
                        // key_attestations_required parameter may be empty, indicating a key attestation is needed
@@ -426,7 +434,7 @@ public class CredentialScopeModel implements ClientScopeModel {
 
     public void setRequiredKeyAttestationUserAuthentication(List<String> userAuthentication) {
         clientScope.setAttribute(VC_KEY_ATTESTATION_REQUIRED_USER_AUTH, Optional.ofNullable(userAuthentication)
-                .map(list -> String.join(",")).orElse(null));
+                .map(list -> String.join(",", list)).orElse(null));
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialScopeRepresentation.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialScopeRepresentation.java
@@ -278,7 +278,11 @@ public class CredentialScopeRepresentation extends ClientScopeRepresentation {
 
     public List<String> getRequiredKeyAttestationKeyStorage() {
         return Optional.ofNullable(getAttribute(VC_KEY_ATTESTATION_REQUIRED_KEY_STORAGE))
-                .map(s -> Arrays.asList(s.split(",")))
+                .map(s -> Arrays.stream(s.split(","))
+                                .map(String::trim)
+                                .filter(value -> !value.isEmpty())
+                                .toList())
+                .filter(values -> !values.isEmpty())
                 // it is important to return null here instead of an empty list:
                 // If both key_storage and user_authentication parameters are absent, the
                 // key_attestations_required parameter may be empty, indicating a key attestation is needed
@@ -288,12 +292,16 @@ public class CredentialScopeRepresentation extends ClientScopeRepresentation {
 
     public CredentialScopeRepresentation setRequiredKeyAttestationKeyStorage(List<String> keyStorage) {
         return setAttribute(VC_KEY_ATTESTATION_REQUIRED_KEY_STORAGE, Optional.ofNullable(keyStorage)
-                .map(list -> String.join(",")).orElse(null));
+                .map(list -> String.join(",", list)).orElse(null));
     }
 
     public List<String> getRequiredKeyAttestationUserAuthentication() {
         return Optional.ofNullable(getAttribute(VC_KEY_ATTESTATION_REQUIRED_USER_AUTH))
-                .map(s -> Arrays.asList(s.split(",")))
+                .map(s -> Arrays.stream(s.split(","))
+                                .map(String::trim)
+                                .filter(value -> !value.isEmpty())
+                                .toList())
+                .filter(values -> !values.isEmpty())
                 // it is important to return null here instead of an empty list:
                 // If both key_storage and user_authentication parameters are absent, the
                 // key_attestations_required parameter may be empty, indicating a key attestation is needed
@@ -303,7 +311,7 @@ public class CredentialScopeRepresentation extends ClientScopeRepresentation {
 
     public CredentialScopeRepresentation setRequiredKeyAttestationUserAuthentication(List<String> userAuthentication) {
         return setAttribute(VC_KEY_ATTESTATION_REQUIRED_USER_AUTH, Optional.ofNullable(userAuthentication)
-                .map(list -> String.join(",")).orElse(null));
+                .map(list -> String.join(",", list)).orElse(null));
     }
 
     public <T> T getCredentialPolicyValue(CredentialClientPolicy<T> policy) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.keycloak.VCFormat;
+import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.ComponentsResource;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.Algorithm;
@@ -62,6 +63,7 @@ import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.model.ProofTypesSupported;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.SupportedProofTypeData;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
@@ -80,6 +82,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.OID4VCConstants.KeyAttestationResistanceLevels.HIGH;
+import static org.keycloak.OID4VCConstants.KeyAttestationResistanceLevels.MODERATE;
 import static org.keycloak.OID4VCConstants.SIGNED_METADATA_JWT_TYPE;
 import static org.keycloak.VCFormat.JWT_VC;
 import static org.keycloak.VCFormat.SD_JWT_VC;
@@ -567,6 +571,118 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerTestBase {
 
         // Non-numeric value should be rejected (parsing exception)
         testBatchSizeValidation("invalid", false, null);
+    }
+
+    /**
+     * Configured key attestation resistance levels must reach the metadata.
+     *
+     * <p>The {@code key-attestation-credential} scope is set up with {@link org.keycloak.OID4VCConstants.KeyAttestationResistanceLevels#MODERATE}
+     * for both members, so the metadata has to advertise it. Asserting the literal value matters here:
+     * deriving the expectation from {@code CredentialScopeModel} would pass even when the configured
+     * values never made it into the client scope attribute in the first place.
+     */
+    @Test
+    public void testKeyAttestationsRequiredAdvertisesConfiguredResistanceLevels() {
+
+        KeyAttestationsRequired keyAttestationsRequired = getKeyAttestationsRequired(
+                keyAttestationCredentialScope.getCredentialConfigurationId(), ProofType.JWT);
+
+        assertNotNull(keyAttestationsRequired, "key_attestations_required should be advertised");
+        MatcherAssert.assertThat("Configured key_storage level should reach the metadata",
+                keyAttestationsRequired.getKeyStorage(), Matchers.contains(MODERATE));
+        MatcherAssert.assertThat("Configured user_authentication level should reach the metadata",
+                keyAttestationsRequired.getUserAuthentication(), Matchers.contains(MODERATE));
+    }
+
+    /**
+     * Key attestation required, but neither resistance level configured.
+     *
+     * <p>Per OID4VCI 12.2.4 {@code key_storage} and {@code user_authentication} are non-empty arrays
+     * when present, and {@code key_attestations_required} may be empty when neither is constrained.
+     * The attribute is stored blank rather than absent in this case, which previously produced
+     * {@code {"key_storage":[""],"user_authentication":[""]}}.
+     */
+    @Test
+    public void testKeyAttestationsRequiredOmitsUnconfiguredResistanceLevels() throws IOException {
+
+        ClientScopeResource scopeResource = testRealm.admin().clientScopes()
+                .get(keyAttestationCredentialScope.getId());
+        ClientScopeRepresentation original = scopeResource.toRepresentation();
+
+        try {
+            // neither constrained -> "key_attestations_required": {}
+            KeyAttestationsRequired neither = updateResistanceLevels(scopeResource, "", "");
+            assertNotNull(neither,
+                    "key_attestations_required should still be advertised when attestation is required");
+            assertNull(neither.getKeyStorage(),
+                    "key_storage must be omitted rather than advertised as an array of blanks");
+            assertNull(neither.getUserAuthentication(),
+                    "user_authentication must be omitted rather than advertised as an array of blanks");
+            assertEquals("{}", JsonSerialization.valueAsString(neither),
+                    "key_attestations_required should serialize to an empty object");
+
+            // only key_storage constrained
+            KeyAttestationsRequired keyStorageOnly = updateResistanceLevels(scopeResource, HIGH, "");
+            MatcherAssert.assertThat(keyStorageOnly.getKeyStorage(), Matchers.contains(HIGH));
+            assertNull(keyStorageOnly.getUserAuthentication(),
+                    "user_authentication must be omitted when it is not constrained");
+
+            // only user_authentication constrained
+            KeyAttestationsRequired userAuthOnly = updateResistanceLevels(scopeResource, "", HIGH);
+            assertNull(userAuthOnly.getKeyStorage(),
+                    "key_storage must be omitted when it is not constrained");
+            MatcherAssert.assertThat(userAuthOnly.getUserAuthentication(), Matchers.contains(HIGH));
+
+            // separator-only and padded values collapse the same way
+            KeyAttestationsRequired separatorOnly = updateResistanceLevels(scopeResource, ",", " , ");
+            assertEquals("{}", JsonSerialization.valueAsString(separatorOnly),
+                    "Separator-only values must not produce blank entries");
+
+            KeyAttestationsRequired padded = updateResistanceLevels(scopeResource, " " + HIGH + " ", "");
+            MatcherAssert.assertThat("Surrounding whitespace should be trimmed",
+                    padded.getKeyStorage(), Matchers.contains(HIGH));
+        } finally {
+            scopeResource.update(original);
+        }
+    }
+
+    /**
+     * Rewrites both resistance-level attributes on a credential scope and returns the
+     * {@code key_attestations_required} the metadata endpoint advertises afterwards.
+     */
+    private KeyAttestationsRequired updateResistanceLevels(ClientScopeResource scopeResource,
+                                                           String keyStorage,
+                                                           String userAuthentication) {
+        ClientScopeRepresentation update = scopeResource.toRepresentation();
+        update.getAttributes().put(CredentialScopeModel.VC_KEY_ATTESTATION_REQUIRED_KEY_STORAGE, keyStorage);
+        update.getAttributes().put(CredentialScopeModel.VC_KEY_ATTESTATION_REQUIRED_USER_AUTH, userAuthentication);
+        scopeResource.update(update);
+
+        return getKeyAttestationsRequired(
+                keyAttestationCredentialScope.getCredentialConfigurationId(), ProofType.JWT);
+    }
+
+    /**
+     * Reads {@code key_attestations_required} for one credential configuration straight off the
+     * metadata endpoint.
+     */
+    private KeyAttestationsRequired getKeyAttestationsRequired(String credentialConfigurationId, String proofType) {
+
+        CredentialIssuer credentialIssuer = oauth.oid4vc()
+                .doIssuerMetadataRequest()
+                .getMetadata();
+
+        SupportedCredentialConfiguration supportedConfig = credentialIssuer.getCredentialsSupported()
+                .get(credentialConfigurationId);
+        assertNotNull(supportedConfig, "Configuration '" + credentialConfigurationId + "' must be present");
+
+        ProofTypesSupported proofTypesSupported = supportedConfig.getProofTypesSupported();
+        assertNotNull(proofTypesSupported, "proof_types_supported must be present");
+
+        SupportedProofTypeData proofTypeData = proofTypesSupported.getSupportedProofTypes().get(proofType);
+        assertNotNull(proofTypeData, proofType + " proof type must be present");
+
+        return proofTypeData.getKeyAttestationsRequired();
     }
 
     @Test


### PR DESCRIPTION
Closes #51347

## Problem

With key attestation enabled, the credential issuer metadata contains empty-string entries:

```json
"key_attestations_required": { "key_storage": [""], "user_authentication": [""] }
```

OID4VCI [12.2.4](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4) requires `key_storage` and `user_authentication` to be **non-empty** arrays when present, and permits an empty `key_attestations_required` object when neither is constrained.

## Root cause

There are two defects, and the first one is why the values are blank in the first place.

**1. The setters discard their argument.** All four key-attestation setters:

```java
// CredentialScopeModel:418, :437 and CredentialScopeRepresentation:291, :306
Optional.ofNullable(keyStorage)
        .map(list -> String.join(","))      // `list` is never passed
        .orElse(null);
```

That is `String.join(CharSequence, CharSequence...)` with **zero** elements, so it returns `""` and ignores `list` entirely. Configuring any resistance level writes an empty attribute.

This is the source of the reported metadata. The testsuite's `key-attestation-credential` scope is built with `List.of(MODERATE)` — `iso_18045_moderate` was configured, silently dropped on write, and the getter then rendered the blank attribute as `[""]`. Introduced in #51261.

**2. The getters turn a blank attribute into `[""]`.**

```java
Optional.ofNullable(clientScope.getAttribute(VC_KEY_ATTESTATION_REQUIRED_KEY_STORAGE))
        .map(s -> Arrays.asList(s.split(",")))
        // it is important to return null here instead of an empty list ...
        .orElse(null);
```

The attribute is present and blank, not absent, so `ofNullable` sees `""`, `"".split(",")` yields a single empty element, and the `orElse(null)` fallback never runs. The existing comment already states that null is the intended result — the guard just does not cover the blank case.

## Fix

- **Setters** → `String.join(",", list)`, in both `CredentialScopeModel` and `CredentialScopeRepresentation`.
- **Getters** → filter blank entries and collapse to null when nothing remains, in both classes so they agree on what a blank attribute means:

```java
.map(s -> Arrays.stream(s.split(","))
                 .map(String::trim)
                 .filter(value -> !value.isEmpty())
                 .toList())
.filter(values -> !values.isEmpty())
.orElse(null);
```

`KeyAttestationsRequired` is already `@JsonInclude(NON_NULL)`, so null members are omitted and the bare `"key_attestations_required": {}` falls out with no change there. Values are also trimmed, so `" a , b "` no longer yields entries with surrounding whitespace.

That covers the four cases enumerated in the issue:

| key_storage | user_authentication | metadata |
|---|---|---|
| unset | unset | `{}` |
| set | unset | only `key_storage` |
| unset | set | only `user_authentication` |
| set | set | both |

## Tests

Per review, these live in the base testsuite rather than as unit tests. Two methods added to `OID4VCIssuerWellKnownProviderTest`, both driving the real metadata endpoint:

- **`testKeyAttestationsRequiredAdvertisesConfiguredResistanceLevels`** — asserts the configured `iso_18045_moderate` actually reaches the metadata. This is the one that pins the setter bug.
- **`testKeyAttestationsRequiredOmitsUnconfiguredResistanceLevels`** — walks the four cases above plus separator-only and padded input, restoring the scope in a `finally`.

Asserting **literal** expected values is deliberate. The existing coverage at `OID4VCIssuerWellKnownProviderTest:714` derives its expectation from the same getter under test:

```java
expectedKeyAttestationsRequired.setKeyStorage(credScope.getRequiredKeyAttestationKeyStorage());
```

so it holds whether that getter returns `[""]` or `null` — which is why this bug shipped with integration coverage already in place.

## Verification

```
./mvnw -pl tests/base test -Dtest='OID4VCIssuerWellKnownProviderTest#testKeyAttestationsRequired*'

Tests run: 2, Failures: 0, Errors: 0
```

Keeping the tests and reverting only the production change:

```
[ERROR] testKeyAttestationsRequiredAdvertisesConfiguredResistanceLevels
Expected: iterable containing ["iso_18045_moderate"]
     but: was null
Tests run: 2, Failures: 1
```

**That is 1, not 2, and the difference matters.** Only the first test fails without the fix. The second passes on `main` too, so it is a spec-compliance guard rather than a regression test for the reported symptom.

The reason is worth flagging: on the reverted build the getter returned **`null`, not `[""]`** — writing `""` through `ClientScopeResource.update()` comes back as an *absent* attribute, so I could not reproduce `{"key_storage":[""]}` through the admin REST path at all. The `[""]` in the report must come from a write path that does persist a blank value. If you know which one, I will point the second test at it so it pins the getter half too. Until then the getter hardening is defensive — it protects realms that already hold blank attributes, but no test here proves it is required.

Note that `tests/base` needs a prior `./mvnw install -DskipTests` before the command above will resolve.

## Scope

- Getter hardening is kept alongside the setter fix on the grounds that blank attributes may already be persisted in existing realms. If you would rather the getters stayed strict and this were handled as a data migration, say so and I will drop that half.
- No other `String.join(",")` call sites are affected — the rest of both classes already pass the list.
