### PR TITLE
Add workflow event providers for user lockout events by brute force protection

### DIFF
--- a/docs/documentation/server_admin/topics/workflows/listening-workflow-events.adoc
+++ b/docs/documentation/server_admin/topics/workflows/listening-workflow-events.adoc
@@ -54,4 +54,6 @@ At the moment, workflows support event functions for the following realm resourc
 | `user-group-membership-removed` | User is removed from a group. | The group name or path
 | `client-created` | Client is added to the realm. | None
 | `client-authenticated` | Client authenticates to the realm. | None
+| `user-disabled-by-temporary-lockout` | User was temporarily disabled by brute force protection. | None
+| `user-disabled-by-permanent-lockout` | User was permanently disabled by brute force protection. | None
 |===

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByPermanentLockoutWorkflowEventFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByPermanentLockoutWorkflowEventFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.models.workflow.events;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.WorkflowEventProvider;
+import org.keycloak.models.workflow.WorkflowEventProviderFactory;
+
+public class UserDisabledByPermanentLockoutWorkflowEventFactory implements WorkflowEventProviderFactory<WorkflowEventProvider> {
+
+    public static final String ID = "user-disabled-by-permanent-lockout";
+
+    @Override
+    public WorkflowEventProvider create(KeycloakSession session, String configParameter) {
+        return new UserDisabledByPermanentLockoutWorkflowEventProvider(session, configParameter, this.getId());
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByPermanentLockoutWorkflowEventProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByPermanentLockoutWorkflowEventProvider.java
@@ -1,0 +1,25 @@
+package org.keycloak.models.workflow.events;
+
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.AbstractWorkflowEventProvider;
+import org.keycloak.models.workflow.ResourceType;
+
+public class UserDisabledByPermanentLockoutWorkflowEventProvider extends AbstractWorkflowEventProvider {
+
+    public UserDisabledByPermanentLockoutWorkflowEventProvider(KeycloakSession session, String configParameter, String providerId) {
+        super(session, configParameter, providerId);
+    }
+
+    @Override
+    public ResourceType getSupportedResourceType() {
+        return ResourceType.USERS;
+    }
+
+    @Override
+    public boolean supports(Event event) {
+        return EventType.USER_DISABLED_BY_PERMANENT_LOCKOUT.equals(event.getType());
+    }
+
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByTemporaryLockoutWorkflowEventFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByTemporaryLockoutWorkflowEventFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.models.workflow.events;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.WorkflowEventProvider;
+import org.keycloak.models.workflow.WorkflowEventProviderFactory;
+
+public class UserDisabledByTemporaryLockoutWorkflowEventFactory implements WorkflowEventProviderFactory<WorkflowEventProvider> {
+
+    public static final String ID = "user-disabled-by-temporary-lockout";
+
+    @Override
+    public WorkflowEventProvider create(KeycloakSession session, String configParameter) {
+        return new UserDisabledByTemporaryLockoutWorkflowEventProvider(session, configParameter, this.getId());
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByTemporaryLockoutWorkflowEventProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/UserDisabledByTemporaryLockoutWorkflowEventProvider.java
@@ -1,0 +1,25 @@
+package org.keycloak.models.workflow.events;
+
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.AbstractWorkflowEventProvider;
+import org.keycloak.models.workflow.ResourceType;
+
+public class UserDisabledByTemporaryLockoutWorkflowEventProvider extends AbstractWorkflowEventProvider {
+
+    public UserDisabledByTemporaryLockoutWorkflowEventProvider(KeycloakSession session, String configParameter, String providerId) {
+        super(session, configParameter, providerId);
+    }
+
+    @Override
+    public ResourceType getSupportedResourceType() {
+        return ResourceType.USERS;
+    }
+
+    @Override
+    public boolean supports(Event event) {
+        return EventType.USER_DISABLED_BY_TEMPORARY_LOCKOUT.equals(event.getType());
+    }
+
+}

--- a/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowEventProviderFactory
+++ b/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowEventProviderFactory
@@ -7,6 +7,8 @@ org.keycloak.models.workflow.events.UserGroupMembershipAddedWorkflowEventFactory
 org.keycloak.models.workflow.events.UserGroupMembershipRemovedWorkflowEventFactory
 org.keycloak.models.workflow.events.UserRoleGrantedWorkflowEventFactory
 org.keycloak.models.workflow.events.UserRoleRevokedWorkflowEventFactory
+org.keycloak.models.workflow.events.UserDisabledByTemporaryLockoutWorkflowEventFactory
+org.keycloak.models.workflow.events.UserDisabledByPermanentLockoutWorkflowEventFactory
 
 # client event providers
 org.keycloak.models.workflow.events.ClientAuthenticatedWorkflowEventFactory

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/RealmBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/RealmBuilder.java
@@ -672,6 +672,38 @@ public class RealmBuilder extends Builder<RealmRepresentation> {
         return this;
     }
 
+    public RealmBuilder maxSecondaryAuthFailures(int maxSecondaryAuthFailures) {
+        rep.setMaxSecondaryAuthFailures(maxSecondaryAuthFailures);
+        return this;
+    }
+
+    public RealmBuilder bruteForceStrategy(RealmRepresentation.BruteForceStrategy bruteForceStrategy) {
+        rep.setBruteForceStrategy(bruteForceStrategy);
+        return this;
+    }
+
+    public RealmBuilder waitIncrementSeconds(int waitIncrementSeconds) {
+        rep.setWaitIncrementSeconds(waitIncrementSeconds);
+        return this;
+    }
+
+    public RealmBuilder maxFailureWaitSeconds(int maxFailureWaitSeconds) {
+        rep.setMaxFailureWaitSeconds(maxFailureWaitSeconds);
+        return this;
+    }
+
+    public RealmBuilder quickLoginCheckMilliSeconds(long quickLoginCheckMilliSeconds) {
+        rep.setQuickLoginCheckMilliSeconds(quickLoginCheckMilliSeconds);
+        return this;
+    }
+
+    public RealmBuilder minimumQuickLoginWaitSeconds(int minimumQuickLoginWaitSeconds) {
+        rep.setMinimumQuickLoginWaitSeconds(minimumQuickLoginWaitSeconds);
+        return this;
+    }
+
+
+
     /**
      * Best practice is to use other convenience methods when configuring a realm, but while the framework is under
      * active development there may not be a way to perform all updates required. In these cases this method allows

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/activation/UserDisabledByLockoutWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/activation/UserDisabledByLockoutWorkflowTest.java
@@ -1,0 +1,116 @@
+package org.keycloak.tests.workflow.activation;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.keycloak.models.UserModel;
+import org.keycloak.models.workflow.SetUserAttributeStepProviderFactory;
+import org.keycloak.models.workflow.events.UserDisabledByPermanentLockoutWorkflowEventFactory;
+import org.keycloak.models.workflow.events.UserDisabledByTemporaryLockoutWorkflowEventFactory;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.workflows.WorkflowRepresentation;
+import org.keycloak.representations.workflows.WorkflowStepRepresentation;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm.RealmUpdate;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.tests.workflow.AbstractWorkflowTest;
+import org.keycloak.tests.workflow.config.WorkflowsBlockingServerConfig;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests that a workflow is triggered when a user is locked out by brute force protection, both for temporary and
+ * permanent lockout.
+ */
+@KeycloakIntegrationTest(config = WorkflowsBlockingServerConfig.class)
+public class UserDisabledByLockoutWorkflowTest extends AbstractWorkflowTest {
+
+    private static final String LOCKOUT_USER = "lockoutuser";
+    private static final String LOCKOUT_ATTRIBUTE = "lockout_triggered";
+    private static final int MAX_LOGIN_FAILURES = 2;
+
+    @InjectUser(ref = LOCKOUT_USER, config = UserDisabledByLockoutWorkflowTest.DefaultUserConfig.class, lifecycle = LifeCycle.METHOD, realmRef = DEFAULT_REALM_NAME)
+    private ManagedUser user;
+
+    static Stream<Arguments> lockoutProvider() {
+        RealmUpdate temporaryLockout = realm -> realm
+                // Brute Force Mode: Lockout temporarily
+                .bruteForceProtected(true)
+                .permanentLockout(false)
+                .maxTemporaryLockouts(0)
+                .failureFactor(MAX_LOGIN_FAILURES)
+                .maxDeltaTimeSeconds((int) TimeUnit.HOURS.toSeconds(12))
+                .maxSecondaryAuthFailures(0)
+                .bruteForceStrategy(RealmRepresentation.BruteForceStrategy.MULTIPLE)
+                .waitIncrementSeconds((int) TimeUnit.MINUTES.toSeconds(1))
+                .maxFailureWaitSeconds((int) TimeUnit.MINUTES.toSeconds(15))
+                .quickLoginCheckMilliSeconds(500L)
+                .minimumQuickLoginWaitSeconds((int) TimeUnit.MINUTES.toSeconds(1));
+
+        RealmUpdate permanentLockout = realm -> realm
+                // Brute Force Mode: Lockout permanently
+                .bruteForceProtected(true)
+                .permanentLockout(true)
+                .failureFactor(MAX_LOGIN_FAILURES);
+
+        return Stream.of(
+                Arguments.of("temporary lockout", temporaryLockout, UserDisabledByTemporaryLockoutWorkflowEventFactory.ID),
+                Arguments.of("permanent lockout", permanentLockout, UserDisabledByPermanentLockoutWorkflowEventFactory.ID)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} triggers workflow")
+    @MethodSource("lockoutProvider")
+    void testUserDisabledByLockoutTriggersWorkflow(String name, RealmUpdate bruteForceConfig, String eventId) {
+        // configure brute force protection
+        managedRealm.updateWithCleanup(bruteForceConfig);
+
+        // create workflow
+        managedRealm.admin().workflows().create(WorkflowRepresentation.withName("lockout-workflow")
+                .onEvent(eventId)
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(SetUserAttributeStepProviderFactory.ID)
+                                .withConfig(LOCKOUT_ATTRIBUTE, "true")
+                                .build()
+                ).build()).close();
+
+        for (int i = 0; i <= MAX_LOGIN_FAILURES; i++) {
+            oauth.realm(managedRealm.getName());
+            oauth.openLoginForm();
+            oauth.fillLoginForm(LOCKOUT_USER, "wrong-password");
+        }
+
+        Awaitility.await()
+            .pollInterval(1, TimeUnit.SECONDS)
+            .atMost(5, TimeUnit.SECONDS)
+            .untilAsserted(() -> runOnServer.run(session -> {
+                UserModel user = session.users().getUserByUsername(session.getContext().getRealm(), LOCKOUT_USER);
+                assertThat("User should exist", user, notNullValue());
+                assertThat("Lockout attribute should be set by workflow",
+                    user.getAttributes().get(LOCKOUT_ATTRIBUTE), notNullValue());
+                assertThat(user.getAttributes().get(LOCKOUT_ATTRIBUTE).get(0), is("true"));
+            }));
+    }
+
+    private static class DefaultUserConfig implements UserConfig {
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            user.username(LOCKOUT_USER);
+            user.password("password");
+            user.name("Lockout", "User");
+            user.email(String.format("%s@email.com", LOCKOUT_USER));
+            return user;
+        }
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/keycloak/keycloak/issues/50452

Ive consolidated the tests into one, as they are almost the same. To that I added the missing `RealmBuilder` functions.

CC: @ahus1