### PR TITLE
Fix stateless cluster and db migrations race

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/DatabaseAwareClusterProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/DatabaseAwareClusterProviderFactory.java
@@ -54,8 +54,6 @@ public class DatabaseAwareClusterProviderFactory extends InfinispanClusterProvid
 
     private static final String DEFAULT_POLL_INTERVAL_MS = "100ms";
 
-    private volatile NodeInfo nodeInfo;
-    private volatile Marshaller protoStreamMarshaller;
     private Timer timer;
 
     private Duration pollInterval;
@@ -66,8 +64,10 @@ public class DatabaseAwareClusterProviderFactory extends InfinispanClusterProvid
 
     @Override
     public ClusterProvider create(KeycloakSession session) {
-        return new DatabaseAwareClusterProvider(super.create(session), session,
-                nodeInfo, protoStreamMarshaller, awaitTimeout);
+        ClusterProvider delegate = super.create(session);
+        InfinispanConnectionProvider ispnConnections = session.getProvider(InfinispanConnectionProvider.class);
+        return new DatabaseAwareClusterProvider(delegate, session,
+                ispnConnections.getNodeInfo(), ispnConnections.getMarshaller(), awaitTimeout);
     }
 
     @Override
@@ -100,8 +100,8 @@ public class DatabaseAwareClusterProviderFactory extends InfinispanClusterProvid
     public void postInit(KeycloakSessionFactory factory) {
         KeycloakModelUtils.runJobInTransaction(factory, session -> {
             InfinispanConnectionProvider ispnConnections = session.getProvider(InfinispanConnectionProvider.class);
-            nodeInfo = ispnConnections.getNodeInfo();
-            this.protoStreamMarshaller = ispnConnections.getMarshaller();
+            NodeInfo nodeInfo = ispnConnections.getNodeInfo();
+            Marshaller protoStreamMarshaller = ispnConnections.getMarshaller();
 
             var pollerTask = new DatabaseClusterEventPollerTask(nodeInfo.clusterName(), protoStreamMarshaller);
             var runner = new ScheduledTaskRunner(factory, pollerTask);

--- a/tests/base/src/test/java/org/keycloak/tests/model/DatabaseAwareClusterProviderFactoryTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/DatabaseAwareClusterProviderFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.model;
+
+import org.keycloak.Config;
+import org.keycloak.cluster.infinispan.DatabaseAwareClusterProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.models.cache.infinispan.ClearCacheEvent;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@KeycloakIntegrationTest(config = DatabaseAwareClusterProviderFactoryTest.ServerConfig.class)
+public class DatabaseAwareClusterProviderFactoryTest {
+
+    @InjectRunOnServer(permittedPackages = "org.keycloak.tests")
+    RunOnServerClient runOnServer;
+
+    @Test
+    public void providerCreatedBeforePostInitCanSendClusterEvent() {
+        assertDoesNotThrow(() -> runOnServer.run(session -> {
+            var factory = new DatabaseAwareClusterProviderFactory();
+            factory.init(Config.scope("cluster", factory.getId()));
+            try {
+                factory.create(session).notify("test", ClearCacheEvent.getInstance(), true);
+            } finally {
+                factory.close();
+            }
+        }));
+    }
+
+    public static class ServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.STATELESS);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This Pull Request fixes a race condition between triggering the migration and bootstrapping Infinispan cluster. 

The race condition has been noticed in UDS Platform.

## Related tickets

Closes #51154
