### PR TITLE
[OID4VCI] Fix IssuerKeyAttestationTest conformance failures

### DIFF
--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/ConformanceSigningKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/ConformanceSigningKey.java
@@ -117,7 +117,11 @@ public final class ConformanceSigningKey {
         return realmDir;
     }
 
-    public static ConformanceSigningKey generate(String realmName, String kid, String name) {
+    /**
+     * Generates a CA-signed key. {@code leafEku} optionally restricts the leaf to a single extended key
+     * usage purpose; pass {@code null} to leave it unrestricted.
+     */
+    public static ConformanceSigningKey generate(String realmName, String kid, String name, KeyPurposeId leafEku) {
         try {
             if (!CryptoIntegration.isInitialised()) {
                 CryptoIntegration.setProvider(new DefaultCryptoProvider());
@@ -129,10 +133,9 @@ public final class ConformanceSigningKey {
 
             // The CA must be a proper v3 CA certificate with the CA basic constraint and keyCertSign key usage,
             // because X509TrustMaterial rejects trust anchors that are not CA certificates. The leaf must be a
-            // plain end-entity certificate carrying the attestation extended key usage, as the key-attestation
-            // validator rejects CA-capable or EKU-less leaves.
+            // plain end-entity certificate, as the key-attestation validator rejects CA-capable leaves.
             X509Certificate caCertificate = generateCaCertificate(caKeyPair, name + " CA");
-            X509Certificate certificate = generateLeafCertificate(keyPair, caKeyPair, caCertificate, name);
+            X509Certificate certificate = generateLeafCertificate(keyPair, caKeyPair, caCertificate, name, leafEku);
             return new ConformanceSigningKey(realmName, kid, keyPair, certificate, caCertificate);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create conformance signing key " + kid, e);
@@ -214,16 +217,16 @@ public final class ConformanceSigningKey {
     }
 
     private static X509Certificate generateLeafCertificate(KeyPair keyPair, KeyPair caKeyPair,
-            X509Certificate caCertificate, String name) throws Exception {
+            X509Certificate caCertificate, String name, KeyPurposeId leafEku) throws Exception {
         X500Name issuer = new X500Name(caCertificate.getSubjectX500Principal().getName());
         X500Name subject = new X500Name("CN=" + name);
         X509v3CertificateBuilder builder = certificateBuilder(issuer, subject, keyPair);
         builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
         builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
-        // The emailProtection extended key usage must match the attestation EKU the conformance realm trusts,
-        // configured as ATTESTER_ATTESTATION_EKU in VciConformanceRealmConfig.
-        builder.addExtension(Extension.extendedKeyUsage, false,
-                new ExtendedKeyUsage(KeyPurposeId.id_kp_emailProtection));
+        // A restrictive EKU is only needed for key attestation; other leaves must stay unrestricted.
+        if (leafEku != null) {
+            builder.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(leafEku));
+        }
         return sign(builder, caKeyPair);
     }
 

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/ConformanceSigningKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/ConformanceSigningKey.java
@@ -19,20 +19,24 @@ package org.keycloak.tests.conformance;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.ECGenParameterSpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.List;
 
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.Base64Url;
-import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.JavaAlgorithm;
@@ -46,6 +50,17 @@ import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 /**
  * EC signing material generated at runtime for conformance tests, so no private key is committed to
@@ -56,6 +71,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 public final class ConformanceSigningKey {
 
     public static final String KEYSTORE_PASSWORD = "password";
+
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     private static final Path KEYSTORES_BASE_DIR;
 
@@ -110,10 +127,12 @@ public final class ConformanceSigningKey {
             KeyPair caKeyPair = keyGenerator.generateKeyPair();
             KeyPair keyPair = keyGenerator.generateKeyPair();
 
-            X509Certificate caCertificate =
-                    CertificateUtils.generateV1SelfSignedCertificate(caKeyPair, name + " CA");
-            X509Certificate certificate =
-                    CertificateUtils.generateV3Certificate(keyPair, caKeyPair.getPrivate(), caCertificate, name);
+            // The CA must be a proper v3 CA certificate with the CA basic constraint and keyCertSign key usage,
+            // because X509TrustMaterial rejects trust anchors that are not CA certificates. The leaf must be a
+            // plain end-entity certificate carrying the attestation extended key usage, as the key-attestation
+            // validator rejects CA-capable or EKU-less leaves.
+            X509Certificate caCertificate = generateCaCertificate(caKeyPair, name + " CA");
+            X509Certificate certificate = generateLeafCertificate(keyPair, caKeyPair, caCertificate, name);
             return new ConformanceSigningKey(realmName, kid, keyPair, certificate, caCertificate);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create conformance signing key " + kid, e);
@@ -184,5 +203,43 @@ public final class ConformanceSigningKey {
         JSONWebKeySet keySet = new JSONWebKeySet();
         keySet.setKeys(new JWK[] {key});
         return JsonSerialization.writeValueAsNode(keySet);
+    }
+
+    private static X509Certificate generateCaCertificate(KeyPair caKeyPair, String commonName) throws Exception {
+        X500Name caName = new X500Name("CN=" + commonName);
+        X509v3CertificateBuilder builder = certificateBuilder(caName, caName, caKeyPair);
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        return sign(builder, caKeyPair);
+    }
+
+    private static X509Certificate generateLeafCertificate(KeyPair keyPair, KeyPair caKeyPair,
+            X509Certificate caCertificate, String name) throws Exception {
+        X500Name issuer = new X500Name(caCertificate.getSubjectX500Principal().getName());
+        X500Name subject = new X500Name("CN=" + name);
+        X509v3CertificateBuilder builder = certificateBuilder(issuer, subject, keyPair);
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+        // The emailProtection extended key usage must match the attestation EKU the conformance realm trusts,
+        // configured as ATTESTER_ATTESTATION_EKU in VciConformanceRealmConfig.
+        builder.addExtension(Extension.extendedKeyUsage, false,
+                new ExtendedKeyUsage(KeyPurposeId.id_kp_emailProtection));
+        return sign(builder, caKeyPair);
+    }
+
+    private static X509v3CertificateBuilder certificateBuilder(X500Name issuer, X500Name subject, KeyPair keyPair) {
+        Instant now = Instant.now();
+        return new X509v3CertificateBuilder(
+                issuer,
+                new BigInteger(160, RANDOM),
+                Date.from(now.minus(1, ChronoUnit.DAYS)),
+                Date.from(now.plus(365, ChronoUnit.DAYS)),
+                subject,
+                SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
+    }
+
+    private static X509Certificate sign(X509v3CertificateBuilder builder, KeyPair signingKeyPair) throws Exception {
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA").build(signingKeyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
     }
 }

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerKeyAttestationTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerKeyAttestationTest.java
@@ -17,10 +17,6 @@
 
 package org.keycloak.tests.conformance.vci;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -30,16 +26,16 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.injection.LifeCycle;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmBuilder;
-import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.tests.conformance.runner.BrowserInteraction;
 import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
 import org.keycloak.tests.conformance.runner.ConformanceResult;
 
 /**
  * Issues a credential whose configuration requires key attestations, so the suite includes a valid key attestation
- * that Keycloak must accept.
+ * that Keycloak must accept. The attestation x5c chain is trusted through the {@code conformance-attester-x509}
+ * trust-material identity provider configured by {@link VciConformanceRealmConfig}.
  */
-@KeycloakIntegrationTest(config = IssuerKeyAttestationTest.KeyAttestationServerConfig.class)
+@KeycloakIntegrationTest(config = VciConformanceRealmConfig.ServerConfig.class)
 public class IssuerKeyAttestationTest extends AbstractVciConformanceTest {
 
     @InjectRealm(config = KeyAttestationRequiredRealmConfig.class, lifecycle = LifeCycle.METHOD)
@@ -55,29 +51,6 @@ public class IssuerKeyAttestationTest extends AbstractVciConformanceTest {
                 "oid4vci-1_0-issuer-happy-flow",
                 ConformanceResult.PASSED,
                 BrowserInteraction.LOGIN);
-    }
-
-    public static class KeyAttestationServerConfig extends VciConformanceRealmConfig.ServerConfig {
-
-        // TODO Drop this truststore path once Keycloak trusts key attestation keys via a trust material identity
-        // provider instead of validating the x5c chain against the server truststore.
-        private static final String ATTESTER_CA_PATH = writeAttesterCaCertificate();
-
-        @Override
-        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return super.configure(config).option("truststore-paths", ATTESTER_CA_PATH);
-        }
-
-        private static String writeAttesterCaCertificate() {
-            try {
-                Path caPath = Files.createTempFile("oid4vci-conformance-attester-ca", ".pem");
-                Files.writeString(caPath, VciAttesterKey.caCertificatePem(), StandardCharsets.UTF_8);
-                caPath.toFile().deleteOnExit();
-                return caPath.toString();
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to write the attester CA certificate for the truststore", e);
-            }
-        }
     }
 
     public static class KeyAttestationRequiredRealmConfig extends VciConformanceRealmConfig {

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciAttesterKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciAttesterKey.java
@@ -20,6 +20,7 @@ package org.keycloak.tests.conformance.vci;
 import org.keycloak.tests.conformance.ConformanceSigningKey;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 
 /**
  * The attester key, generated at runtime so no private key material is committed to the repository. It is signed
@@ -31,8 +32,10 @@ final class VciAttesterKey {
 
     static final String KID = "ct_client_attester_key";
 
+    // The attestation EKU must match ATTESTER_ATTESTATION_EKU in VciConformanceRealmConfig.
     private static final ConformanceSigningKey KEY = ConformanceSigningKey.generate(
-            VciConformanceRealmConfig.REALM, KID, "OID4VCI Conformance Attester");
+            VciConformanceRealmConfig.REALM, KID, "OID4VCI Conformance Attester",
+            KeyPurposeId.id_kp_emailProtection);
 
     private VciAttesterKey() {
     }

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
@@ -73,6 +73,9 @@ public class VciConformanceRealmConfig implements RealmConfig {
     public static final String CREDENTIAL_CONFIGURATION_ID = "conformance_sd_jwt_vc";
     public static final String CONFORMANCE_CALLBACK = OpenIdConformanceSuite.INTERNAL_BASE_URI + "/test/a/keycloak/callback";
     public static final String TRUST_IDP_ALIAS = "conformance-client-attester";
+    public static final String X509_TRUST_IDP_ALIAS = "conformance-attester-x509";
+    // The attester leaf certificate is generated with the emailProtection extended key usage.
+    private static final String ATTESTER_ATTESTATION_EKU = "1.3.6.1.5.5.7.3.4";
 
     @Override
     public RealmBuilder configure(RealmBuilder realm) {
@@ -108,7 +111,7 @@ public class VciConformanceRealmConfig implements RealmConfig {
                     }
                     components.add(KeyProvider.class.getName(), conformanceSigningKeyProvider());
                     components.add(KeyProvider.class.getName(), conformanceEcdhEncryptionKeyProvider());
-                    rep.setIdentityProviders(List.of(attesterTrustIdentityProvider()));
+                    rep.setIdentityProviders(List.of(attesterTrustIdentityProvider(), attesterX509TrustIdentityProvider()));
                 });
         return realm;
     }
@@ -126,13 +129,27 @@ public class VciConformanceRealmConfig implements RealmConfig {
         return trust;
     }
 
+    // Trusts the key attestation x5c certificate chain against the attester CA. Key attestations carry an x5c
+    // header, so Keycloak must be able to validate the chain against a configured X.509 trust domain.
+    private IdentityProviderRepresentation attesterX509TrustIdentityProvider() {
+        IdentityProviderRepresentation trust = new IdentityProviderRepresentation();
+        trust.setAlias(X509_TRUST_IDP_ALIAS);
+        trust.setProviderId(DefaultTrustIdentityProviderFactory.PROVIDER_ID);
+        trust.setEnabled(true);
+        trust.setConfig(Map.of(
+                DefaultTrustIdentityProviderConfig.USE_X509, "true",
+                DefaultTrustIdentityProviderConfig.TRUSTED_CERTIFICATES, VciAttesterKey.caCertificatePem(),
+                DefaultTrustIdentityProviderConfig.ATTESTATION_EXTENDED_KEY_USAGES, ATTESTER_ATTESTATION_EKU));
+        return trust;
+    }
+
     private ClientBuilder conformanceClient(String clientId, boolean wildcardRedirect) {
         return ClientBuilder.create(clientId)
                 .serviceAccountsEnabled(false)
                 .directAccessGrantsEnabled(false)
                 .authenticatorType(AttestationBasedClientAuthenticator.PROVIDER_ID)
                 .attribute(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS, TRUST_IDP_ALIAS)
-                .attribute(OID4VCIConstants.OID4VCI_ATTESTER_TRUST_IDPS_ATTR, TRUST_IDP_ALIAS)
+                .attribute(OID4VCIConstants.OID4VCI_ATTESTER_TRUST_IDPS_ATTR, TRUST_IDP_ALIAS + "," + X509_TRUST_IDP_ALIAS)
                 .defaultClientScopes("basic", "profile", "roles")
                 .optionalClientScopes(SD_JWT_SCOPE, "email")
                 .attribute(OID4VCI_ENABLED_ATTRIBUTE_KEY, "true")

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpVerifierKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vp/VpVerifierKey.java
@@ -23,8 +23,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 final class VpVerifierKey {
 
+    // The request-signing certificate is intentionally not restricted to a specific EKU.
     private static final ConformanceSigningKey KEY = ConformanceSigningKey.generate(
-            VpConformanceRealmConfig.REALM, "vp_verifier_key", "OID4VP Conformance Verifier");
+            VpConformanceRealmConfig.REALM, "vp_verifier_key", "OID4VP Conformance Verifier", null);
 
     private VpVerifierKey() {
     }


### PR DESCRIPTION
This PR fixes the OID4VCI conformance suite (IssuerKeyAttestationTest) failures after the key-attestation x5c validation hardening introduced in #51042.

The updated validation requires attester certificate chains to be resolved through trust-material identity providers instead of the server truststore. The conformance setup is updated to provide the required trust material and generate certificates compliant with the new validation rules.

**Key changes:**
- Add a `conformance-attester-x509` trust-material IdP to the VCI conformance realm, trusting the attester CA with the `emailProtection` attestation extended key usage, and configure the client `oid4vci.attester_trust_idps` attribute.

- Generate compliant test certificates in `ConformanceSigningKey`:
  - a v3 CA certificate with CA basic constraints and `keyCertSign` /  `cRLSign` key usages
  - an end-entity attestation certificate with digital signature usage and the required attestation EKU

- Remove the obsolete `truststore-paths` workaround from `IssuerKeyAttestationTest` and use the base server configuration.

Closes #51399