### PR TITLE
Support custom required actions in add-required-action workflow step

### DIFF
--- a/services/src/main/java/org/keycloak/models/workflow/AddRequiredActionStepProvider.java
+++ b/services/src/main/java/org/keycloak/models/workflow/AddRequiredActionStepProvider.java
@@ -1,8 +1,11 @@
 package org.keycloak.models.workflow;
 
+import java.util.Locale;
+
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
 import org.keycloak.models.UserModel;
 
 import org.jboss.logging.Logger;
@@ -32,20 +35,29 @@ public class AddRequiredActionStepProvider implements WorkflowStepProvider {
                 log.warnv("Missing required configuration option '{0}' in {1}", REQUIRED_ACTION_KEY, AddRequiredActionStepProviderFactory.ID);
                 return;
             }
-            try {
-                // Convert hyphens to underscores and uppercase to match enum naming
-                configuredAction = configuredAction.replace("-", "_").toUpperCase();
-                UserModel.RequiredAction action = UserModel.RequiredAction.valueOf(configuredAction);
-                if (!realm.getRequiredActionProviderByAlias(action.name()).isEnabled()) {
-                    log.warnv("Required action {0} is not enabled in realm {1}", action, realm.getName());
-                    return;
-                }
-                log.debugv("Adding required action {0} to user {1}", action, user.getId());
-                user.addRequiredAction(action);
-            } catch (IllegalArgumentException e) {
-                log.warnv("Invalid required action {0} configured in {1}", stepModel.getConfig().getFirst(REQUIRED_ACTION_KEY),
-                        AddRequiredActionStepProviderFactory.ID);
+            RequiredActionProviderModel provider =
+                    realm.getRequiredActionProviderByAlias(configuredAction);
+
+            if (provider == null) {
+                String normalized = configuredAction.replace("-", "_").toUpperCase(Locale.ROOT);
+                provider = realm.getRequiredActionProviderByAlias(normalized);
             }
+
+            if (provider == null) {
+                log.warnv("Required action {0} is not configured in realm {1}",
+                        configuredAction, realm.getName());
+                return;
+            }
+
+            if (!provider.isEnabled()) {
+                log.warnv("Required action {0} is not enabled in realm {1}",
+                        configuredAction, realm.getName());
+                return;
+            }
+
+            log.debugv("Adding required action {0} to user {1}", provider.getAlias(), user.getId());
+
+            user.addRequiredAction(provider.getAlias());
         }
     }
 

--- a/services/src/main/java/org/keycloak/models/workflow/AddRequiredActionStepProvider.java
+++ b/services/src/main/java/org/keycloak/models/workflow/AddRequiredActionStepProvider.java
@@ -32,20 +32,20 @@ public class AddRequiredActionStepProvider implements WorkflowStepProvider {
                 log.warnv("Missing required configuration option '{0}' in {1}", REQUIRED_ACTION_KEY, AddRequiredActionStepProviderFactory.ID);
                 return;
             }
-            try {
-                // Convert hyphens to underscores and uppercase to match enum naming
-                configuredAction = configuredAction.replace("-", "_").toUpperCase();
-                UserModel.RequiredAction action = UserModel.RequiredAction.valueOf(configuredAction);
-                if (!realm.getRequiredActionProviderByAlias(action.name()).isEnabled()) {
-                    log.warnv("Required action {0} is not enabled in realm {1}", action, realm.getName());
-                    return;
-                }
-                log.debugv("Adding required action {0} to user {1}", action, user.getId());
-                user.addRequiredAction(action);
-            } catch (IllegalArgumentException e) {
-                log.warnv("Invalid required action {0} configured in {1}", stepModel.getConfig().getFirst(REQUIRED_ACTION_KEY),
-                        AddRequiredActionStepProviderFactory.ID);
+            RequiredActionProviderModel provider = realm.getRequiredActionProviderByAlias(configuredAction);
+
+            if (provider == null) {
+                log.warnv("Required action {0} is not configured in realm {1}",
+                        configuredAction, realm.getName());
+                return;
             }
+
+            if (!provider.isEnabled()) {
+                log.warnv("Required action {0} is not enabled in realm {1}",
+                        configuredAction, realm.getName());
+                return;
+            }
+            user.addRequiredAction(configuredAction);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/step/AddRequiredActionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/step/AddRequiredActionTest.java
@@ -21,6 +21,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -55,6 +57,47 @@ public class AddRequiredActionTest extends AbstractWorkflowTest {
                     Assertions.assertTrue(userRepresentation.getRequiredActions() != null && !userRepresentation.getRequiredActions().isEmpty());
                     assertThat(userRepresentation.getRequiredActions(), hasSize(1));
                     assertThat(userRepresentation.getRequiredActions().get(0), is(UserModel.RequiredAction.UPDATE_PASSWORD.name()));
+                });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"verify-email", "VERIFY_EMAIL"})
+    @DisplayName("Test required action name compatibility")
+    public void testRequiredActionNameCompatibility(String action) {
+        managedRealm.admin().workflows().create(
+                WorkflowRepresentation.withName("myworkflow")
+                        .onEvent(UserCreatedWorkflowEventFactory.ID)
+                        .withSteps(
+                                WorkflowStepRepresentation.create()
+                                        .of(AddRequiredActionStepProviderFactory.ID)
+                                        .withConfig(
+                                                AddRequiredActionStepProvider.REQUIRED_ACTION_KEY,
+                                                action
+                                        )
+                                        .build()
+                        )
+                        .build()
+        ).close();
+
+        managedRealm.admin().users()
+                .create(UserBuilder.create().username("myuser").build())
+                .close();
+
+        Awaitility.await()
+                .timeout(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    var users = managedRealm.admin().users().search("myuser");
+
+                    assertThat(users, hasSize(1));
+
+                    var userRepresentation = users.get(0);
+
+                    assertThat(userRepresentation.getRequiredActions(), hasSize(1));
+                    assertThat(
+                            userRepresentation.getRequiredActions().get(0),
+                            is(UserModel.RequiredAction.VERIFY_EMAIL.name())
+                    );
                 });
     }
 


### PR DESCRIPTION
## Summary

The `add-required-action` workflow step currently resolves required actions using the `UserModel.RequiredAction` enum. This prevents custom required actions from being configured because they are not part of the enum.

This change resolves the configured required action by looking up the corresponding `RequiredActionProviderModel` using its alias. If the provider exists and is enabled, its alias is added to the user.

This preserves support for built-in required actions while also allowing custom required actions.

## Testing

- Created a custom required action (`webauthn-register-passwordless`) and configured it in a workflow.
- Verified the required action is added to the user and executed during login.
- Verified built-in required actions such as `VERIFY_EMAIL` continue to work.

Closes #51415