### PR TITLE
[26.6] Align the HTTP/2 max header list size with the HTTP/1.1 max header size

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -62,6 +62,8 @@ quarkus.naming.enable-jndi=true
 # HTTP limits configuration - reverse-engineered from Wildfly
 quarkus.http.limits.max-initial-line-length=32779
 quarkus.http.limits.max-header-size=65535
+# Align the HTTP/2 header-list limit with max-header-size, instead of the much smaller Quarkus default
+quarkus.http.limits.max-header-list-size=65535
 
 # Default and non-production grade database vendor
 %dev.kc.db=dev-file

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -715,6 +715,15 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void testHttp2HeaderListSizeMatchesHttp1HeaderSizeDefault() {
+        ConfigArgsConfigSource.setCliArgs("");
+        SmallRyeConfig config = createConfig();
+        assertEquals(config.getConfigValue("quarkus.http.limits.max-header-size").getValue(),
+                config.getConfigValue("quarkus.http.limits.max-header-list-size").getValue());
+        assertEquals("65535", config.getConfigValue("quarkus.http.limits.max-header-list-size").getValue());
+    }
+
+    @Test
     public void testQuarkusPropertyTakesPrecedenceOverDefault() {
         putEnvVar("QUARKUS_HTTP_PORT", "9090");
         ConfigArgsConfigSource.setCliArgs("");

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
@@ -33,6 +34,16 @@ import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.SocketAddress;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -75,6 +86,54 @@ public class HttpDistTest {
         when().get("/realms/xxx/../master").then().statusCode(400);
         given().urlEncodingEnabled(false)
                 .when().get("/realms/master;xxx").then().statusCode(400);
+    }
+
+    @Test
+    @Launch({"start-dev"})
+    public void largeHeadersTest() throws Exception {
+        String largeValue = "a".repeat(32 * 1024);
+
+        Vertx vertx = Vertx.vertx();
+        try {
+            HttpClient http2Client = vertx.createHttpClient(new HttpClientOptions()
+                    .setSsl(true)
+                    .setTrustAll(true)
+                    .setVerifyHost(false)
+                    .setProtocolVersion(HttpVersion.HTTP_2)
+                    .setUseAlpn(true));
+            HttpClient http1Client = vertx.createHttpClient(new HttpClientOptions()
+                    .setSsl(true)
+                    .setTrustAll(true)
+                    .setVerifyHost(false));
+            try {
+                assertThat("Large headers under the limit are accepted over HTTP/2",
+                        largeHeaderRequest(http2Client, largeValue), Matchers.is(200));
+                assertThat("Large headers under the limit are accepted over HTTP/1.1",
+                        largeHeaderRequest(http1Client, largeValue), Matchers.is(200));
+            } finally {
+                http2Client.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+                http1Client.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+            }
+        } finally {
+            vertx.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    private static int largeHeaderRequest(HttpClient client, String headerValue) throws Exception {
+        RequestOptions options = new RequestOptions()
+                .setServer(SocketAddress.inetSocketAddress(8443, "localhost"))
+                .setPort(8443)
+                .setSsl(true)
+                .setURI("/realms/master")
+                .setMethod(HttpMethod.GET)
+                .putHeader("X-Large-Header", headerValue);
+
+        return client.request(options)
+                .compose(HttpClientRequest::send)
+                .map(HttpClientResponse::statusCode)
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
(#51246)

Keycloak configures quarkus.http.limits.max-header-size=65535 for HTTP/1.1 but never sets max-header-list-size so HTTP/2 requests were held to the much smaller Quarkus default, as noted in the original issue. Any request with headers between the two limits succeeded over HTTP/1.1 but was rejected at the HTTP/2 codec with no HTTP response and nothing logged. This aligns the HTTP/2 limit with HTTP/1.1 and adds an integration test covering large headers over both protocols.

Closes #51182

Signed-off-by: James Gore
<83005220+thejamesgore@users.noreply.github.com>

(cherry picked from commit 506df74ca822a7bb96e6b34b72e10f05fa5eb9c2)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
