### PR TITLE
Disallow protocol change via Registration Access Token

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -178,6 +178,18 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier modified", Response.Status.BAD_REQUEST);
         }
 
+        if (auth.isRegistrationAccessToken()) {
+            String existingProtocol = client.getProtocol();
+            String requestedProtocol = rep.getProtocol();
+            if (requestedProtocol != null && !requestedProtocol.equals(existingProtocol)) {
+                throw new ErrorResponseException(
+                        "invalid_client_metadata",
+                        "Protocol cannot be changed via registration access token",
+                        Response.Status.BAD_REQUEST
+                );
+            }
+        }
+
         ClientResource.updateClientServiceAccount(session, client, rep.isServiceAccountsEnabled());
         RepresentationToModel.updateClient(rep, client, session);
         RepresentationToModel.updateClientProtocolMappers(rep, client);

--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -183,7 +183,7 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
             String requestedProtocol = rep.getProtocol();
             if (requestedProtocol != null && !requestedProtocol.equals(existingProtocol)) {
                 throw new ErrorResponseException(
-                        "invalid_client_metadata",
+                        ErrorCodes.INVALID_CLIENT_METADATA,
                         "Protocol cannot be changed via registration access token",
                         Response.Status.BAD_REQUEST
                 );

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationTest.java
@@ -425,6 +425,73 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
         assertFalse(authzSettings.getPolicies().isEmpty());
     }
 
+    // -- regression test: Issue #51340 -----------------------------------------------
+// A holder of a registration access token must NOT be able to switch the protocol
+// of an already-registered OIDC client to SAML via a DCR PUT.
+    @Test
+    public void updateProtocolViaRegistrationTokenShouldBeRejected() throws ClientRegistrationException {
+        // Register an OIDC client using manage-clients bearer token; capture the RAT.
+        authManageClients();
+        ClientRepresentation created = reg.create(buildClient());
+        assertEquals("openid-connect", created.getProtocol());
+
+        // Switch auth context to the registration access token of that client.
+        reg.auth(Auth.token(created.getRegistrationAccessToken()));
+
+        // Attempt to change protocol to saml — must be rejected with 400.
+        ClientRepresentation update = new ClientRepresentation();
+        update.setClientId(created.getClientId());
+        update.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
+
+        try {
+            reg.update(update);
+            fail("Expected ClientRegistrationException — protocol change via RAT must be rejected");
+        } catch (ClientRegistrationException e) {
+            HttpErrorException cause = (HttpErrorException) e.getCause();
+            assertThat(cause.getStatusLine().getStatusCode(), is(400));
+
+            OAuth2ErrorRepresentation errorRep =
+                    null;
+            try {
+                errorRep = JsonSerialization.readValue(cause.getErrorResponse(), OAuth2ErrorRepresentation.class);
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            assertThat(errorRep.getError(), is(INVALID_CLIENT_METADATA));
+            assertThat(errorRep.getErrorDescription(), CoreMatchers.containsString("Protocol cannot be changed"));
+        }
+
+        // Verify the protocol is still openid-connect — no mutation reached the DB.
+        reg.auth(Auth.token(created.getRegistrationAccessToken()));
+        ClientRepresentation afterAttempt = reg.get(created.getClientId());
+        assertThat(afterAttempt.getProtocol(), is("openid-connect"));
+
+        // Cleanup
+        authManageClients();
+        reg.delete(created.getClientId());
+    }
+
+    // Positive counterpart: an admin bearer token IS allowed to change protocol.
+// This ensures the guard only blocks RAT callers, not legitimate admin updates.
+    @Test
+    public void updateProtocolViaAdminTokenShouldSucceed() throws ClientRegistrationException {
+        authManageClients();
+        ClientRepresentation created = reg.create(buildClient());
+        assertEquals("openid-connect", created.getProtocol());
+
+        // Re-auth as manage-clients admin, not via RAT.
+        authManageClients();
+        ClientRepresentation update = reg.get(created.getClientId());
+        update.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
+
+        ClientRepresentation updated = reg.update(update);
+        assertThat(updated.getProtocol(), is(SamlProtocol.LOGIN_PROTOCOL));
+
+        // Cleanup
+        authManageClients();
+        reg.delete(created.getClientId());
+    }
+
     private void testClientUriValidation(String expectedRootUrlError, String expectedBaseUrlError, String expectedBackchannelLogoutUrlError, String expectedRedirectUrisError, String... testUrls) {
         testClientUriValidation(true, expectedRootUrlError, expectedBaseUrlError, expectedBackchannelLogoutUrlError, expectedRedirectUrisError, testUrls);
         testClientUriValidation(false, expectedRootUrlError, expectedBaseUrlError, expectedBackchannelLogoutUrlError, expectedRedirectUrisError, testUrls);

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationTest.java
@@ -425,20 +425,16 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
         assertFalse(authzSettings.getPolicies().isEmpty());
     }
 
-    // -- regression test: Issue #51340 -----------------------------------------------
-// A holder of a registration access token must NOT be able to switch the protocol
-// of an already-registered OIDC client to SAML via a DCR PUT.
+    //#51340
     @Test
     public void updateProtocolViaRegistrationTokenShouldBeRejected() throws ClientRegistrationException {
         // Register an OIDC client using manage-clients bearer token; capture the RAT.
         authManageClients();
-        ClientRepresentation created = reg.create(buildClient());
+        ClientRepresentation created = registerClient(buildClient(), true);
         assertEquals("openid-connect", created.getProtocol());
-
-        // Switch auth context to the registration access token of that client.
         reg.auth(Auth.token(created.getRegistrationAccessToken()));
 
-        // Attempt to change protocol to saml — must be rejected with 400.
+        // Attempt to change protocol to saml (should be rejected with 400)
         ClientRepresentation update = new ClientRepresentation();
         update.setClientId(created.getClientId());
         update.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
@@ -450,8 +446,7 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
             HttpErrorException cause = (HttpErrorException) e.getCause();
             assertThat(cause.getStatusLine().getStatusCode(), is(400));
 
-            OAuth2ErrorRepresentation errorRep =
-                    null;
+            OAuth2ErrorRepresentation errorRep;
             try {
                 errorRep = JsonSerialization.readValue(cause.getErrorResponse(), OAuth2ErrorRepresentation.class);
             } catch (IOException ex) {
@@ -461,22 +456,16 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
             assertThat(errorRep.getErrorDescription(), CoreMatchers.containsString("Protocol cannot be changed"));
         }
 
-        // Verify the protocol is still openid-connect — no mutation reached the DB.
+        // Verify the protocol is still openid-connect
         reg.auth(Auth.token(created.getRegistrationAccessToken()));
         ClientRepresentation afterAttempt = reg.get(created.getClientId());
         assertThat(afterAttempt.getProtocol(), is("openid-connect"));
-
-        // Cleanup
-        authManageClients();
-        reg.delete(created.getClientId());
     }
 
-    // Positive counterpart: an admin bearer token IS allowed to change protocol.
-// This ensures the guard only blocks RAT callers, not legitimate admin updates.
     @Test
     public void updateProtocolViaAdminTokenShouldSucceed() throws ClientRegistrationException {
         authManageClients();
-        ClientRepresentation created = reg.create(buildClient());
+        ClientRepresentation created = registerClient(buildClient(), true);
         assertEquals("openid-connect", created.getProtocol());
 
         // Re-auth as manage-clients admin, not via RAT.
@@ -486,10 +475,6 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
 
         ClientRepresentation updated = reg.update(update);
         assertThat(updated.getProtocol(), is(SamlProtocol.LOGIN_PROTOCOL));
-
-        // Cleanup
-        authManageClients();
-        reg.delete(created.getClientId());
     }
 
     private void testClientUriValidation(String expectedRootUrlError, String expectedBaseUrlError, String expectedBackchannelLogoutUrlError, String expectedRedirectUrisError, String... testUrls) {


### PR DESCRIPTION
Closes #51340 

Added check to in [AbstractClientRegistrationProvider.update()](vscode-webview://0id6731fquae15j5fs85j5sd597fpahgnp4d08q9ejqgmmu6ebh7/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java:181) that rejects any attempt to change a client's protocol field when the caller authenticates with a Registration Access Token, preventing an OIDC client from being silently converted to SAML via DCR.