### PR TITLE
Reset the page offset when the search term changes

### DIFF
--- a/js/apps/admin-ui/test/clients/main.spec.ts
+++ b/js/apps/admin-ui/test/clients/main.spec.ts
@@ -8,7 +8,9 @@ import { assertNotificationMessage } from "../utils/masthead.ts";
 import { assertModalTitle, confirmModal } from "../utils/modal.ts";
 import { goToClients, goToRealm } from "../utils/sidebar.ts";
 import {
+  assertRowExists,
   clearAllFilters,
+  clickNextPageButton,
   clickRowKebabItem,
   getRowByCellText,
   searchItem,
@@ -117,6 +119,36 @@ test.describe.serial("Clients test", () => {
 
     await clearAllFilters(page);
     await expect(getRowByCellText(page, "account")).toBeVisible();
+  });
+
+  test.describe.serial("Search from a later page", () => {
+    const pagedClient = "paged-client";
+    const otherClient = "other-client";
+
+    // One more than the default page size, so the results span two pages
+    test.beforeAll(async () => {
+      for (let i = 0; i < 11; i++) {
+        await adminClient.createClient({
+          clientId: `${pagedClient}-${i}`,
+          realm: realmName,
+        });
+      }
+      await adminClient.createClient({
+        clientId: otherClient,
+        realm: realmName,
+      });
+    });
+
+    test("Searching while on the second page shows the matches", async ({
+      page,
+    }) => {
+      await searchItem(page, placeHolder, pagedClient);
+      await clickNextPageButton(page);
+
+      await searchItem(page, placeHolder, otherClient);
+
+      await assertRowExists(page, otherClient);
+    });
   });
 
   test.describe.serial("Clients import", () => {

--- a/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
+++ b/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
@@ -409,12 +409,23 @@ export function KeycloakDataTable<T>({
   const [max, setMax] = useState(defaultPageSize);
   const [first, setFirst] = useState(0);
   const [search, setSearch] = useState<string>("");
-  const prevSearch = useRef<string>();
 
   const [key, setKey] = useState(0);
   const prevKey = useRef<number>();
   const refresh = () => setKey(key + 1);
   const id = useId();
+
+  // A different search term yields a different result set, so the current page
+  // offset no longer applies and has to be reset along with it. Without this the
+  // offset is carried over and applied to the new results, which makes the table
+  // come up empty even when there are matches on the first page.
+  const onSearchChange = (value: string) => {
+    if (value === search) {
+      return;
+    }
+    setFirst(0);
+    setSearch(value);
+  };
 
   const renderCell = (columns: (Field<T> | DetailField<T>)[], value: T) => {
     return columns.map((col) => {
@@ -499,19 +510,13 @@ export function KeycloakDataTable<T>({
   useFetch(
     async () => {
       setLoading(true);
-      const newSearch = prevSearch.current === "" && search !== "";
-
-      if (newSearch) {
-        setFirst(0);
-      }
-      prevSearch.current = search;
       const loaderFn =
         typeof loader === "function"
           ? loader
           : "loader" in loader
             ? loader.loader
             : async () => loader;
-      return await loaderFn(newSearch ? 0 : first, max + 1, search);
+      return await loaderFn(first, max + 1, search);
     },
     (data) => {
       prevKey.current = key;
@@ -551,7 +556,7 @@ export function KeycloakDataTable<T>({
         );
         if (result) {
           if (!isPaginated) {
-            setSearch("");
+            onSearchChange("");
           }
           refresh();
         }
@@ -589,7 +594,7 @@ export function KeycloakDataTable<T>({
           inputGroupName={
             searchPlaceholderKey ? `${ariaLabelKey}input` : undefined
           }
-          inputGroupOnEnter={setSearch}
+          inputGroupOnEnter={onSearchChange}
           inputGroupPlaceholder={t(searchPlaceholderKey || "")}
           searchTypeComponent={searchTypeComponent}
           toolbarItem={
@@ -636,7 +641,7 @@ export function KeycloakDataTable<T>({
                   ? [
                       {
                         text: t("clearAllFilters"),
-                        onClick: () => setSearch(""),
+                        onClick: () => onSearchChange(""),
                         type: ButtonVariant.link,
                       },
                     ]


### PR DESCRIPTION
Closes #51372

The page offset was only reset when the previous search term was empty, so changing the term from one non-empty value to another kept the old offset and applied it to the new result set. The table then rendered the "No search results" empty state even when the search had matches on the first page, and the pager stayed on the old page.

This moves the reset to the point where the search term changes, so it covers every transition — including clearing the term — and the offset is already correct by the time the data is loaded. That also removes the need for the `prevSearch` ref, and for client-side filtered tables it avoids an intermediate render where the stale offset was applied to the filtered rows.

Since `KeycloakDataTable` is shared, this affects the tables that use its built-in search box, both the server-side paginated ones and the ones filtering client-side. Tables that supply their own search UI (Users, Groups, events, …) were never affected, because their search triggers a `refresh()` that remounts the component.

### Testing

Added an integration test in `js/apps/admin-ui/test/clients/main.spec.ts` that searches, moves to the second page, searches again for a different term, and asserts the match is shown. Verified that it fails without the change and passes with it.
