### PR TITLE
Fix SCIM filter case-insensitive matching for attributes stored in lowercase

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/resource/schema/attribute/Attribute.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/schema/attribute/Attribute.java
@@ -105,6 +105,7 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
     private Class<?> complexType;
     private boolean required;
     private boolean caseExact;
+    private boolean storedLowerCase;
     private String uniqueness;
 
     private Attribute(String name, AttributeMapper<M, R> mapper, String parentName, String alias) {
@@ -215,6 +216,14 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
 
     public boolean isCaseExact() {
         return caseExact;
+    }
+
+    private void setStoredLowerCase(boolean storedLowerCase) {
+        this.storedLowerCase = storedLowerCase;
+    }
+
+    public boolean isStoredLowerCase() {
+        return storedLowerCase;
     }
 
     public void setUniqueness(String uniqueness) {
@@ -345,6 +354,7 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
         private TriConsumer<M, String, Set<?>> modelAdder;
         private boolean required;
         private boolean caseExact = true;
+        private boolean storedLowerCase;
         private String uniqueness = "none";
 
         private Builder(String name, Class<?> complexType) {
@@ -424,6 +434,7 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
             Attribute<M, R> attribute = assembleAttribute(name, null, null,
                     new AttributeMapper<>(modelSetter, representationSetter, modelRemover, modelAdder),
                     modelAttributeResolver, type, mutability, returned, multivalued, required, caseExact, uniqueness, complexType);
+            attribute.setStoredLowerCase(storedLowerCase);
             if (attributes.isEmpty()) {
                 // do not add the root attribute if there are subattributes
                 attributes.add(attribute);
@@ -477,6 +488,11 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
 
         public Builder<M, R> notCaseExact() {
             this.caseExact = false;
+            return this;
+        }
+
+        public Builder<M, R> storedLowerCase() {
+            this.storedLowerCase = true;
             return this;
         }
 

--- a/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateProvider.java
@@ -140,9 +140,13 @@ public class ScimJPAPredicateProvider {
             basePredicate = cb.equal(join.get("name"), modelAttributeName);
         }
 
-        if (value != null && !attrInfo.isCaseExact() && "string".equals(attrInfo.getType())) {
+        // compare case-insensitive attributes in lowercase. Attributes the model already stores in lowercase
+        // are compared directly so the database can use indexes on the column
+        if (value instanceof String && !attrInfo.isCaseExact()) {
             value = value.toString().toLowerCase();
-            expression = cb.lower((Expression<String>) expression);
+            if (!attrInfo.isStoredLowerCase()) {
+                expression = cb.lower((Expression<String>) expression);
+            }
         }
 
         Predicate predicate = operatorMap.get(operation).apply(cb, expression, value);

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
@@ -58,6 +58,7 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
         attributes.addAll(Attribute.<UserModel, User>simple("userName")
                 .required()
                 .notCaseExact()
+                .storedLowerCase()
                 .serverUnique()
                 .modelAttributeResolver(this::createModelAttributeResolver)
                 .withModelSetter(UserModel::setSingleAttribute)
@@ -65,6 +66,7 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
         attributes.addAll(Attribute.<UserModel, User>complex("emails", Email.class)
                 .modelAttributeResolver(this::createModelAttributeResolver)
                 .notCaseExact()
+                .storedLowerCase()
                 .globalUnique()
                 .multivalued()
                 .withModelSetter((TriConsumer<UserModel, String, Set<Email>>) (model, name, values) -> {

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -100,6 +100,27 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
+    public void testFiltersAreCaseInsensitiveForNotCaseExactAttributes() {
+        User bob = createUser("bob", "bob@keycloak.org");
+        createUser("alice", "alice@keycloak.org");
+
+        String filter = ResourceFilter.filter().eq("userName", "BOB").build();
+        assertSingleResult(client.users().getAll(filter), bob.getUserName());
+
+        filter = ResourceFilter.filter().eq("emails.value", "BOB@KEYCLOAK.ORG").build();
+        assertSingleResult(client.users().getAll(filter), bob.getUserName());
+
+        filter = ResourceFilter.filter().eq("emails", "Bob@Keycloak.org").build();
+        assertSingleResult(client.users().getAll(filter), bob.getUserName());
+
+        filter = ResourceFilter.filter().sw("emails.value", "BOB@").build();
+        assertSingleResult(client.users().getAll(filter), bob.getUserName());
+
+        filter = ResourceFilter.filter().co("userName", "OB").build();
+        assertSingleResult(client.users().getAll(filter), bob.getUserName());
+    }
+
+    @Test
     public void testNotEqualFilter() {
         User bob = createUser("bob");
         User alice = createUser("alice");


### PR DESCRIPTION
For `userName` the predicate builder was wrapping the column in `LOWER()` for every non caseExact string attribute. Usernames are already stored in lowercase so lowering the filter value and comparing the column directly means Postgres can use the `(realm_id, username)` index again. It's actually the same thing that `JpaUserProvider.predicates()` does for username and e-mail.

The old condition only applied attributes of type string but `emails.value` resolves to the emails complex attribute meaning the value never got lowered and an uppwercase filter just matched nothing against the stored lowercase email. 

Also I left group `displayName` alone since the issue points out case insensitive matching there might not even be the right semantics but can include that too if wanted.

The schema declares which attributes the model stores in lowercase through the new `storedLowerCase()` builder flag, set on `userName` and `emails`. 

Testing

- Added new `FilterTest` case covering uppercase `userName eq`,  `emails.value eq`, mixed case `emails eq` and `sw` & `co` variants which fails without the fix and the full `FilterTest` suite passes with it (34/34)
- Verified on a real server, Postgres 16, and seeded users

Before
`filter=emails.value eq "TESTUSER@EXAMPLE.COM"` returns `totalResults: 0` while lowercase value returns the user
Server emits `where lower(ue1_0.USERNAME)=?`  EXPLAIN ANALYZE: Seq Scan in104.5 ms at 50k users.

After
Both return the user
Server emits `where ue1_0.USERNAME=?`  Index Scan using the unique index in 0.18 ms