### PR TITLE
Suppress noisy JacksonCodeGenerator INFO log messages during build

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -30,6 +30,7 @@ quarkus.log.category."io.quarkus.arc.processor.BeanArchives".level=off
 quarkus.log.category."io.quarkus.arc.processor.IndexClassLookupUtils".level=off
 quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
 quarkus.log.category."io.quarkus.deployment.steps.ReflectiveHierarchyStep".level=error
+quarkus.log.category."io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator".level=warn
 
 # Disable irrelevant EDB warning: EnterpriseDB does not store DATE columns. Instead, it auto-converts them to TIMESTAMPs. (edb_redwood_date=true)
 quarkus.log.category."liquibase.database.core.PostgresDatabase".level=error


### PR DESCRIPTION
- Closes #51446

Final output: 
```
Updating the configuration and installing your custom providers, if any. Please wait.
2026-08-05 09:19:20,356 WARN  [org.keycloak.common.Profile] (build-41) Deprecated features identity-brokering-api:v1, twitter-broker:v1 enabled by default. Check the upgrading guide for steps to use later versions if available.
2026-08-05 09:19:22,039 INFO  [org.freedesktop.dbus.connections.transports.TransportBuilder] (build-27) Using transport dbus-java-transport-native-unixsocket for address unix:path=/var/run/dbus/system_bus_socket
2026-08-05 09:19:25,329 INFO  [io.quarkus.deployment.QuarkusAugmentor] (main) Quarkus augmentation completed in 9720ms
Running the server in development mode. DO NOT use this configuration in production.
2026-08-05 09:19:29,786 INFO  [org.infinispan.CONTAINER] (main) ISPN000974: Virtual threads support: enabled
2026-08-05 09:19:31,097 INFO  [org.hibernate.orm.jdbc.batch] (JPA Startup Thread) HHH100501: Automatic JDBC statement batching enabled (maximum batch size 32)
2026-08-05 09:19:31,145 WARN  [org.keycloak.common.Profile] (main) Deprecated features identity-brokering-api:v1, twitter-broker:v1 enabled by default. Check the upgrading guide for steps to use later versions if available.
2026-08-05 09:19:32,202 INFO  [org.keycloak.quarkus.runtime.storage.database.liquibase.QuarkusJpaUpdaterProvider] (main) Initializing database schema. Using changelog META-INF/jpa-changelog-master.xml
2026-08-05 09:19:36,461 INFO  [org.infinispan.CONTAINER] (main) ISPN000556: Starting user marshaller 'org.infinispan.commons.marshall.ImmutableProtoStreamMarshaller'
2026-08-05 09:19:36,888 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Node name: node_294181, Site name: null, Cluster name: ISPN
2026-08-05 09:19:37,050 INFO  [org.keycloak.quarkus.runtime.storage.database.jpa.DatabaseIndexChecker] (db-index-checker) Running database index checker
2026-08-05 09:19:37,090 INFO  [org.keycloak.models.workflow.WorkflowsEventListenerFactory] (main) Workflow runner task scheduled: next execution at 21:19:37, then every PT12H
2026-08-05 09:19:37,226 INFO  [org.keycloak.services] (main) KC-SERVICES0050: Initializing master realm
2026-08-05 09:19:39,066 INFO  [org.keycloak.services.resources.KeycloakApplication] (main) Bootstrap completed in 7.919 seconds
2026-08-05 09:19:39,211 INFO  [io.quarkus] (main) Keycloak 999.0.0-SNAPSHOT on JVM (powered by Quarkus 3.38.0) started in 13.710s. Listening on: http://localhost:8080
2026-08-05 09:19:39,211 INFO  [io.quarkus] (main) Profile dev activated. 
2026-08-05 09:19:39,211 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, jdbc-h2, keycloak, narayana-jta, opentelemetry, rest, rest-jackson, smallrye-context-propagation, vertx]
^C2026-08-05 09:19:44,751 INFO  [com.arjuna.ats.jbossatx] (Shutdown thread) ARJUNA032014: Stopping transaction recovery manager
2026-08-05 09:19:44,864 INFO  [io.quarkus] (Shutdown thread) Keycloak stopped in 1.139s
```

No logs like: 
```
[INFO] [io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator] Skipping generation of reflection-free Jackson serializer for class org.keycloak.representations.idm.authorization.AuthorizationSchema because it contains the unsupported Jackson annotation com.fasterxml.jackson.databind.annotation.JsonDeserialize
[INFO] [io.quarkus.resteasy.reactive.jackson.deployment.processor.JacksonCodeGenerator] Skipping generation of reflection-free Jackson serializer for class org.keycloak.representations.idm.authorization.ResourceRepresentation because it contains the unsupported Jackson annotation com.fasterxml.jackson.databind.annotation.JsonDeserialize
...
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

@keycloak/cloud-native Could you please check this small PR? Thanks!