### PR TITLE
fix(admin/api): handle disabled email sender provider gracefully

### DIFF
--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -315,6 +315,9 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
 
     protected void send(Map<String, String> config, String subject, String textBody, String htmlBody, String address) throws EmailException {
         EmailSenderProvider emailSender = session.getProvider(EmailSenderProvider.class);
+        if (emailSender == null) {
+            throw new EmailException("Email sender provider is disabled or not configured");
+        }
         if (address == null) {
             emailSender.send(config, user, subject, textBody, htmlBody);
         } else {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -1185,6 +1185,13 @@ public class RealmAdminResource {
                 settings.put("authTokenClientSecret", realm.getSmtpConfig().get("authTokenClientSecret"));
             }
             session.getProvider(EmailTemplateProvider.class).sendSmtpTestEmail(settings, user);
+        } catch (EmailException e) {
+            if ("Email sender provider is disabled or not configured".equals(e.getMessage())) {
+                logger.error(e.getMessage(), e);
+                throw ErrorResponse.error(e.getMessage(), Response.Status.BAD_REQUEST);
+            }
+            logger.errorf(e, "Failed to send email \n %s", e.getCause());
+            throw ErrorResponse.error("Failed to send email", Response.Status.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             logger.errorf(e, "Failed to send email \n %s", e.getCause());
             throw ErrorResponse.error("Failed to send email", Response.Status.INTERNAL_SERVER_ERROR);

--- a/services/src/main/java/org/keycloak/utils/SMTPUtil.java
+++ b/services/src/main/java/org/keycloak/utils/SMTPUtil.java
@@ -48,6 +48,9 @@ public class SMTPUtil {
         }
 
         final EmailSenderProvider sender = session.getProvider(EmailSenderProvider.class);
+        if (sender == null) {
+            throw new EmailException("Email sender provider is disabled or not configured");
+        }
         sender.validate(config);
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/SMTPConnectionDisabledProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/SMTPConnectionDisabledProviderTest.java
@@ -1,0 +1,68 @@
+package org.keycloak.tests.admin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest(config = SMTPConnectionDisabledProviderTest.SMTPDisabledProviderConfig.class)
+public class SMTPConnectionDisabledProviderTest {
+
+    @InjectRealm(config = SMTPConnectionTest.SMTPRealmWithClientAndUser.class)
+    private ManagedRealm managedRealm;
+
+    @InjectAdminClient(mode = InjectAdminClient.Mode.MANAGED_REALM, client = "myclient", user = "myadmin")
+    private Keycloak adminClient;
+
+    @Test
+    public void testUpdateRealmWithDisabledEmailSenderProviderReturns400() {
+        RealmResource realmResource = adminClient.realms().realm(managedRealm.getName());
+        RealmRepresentation realmRep = realmResource.toRepresentation();
+        
+        Map<String, String> smtpSettings = new HashMap<>();
+        smtpSettings.put("host", "127.0.0.1");
+        smtpSettings.put("port", "3025");
+        smtpSettings.put("from", "auto@keycloak.org");
+        realmRep.setSmtpServer(smtpSettings);
+        
+        BadRequestException exception = Assertions.assertThrows(BadRequestException.class, () -> realmResource.update(realmRep));
+        Assertions.assertNotNull(exception.getResponse(), "Response should not be null");
+        String body = exception.getResponse().readEntity(String.class);
+        Assertions.assertTrue(body.contains("Email sender provider is disabled or not configured"), "Message should indicate disabled provider. Found: " + body);
+    }
+
+    @Test
+    public void testSMTPConnectionWithDisabledEmailSenderProviderReturns400() throws Exception {
+        Map<String, String> settings = new HashMap<>();
+        settings.put("host", "127.0.0.1");
+        settings.put("port", "3025");
+        settings.put("from", "auto@keycloak.org");
+
+        Response response = adminClient.realms().realm(managedRealm.getName()).testSMTPConnection(settings);
+        Assertions.assertEquals(400, response.getStatus());
+        String body = response.readEntity(String.class);
+        Assertions.assertTrue(body.contains("Email sender provider is disabled or not configured"), "Message should indicate disabled provider. Found: " + body);
+        response.close();
+    }
+
+    public static class SMTPDisabledProviderConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.option("spi-email-sender-default-enabled", "false");
+        }
+    }
+}


### PR DESCRIPTION
Properly validates if the EmailSenderProvider is disabled (null) before attempting to use it in SMTP validation and test email APIs. Throws an EmailException which translates into a 400 Bad Request instead of an unhandled NullPointerException causing 500 Internal Server Error.

Closes #51352

Hi @Softwaregeek-Sam, I already had a fix ready and tested for this, so I opened a PR. Hope you don't mind!