### PR TITLE
Introduce dedicated delegation permission for token exchange delegation

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/client/ClientPolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/client/ClientPolicyProvider.java
@@ -32,7 +32,7 @@ public class ClientPolicyProvider implements PolicyProvider {
         for (String client : representation.getClients()) {
             ClientModel clientModel = realm.getClientById(client);
             if (clientModel != null) {
-                if (context.getAttributes().containsValue("kc.client.id", clientModel.getClientId())) {
+                if (context.getAttributes().containsValue(EvaluationContext.CLIENT_ID_ATTRIBUTE, clientModel.getClientId())) {
                     evaluation.grant();
                     logger.debugf("Client policy %s matched with client %s and was granted", evaluation.getPolicy().getName(), clientModel.getClientId());
                     return;

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -38,6 +38,17 @@ Custom login themes that override `social-providers.ftl` or apply CSS targeting 
 
 Test your custom login theme to ensure the identity provider buttons display correctly.
 
+=== Token exchange delegation now requires FGAP V2 permissions
+
+The experimental token exchange delegation feature no longer uses the `impersonation` role from the `realm-management` client to authorize delegation. Instead, delegation is controlled exclusively through link:{adminguide_link}#_fine_grained_permissions[Fine-grained admin permissions version 2] (FGAP V2) using the new `delegate` scope on the Users resource type and the `delegate-members` scope on the Groups resource type.
+
+If you were previously using delegation with the `impersonation` role, you need to:
+
+. Enable Admin Permissions (FGAP V2) on your realm.
+. Create a User permission with the `delegate` scope and assign a policy targeting the administrators or service accounts that should be allowed to delegate. Alternatively, create a Group permission with the `delegate-members` scope to grant delegation for members of a specific group.
+
+FGAP V1 does not support delegation permissions.
+
 === Email is no longer marked as verified by other flows
 
 Previously, some flows marked the email of a user as verified even though their purpose was not email verification.

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -52,6 +52,17 @@ Two changes affect how claims are handled in the authorization services token en
 
 * When both a UMA permission ticket and a `claim_token` contain claims with the same key, ticket claims now take precedence. Previously, `claim_token` claims would silently override ticket claims on collision. This change ensures that claims set by the resource server when creating the permission ticket cannot be overridden by the requesting party.
 
+=== Token exchange delegation now requires FGAP V2 permissions
+
+The experimental token exchange delegation feature no longer uses the `impersonation` role from the `realm-management` client to authorize delegation. Instead, delegation is controlled exclusively through link:{adminguide_link}#_fine_grained_permissions[Fine-grained admin permissions version 2] (FGAP V2) using the new `delegate` scope on the Users resource type and the `delegate-members` scope on the Groups resource type.
+
+If you were previously using delegation with the `impersonation` role, you need to:
+
+. Enable Admin Permissions (FGAP V2) on your realm.
+. Create a User permission with the `delegate` scope and assign a policy targeting the administrators or service accounts that should be allowed to delegate. Alternatively, create a Group permission with the `delegate-members` scope to grant delegation for members of a specific group.
+
+FGAP V1 does not support delegation permissions.
+
 === Email is no longer marked as verified by other flows
 
 Previously, some flows marked the email of a user as verified even though their purpose was not email verification.

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -352,14 +352,36 @@ bin/kc.[sh|bat] start --features=token-exchange-delegation,parameterized-scopes
 
 === Admin delegation
 
-Admin delegation allows a user (subject) to delegate their token to an administrator. The client requests the `delegation` scope with the administrator's identifier as a parameter using the https://datatracker.ietf.org/doc/html/rfc9396[parameterized scopes] syntax.
+Admin delegation allows a user (subject) to delegate their token to an administrator (actor). The client requests the `delegation` scope with the administrator's identifier as a parameter using the https://datatracker.ietf.org/doc/html/rfc9396[parameterized scopes] syntax.
 
 When the feature is enabled, a `delegation` client scope is automatically created in new realms. Clients that want to use delegation must add the `delegation` scope to their optional client scopes in the Admin Console.
+
+==== Granting delegation permission
+
+Delegation permissions are managed through link:{adminguide_link}#_fine_grained_permissions[Fine-grained admin permissions version 2] (FGAP V2). Unlike impersonation, delegation does not use admin roles. Instead, you configure FGAP permissions to control which administrators can be delegated to and for which users.
+
+===== Granting delegation to all users
+
+. Go to *Realm Settings* -> *Admin Permissions* and enable Admin Permissions.
+. Navigate to *Admin Permissions* -> *Users*.
+. Create a new permission on the *Users* resource type.
+. Add the *delegate* scope.
+. Assign a policy that grants this permission.
+
+NOTE: To restrict delegation to specific users, select individual users when creating the permission. To restrict which administrators or service accounts can delegate, use a more specific policy (for example, a *User* or *Client* policy).
+
+===== Granting delegation to members of a specific group
+
+. Navigate to *Admin Permissions* -> *Groups*.
+. Select the target group.
+. Create a new permission on the group.
+. Add the *delegate-members* scope.
+. Assign a policy targeting the administrator or service account allowed to delegate.
 
 ==== How it works
 
 . The client requests the `delegation` scope with the administrator's (actor) identifier as a parameter, for example `scope=openid delegation:admin`.
-. {project_name} validates that the specified administrator (actor) exists and has the `impersonation` role from the `realm-management` client.
+. {project_name} validates that the specified administrator (actor) exists and has the `delegate` permission for the user (subject) through FGAP V2.
 . The user (subject) is presented with a consent screen to approve the delegation.
 . If the user consents and validation passes, the issued token includes the `may_act` claim with the actor's user ID as the `sub`:
 +
@@ -377,7 +399,9 @@ When the feature is enabled, a `delegation` client scope is automatically create
 
 The `may_act` claim declares that the specified administrator (actor) is authorized to act on behalf of the user (subject). The `sub` inside `may_act` contains the actor's user ID, consistent with {project_name}'s standard `sub` claim semantics. An external Security Token Service (STS) receiving this token can verify the delegation authorization directly from the claim without querying back to {project_name}.
 
-If the administrator (actor) does not have impersonation permission, the delegation scope is silently dropped and the `may_act` claim is not included in the token. The consent for delegation is always required and is not stored permanently - the user must approve delegation each login session.
+If the administrator (actor) does not have the delegation permission, the delegation scope is silently dropped and the `may_act` claim is not included in the token. The consent for delegation is always required and is not stored permanently - the user must approve delegation each login session.
+
+NOTE: Delegation permissions require FGAP V2. FGAP V1 does not support delegation.
 
 ==== Adding additional claims to `may_act`
 

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -368,7 +368,7 @@ Delegation permissions are managed through link:{adminguide_link}#_fine_grained_
 . Add the *delegate* scope.
 . Assign a policy that grants this permission.
 
-NOTE: To restrict delegation to specific users, select individual users when creating the permission. To restrict which administrators or service accounts can delegate, use a more specific policy (for example, a *User* or *Client* policy).
+NOTE: To restrict delegation to specific users, select individual users when creating the permission. To restrict which administrators or service accounts can delegate, use a more specific *User* policy that selects the corresponding user, including a service-account user.
 
 ===== Granting delegation to members of a specific group
 

--- a/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo26_8_0.java
+++ b/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo26_8_0.java
@@ -1,0 +1,22 @@
+package org.keycloak.migration.migrators;
+
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.migration.ModelVersion;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+public class MigrateTo26_8_0 extends RealmMigration {
+
+    public static final ModelVersion VERSION = new ModelVersion("26.8.0");
+
+    @Override
+    public ModelVersion getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public void migrateRealm(KeycloakSession session, RealmModel realm) {
+        AdminPermissionsSchema.SCHEMA.addResourceTypeScope(session, realm, AdminPermissionsSchema.USERS_RESOURCE_TYPE, AdminPermissionsSchema.DELEGATE);
+        AdminPermissionsSchema.SCHEMA.addResourceTypeScope(session, realm, AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, AdminPermissionsSchema.DELEGATE_MEMBERS);
+    }
+}

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultMigrationManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultMigrationManager.java
@@ -52,6 +52,7 @@ import org.keycloak.migration.migrators.MigrateTo26_4_3;
 import org.keycloak.migration.migrators.MigrateTo26_6_1;
 import org.keycloak.migration.migrators.MigrateTo26_6_2;
 import org.keycloak.migration.migrators.MigrateTo26_7_0;
+import org.keycloak.migration.migrators.MigrateTo26_8_0;
 import org.keycloak.migration.migrators.MigrateTo2_0_0;
 import org.keycloak.migration.migrators.MigrateTo2_1_0;
 import org.keycloak.migration.migrators.MigrateTo2_2_0;
@@ -138,6 +139,7 @@ public class DefaultMigrationManager implements MigrationManager {
             new MigrateTo26_6_1(),
             new MigrateTo26_6_2(),
             new MigrateTo26_7_0(),
+            new MigrateTo26_8_0(),
     };
 
     private final KeycloakSession session;

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/AdminPermissionsSchema.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/AdminPermissionsSchema.java
@@ -109,14 +109,18 @@ public class AdminPermissionsSchema extends AuthorizationSchema {
 
     // user specific scopes
     public static final String IMPERSONATE = "impersonate";
+    public static final String DELEGATE = "delegate";
     public static final String RESET_PASSWORD = "reset-password";
 
     public static final String MANAGE_GROUP_MEMBERSHIP = "manage-group-membership";
 
+    // group specific scope for delegation
+    public static final String DELEGATE_MEMBERS = "delegate-members";
+
     public static final ResourceType CLIENTS = new ResourceType(CLIENTS_RESOURCE_TYPE, Set.of(MANAGE, MAP_ROLES, MAP_ROLES_CLIENT_SCOPE, MAP_ROLES_COMPOSITE, VIEW));
-    public static final ResourceType GROUPS = new ResourceType(GROUPS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, MANAGE_MEMBERSHIP, MANAGE_MEMBERSHIP_OF_MEMBERS, MANAGE_MEMBERS, VIEW_MEMBERS, IMPERSONATE_MEMBERS));
+    public static final ResourceType GROUPS = new ResourceType(GROUPS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, MANAGE_MEMBERSHIP, MANAGE_MEMBERSHIP_OF_MEMBERS, MANAGE_MEMBERS, VIEW_MEMBERS, IMPERSONATE_MEMBERS, DELEGATE_MEMBERS));
     public static final ResourceType ROLES = new ResourceType(ROLES_RESOURCE_TYPE, Set.of(MAP_ROLE, MAP_ROLE_CLIENT_SCOPE, MAP_ROLE_COMPOSITE));
-    public static final ResourceType USERS = new ResourceType(USERS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, IMPERSONATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP, RESET_PASSWORD), Map.of(VIEW, Set.of(VIEW_MEMBERS), MANAGE, Set.of(MANAGE_MEMBERS), IMPERSONATE, Set.of(IMPERSONATE_MEMBERS), MANAGE_GROUP_MEMBERSHIP, Set.of(MANAGE_MEMBERSHIP_OF_MEMBERS)), GROUPS.getType());
+    public static final ResourceType USERS = new ResourceType(USERS_RESOURCE_TYPE, Set.of(MANAGE, VIEW, IMPERSONATE, DELEGATE, MAP_ROLES, MANAGE_GROUP_MEMBERSHIP, RESET_PASSWORD), Map.of(VIEW, Set.of(VIEW_MEMBERS), MANAGE, Set.of(MANAGE_MEMBERS), IMPERSONATE, Set.of(IMPERSONATE_MEMBERS), DELEGATE, Set.of(DELEGATE_MEMBERS), MANAGE_GROUP_MEMBERSHIP, Set.of(MANAGE_MEMBERSHIP_OF_MEMBERS)), GROUPS.getType());
     public static final ResourceType ORGANIZATIONS = new ResourceType(ORGANIZATIONS_RESOURCE_TYPE, Set.of(MANAGE, VIEW));
     private static final String SKIP_EVALUATION = "kc.authz.fgap.skip";
     public static final AdminPermissionsSchema SCHEMA = new AdminPermissionsSchema();

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/EvaluationContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/evaluation/EvaluationContext.java
@@ -29,6 +29,9 @@ import org.keycloak.authorization.identity.Identity;
  */
 public interface EvaluationContext {
 
+    String REALM_NAME_ATTRIBUTE = "kc.realm.name";
+    String CLIENT_ID_ATTRIBUTE = "kc.client.id";
+
     /**
      * Returns the {@link Identity} that represents an entity (person or non-person) to which the permissions must be granted, or not.
      *

--- a/services/src/main/java/org/keycloak/authorization/common/DefaultEvaluationContext.java
+++ b/services/src/main/java/org/keycloak/authorization/common/DefaultEvaluationContext.java
@@ -71,7 +71,7 @@ public class DefaultEvaluationContext implements EvaluationContext {
             attributes.put("kc.client.user_agent", userAgents);
         }
 
-        attributes.put("kc.realm.name", Arrays.asList(this.keycloakSession.getContext().getRealm().getName()));
+        attributes.put(REALM_NAME_ATTRIBUTE, Arrays.asList(this.keycloakSession.getContext().getRealm().getName()));
 
         if (claims != null) {
             for (Entry<String, List<String>> entry : claims.entrySet()) {
@@ -83,7 +83,7 @@ public class DefaultEvaluationContext implements EvaluationContext {
             AccessToken accessToken = KeycloakIdentity.class.cast(this.identity).getAccessToken();
 
             if (accessToken != null) {
-                attributes.put("kc.client.id", Arrays.asList(accessToken.getIssuedFor()));
+                attributes.put(CLIENT_ID_ATTRIBUTE, Arrays.asList(accessToken.getIssuedFor()));
             }
         }
 

--- a/services/src/main/java/org/keycloak/authorization/common/DefaultEvaluationContext.java
+++ b/services/src/main/java/org/keycloak/authorization/common/DefaultEvaluationContext.java
@@ -72,13 +72,13 @@ public class DefaultEvaluationContext implements EvaluationContext {
             attributes.put("kc.client.user_agent", userAgents);
         }
 
-        attributes.put("kc.realm.name", Arrays.asList(this.keycloakSession.getContext().getRealm().getName()));
+        attributes.put(REALM_NAME_ATTRIBUTE, Arrays.asList(this.keycloakSession.getContext().getRealm().getName()));
 
         if (identity instanceof KeycloakIdentity) {
             AccessToken accessToken = ((KeycloakIdentity) this.identity).getAccessToken();
 
             if (accessToken != null) {
-                attributes.put("kc.client.id", Collections.singletonList(accessToken.getIssuedFor()));
+                attributes.put(CLIENT_ID_ATTRIBUTE, Collections.singletonList(accessToken.getIssuedFor()));
             }
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/rar/parsers/ClientScopeAuthorizationRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/rar/parsers/ClientScopeAuthorizationRequestParser.java
@@ -156,6 +156,9 @@ public class ClientScopeAuthorizationRequestParser implements AuthorizationReque
                 } catch (InvalidScopeParameterException e) {
                     logger.warnf("Invalid scope parameter for '%s': %s", clientScopeModel.getName(), e.getMessage());
                     return Optional.empty();
+                } catch (UnsupportedOperationException e) {
+                    logger.warnf("Unsupported scope type operation for '%s': %s", clientScopeModel.getName(), e.getMessage());
+                    return Optional.empty();
                 }
                 return Optional.of(new IntermediaryScopeRepresentation(clientScopeModel, paramValue, requestScope));
             } else {

--- a/services/src/main/java/org/keycloak/protocol/oidc/scope/DelegationScopeType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/scope/DelegationScopeType.java
@@ -69,9 +69,9 @@ public class DelegationScopeType extends UsernameScopeType {
         }
         RealmModel realm = scope.getRealm();
         AdminPermissionEvaluator evaluator = AdminPermissions.evaluator(session, realm, realm, targetUser);
-        if (!evaluator.users().canImpersonate(currentUser, null)) {
-            throw new InvalidScopeParameterException(String.format("User '%s' cannot be impersonated by the administrator '%s' in realm '%s'",
-                    currentUser.getUsername(), targetUser.getUsername(), realm.getName()));
+        if (!evaluator.users().canDelegate(currentUser)) {
+            throw new InvalidScopeParameterException(String.format("Administrator '%s' is not allowed to delegate as user '%s' in realm '%s'",
+                    targetUser.getUsername(), currentUser.getUsername(), realm.getName()));
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissions.java
@@ -371,7 +371,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             @Override
             public Map<String, Collection<String>> getBaseAttributes() {
                 Map<String, Collection<String>> attributes = super.getBaseAttributes();
-                attributes.put("kc.client.id", Arrays.asList(authorizedClient.getClientId()));
+                attributes.put(CLIENT_ID_ATTRIBUTE, Arrays.asList(authorizedClient.getClientId()));
                 return attributes;
             }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/IdentityProviderPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/IdentityProviderPermissions.java
@@ -185,7 +185,7 @@ class IdentityProviderPermissions implements  IdentityProviderPermissionManageme
             @Override
             public Map<String, Collection<String>> getBaseAttributes() {
                 Map<String, Collection<String>> attributes = super.getBaseAttributes();
-                attributes.put("kc.client.id", Arrays.asList(authorizedClient.getClientId()));
+                attributes.put(CLIENT_ID_ATTRIBUTE, Arrays.asList(authorizedClient.getClientId()));
                 return attributes;
             }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionEvaluator.java
@@ -18,10 +18,11 @@ package org.keycloak.services.resources.admin.fgap;
 
 import java.util.Map;
 
+import jakarta.ws.rs.ForbiddenException;
+
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.ImpersonationConstants;
 import org.keycloak.models.UserModel;
 
 /**
@@ -62,7 +63,7 @@ public interface UserPermissionEvaluator {
      */
     default void requireResetPassword(UserModel user) {
         if (!canResetPassword(user)) {
-            throw new jakarta.ws.rs.ForbiddenException();
+            throw new ForbiddenException();
         }
     }
 
@@ -129,13 +130,44 @@ public interface UserPermissionEvaluator {
     boolean canImpersonate();
 
     /**
-     * Returns {@code true} if the caller has the {@link ImpersonationConstants#IMPERSONATION_ROLE}.
+     * Returns {@code true} if the caller has the {@link AdminRoles#IMPERSONATION} role.
      * <p/>
-     * NOTE: If requester is provided, it's clientId is added to evaluation context.
+     * NOTE: If requester is provided, its clientId is added to evaluation context.
      * <p/>
      * Or if it has a permission to {@link AdminPermissionsSchema#IMPERSONATE} the user.
      */
     boolean canImpersonate(UserModel user, ClientModel requester);
+
+    /**
+     * Throws ForbiddenException if {@link #canDelegate(UserModel)} returns {@code false}.
+     */
+    default void requireDelegate(UserModel user) {
+        if (!canDelegate(user)) {
+            throw new ForbiddenException();
+        }
+    }
+
+    /**
+     * Returns {@code true} if the caller has a permission to {@link AdminPermissionsSchema#DELEGATE} users.
+     */
+    default boolean canDelegate() {
+        return canDelegate((UserModel) null);
+    }
+
+    /**
+     * Returns {@code true} if the caller has a permission to {@link AdminPermissionsSchema#DELEGATE} the user.
+     */
+    default boolean canDelegate(UserModel user) {
+        return canDelegate(user, null);
+    }
+
+    /**
+     * Returns {@code true} if the caller has a permission to {@link AdminPermissionsSchema#DELEGATE} the user.
+     * <p/>
+     * NOTE: The requester's clientId is added to the evaluation context for
+     * client-aware FGAP policy evaluation.
+     */
+    boolean canDelegate(UserModel user, ClientModel requester);
 
     /**
      * Returns Map with information what access the caller for the provided user has.

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionEvaluator.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionEvaluator.java
@@ -157,17 +157,7 @@ public interface UserPermissionEvaluator {
     /**
      * Returns {@code true} if the caller has a permission to {@link AdminPermissionsSchema#DELEGATE} the user.
      */
-    default boolean canDelegate(UserModel user) {
-        return canDelegate(user, null);
-    }
-
-    /**
-     * Returns {@code true} if the caller has a permission to {@link AdminPermissionsSchema#DELEGATE} the user.
-     * <p/>
-     * NOTE: The requester's clientId is added to the evaluation context for
-     * client-aware FGAP policy evaluation.
-     */
-    boolean canDelegate(UserModel user, ClientModel requester);
+    boolean canDelegate(UserModel user);
 
     /**
      * Returns Map with information what access the caller for the provided user has.

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissions.java
@@ -49,6 +49,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.authorization.Permission;
 
+import static org.keycloak.authorization.policy.evaluation.EvaluationContext.CLIENT_ID_ATTRIBUTE;
+
 /**
  * Manages default policies for all users.
  *
@@ -342,7 +344,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
             @Override
             public Map<String, Collection<String>> getBaseAttributes() {
                 Map<String, Collection<String>> attributes = super.getBaseAttributes();
-                attributes.put("kc.client.id", Arrays.asList(client.getClientId()));
+                attributes.put(CLIENT_ID_ATTRIBUTE, Arrays.asList(client.getClientId()));
                 return attributes;
             }
 
@@ -395,7 +397,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         if (requester != null) {
             // make sure the requesting client id is available from the context as we are using a user identity that does not rely on token claims
             additionalClaims = new HashMap<>();
-            additionalClaims.put("kc.client.id", Arrays.asList(requester.getClientId()));
+            additionalClaims.put(CLIENT_ID_ATTRIBUTE, Arrays.asList(requester.getClientId()));
         }
 
         return hasPermission(new DefaultEvaluationContext(new UserModelIdentity(root.realm, user), additionalClaims, session), USER_IMPERSONATED_SCOPE);
@@ -424,6 +426,11 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
         if (!canImpersonate(user)) {
             throw new ForbiddenException();
         }
+    }
+
+    @Override
+    public boolean canDelegate(UserModel user, ClientModel requester) {
+        throw new UnsupportedOperationException("Delegation permissions are only supported with FGAP V2");
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissions.java
@@ -429,7 +429,7 @@ class UserPermissions implements UserPermissionEvaluator, UserPermissionManageme
     }
 
     @Override
-    public boolean canDelegate(UserModel user, ClientModel requester) {
+    public boolean canDelegate(UserModel user) {
         throw new UnsupportedOperationException("Delegation permissions are only supported with FGAP V2");
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
@@ -27,7 +27,6 @@ import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.authorization.identity.UserModelIdentity;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
-import org.keycloak.common.Profile;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -134,15 +133,8 @@ class UserPermissionsV2 extends UserPermissions {
     }
 
     @Override
-    public boolean canDelegate(UserModel user, ClientModel requester) {
-        if (!Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION)) {
-            return false;
-        }
-
-        DefaultEvaluationContext context = requester == null ? null :
-                new DefaultEvaluationContext(new UserModelIdentity(root.realm, user), Map.of(CLIENT_ID_ATTRIBUTE, List.of(requester.getClientId())), session);
-
-        return eval.hasPermission(new UserModelRecord(user), context, AdminPermissionsSchema.DELEGATE);
+    public boolean canDelegate(UserModel user) {
+        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.DELEGATE);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
@@ -27,11 +27,14 @@ import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.authorization.identity.UserModelIdentity;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.model.Resource;
+import org.keycloak.common.Profile;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.services.resources.admin.fgap.ModelRecord.UserModelRecord;
+
+import static org.keycloak.authorization.policy.evaluation.EvaluationContext.CLIENT_ID_ATTRIBUTE;
 
 class UserPermissionsV2 extends UserPermissions {
 
@@ -125,9 +128,28 @@ class UserPermissionsV2 extends UserPermissions {
         }
 
         DefaultEvaluationContext context = requester == null ? null :
-                new DefaultEvaluationContext(new UserModelIdentity(root.realm, user), Map.of("kc.client.id", List.of(requester.getClientId())), session);
+                new DefaultEvaluationContext(new UserModelIdentity(root.realm, user), Map.of(CLIENT_ID_ATTRIBUTE, List.of(requester.getClientId())), session);
 
         return eval.hasPermission(new UserModelRecord(user), context, AdminPermissionsSchema.IMPERSONATE);
+    }
+
+    @Override
+    public boolean canDelegate(UserModel user, ClientModel requester) {
+        if (!Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION)) {
+            return false;
+        }
+
+        DefaultEvaluationContext context = requester == null ? null :
+                new DefaultEvaluationContext(new UserModelIdentity(root.realm, user), Map.of(CLIENT_ID_ATTRIBUTE, List.of(requester.getClientId())), session);
+
+        return eval.hasPermission(new UserModelRecord(user), context, AdminPermissionsSchema.DELEGATE);
+    }
+
+    @Override
+    public Map<String, Boolean> getAccess(UserModel user) {
+        Map<String, Boolean> map = super.getAccess(user);
+        map.put("delegate", canDelegate(user));
+        return map;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
@@ -18,6 +18,7 @@ package org.keycloak.services.resources.admin.fgap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import jakarta.ws.rs.ForbiddenException;
 
@@ -134,7 +135,15 @@ class UserPermissionsV2 extends UserPermissions {
 
     @Override
     public boolean canDelegate(UserModel user) {
-        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.DELEGATE);
+        // When the evaluator's identity is a service account, include CLIENT_ID_ATTRIBUTE
+        // from its associated client so that FGAP Client policies can match on the client_id.
+        DefaultEvaluationContext context = Optional.ofNullable(root.admin())
+                .map(UserModel::getServiceAccountClientLink)
+                .map(root.realm::getClientById)
+                .map(client -> new DefaultEvaluationContext(root.identity(), Map.of(CLIENT_ID_ATTRIBUTE, List.of(client.getClientId())), session))
+                .orElse(null);
+
+        return eval.hasPermission(new UserModelRecord(user), context, AdminPermissionsSchema.DELEGATE);
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesOAuthGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopesOAuthGrantTest.java
@@ -2,16 +2,17 @@ package org.keycloak.tests.oauth;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
-import org.keycloak.models.AdminRoles;
 import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
@@ -26,7 +27,8 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
-import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -51,6 +53,7 @@ import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.OAuthGrantPage;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.admin.authz.fgap.PermissionTestUtils;
 import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
@@ -686,7 +689,10 @@ public class ParameterizedScopesOAuthGrantTest {
 
     @Test
     public void delegationScopeWithImplicitFlow() {
-        // create impersonation parameterized role with a hardcoded claim
+        // enable FGAP V2 admin permissions (delegation requires it)
+        realm.updateWithCleanup(r -> r.adminPermissionsEnabled(true));
+
+        // create delegation parameterized scope with a hardcoded claim
         createAndAssignOptionalScope(ParameterizedScopeBuilder.create("delegated-act")
                 .parameterizedScopeType("delegation")
                 .mappers(ProtocolMapperBuilder.create().name("Hardcoded Claim")
@@ -709,12 +715,11 @@ public class ParameterizedScopesOAuthGrantTest {
             r.clients().get(thirdParty.getId()).update(rep);
         });
 
-        // add impersonation to the admin user
-        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
-        final String clientUUID = realmManagement.toRepresentation().getId();
-        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        AdminApiUtil.findUserByUsernameId(realm.admin(), DEFAULT_ADMIN_USERNAME).roles()
-                .clientLevel(clientUUID).add(List.of(impersonation));
+        // grant delegation permission to the admin user via FGAP V2
+        final ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        final String adminUserId = AdminApiUtil.findUserByUsernameId(realm.admin(), DEFAULT_ADMIN_USERNAME).toRepresentation().getId();
+        UserPolicyRepresentation policy = PermissionTestUtils.createUserPolicy(realm, adminPerms, "Delegation Policy", adminUserId);
+        ScopePermissionRepresentation permission = PermissionTestUtils.createAllPermission(adminPerms, AdminPermissionsSchema.USERS_RESOURCE_TYPE, policy, Set.of(AdminPermissionsSchema.DELEGATE));
 
         // implicit flow login with the delegation scope granted
         String requestedScope = "delegated-act:" + DEFAULT_ADMIN_USERNAME;
@@ -733,10 +738,9 @@ public class ParameterizedScopesOAuthGrantTest {
         MatcherAssert.assertThat(List.of(token.getScope().split(" ")), Matchers.hasItem(requestedScope));
         Assertions.assertEquals("implicit-delegation", token.getOtherClaims().get("matched_scope"));
 
-        // logout and remove the permission
+        // logout and remove the delegation permission
         AccountHelper.logout(realm.admin(), DEFAULT_USERNAME);
-        AdminApiUtil.findUserByUsernameId(realm.admin(), DEFAULT_ADMIN_USERNAME).roles()
-                .clientLevel(clientUUID).remove(List.of(impersonation));
+        adminPerms.authorization().permissions().scope().findById(permission.getId()).remove();
 
         // implicit flow login with the delegation scope not granted
         oauth.client(THIRD_PARTY_APP)
@@ -784,7 +788,7 @@ public class ParameterizedScopesOAuthGrantTest {
 
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.PARAMETERIZED_SCOPES)
+            return config.features(Profile.Feature.PARAMETERIZED_SCOPES, Profile.Feature.TOKEN_EXCHANGE_DELEGATION)
                     .option("spi-ciba-auth-channel-ciba-http-auth-channel-http-authentication-channel-uri",
                             "http://localhost:8500/ciba/request-authentication-channel");
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
@@ -18,7 +18,6 @@ import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
-import org.keycloak.models.AdminRoles;
 import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
@@ -37,8 +36,9 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
-import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.authorization.Logic;
 import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.representations.oidc.TokenMetadataRepresentation;
@@ -68,6 +68,7 @@ import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.OAuthGrantPage;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.admin.authz.fgap.PermissionTestUtils;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
@@ -129,11 +130,26 @@ public class TokenExchangeDelegationTest {
     }
 
     @Test
-    public void delegationNoImpersonation() {
-        // request delegation with a user that cannot impersonate — scope is silently dropped
-        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+    public void delegationWithoutFGAPEnabled() {
+        // disable FGAP V2 - delegation requires it, so the scope should be silently dropped
+        realm.updateWithCleanup(r -> r.adminPermissionsEnabled(false));
 
-        // request delegation with a user that cannot impersonate
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope, grants -> MatcherAssert.assertThat(grants,
+                Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token")))));
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void delegationNoDelegatePermission() {
+        // request delegation with a user that has no delegate permission
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         AccessTokenResponse res = loginWithDelegation(scope, grants -> MatcherAssert.assertThat(grants,
                 Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token")))));
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
@@ -147,10 +163,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void delegation() {
-        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
-        final String clientUUID = realmManagement.toRepresentation().getId();
-        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
+        ScopePermissionRepresentation permission = addDelegationPermission();
 
         // request the delegation to administrator and accept the delegation
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
@@ -169,8 +182,9 @@ public class TokenExchangeDelegationTest {
         // perform the token exchange with delegation
         tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
 
-        // remove the impersonation and refresh the token
-        administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
+        // remove the delegation permission and refresh the token
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        adminPerms.authorization().permissions().scope().findById(permission.getId()).remove();
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
@@ -189,29 +203,12 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void delegationFGAP() throws Exception {
-        realm.updateWithCleanup(r -> r.adminPermissionsEnabled(true));
 
-        // create a policy that allows administrator to impersonate
         ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
-        UserPolicyRepresentation policy = new UserPolicyRepresentation();
-        policy.setName("Administrator Policy");
-        policy.addUser(administrator.getId());
-        try (Response response = adminPerms.authorization().policies().user().create(policy)) {
-            Assertions.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-            policy = response.readEntity(UserPolicyRepresentation.class);
-        }
-
-        // create the permission to impersonate the user
-        ScopePermissionRepresentation permission = new ScopePermissionRepresentation();
-        permission.setName("Administrator impersonation");
-        permission.setScopes(Set.of(AdminPermissionsSchema.IMPERSONATE));
-        permission.setResourceType(AdminPermissionsSchema.USERS_RESOURCE_TYPE);
-        permission.setResources(Set.of(AdminApiUtil.findUserByUsername(realm.admin(), USERNAME).getId()));
-        permission.setPolicies(Set.of(policy.getId()));
-        try (Response response = adminPerms.authorization().permissions().scope().create(permission)) {
-            Assertions.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-            permission = response.readEntity(ScopePermissionRepresentation.class);
-        }
+        UserPolicyRepresentation policy = PermissionTestUtils.createUserPolicy(realm, adminPerms, "Administrator Policy", administrator.getId());
+        String subjectUserId = AdminApiUtil.findUserByUsername(realm.admin(), USERNAME).getId();
+        ScopePermissionRepresentation permission = PermissionTestUtils.createPermission(adminPerms, subjectUserId,
+                AdminPermissionsSchema.USERS_RESOURCE_TYPE, Set.of(AdminPermissionsSchema.DELEGATE), policy);
 
         // request the delegation to administrator and accept the delegation
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
@@ -230,9 +227,8 @@ public class TokenExchangeDelegationTest {
         // perform the token exchange with delegation
         tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
 
-        // remove the impersonation and refresh the token
+        // remove the delegation permission and refresh the token
         adminPerms.authorization().permissions().scope().findById(permission.getId()).remove();
-        adminPerms.authorization().policies().user().findById(policy.getId()).remove();
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
@@ -250,11 +246,98 @@ public class TokenExchangeDelegationTest {
     }
 
     @Test
+    public void delegationFGAPDelegateMembersViaGroup() throws Exception {
+
+        // create a group and add the subject user as member
+        GroupRepresentation group = new GroupRepresentation();
+        group.setName("delegation-group");
+        try (Response response = realm.admin().groups().add(group)) {
+            group.setId(ApiUtil.getCreatedId(response));
+        }
+        String subjectUserId = AdminApiUtil.findUserByUsername(realm.admin(), USERNAME).getId();
+        realm.admin().users().get(subjectUserId).joinGroup(group.getId());
+
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        UserPolicyRepresentation policy = PermissionTestUtils.createUserPolicy(realm, adminPerms, "Administrator Policy", administrator.getId());
+        ScopePermissionRepresentation permission = PermissionTestUtils.createPermission(adminPerms, group.getId(),
+                AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, Set.of(AdminPermissionsSchema.DELEGATE_MEMBERS), policy);
+
+        // request the delegation to administrator and accept the delegation
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope);
+
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertScopeContains(res.getScope(), scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
+
+        // perform the token exchange with delegation
+        tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
+
+        // remove the permission and verify delegation stops working on refresh
+        adminPerms.authorization().permissions().scope().findById(permission.getId()).remove();
+        res = oauth.doRefreshTokenRequest(res.getRefreshToken());
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void delegationFGAPImpersonateDoesNotGrantDelegation() throws Exception {
+
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        UserPolicyRepresentation policy = PermissionTestUtils.createUserPolicy(realm, adminPerms, "Administrator Policy", administrator.getId());
+        String subjectUserId = AdminApiUtil.findUserByUsername(realm.admin(), USERNAME).getId();
+        PermissionTestUtils.createPermission(adminPerms, subjectUserId,
+                AdminPermissionsSchema.USERS_RESOURCE_TYPE, Set.of(AdminPermissionsSchema.IMPERSONATE), policy);
+
+        // delegation scope should be silently dropped since only impersonate is granted, not delegate
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope, grants -> MatcherAssert.assertThat(grants,
+                Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token")))));
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
+    public void delegationFGAPDeniedByNegativePolicy() throws Exception {
+
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        UserPolicyRepresentation allowPolicy = PermissionTestUtils.createUserPolicy(realm, adminPerms, "Allow Administrator Policy", administrator.getId());
+        UserPolicyRepresentation denyPolicy = PermissionTestUtils.createUserPolicy(Logic.NEGATIVE, realm, adminPerms, "Deny Administrator Policy", administrator.getId());
+
+        // grant delegate on all users
+        PermissionTestUtils.createAllPermission(adminPerms, AdminPermissionsSchema.USERS_RESOURCE_TYPE, allowPolicy, Set.of(AdminPermissionsSchema.DELEGATE));
+
+        // deny delegate on the specific user
+        String subjectUserId = AdminApiUtil.findUserByUsername(realm.admin(), USERNAME).getId();
+        PermissionTestUtils.createPermission(adminPerms, subjectUserId,
+                AdminPermissionsSchema.USERS_RESOURCE_TYPE, Set.of(AdminPermissionsSchema.DELEGATE), denyPolicy);
+
+        // delegation scope should be silently dropped due to negative policy on the specific user
+        final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
+        AccessTokenResponse res = loginWithDelegation(scope, grants -> MatcherAssert.assertThat(grants,
+                Matchers.not(Matchers.hasItem(Matchers.containsString("Delegate token")))));
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
+
+        // logout
+        LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
+        Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @Test
     public void delegationImplicit() {
-        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
-        final String clientUUID = realmManagement.toRepresentation().getId();
-        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
+        ScopePermissionRepresentation permission = addDelegationPermission();
 
         // enable implicit flow for the client
         ClientRepresentation clientRep = oauth.clientResource().toRepresentation();
@@ -285,8 +368,9 @@ public class TokenExchangeDelegationTest {
         // logout
         AdminApiUtil.findUserByUsernameId(realm.admin(), USERNAME).logout();
 
-        // remove the impersonation from the user and try again
-        administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
+        // remove the delegation permission and try again
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        adminPerms.authorization().permissions().scope().findById(permission.getId()).remove();
 
         oauth.scope(scope).responseType(OAuth2Constants.TOKEN).openLoginForm();
         oauth.fillLoginForm(USERNAME, PASSWORD);
@@ -304,12 +388,8 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void delegationWithPreferredUsernameMapper() {
-        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
-        final String clientUUID = realmManagement.toRepresentation().getId();
-        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
+        addDelegationPermission();
 
-        realm.cleanup().add(r -> r.users().get(administrator.getId()).roles().clientLevel(clientUUID).remove(List.of(impersonation)));
         String delegationScopeId = findDelegationScopeId();
         ProtocolMapperModel preferredUsernameMapper = ParameterizedScopeUserPropertyMapper.create(
                 "may_act preferred_username", "username",
@@ -353,8 +433,9 @@ public class TokenExchangeDelegationTest {
     }
 
     @Test
-    public void cibaDelegationNoImpersonation() throws Exception {
-        // request delegation with a user that cannot impersonate — scope is silently dropped
+    public void cibaDelegationNoDelegatePermission() throws Exception {
+
+        // request delegation with a user that has no delegate permission
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         oauth.scope(scope);
         AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(USERNAME)
@@ -372,7 +453,7 @@ public class TokenExchangeDelegationTest {
         ClientNotificationEndpointRequest pushedClientNotification = ciba.getPushedCibaClientNotification("client-notification-token");
         Assertions.assertEquals(pushedClientNotification.getAuthReqId(), response.getAuthReqId());
 
-        // delegation scope should not be present as user cannot impersonate
+        // delegation scope should not be present as user has no delegate permission
         AccessTokenResponse res = oauth.ciba().doBackchannelAuthenticationTokenRequest(response.getAuthReqId());
         Assertions.assertTrue(res.isSuccess());
         assertScopeNotContains(res.getScope(), scope);
@@ -384,10 +465,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void cibaDelegation() throws Exception {
-        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
-        final String clientUUID = realmManagement.toRepresentation().getId();
-        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
+        ScopePermissionRepresentation permission = addDelegationPermission();
 
         // client Backchannel Authentication Request
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
@@ -439,8 +517,9 @@ public class TokenExchangeDelegationTest {
         // perform the token exchange with delegation
         tokenExchangeDelegationSuccess(res.getAccessToken(), getActorToken());
 
-        // remove the impersonation and refresh the token
-        administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
+        // remove the delegation permission and refresh the token
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        adminPerms.authorization().permissions().scope().findById(permission.getId()).remove();
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
@@ -459,7 +538,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void failIfDisabledActor() {
-        addImpersonationToAdministrator();
+        addDelegationPermission();
 
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         AccessTokenResponse res = loginWithDelegation(scope);
@@ -481,7 +560,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void failIfInvalidAudienceInActorToken() {
-        addImpersonationToAdministrator();
+        addDelegationPermission();
 
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         AccessTokenResponse res = loginWithDelegation(scope);
@@ -502,7 +581,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void failIfNoAccessTokenRequested() {
-        addImpersonationToAdministrator();
+        addDelegationPermission();
 
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         AccessTokenResponse res = loginWithDelegation(scope);
@@ -521,7 +600,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void failIfOtherAdminInMayAct() {
-        addImpersonationToAdministrator();
+        addDelegationPermission();
 
         final String scope = OIDCLoginProtocolFactory.DELEGATION_SCOPE + ClientScopeModel.VALUE_SEPARATOR + administrator.getUsername();
         AccessTokenResponse res = loginWithDelegation(scope);
@@ -540,7 +619,7 @@ public class TokenExchangeDelegationTest {
 
     @Test
     public void issuerInMayAct() {
-        addImpersonationToAdministrator();
+        addDelegationPermission();
 
         // create a hardcoded claim to add the iss of the realm
         ProtocolMapperRepresentation issMapper = new ProtocolMapperRepresentation();
@@ -588,12 +667,10 @@ public class TokenExchangeDelegationTest {
         Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
     }
 
-    private void addImpersonationToAdministrator() {
-        final ClientResource realmManagement = AdminApiUtil.findClientByClientId(realm.admin(), Constants.REALM_MANAGEMENT_CLIENT_ID);
-        final String clientUUID = realmManagement.toRepresentation().getId();
-        final RoleRepresentation impersonation = realmManagement.roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        administrator.admin().roles().clientLevel(clientUUID).add(List.of(impersonation));
-        administrator.cleanup().add(user -> user.roles().clientLevel(clientUUID).remove(List.of(impersonation)));
+    private ScopePermissionRepresentation addDelegationPermission() {
+        ClientResource adminPerms = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ADMIN_PERMISSIONS_CLIENT_ID);
+        UserPolicyRepresentation policy = PermissionTestUtils.createUserPolicy(realm, adminPerms, "Administrator Policy", administrator.getId());
+        return PermissionTestUtils.createAllPermission(adminPerms, AdminPermissionsSchema.USERS_RESOURCE_TYPE, policy, Set.of(AdminPermissionsSchema.DELEGATE));
     }
 
     private void assertExchangeError(AccessTokenResponse tokenExchangeRes, String error, String reason) {
@@ -759,7 +836,8 @@ public class TokenExchangeDelegationTest {
 
         @Override
         public RealmBuilder configure(RealmBuilder realm) {
-            return realm.users(
+            return realm.adminPermissionsEnabled(true)
+                    .users(
                     UserBuilder.create(USERNAME).password(PASSWORD)
                             .email("test@localhost").firstName("Test").lastName("User"),
                     UserBuilder.create("otheruser").password(PASSWORD)


### PR DESCRIPTION
- Closes #51481
- New `delegate` scope on USERS resource type and `delegate-members` on GROUPS (mirrors impersonate/impersonate-members pattern)
- Delegation permissions managed exclusively through FGAP V2 (no admin roles)
- canDelegate() only supported in FGAP V2, V1 throws UnsupportedOperationException - which is handled as warn log and ignored for client scopes
- DelegationScopeType now calls canDelegate() instead of canImpersonate()
