### PR TITLE
[OID4VCI]: Enforce ownership validation when deleting issued verifiable credentials via the account API

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -956,6 +956,11 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     @Override
+    public boolean removeIssuedVerifiableCredential(String userId, String credentialId) {
+        return getDelegate().removeIssuedVerifiableCredential(userId, credentialId);
+    }
+
+    @Override
     public void removeExpiredIssuedVerifiableCredentials() {
         getDelegate().removeExpiredIssuedVerifiableCredentials();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -1198,6 +1198,17 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         return true;
     }
 
+    @Override
+    public boolean removeIssuedVerifiableCredential(String userId, String credentialId) {
+        IssuedVerifiableCredentialEntity entity = em.find(IssuedVerifiableCredentialEntity.class, credentialId, LockModeType.PESSIMISTIC_WRITE);
+        if (entity == null || !userId.equals(entity.getUser().getId())) {
+            return false;
+        }
+        em.remove(entity);
+        em.flush();
+        return true;
+    }
+
     // Could override this to provide a custom behavior.
     protected void ensureEmailConstraint(List<UserEntity> users, RealmModel realm) {
         UserEntity user = users.get(0);

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -1206,6 +1206,18 @@ public class JpaUserFederatedStorageProvider implements
     }
 
     @Override
+    public boolean removeIssuedVerifiableCredential(String userId, String issuedCredentialId) {
+        FederatedUserIssuedVerifiableCredentialEntity entity = em.find(FederatedUserIssuedVerifiableCredentialEntity.class, issuedCredentialId);
+        if (entity == null || !userId.equals(entity.getUserId())) {
+            return false;
+        }
+
+        em.remove(entity);
+        em.flush();
+        return true;
+    }
+
+    @Override
     public void removeExpiredIssuedVerifiableCredentials() {
         long currentTime = Time.currentTimeMillis();
         int deletedCount = em.createNamedQuery("deleteExpiredFederatedIssuedVcs")

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -1207,7 +1207,7 @@ public class JpaUserFederatedStorageProvider implements
 
     @Override
     public boolean removeIssuedVerifiableCredential(String userId, String issuedCredentialId) {
-        FederatedUserIssuedVerifiableCredentialEntity entity = em.find(FederatedUserIssuedVerifiableCredentialEntity.class, issuedCredentialId);
+        FederatedUserIssuedVerifiableCredentialEntity entity = em.find(FederatedUserIssuedVerifiableCredentialEntity.class, issuedCredentialId, LockModeType.PESSIMISTIC_WRITE);
         if (entity == null || !userId.equals(entity.getUserId())) {
             return false;
         }

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -1017,6 +1017,14 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     }
 
     @Override
+    public boolean removeIssuedVerifiableCredential(String userId, String credentialId) {
+        if (StorageId.isLocalStorage(userId)) {
+            return localStorage().removeIssuedVerifiableCredential(userId, credentialId);
+        }
+        return getFederatedStorage() != null && getFederatedStorage().removeIssuedVerifiableCredential(userId, credentialId);
+    }
+
+    @Override
     public void removeExpiredIssuedVerifiableCredentials() {
         localStorage().removeExpiredIssuedVerifiableCredentials();
         if (getFederatedStorage() != null) getFederatedStorage().removeExpiredIssuedVerifiableCredentials();

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
@@ -100,6 +100,15 @@ public interface UserVerifiableCredentialFederatedStorage {
     boolean removeIssuedVerifiableCredential(String issuedCredentialId);
 
     /**
+     * Remove an issued verifiable credential by its ID if it belongs to the specified federated user.
+     *
+     * @param userId the ID of the federated user owning the credential
+     * @param issuedCredentialId the ID of the issued verifiable credential to remove
+     * @return true if removed, false if not found or not owned by the user
+     */
+    boolean removeIssuedVerifiableCredential(String userId, String issuedCredentialId);
+
+    /**
      *  Remove expired issued verifiable credentials for all users.
      */
     void removeExpiredIssuedVerifiableCredentials();

--- a/server-spi/src/main/java/org/keycloak/models/UserProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserProvider.java
@@ -382,6 +382,15 @@ public interface UserProvider extends Provider,
     boolean removeIssuedVerifiableCredential(String credentialId);
 
     /**
+     * Remove an issued verifiable credential by its ID if it belongs to the specified user.
+     *
+     * @param userId the ID of the user owning the credential
+     * @param credentialId the ID of the issued credential to remove
+     * @return {@code true} if the credential was removed, {@code false} if it was not found or does not belong to the user
+     */
+    boolean removeIssuedVerifiableCredential(String userId, String credentialId);
+
+    /**
      * Remove all expired issued verifiable credentials across all realms.
      * This is called periodically by the scheduled cleanup task.
      */

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
@@ -97,7 +97,7 @@ public class AccountIssuedVerifiableCredentialResource {
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.MANAGE_VERIFIABLE_CREDENTIALS);
         checkOid4VCIEnabled();
 
-        boolean removed = session.users().removeIssuedVerifiableCredential(credentialId);
+        boolean removed = session.users().removeIssuedVerifiableCredential(user.getId(), credentialId);
         if (!removed) {
             logger.warn(String.format("Issued credential with ID '%s' not found for user '%s' in the realm '%s'.", credentialId, user.getUsername(), realm.getName()));
             throw new NotFoundException("Issued credential not found");

--- a/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceRolesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceRolesTest.java
@@ -15,6 +15,8 @@ import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.Profile;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.Constants;
+import org.keycloak.models.IssuedVerifiableCredentialModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -25,6 +27,8 @@ import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
@@ -39,6 +43,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -64,6 +69,9 @@ public class AccountRestServiceRolesTest {
 
     @InjectHttpClient
     CloseableHttpClient httpClient;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
 
     @Test
     public void applicationsEndpointAccess() throws IOException {
@@ -95,6 +103,35 @@ public class AccountRestServiceRolesTest {
         assertEndpointStatus("view-verifiable-credentials-user", "issued-verifiable-credentials", 200);
         assertEndpointStatus("manage-verifiable-credentials-user", "issued-verifiable-credentials", 200);
         assertEndpointStatus("no-access-user", "issued-verifiable-credentials", 403);
+    }
+
+    @Test
+    public void revokeIssuedCredentialOwnershipEnforced() throws IOException {
+        String userA = "manage-account-user";
+        String userB = "other-manage-account-user";
+        String userIdB = realm.admin().users().searchByUsername(userB, true).get(0).getId();
+
+        String credentialIdB = createIssuedVerifiableCredential(userIdB);
+
+        // User A must not be able to revoke a credential issued to User B
+        assertDeleteEndpointStatus(userA, credentialIdB, 404);
+        assertEquals(1, countIssuedCredentials(userIdB), "Credential of User B must not be deleted by User A");
+
+        // User B can revoke its own credential
+        assertDeleteEndpointStatus(userB, credentialIdB, 204);
+        assertEquals(0, countIssuedCredentials(userIdB), "Credential of User B should be deleted by its owner");
+
+        // Revoking an already removed credential is reported as not found
+        assertDeleteEndpointStatus(userB, credentialIdB, 404);
+    }
+
+    @Test
+    public void revokeIssuedCredentialRoleEnforced() throws IOException {
+        String userId = realm.admin().users().searchByUsername("manage-account-user", true).get(0).getId();
+        String credentialId = createIssuedVerifiableCredential(userId);
+
+        assertDeleteEndpointStatus("no-access-user", credentialId, 403);
+        assertEquals(1, countIssuedCredentials(userId), "Credential must not be deleted without the required role");
     }
 
     @Test
@@ -242,6 +279,36 @@ public class AccountRestServiceRolesTest {
         return existing + "; " + additional;
     }
 
+    private String createIssuedVerifiableCredential(String userId) {
+        return runOnServer.fetch(session -> {
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(null, "test-scope");
+            vcModel.setRevision("rev-1");
+            UserVerifiableCredentialModel addedVc = session.users().addVerifiableCredential(userId, vcModel);
+
+            IssuedVerifiableCredentialModel issuedVc = new IssuedVerifiableCredentialModel(userId, addedVc.getId(), "wallet-client");
+            issuedVc.setRevision("rev-1");
+            return session.users().addIssuedVerifiableCredential(issuedVc).getId();
+        }, String.class);
+    }
+
+    private long countIssuedCredentials(String userId) {
+        return runOnServer.fetch(session -> session.users().getIssuedVerifiableCredentialsStreamByUser(userId).count(), Long.class);
+    }
+
+    private void assertDeleteEndpointStatus(String username, String credentialId, int expectedStatus) throws IOException {
+        AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest(username, PASSWORD);
+        assertTrue(tokenResponse.isSuccess(), "Token request failed for " + username + ": " + tokenResponse.getErrorDescription());
+
+        HttpDelete request = new HttpDelete(realm.getBaseUrl() + "/account/issued-verifiable-credentials/" + credentialId);
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.getAccessToken());
+        request.addHeader(HttpHeaders.ACCEPT, "application/json");
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            assertEquals(expectedStatus, response.getStatusLine().getStatusCode(),
+                    "Unexpected status for DELETE issued-verifiable-credentials with user " + username);
+        }
+    }
+
     private void assertEndpointStatus(String username, String endpoint, int expectedStatus) throws IOException {
         AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest(username, PASSWORD);
         assertTrue(tokenResponse.isSuccess(), "Token request failed for " + username + ": " + tokenResponse.getErrorDescription());
@@ -299,7 +366,12 @@ public class AccountRestServiceRolesTest {
                         .name("Manage", "VerifiableCredentials")
                         .email("manage-verifiable-credentials@localhost")
                         .password(PASSWORD)
-                        .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.MANAGE_VERIFIABLE_CREDENTIALS, AccountRoles.VIEW_PROFILE));
+                        .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.MANAGE_VERIFIABLE_CREDENTIALS, AccountRoles.VIEW_PROFILE),
+                    UserBuilder.create("other-manage-account-user")
+                        .name("Other", "ManageAccount")
+                        .email("other-manage-account@localhost")
+                        .password(PASSWORD)
+                        .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE));
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedIssuedVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedIssuedVerifiableCredentialTest.java
@@ -20,6 +20,7 @@ import org.keycloak.tests.suites.DatabaseTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -100,6 +101,45 @@ public class FederatedIssuedVerifiableCredentialTest extends AbstractUserTest {
         runOnServer.run(session -> {
             long count = session.users().getIssuedVerifiableCredentialsStreamByUser(federatedUserId).count();
             assertEquals(0, count);
+        });
+    }
+
+    @Test
+    @DatabaseTest
+    public void testRemoveIssuedCredentialForFederatedUserScopedToOwner() {
+        String federatedUserId = createFederatedUser("fed-user-scoped-owner");
+        String otherFederatedUserId = createFederatedUser("fed-user-scoped-other");
+        String clientId = createTestClient("wallet-client");
+        String scopeId = resolveScopeId(CLIENT_SCOPE_NAME_1);
+
+        // Add VC and Issued VC for the owner, get Issued VC Id
+        String issuedVcId = runOnServer.fetchString(session -> {
+            UserVerifiableCredentialModel addedVC = session.users().addVerifiableCredential(federatedUserId, new UserVerifiableCredentialModel("vc_01", scopeId));
+            IssuedVerifiableCredentialModel issuedVc = new IssuedVerifiableCredentialModel(federatedUserId, addedVC.getId(), clientId);
+            issuedVc.setRevision("rev-001");
+            return session.users().addIssuedVerifiableCredential(issuedVc).getId();
+        });
+
+        // A non-owner federated user must not be able to remove the credential
+        runOnServer.run(session -> {
+            boolean removed = session.users().removeIssuedVerifiableCredential(otherFederatedUserId, issuedVcId);
+            assertFalse(removed);
+        });
+        runOnServer.run(session -> {
+            long count = session.users().getIssuedVerifiableCredentialsStreamByUser(federatedUserId).count();
+            assertEquals(1, count);
+        });
+
+        // The owner can remove the credential
+        runOnServer.run(session -> {
+            boolean removed = session.users().removeIssuedVerifiableCredential(federatedUserId, issuedVcId);
+            assertTrue(removed);
+        });
+
+        // Removing a non-existent or already removed credential returns false
+        runOnServer.run(session -> {
+            assertFalse(session.users().removeIssuedVerifiableCredential(federatedUserId, issuedVcId));
+            assertFalse(session.users().removeIssuedVerifiableCredential(federatedUserId, "non-existent-id"));
         });
     }
 


### PR DESCRIPTION
This PR fixes an object-level authorization gap in the account REST API where the delete endpoint for issued verifiable credentials performed a global primary-key lookup and removal without verifying ownership of the credential.

**Key changes:**
- Added a user-scoped removeIssuedVerifiableCredential(userId, credentialId) method to the UserProvider SPI and UserVerifiableCredentialFederatedStorage, implemented with an atomic lock-protected ownership check in the JPA local and federated providers.
- Routed scoped credential removal through UserStorageManager and UserCacheSession, preserving local and federated storage handling.
- Updated AccountIssuedVerifiableCredentialResource#delete to remove only credentials owned by the authenticated user and return 404 for unauthorized access, matching the list endpoint authorization behavior.
- Added integration tests covering cross-user deletion attempts, successful owner deletion, and missing-role authorization checks.

Closes #50368