### PR TITLE
[OID4VCI] Reject assignment of OID4VCI client scopes as realm optional scopes 

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
@@ -96,9 +96,11 @@ public interface LoginProtocolFactory extends ProviderFactory<LoginProtocol> {
      * @param clientScope  the client scope to be assigned
      * @param defaultScope true if assigning as Default scope, false if Optional
      * @param realm        the realm where the assignment is happening
+     * @param realmLevel   true if the scope is assigned as a realm default/optional client scope (affecting all
+     *                     clients of the matching protocol), false if it is assigned to a specific client
      * @throws BadRequestException if the assignment is not allowed
      */
-    default void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope, boolean defaultScope, RealmModel realm) {
+    default void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope, boolean defaultScope, RealmModel realm, boolean realmLevel) {
         // Default implementation: no validation (allows all assignments)
         // Protocol-specific implementations can override to enforce restrictions
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -258,7 +258,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
     }
 
     @Override
-    public void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope, boolean defaultScope, RealmModel realm) {
+    public void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope, boolean defaultScope, RealmModel realm, boolean realmLevel) {
         if (!OID4VC_PROTOCOL.equals(clientScope.getProtocol())) {
             return;
         }
@@ -266,6 +266,17 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
         if (!realm.isVerifiableCredentialsEnabled()) {
             throw new ErrorResponseException("invalid_request",
                     "OID4VCI client scopes cannot be assigned when Verifiable Credentials is disabled for the realm",
+                    Response.Status.BAD_REQUEST);
+        }
+
+        // Realm default/optional client scopes are only propagated to clients of the same protocol
+        // (see AbstractLoginProtocolFactory.addDefaultClientScopes) and OID4VCI cannot be used as a client
+        // protocol. A realm-level assignment of an OID4VCI client scope would therefore silently have no
+        // effect on any client. OID4VCI client scopes must be assigned explicitly to each OID4VCI-enabled client.
+        if (realmLevel) {
+            throw new ErrorResponseException("invalid_request",
+                    "OID4VCI client scopes cannot be assigned as realm Default or Optional client scopes. " +
+                            "They must be assigned explicitly to clients with OID4VCI enabled.",
                     Response.Status.BAD_REQUEST);
         }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -443,7 +443,7 @@ public class ClientResource {
             throw new ErrorResponseException("invalid_request", "Can't assign a Parameterized Scope to a Client as a Default Scope", Response.Status.BAD_REQUEST);
         }
 
-        validateClientScopeAssignment(session, clientScope, defaultScope, realm);
+        validateClientScopeAssignment(session, clientScope, defaultScope, realm, false);
 
         client.addClientScope(clientScope, defaultScope);
 
@@ -870,13 +870,15 @@ public class ClientResource {
      * @param clientScope  the client scope to be assigned
      * @param defaultScope true if assigning as Default scope, false if Optional
      * @param realm        the realm where the assignment is happening
+     * @param realmLevel   true if the scope is assigned as a realm default/optional client scope,
+     *                     false if it is assigned to a specific client
      */
     public static void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope,
-                                                     boolean defaultScope, RealmModel realm) {
+                                                     boolean defaultScope, RealmModel realm, boolean realmLevel) {
         LoginProtocolFactory loginProtocolFactory = (LoginProtocolFactory) session.getKeycloakSessionFactory()
                 .getProviderFactory(LoginProtocol.class, clientScope.getProtocol());
         if (loginProtocolFactory != null) {
-            loginProtocolFactory.validateClientScopeAssignment(session, clientScope, defaultScope, realm);
+            loginProtocolFactory.validateClientScopeAssignment(session, clientScope, defaultScope, realm, realmLevel);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -299,7 +299,7 @@ public class RealmAdminResource {
             throw ErrorResponse.error("Can't assign a Parameterized Scope as a Default Scope", Status.BAD_REQUEST);
         }
 
-        ClientResource.validateClientScopeAssignment(session, clientScope, defaultScope, realm);
+        ClientResource.validateClientScopeAssignment(session, clientScope, defaultScope, realm, true);
         
         realm.addDefaultClientScope(clientScope, defaultScope);
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -1583,8 +1583,60 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             fail("Expected BadRequestException when trying to assign OID4VCI scope as realm Default");
         } catch (BadRequestException e) {
             OAuth2ErrorRepresentation error = e.getResponse().readEntity(OAuth2ErrorRepresentation.class);
-            assertEquals("OID4VCI client scopes cannot be assigned as Default scopes. Only Optional scope assignment is supported.",
+            assertEquals("OID4VCI client scopes cannot be assigned as realm Default or Optional client scopes. " +
+                            "They must be assigned explicitly to clients with OID4VCI enabled.",
                     error.getErrorDescription());
+        }
+    }
+
+    @Test
+    public void testCannotAssignOid4vciScopeAsOptionalToRealm() {
+        ClientScopeRepresentation oid4vciScope = createOptionalClientScope(
+                "test-oid4vci-realm-optional-scope",
+                TEST_ISSUER_DID,
+                "test-oid4vci-realm-optional-config-id",
+                null, null,
+                VCFormat.JWT_VC,
+                null, null
+        );
+
+        oid4vciScope = registerOptionalClientScope(oid4vciScope);
+
+        try {
+            testRealm.admin().addDefaultOptionalClientScope(oid4vciScope.getId());
+            fail("Expected BadRequestException when trying to assign OID4VCI scope as realm Optional");
+        } catch (BadRequestException e) {
+            OAuth2ErrorRepresentation error = e.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("OID4VCI client scopes cannot be assigned as realm Default or Optional client scopes. " +
+                            "They must be assigned explicitly to clients with OID4VCI enabled.",
+                    error.getErrorDescription());
+        }
+    }
+
+    @Test
+    public void testCanAssignOid4vciScopeAsOptionalToClient() {
+        ClientScopeRepresentation oid4vciScope = createOptionalClientScope(
+                "test-oid4vci-client-optional-scope",
+                TEST_ISSUER_DID,
+                "test-oid4vci-client-optional-config-id",
+                null, null,
+                VCFormat.JWT_VC,
+                null, null
+        );
+
+        oid4vciScope = registerOptionalClientScope(oid4vciScope);
+        final String oid4vciScopeId = oid4vciScope.getId();
+        ClientRepresentation testClient = testRealm.admin().clients().findByClientId(OID4VCI_CLIENT_ID).get(0);
+        ClientResource clientResource = testRealm.admin().clients().get(testClient.getId());
+
+        try {
+            clientResource.addOptionalClientScope(oid4vciScopeId);
+            // Explicit per-client assignment of an OID4VCI scope as Optional remains the supported way to enable it
+            assertTrue(clientResource.getOptionalClientScopes().stream()
+                            .anyMatch(scope -> scope.getId().equals(oid4vciScopeId)),
+                    "The OID4VCI scope should be assigned as an Optional client scope");
+        } finally {
+            clientResource.removeOptionalClientScope(oid4vciScopeId);
         }
     }
 


### PR DESCRIPTION
- Motivation: Assigning an OID4VCI client scope (e.g.  oid4vc_natural_person_jwt ) as a realm "optional" client scope is accepted by the admin REST API/console but has no effect: realm scopes are only propagated to clients of the same protocol, and OID4VCI cannot be a client protocol (see issue #51187).

- Change:  LoginProtocolFactory.validateClientScopeAssignment()  now receives a  realmLevel  flag;  OID4VCLoginProtocolFactory  rejects realm-level assignments (Default and Optional), while client-level Optional assignment remains supported.

- Behavior: Admins must assign OID4VCI scopes explicitly per client — deterministic and consistent with the existing realm-Default restriction.

- Tests: added realm-Optional rejection + client-Optional success tests; updated realm-Default message assertion.

Closes #51187