### PR TITLE
Fix translation notify after checkout update

### DIFF
--- a/.github/workflows/translation-notify.yml
+++ b/.github/workflows/translation-notify.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This only runs after a pull request has been merged to the current branch, so this is safe
+          allow-unsafe-pr-checkout: true
 
       - name: Install Yq
         run: sudo snap install yq


### PR DESCRIPTION
Closes #51363

While the change for the related PR was different as it checked out the base branch for the PR, this one prefers to check out the PR itself to pick up updated language maintainers. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
