### PR TITLE
Skip unnecessary provider initialization for non-server commands

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -27,6 +27,7 @@ import org.keycloak.Config;
 import org.keycloak.authentication.jpa.JpaAuthenticationSessionProviderFactory;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.Environment;
 import org.keycloak.common.util.MultiSiteUtils;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
@@ -204,11 +205,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             // The expired events for offline sessions will be triggered by JpaUserSessionPersisterProvider
             sessionCacheHolder.cache().addListener(expirationListener);
         }
-        // we need the expiration task running because of offline sessions
-        try (var session = factory.create()) {
-            expirationTask = ExpirationTaskFactory.create(session, expirationPeriodSeconds);
-        }
-        expirationTask.start();
+        startExpirationTask(factory);
         if (factory.getProviderFactory(AuthenticationSessionProvider.class) instanceof JpaAuthenticationSessionProviderFactory) {
             // Based on our internal knowledge on the JpaAuthenticationSessionProviderFactory, we can now assume that
             // all actions on the authentication sessions are done with pessimistic locking in place. With this knowledge,
@@ -218,6 +215,20 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             // behavior to avoid reflection and internal knowledge.
             pessimisticLockingAuthenticationSession = true;
         }
+    }
+
+    /**
+     * Start the expiration task for offline sessions.
+     * Skipped in non-server mode (export, import) as session expiration is not needed for one-time commands.
+     */
+    private void startExpirationTask(KeycloakSessionFactory factory) {
+        if (Environment.isNonServerMode()) {
+            return;
+        }
+        try (var session = factory.create()) {
+            expirationTask = ExpirationTaskFactory.create(session, expirationPeriodSeconds);
+        }
+        expirationTask.start();
     }
 
     public void initializePersisterLastSessionRefreshStore(final KeycloakSessionFactory sessionFactory) {

--- a/services/src/main/java/org/keycloak/models/workflow/WorkflowsEventListenerFactory.java
+++ b/services/src/main/java/org/keycloak/models/workflow/WorkflowsEventListenerFactory.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeParseException;
 import org.keycloak.Config.Scope;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.DurationConverter;
+import org.keycloak.common.util.Environment;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventListenerProviderFactory;
 import org.keycloak.models.KeycloakSession;
@@ -73,6 +74,11 @@ public class WorkflowsEventListenerFactory implements EventListenerProviderFacto
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
+        // skip event listener registration and scheduled tasks in non-server mode (export, import)
+        if (Environment.isNonServerMode()) {
+            return;
+        }
+
         factory.register(event -> {
             KeycloakSession session = event.getKeycloakSession();
 

--- a/services/src/main/java/org/keycloak/timer/basic/BasicTimerProvider.java
+++ b/services/src/main/java/org/keycloak/timer/basic/BasicTimerProvider.java
@@ -57,6 +57,12 @@ public class BasicTimerProvider implements TimerProvider {
 
     @Override
     public void schedule(final Runnable runnable, final long initialDelayMillis, final long intervalMillis, String taskName) {
+        // timer is not created in non-server mode (export, import) as scheduled tasks are not needed
+        if (timer == null) {
+            logger.debugf("Ignoring scheduled task '%s' in non-server mode", taskName);
+            return;
+        }
+
         TimerTask task = new BasicTimerTask(runnable);
 
         TimerTaskContextImpl taskContext = new TimerTaskContextImpl(runnable, task, Time.currentTimeMillis(), intervalMillis);

--- a/services/src/main/java/org/keycloak/timer/basic/BasicTimerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/timer/basic/BasicTimerProviderFactory.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.keycloak.Config;
+import org.keycloak.common.util.Environment;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.timer.TimerProvider;
@@ -49,7 +50,10 @@ public class BasicTimerProviderFactory implements TimerProviderFactory {
     @Override
     public void init(Config.Scope config) {
         transactionTimeout = config.getInt(TRANSACTION_TIMEOUT, 0);
-        timer = new Timer(true);
+        // skip timer creation in non-server mode (export, import) as scheduled tasks are not needed
+        if (!Environment.isNonServerMode()) {
+            timer = new Timer(true);
+        }
     }
 
     @Override


### PR DESCRIPTION
- Closes #51506
- The DBUS check is done at build time, and it might require more effort - left as is
- No more logs for timers:
```
Next time you run the server, just add --optimized to the command to ensure this build is used.
2026-08-06 14:53:14,844 INFO  [org.infinispan.CONTAINER] (main) ISPN000974: Virtual threads support: enabled
2026-08-06 14:53:16,153 INFO  [org.hibernate.orm.jdbc.batch] (JPA Startup Thread) HHH100501: Automatic JDBC statement batching enabled (maximum batch size 32)
2026-08-06 14:53:16,200 WARN  [org.keycloak.common.Profile] (main) Deprecated features identity-brokering-api:v1, twitter-broker:v1 enabled by default. Check the upgrading guide for steps to use later versions if available.
2026-08-06 14:53:17,377 INFO  [org.keycloak.quarkus.runtime.storage.database.liquibase.QuarkusJpaUpdaterProvider] (main) Initializing database schema. Using changelog META-INF/jpa-changelog-master.xml
2026-08-06 14:53:21,919 INFO  [org.infinispan.CONTAINER] (main) ISPN000556: Starting user marshaller 'org.infinispan.commons.marshall.ImmutableProtoStreamMarshaller'
2026-08-06 14:53:22,307 INFO  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Node name: node_878793, Site name: null, Cluster name: ISPN
2026-08-06 14:53:22,472 INFO  [org.keycloak.quarkus.runtime.storage.database.jpa.DatabaseIndexChecker] (db-index-checker) Running database index checker
2026-08-06 14:53:22,575 INFO  [org.keycloak.services] (main) KC-SERVICES0050: Initializing master realm
2026-08-06 14:53:24,583 INFO  [org.keycloak.services] (main) KC-SERVICES0033: Full model export requested
2026-08-06 14:53:24,583 INFO  [org.keycloak.exportimport.singlefile.SingleFileExportProvider] (main) Exporting model into file /home/mabartos/Documents/RH/keycloak/quarkus/dist/target/keycloak-999.0.0-SNAPSHOT/bin/test-realm.json
2026-08-06 14:53:25,316 INFO  [org.keycloak.services] (main) KC-SERVICES0035: Export finished successfully
2026-08-06 14:53:25,342 INFO  [org.keycloak.services.resources.KeycloakApplication] (main) Bootstrap completed in 9.141 seconds
2026-08-06 14:53:25,365 INFO  [io.quarkus] (main) Keycloak 999.0.0-SNAPSHOT on JVM (powered by Quarkus 3.38.0) started in 14.869s. Listening on: 
2026-08-06 14:53:25,365 INFO  [io.quarkus] (main) Profile nonserver activated. 
2026-08-06 14:53:25,365 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, jdbc-h2, keycloak, narayana-jta, opentelemetry, rest, rest-jackson, smallrye-context-propagation, vertx]
2026-08-06 14:53:26,390 INFO  [com.arjuna.ats.jbossatx] (main) ARJUNA032014: Stopping transaction recovery manager
2026-08-06 14:53:26,504 INFO  [io.quarkus] (main) Keycloak stopped in 1.132s

```


And these timers are skipped for the non-server command: 

```
2026-08-06 14:54:47,737 DEBUG [org.keycloak.timer.basic.BasicTimerProvider] (main) Ignoring scheduled task 'ClearExpiredRevokedTokens' in non-server mode
2026-08-06 14:54:48,170 INFO  [org.keycloak.services] (main) KC-SERVICES0033: Full model export requested
2026-08-06 14:54:48,170 INFO  [org.keycloak.exportimport.singlefile.SingleFileExportProvider] (main) Exporting model into file /home/mabartos/Documents/RH/keycloak/quarkus/dist/target/keycloak-999.0.0-SNAPSHOT/bin/test-realm.json
2026-08-06 14:54:48,947 INFO  [org.keycloak.services] (main) KC-SERVICES0035: Export finished successfully
2026-08-06 14:54:48,958 DEBUG [org.keycloak.timer.basic.BasicTimerProvider] (main) Ignoring scheduled task 'ClearExpiredEvents' in non-server mode
2026-08-06 14:54:48,959 DEBUG [org.keycloak.timer.basic.BasicTimerProvider] (main) Ignoring scheduled task 'ClearExpiredAdminEvents' in non-server mode
2026-08-06 14:54:48,959 DEBUG [org.keycloak.timer.basic.BasicTimerProvider] (main) Ignoring scheduled task 'ClearExpiredClientInitialAccessTokens' in non-server mode
2026-08-06 14:54:48,959 DEBUG [org.keycloak.timer.basic.BasicTimerProvider] (main) Ignoring scheduled task 'ClearExpiredUserSessions' in non-server mode
2026-08-06 14:54:48,959 DEBUG [org.keycloak.timer.basic.BasicTimerProvider] (main) Ignoring scheduled task 'ClearExpiredIssuedVerifiableCredentials' in non-server mode
```
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
