### PR TITLE
Complete Identity Provider DSL support in test framework

### DIFF
--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/IdentityProviderBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/IdentityProviderBuilder.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.testframework.realm;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
@@ -98,12 +97,6 @@ public class IdentityProviderBuilder extends Builder<IdentityProviderRepresentat
     public IdentityProviderBuilder attribute(String name, String value) {
         rep.setConfig(createIfNull(rep.getConfig(), HashMap::new));
         rep.getConfig().put(name, value);
-        return this;
-    }
-
-    public IdentityProviderBuilder type(String type) {
-        rep.setTypes(createIfNull(rep.getTypes(), ArrayList::new));
-        rep.getTypes().add(type);
         return this;
     }
 

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/IdentityProviderBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/IdentityProviderBuilder.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testframework.realm;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
@@ -64,9 +65,45 @@ public class IdentityProviderBuilder extends Builder<IdentityProviderRepresentat
         return this;
     }
 
+    public IdentityProviderBuilder enabled(boolean enabled) {
+        rep.setEnabled(enabled);
+        return this;
+    }
+
+    public IdentityProviderBuilder trustEmail(boolean trustEmail) {
+        rep.setTrustEmail(trustEmail);
+        return this;
+    }
+
+    public IdentityProviderBuilder linkOnly(boolean linkOnly) {
+        rep.setLinkOnly(linkOnly);
+        return this;
+    }
+
+    public IdentityProviderBuilder firstBrokerLoginFlowAlias(String firstBrokerLoginFlowAlias) {
+        rep.setFirstBrokerLoginFlowAlias(firstBrokerLoginFlowAlias);
+        return this;
+    }
+
+    public IdentityProviderBuilder postBrokerLoginFlowAlias(String postBrokerLoginFlowAlias) {
+        rep.setPostBrokerLoginFlowAlias(postBrokerLoginFlowAlias);
+        return this;
+    }
+
+    public IdentityProviderBuilder organizationId(String organizationId) {
+        rep.setOrganizationId(organizationId);
+        return this;
+    }
+
     public IdentityProviderBuilder attribute(String name, String value) {
         rep.setConfig(createIfNull(rep.getConfig(), HashMap::new));
         rep.getConfig().put(name, value);
+        return this;
+    }
+
+    public IdentityProviderBuilder type(String type) {
+        rep.setTypes(createIfNull(rep.getTypes(), ArrayList::new));
+        rep.getTypes().add(type);
         return this;
     }
 

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/IdentityProviderMapperBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/IdentityProviderMapperBuilder.java
@@ -1,0 +1,41 @@
+package org.keycloak.testframework.realm;
+
+import java.util.HashMap;
+
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+
+public class IdentityProviderMapperBuilder extends Builder<IdentityProviderMapperRepresentation> {
+
+    private IdentityProviderMapperBuilder(IdentityProviderMapperRepresentation rep) {
+        super(rep);
+    }
+
+    public static IdentityProviderMapperBuilder create() {
+        return new IdentityProviderMapperBuilder(new IdentityProviderMapperRepresentation());
+    }
+
+    public IdentityProviderMapperBuilder name(String name) {
+        rep.setName(name);
+        return this;
+    }
+
+    public IdentityProviderMapperBuilder identityProviderAlias(String identityProviderAlias) {
+        rep.setIdentityProviderAlias(identityProviderAlias);
+        return this;
+    }
+
+    public IdentityProviderMapperBuilder identityProviderMapper(String identityProviderMapper) {
+        rep.setIdentityProviderMapper(identityProviderMapper);
+        return this;
+    }
+
+    public IdentityProviderMapperBuilder attribute(String name, String value) {
+        rep.setConfig(createIfNull(rep.getConfig(), HashMap::new));
+        rep.getConfig().put(name, value);
+        return this;
+    }
+
+    public IdentityProviderMapperRepresentation build() {
+        return rep;
+    }
+}

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/RealmBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/RealmBuilder.java
@@ -159,6 +159,11 @@ public class RealmBuilder extends Builder<RealmRepresentation> {
         return this;
     }
 
+    public RealmBuilder identityProviderMappers(IdentityProviderMapperBuilder... identityProviderMappers) {
+        rep.setIdentityProviderMappers(combine(rep.getIdentityProviderMappers(), identityProviderMappers));
+        return this;
+    }
+
     public RealmBuilder loginWithEmailAllowed(boolean loginWithEmailAllowed) {
         rep.setLoginWithEmailAllowed(loginWithEmailAllowed);
         return this;

--- a/test-framework/builders/src/test/java/org/keycloak/testframework/realm/RealmBuilderTest.java
+++ b/test-framework/builders/src/test/java/org/keycloak/testframework/realm/RealmBuilderTest.java
@@ -1,0 +1,57 @@
+package org.keycloak.testframework.realm;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+
+public class RealmBuilderTest {
+
+    @Test
+    public void builderCombineIdentityProviderMappers() {
+        IdentityProviderMapperBuilder builder1 = IdentityProviderMapperBuilder.create()
+                .attribute("TEST_ATTRIBUTE_A", "TEST_VALUE_A")
+                .attribute("TEST_ATTRIBUTE_B", "TEST_VALUE_B")
+                .identityProviderAlias("TEST_ALIAS")
+                .identityProviderMapper("TEST_MAPPER")
+                .name("TEST_NAME");
+
+        RealmBuilder realmBuilder = RealmBuilder.create().identityProviderMappers(builder1);
+        List<IdentityProviderMapperRepresentation> ipmrList = realmBuilder.build().getIdentityProviderMappers();
+        Assertions.assertEquals(1, ipmrList.size());
+        
+        // Checks if the mapper has been build correctly
+        IdentityProviderMapperRepresentation ipmr = ipmrList.stream().filter(i -> i.getName().equals("TEST_NAME")).findFirst().get();
+        Assertions.assertEquals("TEST_NAME", ipmr.getName());
+        Assertions.assertEquals("TEST_MAPPER", ipmr.getIdentityProviderMapper());
+        Assertions.assertEquals("TEST_ALIAS", ipmr.getIdentityProviderAlias());
+        Assertions.assertEquals(Map.of("TEST_ATTRIBUTE_A", "TEST_VALUE_A", "TEST_ATTRIBUTE_B", "TEST_VALUE_B"), ipmr.getConfig());
+
+        IdentityProviderMapperBuilder builder2 = IdentityProviderMapperBuilder.create()
+                .attribute("TEST_ATTRIBUTE_2", "TEST_VALUE_2")
+                .identityProviderAlias("TEST_ALIAS_2")
+                .identityProviderMapper("TEST_MAPPER_2")
+                .name("TEST_NAME_2");
+        realmBuilder.identityProviderMappers(builder2);
+
+        ipmrList = realmBuilder.build().getIdentityProviderMappers();
+        Assertions.assertEquals(2, ipmrList.size());
+        
+        // Checks if the first mapper is still there
+        ipmr = ipmrList.stream().filter(i -> i.getName().equals("TEST_NAME")).findFirst().get();
+        Assertions.assertEquals("TEST_NAME", ipmr.getName());
+        Assertions.assertEquals("TEST_MAPPER", ipmr.getIdentityProviderMapper());
+        Assertions.assertEquals("TEST_ALIAS", ipmr.getIdentityProviderAlias());
+        Assertions.assertEquals(Map.of("TEST_ATTRIBUTE_A", "TEST_VALUE_A", "TEST_ATTRIBUTE_B", "TEST_VALUE_B"), ipmr.getConfig());
+
+        // Checks if the second mapper has been added correctly
+        ipmr = ipmrList.stream().filter(i -> i.getName().equals("TEST_NAME_2")).findFirst().get();
+        Assertions.assertEquals("TEST_NAME_2", ipmr.getName());
+        Assertions.assertEquals("TEST_MAPPER_2", ipmr.getIdentityProviderMapper());
+        Assertions.assertEquals("TEST_ALIAS_2", ipmr.getIdentityProviderAlias());
+        Assertions.assertEquals(Map.of("TEST_ATTRIBUTE_2", "TEST_VALUE_2"), ipmr.getConfig());
+
+    }
+}

--- a/test-framework/builders/src/test/java/org/keycloak/testframework/realm/RealmBuilderTest.java
+++ b/test-framework/builders/src/test/java/org/keycloak/testframework/realm/RealmBuilderTest.java
@@ -3,9 +3,10 @@ package org.keycloak.testframework.realm;
 import java.util.List;
 import java.util.Map;
 
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 
 public class RealmBuilderTest {
 


### PR DESCRIPTION
This PR completes the Identity Provider DSL in the Keycloak Test Framework.

It includes:

- additional configuration methods in IdentityProviderBuilder for properties already available in IdentityProviderRepresentation but not mapped in the builder
- a new IdentityProviderMapperBuilder for IdentityProviderMapperRepresentation building
- a RealmBuilder overload accepting IdentityProviderMapperBuilder instances

The changes allow complete broker configurations to be expressed using the fluent Realm DSL without directly manipulating representation classes.

Closes #51359
