### PR TITLE
fix: refresh expired stored token in exchangeStoredToken (#49341) [fk4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -501,6 +501,28 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             return exchangeNotLinked(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
         }
 
+        try {
+            String modelTokenString = model.getToken();
+            if (modelTokenString.startsWith("{")) {
+                OAuthResponse previousResponse = JsonSerialization.readValue(modelTokenString, OAuthResponse.class);
+                Long exp = previousResponse.getAccessTokenExpiration();
+                if (needsRefresh(exp) && previousResponse.getRefreshToken() != null) {
+                    OAuthResponse newResponse = refreshToken(previousResponse, session);
+                    if (newResponse.getExpiresIn() != null && newResponse.getExpiresIn() > 0) {
+                        long accessTokenExpiration = Time.currentTime() + newResponse.getExpiresIn();
+                        newResponse.setAccessTokenExpiration(accessTokenExpiration);
+                    }
+                    model.setToken(JsonSerialization.writeValueAsString(newResponse));
+                    session.users().updateFederatedIdentity(realm, tokenSubject, model);
+                    AccessTokenResponse tokenResponse = new AccessTokenResponse();
+                    tokenResponse.setToken(newResponse.getToken());
+                    return buildTokenResponse(uriInfo, event, authorizedClient, tokenUserSession, tokenResponse, OAuth2Constants.ACCESS_TOKEN_TYPE);
+                }
+            }
+        } catch (IOException e) {
+            logger.debugf("Failed to refresh stored token", e);
+        }
+
         String accessToken = extractTokenFromResponse(model.getToken(), getAccessTokenResponseParameter());
         if (accessToken == null) {
             model.setToken(null);


### PR DESCRIPTION
## Summary

The `exchangeStoredToken` method in `AbstractOAuth2IdentityProvider` (used by the V2 `/broker/{alias}/token` endpoint and the token exchange path) returns the stored access token without checking whether it has expired. When the token is expired, the caller receives a stale token that will fail when used.

The V1 `retrieveToken` method already handles this correctly: it checks `accessTokenExpiration`, and if the token needs refresh and a refresh token is available, it calls `refreshToken` and updates the stored token.

## Changes

This PR backports the same token refresh logic to `exchangeStoredToken`:

1. Parse the stored token as `OAuthResponse` (the same class used by V1 `retrieveToken`)
2. Check if the token needs refresh using `needsRefresh()` (expired or within `minValidityToken`)
3. If a refresh token is available, call `refreshToken()` to obtain a new token
4. Update `accessTokenExpiration` on the new response
5. Persist the refreshed token via `updateFederatedIdentity`
6. Return the refreshed token

If the token is not JSON (e.g., form-encoded), the original `extractTokenFromResponse` fallback path is preserved.

## Related

- Closes #49341
- The V1 fix was done in #39508, but `exchangeStoredToken` (V2 and token exchange paths) was not updated at that time
- `OIDCIdentityProvider` already had its own override of `exchangeStoredToken` with refresh logic; this change brings the same behavior to the base class, benefiting all OAuth2-based identity providers (GitHub, Facebook, Google, etc.)