### PR TITLE
fix(admin-ui-ext): include representation in role mapping delete events

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
@@ -58,13 +58,7 @@ public class RoleMappingDeleteResource {
         }
         auth.groups().requireManageMembership(group);
 
-        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> group.deleteRoleMapping(role));
-
-        adminEvent.operation(OperationType.DELETE)
-                .resourcePath(session.getContext().getUri())
-                .resource(ResourceType.REALM_ROLE_MAPPING)
-                .representation(reps)
-                .success();
+        deleteRoleMappings(roles, role -> group.deleteRoleMapping(role), ResourceType.REALM_ROLE_MAPPING, ResourceType.CLIENT_ROLE_MAPPING);
     }
 
     @POST
@@ -84,13 +78,7 @@ public class RoleMappingDeleteResource {
         }
         auth.users().requireMapRoles(user);
 
-        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> user.deleteRoleMapping(role));
-
-        adminEvent.operation(OperationType.DELETE)
-                .resourcePath(session.getContext().getUri())
-                .resource(ResourceType.REALM_ROLE_MAPPING)
-                .representation(reps)
-                .success();
+        deleteRoleMappings(roles, role -> user.deleteRoleMapping(role), ResourceType.REALM_ROLE_MAPPING, ResourceType.CLIENT_ROLE_MAPPING);
     }
 
     @POST
@@ -109,13 +97,7 @@ public class RoleMappingDeleteResource {
         }
         auth.clients().requireManage(clientScope);
 
-        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> clientScope.deleteScopeMapping(role));
-
-        adminEvent.operation(OperationType.DELETE)
-                .resourcePath(session.getContext().getUri())
-                .resource(ResourceType.CLIENT_SCOPE_MAPPING)
-                .representation(reps)
-                .success();
+        deleteRoleMappings(roles, role -> clientScope.deleteScopeMapping(role), ResourceType.REALM_SCOPE_MAPPING, ResourceType.CLIENT_SCOPE_MAPPING);
     }
 
     @POST
@@ -134,13 +116,7 @@ public class RoleMappingDeleteResource {
         }
         auth.clients().requireManage(client);
 
-        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> client.deleteScopeMapping(role));
-
-        adminEvent.operation(OperationType.DELETE)
-                .resourcePath(session.getContext().getUri())
-                .resource(ResourceType.CLIENT_SCOPE_MAPPING)
-                .representation(reps)
-                .success();
+        deleteRoleMappings(roles, role -> client.deleteScopeMapping(role), ResourceType.REALM_SCOPE_MAPPING, ResourceType.CLIENT_SCOPE_MAPPING);
     }
 
     @POST
@@ -163,17 +139,13 @@ public class RoleMappingDeleteResource {
         auth.roles().requireManage(role);
 
         final RoleModel parentRole = role;
-        List<RoleRepresentation> reps = deleteRoleMappings(roles, compositeRole -> parentRole.removeCompositeRole(compositeRole));
-
-        adminEvent.operation(OperationType.DELETE)
-                .resourcePath(session.getContext().getUri())
-                .resource(ResourceType.REALM_ROLE)
-                .representation(reps)
-                .success();
+        deleteRoleMappings(roles, compositeRole -> parentRole.removeCompositeRole(compositeRole), ResourceType.REALM_ROLE, ResourceType.CLIENT_ROLE);
     }
 
-    private List<RoleRepresentation> deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction) {
-        List<RoleRepresentation> reps = new ArrayList<>();
+    private void deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction, ResourceType realmResourceType, ResourceType clientResourceType) {
+        List<RoleRepresentation> realmRoles = new ArrayList<>();
+        java.util.Map<String, List<RoleRepresentation>> clientRoles = new java.util.HashMap<>();
+
         for (RoleDeleteRequest roleRequest : roles) {
             RoleModel role = this.realm.getRoleById(roleRequest.getRoleId());
             if (role == null) {
@@ -182,9 +154,31 @@ public class RoleMappingDeleteResource {
             if (role != null) {
                 auth.roles().requireMapRole(role);
                 deleteAction.accept(role);
-                reps.add(ModelToRepresentation.toBriefRepresentation(role));
+                RoleRepresentation rep = ModelToRepresentation.toBriefRepresentation(role);
+                if (role.isClientRole()) {
+                    clientRoles.computeIfAbsent(role.getContainerId(), k -> new ArrayList<>()).add(rep);
+                } else {
+                    realmRoles.add(rep);
+                }
             }
         }
-        return reps;
+
+        if (!realmRoles.isEmpty()) {
+            adminEvent.clone(session)
+                    .operation(OperationType.DELETE)
+                    .resourcePath(session.getContext().getUri())
+                    .resource(realmResourceType)
+                    .representation(realmRoles)
+                    .success();
+        }
+
+        for (java.util.Map.Entry<String, List<RoleRepresentation>> entry : clientRoles.entrySet()) {
+            adminEvent.clone(session)
+                    .operation(OperationType.DELETE)
+                    .resourcePath(session.getContext().getUri())
+                    .resource(clientResourceType)
+                    .representation(entry.getValue())
+                    .success();
+        }
     }
 }

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
@@ -139,13 +139,17 @@ public class RoleMappingDeleteResource {
         auth.roles().requireManage(role);
 
         final RoleModel parentRole = role;
-        deleteRoleMappings(roles, compositeRole -> parentRole.removeCompositeRole(compositeRole), ResourceType.REALM_ROLE, ResourceType.CLIENT_ROLE);
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, compositeRole -> parentRole.removeCompositeRole(compositeRole));
+
+        adminEvent.operation(OperationType.DELETE)
+                .resourcePath(session.getContext().getUri())
+                .resource(parentRole.isClientRole() ? ResourceType.CLIENT_ROLE : ResourceType.REALM_ROLE)
+                .representation(reps)
+                .success();
     }
 
-    private void deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction, ResourceType realmResourceType, ResourceType clientResourceType) {
-        List<RoleRepresentation> realmRoles = new ArrayList<>();
-        java.util.Map<String, List<RoleRepresentation>> clientRoles = new java.util.HashMap<>();
-
+    private List<RoleRepresentation> deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction) {
+        List<RoleRepresentation> reps = new ArrayList<>();
         for (RoleDeleteRequest roleRequest : roles) {
             RoleModel role = this.realm.getRoleById(roleRequest.getRoleId());
             if (role == null) {
@@ -154,12 +158,23 @@ public class RoleMappingDeleteResource {
             if (role != null) {
                 auth.roles().requireMapRole(role);
                 deleteAction.accept(role);
-                RoleRepresentation rep = ModelToRepresentation.toBriefRepresentation(role);
-                if (role.isClientRole()) {
-                    clientRoles.computeIfAbsent(role.getContainerId(), k -> new ArrayList<>()).add(rep);
-                } else {
-                    realmRoles.add(rep);
-                }
+                reps.add(ModelToRepresentation.toBriefRepresentation(role));
+            }
+        }
+        return reps;
+    }
+
+    private void deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction, ResourceType realmResourceType, ResourceType clientResourceType) {
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, deleteAction);
+
+        List<RoleRepresentation> realmRoles = new ArrayList<>();
+        java.util.Map<String, List<RoleRepresentation>> clientRoles = new java.util.HashMap<>();
+
+        for (RoleRepresentation rep : reps) {
+            if (Boolean.TRUE.equals(rep.getClientRole())) {
+                clientRoles.computeIfAbsent(rep.getContainerId(), k -> new ArrayList<>()).add(rep);
+            } else {
+                realmRoles.add(rep);
             }
         }
 

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
@@ -1,5 +1,6 @@
 package org.keycloak.admin.ui.rest;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.ws.rs.Consumes;
@@ -20,6 +21,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 
@@ -55,11 +58,12 @@ public class RoleMappingDeleteResource {
         }
         auth.groups().requireManageMembership(group);
 
-        deleteRoleMappings(roles, role -> group.deleteRoleMapping(role));
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> group.deleteRoleMapping(role));
 
         adminEvent.operation(OperationType.DELETE)
                 .resourcePath(session.getContext().getUri())
                 .resource(ResourceType.REALM_ROLE_MAPPING)
+                .representation(reps)
                 .success();
     }
 
@@ -80,11 +84,12 @@ public class RoleMappingDeleteResource {
         }
         auth.users().requireMapRoles(user);
 
-        deleteRoleMappings(roles, role -> user.deleteRoleMapping(role));
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> user.deleteRoleMapping(role));
 
         adminEvent.operation(OperationType.DELETE)
                 .resourcePath(session.getContext().getUri())
                 .resource(ResourceType.REALM_ROLE_MAPPING)
+                .representation(reps)
                 .success();
     }
 
@@ -104,11 +109,12 @@ public class RoleMappingDeleteResource {
         }
         auth.clients().requireManage(clientScope);
 
-        deleteRoleMappings(roles, role -> clientScope.deleteScopeMapping(role));
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> clientScope.deleteScopeMapping(role));
 
         adminEvent.operation(OperationType.DELETE)
                 .resourcePath(session.getContext().getUri())
                 .resource(ResourceType.CLIENT_SCOPE_MAPPING)
+                .representation(reps)
                 .success();
     }
 
@@ -128,11 +134,12 @@ public class RoleMappingDeleteResource {
         }
         auth.clients().requireManage(client);
 
-        deleteRoleMappings(roles, role -> client.deleteScopeMapping(role));
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, role -> client.deleteScopeMapping(role));
 
         adminEvent.operation(OperationType.DELETE)
                 .resourcePath(session.getContext().getUri())
                 .resource(ResourceType.CLIENT_SCOPE_MAPPING)
+                .representation(reps)
                 .success();
     }
 
@@ -156,15 +163,17 @@ public class RoleMappingDeleteResource {
         auth.roles().requireManage(role);
 
         final RoleModel parentRole = role;
-        deleteRoleMappings(roles, compositeRole -> parentRole.removeCompositeRole(compositeRole));
+        List<RoleRepresentation> reps = deleteRoleMappings(roles, compositeRole -> parentRole.removeCompositeRole(compositeRole));
 
         adminEvent.operation(OperationType.DELETE)
                 .resourcePath(session.getContext().getUri())
                 .resource(ResourceType.REALM_ROLE)
+                .representation(reps)
                 .success();
     }
 
-    private void deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction) {
+    private List<RoleRepresentation> deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction) {
+        List<RoleRepresentation> reps = new ArrayList<>();
         for (RoleDeleteRequest roleRequest : roles) {
             RoleModel role = this.realm.getRoleById(roleRequest.getRoleId());
             if (role == null) {
@@ -173,7 +182,9 @@ public class RoleMappingDeleteResource {
             if (role != null) {
                 auth.roles().requireMapRole(role);
                 deleteAction.accept(role);
+                reps.add(ModelToRepresentation.toBriefRepresentation(role));
             }
         }
+        return reps;
     }
 }

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/RoleMappingDeleteResource.java
@@ -1,7 +1,10 @@
 package org.keycloak.admin.ui.rest;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.ForbiddenException;
@@ -148,7 +151,7 @@ public class RoleMappingDeleteResource {
                 .success();
     }
 
-    private List<RoleRepresentation> deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction) {
+    private List<RoleRepresentation> deleteRoleMappings(List<RoleDeleteRequest> roles, Consumer<RoleModel> deleteAction) {
         List<RoleRepresentation> reps = new ArrayList<>();
         for (RoleDeleteRequest roleRequest : roles) {
             RoleModel role = this.realm.getRoleById(roleRequest.getRoleId());
@@ -164,11 +167,11 @@ public class RoleMappingDeleteResource {
         return reps;
     }
 
-    private void deleteRoleMappings(List<RoleDeleteRequest> roles, java.util.function.Consumer<RoleModel> deleteAction, ResourceType realmResourceType, ResourceType clientResourceType) {
+    private void deleteRoleMappings(List<RoleDeleteRequest> roles, Consumer<RoleModel> deleteAction, ResourceType realmResourceType, ResourceType clientResourceType) {
         List<RoleRepresentation> reps = deleteRoleMappings(roles, deleteAction);
 
         List<RoleRepresentation> realmRoles = new ArrayList<>();
-        java.util.Map<String, List<RoleRepresentation>> clientRoles = new java.util.HashMap<>();
+        Map<String, List<RoleRepresentation>> clientRoles = new HashMap<>();
 
         for (RoleRepresentation rep : reps) {
             if (Boolean.TRUE.equals(rep.getClientRole())) {
@@ -178,21 +181,22 @@ public class RoleMappingDeleteResource {
             }
         }
 
+        // adminEvent is intentionally reused across multiple success() calls: AdminEventBuilder#send()
+        // copies its state into a new event before dispatch, so firing several correctly-typed events
+        // from a single bulk delete request is safe without cloning the builder.
         if (!realmRoles.isEmpty()) {
-            adminEvent.clone(session)
-                    .operation(OperationType.DELETE)
+            adminEvent.operation(OperationType.DELETE)
                     .resourcePath(session.getContext().getUri())
                     .resource(realmResourceType)
                     .representation(realmRoles)
                     .success();
         }
 
-        for (java.util.Map.Entry<String, List<RoleRepresentation>> entry : clientRoles.entrySet()) {
-            adminEvent.clone(session)
-                    .operation(OperationType.DELETE)
+        for (List<RoleRepresentation> clientRoleReps : clientRoles.values()) {
+            adminEvent.operation(OperationType.DELETE)
                     .resourcePath(session.getContext().getUri())
                     .resource(clientResourceType)
-                    .representation(entry.getValue())
+                    .representation(clientRoleReps)
                     .success();
         }
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/RoleMappingDeleteResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/RoleMappingDeleteResourceTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.admin;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.BearerAuthFilter;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.ui.rest.model.RoleDeleteRequest;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectAdminEvents;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.testframework.events.AdminEvents;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.GroupBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RoleBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.util.ApiUtil;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for the "ui-ext/role-mapping-delete" endpoints ({@code RoleMappingDeleteResource}), used by the Admin
+ * Console to bulk-remove role mappings from users, groups, clients, client scopes and composite roles.
+ *
+ * Regression coverage for #51459 / #52230: deleting role mappings through these endpoints previously produced
+ * admin events with a null representation, unlike the equivalent Admin API calls (e.g. RoleMapperResource,
+ * ClientRoleMappingsResource, ScopeMappedResource and RoleResource).
+ *
+ * These endpoints accept a mix of realm and client roles in a single bulk request, unlike the Admin API where
+ * realm and client role mappings are always handled by separate, single-type resources/routes. To keep the
+ * resulting admin events accurate, deleted roles are grouped by their actual type (and, for client roles, by
+ * client) and one correctly-typed event is fired per group - so a single bulk request can produce more than
+ * one admin event.
+ */
+@KeycloakIntegrationTest
+public class RoleMappingDeleteResourceTest {
+
+    @InjectRealm(lifecycle = LifeCycle.METHOD)
+    ManagedRealm managedRealm;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectAdminEvents
+    AdminEvents adminEvents;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @Test
+    public void deleteUserRealmRoleMappingIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+        RoleRepresentation role = createRealmRole(realm, "user-realm-role");
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("roledeleteuser");
+        String userId;
+        try (Response response = realm.users().create(user)) {
+            userId = ApiUtil.getCreatedId(response);
+        }
+        realm.users().get(userId).roles().realmLevel().add(List.of(role));
+
+        assertDeleteIncludesRepresentation("users", userId, ResourceType.REALM_ROLE_MAPPING, List.of(role));
+    }
+
+    @Test
+    public void deleteGroupRealmRoleMappingIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+        RoleRepresentation role = createRealmRole(realm, "group-realm-role");
+
+        GroupRepresentation group = GroupBuilder.create().name("roledeletegroup").build();
+        String groupId;
+        try (Response response = realm.groups().add(group)) {
+            groupId = ApiUtil.getCreatedId(response);
+        }
+        realm.groups().group(groupId).roles().realmLevel().add(List.of(role));
+
+        assertDeleteIncludesRepresentation("groups", groupId, ResourceType.REALM_ROLE_MAPPING, List.of(role));
+    }
+
+    @Test
+    public void deleteClientScopeRoleMappingIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+        RoleRepresentation role = createRealmRole(realm, "client-scope-role");
+
+        ClientScopeRepresentation clientScope = new ClientScopeRepresentation();
+        clientScope.setName("roledeletescope");
+        clientScope.setProtocol("openid-connect");
+        String scopeId;
+        try (Response response = realm.clientScopes().create(clientScope)) {
+            scopeId = ApiUtil.getCreatedId(response);
+        }
+        realm.clientScopes().get(scopeId).getScopeMappings().realmLevel().add(List.of(role));
+
+        assertDeleteIncludesRepresentation("clientScopes", scopeId, ResourceType.REALM_SCOPE_MAPPING, List.of(role));
+    }
+
+    @Test
+    public void deleteClientRoleMappingIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+        RoleRepresentation role = createRealmRole(realm, "client-scope-mapping-role");
+
+        ClientRepresentation client = ClientBuilder.create().clientId("roledeleteclient").build();
+        String clientUuid;
+        try (Response response = realm.clients().create(client)) {
+            clientUuid = ApiUtil.getCreatedId(response);
+        }
+        realm.clients().get(clientUuid).getScopeMappings().realmLevel().add(List.of(role));
+
+        // a realm role removed from a client's scope mappings must be tagged REALM_SCOPE_MAPPING, matching
+        // ClientResource.getScopeMappedResource() (ScopeMappedResource), regardless of which container
+        // (client or client scope) the ui-ext request targets
+        assertDeleteIncludesRepresentation("clients", clientUuid, ResourceType.REALM_SCOPE_MAPPING, List.of(role));
+    }
+
+    @Test
+    public void deleteUserClientRoleMappingIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+
+        ClientRepresentation client = ClientBuilder.create().clientId("roledeleteuserclientrole").build();
+        String clientUuid;
+        try (Response response = realm.clients().create(client)) {
+            clientUuid = ApiUtil.getCreatedId(response);
+        }
+        RoleRepresentation role = createClientRole(realm, clientUuid, "user-client-role");
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("roledeleteuserclient");
+        String userId;
+        try (Response response = realm.users().create(user)) {
+            userId = ApiUtil.getCreatedId(response);
+        }
+        realm.users().get(userId).roles().clientLevel(clientUuid).add(List.of(role));
+
+        // a client role removed from a user must be tagged CLIENT_ROLE_MAPPING, not REALM_ROLE_MAPPING
+        assertDeleteIncludesRepresentation("users", userId, ResourceType.CLIENT_ROLE_MAPPING, List.of(role));
+    }
+
+    /**
+     * Deleting a mix of realm and client roles from a user in a single bulk request must produce two
+     * separately-typed admin events - one REALM_ROLE_MAPPING and one CLIENT_ROLE_MAPPING - each carrying only
+     * the representations of the roles of that type. This matches the granularity of the equivalent Admin API
+     * calls (RoleMapperResource vs ClientRoleMappingsResource), which are always scoped to a single role type.
+     */
+    @Test
+    public void deleteUserMixedRealmAndClientRoleMappingsFiresSeparateEvents() {
+        RealmResource realm = managedRealm.admin();
+        RoleRepresentation realmRole = createRealmRole(realm, "mixed-realm-role");
+
+        ClientRepresentation client = ClientBuilder.create().clientId("roledeletemixedclient").build();
+        String clientUuid;
+        try (Response response = realm.clients().create(client)) {
+            clientUuid = ApiUtil.getCreatedId(response);
+        }
+        RoleRepresentation clientRole = createClientRole(realm, clientUuid, "mixed-client-role");
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("roledeletemixeduser");
+        String userId;
+        try (Response response = realm.users().create(user)) {
+            userId = ApiUtil.getCreatedId(response);
+        }
+        realm.users().get(userId).roles().realmLevel().add(List.of(realmRole));
+        realm.users().get(userId).roles().clientLevel(clientUuid).add(List.of(clientRole));
+
+        adminEvents.clear();
+        List<RoleDeleteRequest> body = List.of(
+                new RoleDeleteRequest(realmRole.getId(), realmRole.getName(), null),
+                new RoleDeleteRequest(clientRole.getId(), clientRole.getName(), clientUuid));
+
+        try (Client httpClient = Keycloak.getClientProvider().newRestEasyClient(null, null, true)) {
+            WebTarget target = httpClient.target(keycloakUrls.getBaseUrl().toString())
+                    .path("admin").path("realms").path(managedRealm.getName())
+                    .path("ui-ext").path("role-mapping-delete").path("users").path(userId)
+                    .register(new BearerAuthFilter(adminClient.tokenManager()));
+
+            try (Response response = target.request(MediaType.APPLICATION_JSON).post(Entity.json(body))) {
+                assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            }
+        }
+
+        // realm roles are grouped and emitted before client roles, see RoleMappingDeleteResource#deleteRoleMappings
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.DELETE)
+                .resourceType(ResourceType.REALM_ROLE_MAPPING)
+                .representation(List.of(realmRole));
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.DELETE)
+                .resourceType(ResourceType.CLIENT_ROLE_MAPPING)
+                .representation(List.of(clientRole));
+    }
+
+    @Test
+    public void deleteCompositeRoleIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+        RoleRepresentation parentRole = createRealmRole(realm, "composite-parent-role");
+        RoleRepresentation childRole = createRealmRole(realm, "composite-child-role");
+
+        realm.roles().get(parentRole.getName()).addComposites(List.of(childRole));
+
+        assertDeleteIncludesRepresentation("roles", parentRole.getId(), ResourceType.REALM_ROLE, List.of(childRole));
+    }
+
+    /**
+     * Unlike the other delete endpoints, deleteCompositeRoles() picks the admin event's resource type based on
+     * whether the parent role is a client role or a realm role. This covers the CLIENT_ROLE branch, the realm
+     * role parent case is covered by {@link #deleteCompositeRoleIncludesRepresentation()}.
+     */
+    @Test
+    public void deleteCompositeClientRoleIncludesRepresentation() {
+        RealmResource realm = managedRealm.admin();
+
+        ClientRepresentation client = ClientBuilder.create().clientId("roledeletecompositeclient").build();
+        String clientUuid;
+        try (Response response = realm.clients().create(client)) {
+            clientUuid = ApiUtil.getCreatedId(response);
+        }
+
+        RoleRepresentation parentRole = createClientRole(realm, clientUuid, "composite-client-parent-role");
+        RoleRepresentation childRole = createClientRole(realm, clientUuid, "composite-client-child-role");
+
+        realm.clients().get(clientUuid).roles().get(parentRole.getName()).addComposites(List.of(childRole));
+
+        assertDeleteIncludesRepresentation("roles", parentRole.getId(), ResourceType.CLIENT_ROLE, List.of(childRole));
+    }
+
+    private RoleRepresentation createRealmRole(RealmResource realm, String name) {
+        realm.roles().create(RoleBuilder.create().name(name).build());
+        return realm.roles().get(name).toRepresentation();
+    }
+
+    private RoleRepresentation createClientRole(RealmResource realm, String clientUuid, String name) {
+        realm.clients().get(clientUuid).roles().create(RoleBuilder.create().name(name).build());
+        return realm.clients().get(clientUuid).roles().get(name).toRepresentation();
+    }
+
+    /**
+     * Calls the ui-ext role-mapping-delete endpoint for the given resource/roles and asserts that the
+     * resulting admin event includes the representation of the deleted roles.
+     */
+    private void assertDeleteIncludesRepresentation(String resourcePathSegment, String resourceId,
+            ResourceType expectedResourceType, List<RoleRepresentation> deletedRoles) {
+        List<RoleDeleteRequest> body = deletedRoles.stream()
+                .map(role -> new RoleDeleteRequest(role.getId(), role.getName(), null))
+                .collect(Collectors.toList());
+
+        adminEvents.clear();
+
+        try (Client httpClient = Keycloak.getClientProvider().newRestEasyClient(null, null, true)) {
+            WebTarget target = httpClient.target(keycloakUrls.getBaseUrl().toString())
+                    .path("admin").path("realms").path(managedRealm.getName())
+                    .path("ui-ext").path("role-mapping-delete").path(resourcePathSegment).path(resourceId)
+                    .register(new BearerAuthFilter(adminClient.tokenManager()));
+
+            try (Response response = target.request(MediaType.APPLICATION_JSON).post(Entity.json(body))) {
+                assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            }
+        }
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.DELETE)
+                .resourceType(expectedResourceType)
+                .representation(deletedRoles);
+    }
+}


### PR DESCRIPTION
Currently, when unassigning a realm role via the Admin Console, the generated REALM_ROLE_MAPPING admin event has a null representation. This happens because the Admin UI extension `RoleMappingDeleteResource` was simply reporting success without capturing and providing the deleted role representations to the event builder.

This PR fixes it by collecting the `RoleRepresentation` list inside `deleteRoleMappings` and passing it to `adminEvent.representation(...)`, which restores parity with the classic REST API endpoints.

The fix covers all role-deletion paths through the Admin UI extension (users, groups, client roles, client scopes, and composite roles), splitting events by realm vs. client role type where the UI batches multiple roles in one request.

Closes #52230