### PR TITLE
Fix organization invitation endpoints to return 201 with Location header

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.organization.admin.resource;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,7 @@ import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.LoginActionsService;
+import org.keycloak.services.resources.admin.AdminRoot;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.util.ResolveRelative;
@@ -204,7 +206,14 @@ public class OrganizationInvitationResource {
                 .resourcePath(session.getContext().getUri())
                 .success();
 
-        return Response.noContent().build();
+        URI location = AdminRoot.realmsUrl(session.getContext().getUri())
+                .path(realm.getName())
+                .path("organizations")
+                .path(organization.getId())
+                .path("invitations")
+                .path(invitation.getId())
+                .build();
+        return Response.created(location).build();
     }
 
     private int getActionTokenLifespan() {
@@ -343,7 +352,7 @@ public class OrganizationInvitationResource {
     @Path("/{id}/resend")
     @Operation(summary = "Resend an invitation")
     @APIResponses(value = {
-        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
         @APIResponse(responseCode = "404", description = "Not Found")
     })

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -133,7 +133,7 @@ public class OrganizationMemberResource {
     @Operation(summary = "Invites an existing user or sends a registration link to a new user, based on the provided e-mail address.",
             description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link.")
     @APIResponses(value = {
-        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
         @APIResponse(responseCode = "409", description = "Conflict"),
@@ -151,7 +151,7 @@ public class OrganizationMemberResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Invites an existing user to the organization, using the specified user id")
     @APIResponses(value = {
-        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "201", description = "Created"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
         @APIResponse(responseCode = "500", description = "Internal Server Error")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -148,7 +148,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
             OrganizationAttributeUpdater oau = new OrganizationAttributeUpdater(organization).setRedirectUrl(OAuthClient.APP_AUTH_ROOT).update();
             Response response = organization.members().inviteExistingUser(user.getId());
         ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             acceptInvitation(organization, user, "AUTH_RESPONSE");
         }
@@ -164,7 +164,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
                 OrganizationAttributeUpdater oau = new OrganizationAttributeUpdater(organization).setRedirectUrl(OAuthClient.APP_AUTH_ROOT).update();
                 Response response = organization.members().inviteExistingUser(user.getId());
         ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             acceptInvitation(organization, user, "AUTH_RESPONSE");
 
@@ -200,7 +200,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
             OrganizationAttributeUpdater oau = new OrganizationAttributeUpdater(organization).setRedirectUrl(OAuthClient.APP_AUTH_ROOT).update();
             Response response = organization.members().inviteUser(user.getEmail(), "Homer", "Simpson");
         ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             acceptInvitation(organization, user, "AUTH_RESPONSE");
         }
@@ -218,7 +218,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
                 .update();
             Response response = organization.members().inviteExistingUser(user.getId());
         ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             acceptInvitation(organization, user, "AUTH_RESPONSE");
         }
@@ -384,7 +384,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
             OrganizationAttributeUpdater oau = new OrganizationAttributeUpdater(organization).setRedirectUrl(OAuthClient.APP_AUTH_ROOT).update();
             Response response = organization.members().inviteUser(email, firstName, lastName);
         ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             registerUser(organization, email);
 
@@ -410,7 +410,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
                 RealmAttributeUpdater rau = new RealmAttributeUpdater(managedRealm.admin()).setRegistrationAllowed(Boolean.TRUE).update();
                 Response response = organization.members().inviteUser(email, null, null)
             ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             registerUser(organization, email);
 
@@ -443,7 +443,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
                 managedRealm.admin().update(realmRep);
             });
 
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             String link = getInvitationLinkFromEmail();
             driver.navigate().to(link);
@@ -625,7 +625,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
                 RealmAttributeUpdater rau = new RealmAttributeUpdater(managedRealm.admin()).setRegistrationAllowed(Boolean.TRUE).update();
                 Response response = organization.members().inviteUser(email, null, null)
             ) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             // Get the invitation link from email
             String invitationLink = getInvitationLinkFromEmail();
@@ -662,7 +662,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
 
         try (Response response = organization.members().inviteExistingUser(user.getId())) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             // Get the invitation link from email
             String invitationLink = getInvitationLinkFromEmail(user.getFirstName(), user.getLastName());
@@ -697,7 +697,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         String firstInvitationLink;
 
         try (Response response = organization.members().inviteExistingUser(user.getId())) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
             // Get the invitation link from email
             firstInvitationLink = getInvitationLinkFromEmail(user.getFirstName(), user.getLastName());
         }
@@ -708,7 +708,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         OrganizationInvitationRepresentation firstInvitation = invitations.get(0);
 
         try (Response response = organization.invitations().resend(firstInvitation.getId())) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
             // Get the invitation ID and delete it from the database
             invitations = organization.invitations().list();
             assertThat(invitations, Matchers.hasSize(1));
@@ -744,7 +744,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         assertThat(invitations, Matchers.hasSize(1));
         OrganizationInvitationRepresentation invitation = invitations.get(0);
         try (Response response = organization.invitations().resend(invitation.getId())) {
-            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            assertThat(response.getStatus(), equalTo(Response.Status.CREATED.getStatusCode()));
 
             // Try to use the first invitation link (should fail)
             driver.navigate().to(link);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -154,7 +154,7 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
         
         // Resend invitation
         try (Response response = organization.invitations().resend(invitationId)) {
-            assertThat(response.getStatus(), equalTo(204));
+            assertThat(response.getStatus(), equalTo(201));
         }
         
         // Verify invitation is still pending
@@ -519,7 +519,7 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
     
     private void sendInvitationToOrganization(OrganizationResource org, String email, String firstName, String lastName) {
         try (Response response = org.members().inviteUser(email, firstName, lastName)) {
-            assertThat(response.getStatus(), equalTo(204));
+            assertThat(response.getStatus(), equalTo(201));
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -155,6 +155,8 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
         // Resend invitation
         try (Response response = organization.invitations().resend(invitationId)) {
             assertThat(response.getStatus(), equalTo(201));
+            assertThat(response.getLocation(), notNullValue());
+            assertThat(response.getLocation().getPath(), containsString("/organizations/" + organizationId + "/invitations/"));
         }
         
         // Verify invitation is still pending
@@ -166,7 +168,8 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
 
         invitations = organization.invitations().list();
         assertThat(invitations, hasSize(1));
-        assertThat(invitations.get(0).getId(), not(equalTo(invitationId)));
+        String newInvitationId = invitations.get(0).getId();
+        assertThat(newInvitationId, not(equalTo(invitationId)));
     }
 
     @Test
@@ -520,6 +523,8 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
     private void sendInvitationToOrganization(OrganizationResource org, String email, String firstName, String lastName) {
         try (Response response = org.members().inviteUser(email, firstName, lastName)) {
             assertThat(response.getStatus(), equalTo(201));
+            assertThat(response.getLocation(), notNullValue());
+            assertThat(response.getLocation().getPath(), containsString("/invitations/"));
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #51298

The organization invitation endpoints (`invite-user`, `invite-existing-user`, and `resend`) were returning HTTP 204 No Content. Per REST conventions, creating a resource should return HTTP 201 Created with a `Location` header pointing to the newly created resource.

### Changes

- **`OrganizationInvitationResource.sendInvitation()`**: Changed `Response.noContent().build()` to `Response.created(location).build()`, where the Location URI points to `/admin/realms/{realm}/organizations/{orgId}/invitations/{invitationId}`
- **OpenAPI annotations**: Updated `@APIResponse` annotations on `inviteUser`, `inviteExistingUser`, and `resendInvitation` from `204 No Content` to `201 Created`
- The Location URI is built using `AdminRoot.realmsUrl()` following the existing Keycloak pattern used in other admin resources (`OrganizationsResource`, `UsersResource`, `ClientsResource`, etc.)

### Affected endpoints

| Endpoint | Before | After |
|---|---|---|
| `POST /admin/realms/{realm}/organizations/{orgId}/members/invite-user` | 204 No Content | 201 Created + Location |
| `POST /admin/realms/{realm}/organizations/{orgId}/members/invite-existing-user` | 204 No Content | 201 Created + Location |
| `POST /admin/realms/{realm}/organizations/{orgId}/invitations/{id}/resend` | 204 No Content | 201 Created + Location |