### PR TITLE
Return SPNEGO mutual authentication token

### DIFF
--- a/common/src/main/java/org/keycloak/common/constants/KerberosConstants.java
+++ b/common/src/main/java/org/keycloak/common/constants/KerberosConstants.java
@@ -82,7 +82,7 @@ public class KerberosConstants {
 
 
     /**
-     * Internal attribute used in "state" map . Contains token to be passed in HTTP Response back to browser to continue handshake
+     * Internal attribute used in "state" map. Contains a token to be passed in the HTTP response to continue or complete the handshake.
      */
     public static final String RESPONSE_TOKEN = "SpnegoResponseToken";
 

--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosFederationProvider.java
@@ -215,6 +215,11 @@ public class KerberosFederationProvider implements UserStorageProvider,
 
                     return CredentialValidationOutput.fallback();
                 } else {
+                    String responseToken = spnegoAuthenticator.getResponseToken();
+                    if (responseToken != null) {
+                        state.put(KerberosConstants.RESPONSE_TOKEN, responseToken);
+                    }
+
                     String delegationCredential = spnegoAuthenticator.getSerializedDelegationCredential();
                     if (delegationCredential != null) {
                         state.put(KerberosConstants.GSS_DELEGATION_CREDENTIAL, delegationCredential);

--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/impl/SPNEGOAuthenticator.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/impl/SPNEGOAuthenticator.java
@@ -166,7 +166,10 @@ public class SPNEGOAuthenticator {
 
         byte[] inputToken = Base64.getMimeDecoder().decode(spnegoToken);
         byte[] respToken = gssContext.acceptSecContext(inputToken, 0, inputToken.length);
-        responseToken = Base64.getEncoder().encodeToString(respToken);
+        if (respToken != null && respToken.length > 0) {
+            // MIME Base64 can insert CRLF and must not be used for a value sent in an HTTP header.
+            responseToken = Base64.getEncoder().encodeToString(respToken);
+        }
 
         return gssContext;
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -981,6 +981,11 @@ public class LDAPStorageProvider implements UserStorageProvider,
                         credential.setNote(KerberosConstants.AUTHENTICATED_SPNEGO_CONTEXT, spnegoAuthenticator);
                         return CredentialValidationOutput.fallback();
                     } else {
+                        String responseToken = spnegoAuthenticator.getResponseToken();
+                        if (responseToken != null) {
+                            state.put(KerberosConstants.RESPONSE_TOKEN, responseToken);
+                        }
+
                         String delegationCredential = spnegoAuthenticator.getSerializedDelegationCredential();
                         if (delegationCredential != null) {
                             state.put(KerberosConstants.GSS_DELEGATION_CREDENTIAL, delegationCredential);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java
@@ -104,7 +104,12 @@ public class SpnegoAuthenticator extends AbstractUsernameFormAuthenticator imple
             context.setUser(output.getAuthenticatedUser());
             if (output.getState() != null && !output.getState().isEmpty()) {
                 for (Map.Entry<String, String> entry : output.getState().entrySet()) {
-                    context.getAuthenticationSession().setUserSessionNote(entry.getKey(), entry.getValue());
+                    if (KerberosConstants.RESPONSE_TOKEN.equals(entry.getKey())) {
+                        String negotiateHeader = KerberosConstants.NEGOTIATE + " " + entry.getValue();
+                        context.getSession().getContext().getHttpResponse().setHeader(HttpHeaders.WWW_AUTHENTICATE, negotiateHeader);
+                    } else {
+                        context.getAuthenticationSession().setUserSessionNote(entry.getKey(), entry.getValue());
+                    }
                 }
             }
             context.success(UserCredentialModel.KERBEROS);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/SpnegoAuthenticator.java
@@ -18,6 +18,7 @@
 package org.keycloak.authentication.authenticators.browser;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.ws.rs.core.HttpHeaders;
@@ -103,14 +104,14 @@ public class SpnegoAuthenticator extends AbstractUsernameFormAuthenticator imple
         if (output.getAuthStatus() == CredentialValidationOutput.Status.AUTHENTICATED) {
             context.setUser(output.getAuthenticatedUser());
             if (output.getState() != null && !output.getState().isEmpty()) {
-                for (Map.Entry<String, String> entry : output.getState().entrySet()) {
-                    if (KerberosConstants.RESPONSE_TOKEN.equals(entry.getKey())) {
-                        String negotiateHeader = KerberosConstants.NEGOTIATE + " " + entry.getValue();
-                        context.getSession().getContext().getHttpResponse().setHeader(HttpHeaders.WWW_AUTHENTICATE, negotiateHeader);
-                    } else {
-                        context.getAuthenticationSession().setUserSessionNote(entry.getKey(), entry.getValue());
-                    }
+                Map<String, String> state = new HashMap<>(output.getState());
+                String spnegoResponseToken = state.remove(KerberosConstants.RESPONSE_TOKEN);
+                if (spnegoResponseToken != null && !spnegoResponseToken.isEmpty()) {
+                    String negotiateHeader = KerberosConstants.NEGOTIATE + " " + spnegoResponseToken;
+                    // The authenticator does not own the final flow response, so attach the final GSS token before the flow continues.
+                    context.getSession().getContext().getHttpResponse().setHeader(HttpHeaders.WWW_AUTHENTICATE, negotiateHeader);
                 }
+                state.forEach(context.getAuthenticationSession()::setUserSessionNote);
             }
             context.success(UserCredentialModel.KERBEROS);
         } else if (output.getAuthStatus() == CredentialValidationOutput.Status.CONTINUE) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.federation.kerberos;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -42,6 +43,7 @@ import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.TestAppHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
+import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSCredential;
 import org.junit.Assume;
 import org.junit.Ignore;
@@ -119,15 +121,48 @@ public abstract class AbstractKerberosSingleRealmTest extends AbstractKerberosTe
     }
 
     @Test
-    public void spnegoMutualAuthenticationTest() {
-        Response response = spnegoLogin("hnelson", "secret");
+    public void spnegoMutualAuthenticationTest() throws Exception {
+        ProtocolMapperModel protocolMapper = UserSessionNoteMapper.createClaimMapper("SPNEGO response token",
+                KerberosConstants.RESPONSE_TOKEN, KerberosConstants.RESPONSE_TOKEN, "String",
+                true, false, true, true);
+        ProtocolMapperRepresentation protocolMapperRep = ModelToRepresentation.toRepresentation(protocolMapper);
+        ClientResource clientResource = findClientByClientId(testRealmResource(), "kerberos-app");
+        Response mapperResponse = clientResource.getProtocolMappers().createMapper(protocolMapperRep);
+        String protocolMapperId = ApiUtil.getCreatedId(mapperResponse);
+        mapperResponse.close();
 
-        Assertions.assertEquals(302, response.getStatus());
-        String negotiateHeader = response.getHeaderString(HttpHeaders.WWW_AUTHENTICATE);
-        Assertions.assertNotNull(negotiateHeader);
-        Assertions.assertTrue(negotiateHeader.startsWith(KerberosConstants.NEGOTIATE + " "));
-        Assertions.assertTrue(negotiateHeader.length() > KerberosConstants.NEGOTIATE.length() + 1);
-        response.close();
+        try {
+            Response response = spnegoLoginWithoutRedirect("hnelson", "secret");
+            String codeUrl;
+            try {
+                Assertions.assertEquals(302, response.getStatus());
+                codeUrl = response.getLocation().toString();
+
+                String negotiatePrefix = KerberosConstants.NEGOTIATE + " ";
+                String negotiateHeader = response.getHeaderString(HttpHeaders.WWW_AUTHENTICATE);
+                Assertions.assertNotNull(negotiateHeader);
+                Assertions.assertTrue(negotiateHeader.startsWith(negotiatePrefix));
+
+                byte[] responseToken = Base64.getDecoder().decode(negotiateHeader.substring(negotiatePrefix.length()));
+                GSSContext gssContext = spnegoSchemeFactory.getGssContext();
+                Assertions.assertNotNull(gssContext);
+                try {
+                    gssContext.initSecContext(responseToken, 0, responseToken.length);
+                    Assertions.assertTrue(gssContext.isEstablished());
+                    Assertions.assertTrue(gssContext.getMutualAuthState());
+                } finally {
+                    gssContext.dispose();
+                }
+            } finally {
+                response.close();
+            }
+
+            AccessTokenResponse tokenResponse = assertAuthenticationSuccess(codeUrl);
+            AccessToken token = oauth.verifyToken(tokenResponse.getAccessToken());
+            Assertions.assertFalse(token.getOtherClaims().containsKey(KerberosConstants.RESPONSE_TOKEN));
+        } finally {
+            clientResource.getProtocolMappers().delete(protocolMapperId);
+        }
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
@@ -118,6 +118,18 @@ public abstract class AbstractKerberosSingleRealmTest extends AbstractKerberosTe
         Assertions.assertEquals(302, response.getStatus());
     }
 
+    @Test
+    public void spnegoMutualAuthenticationTest() {
+        Response response = spnegoLogin("hnelson", "secret");
+
+        Assertions.assertEquals(302, response.getStatus());
+        String negotiateHeader = response.getHeaderString(HttpHeaders.WWW_AUTHENTICATE);
+        Assertions.assertNotNull(negotiateHeader);
+        Assertions.assertTrue(negotiateHeader.startsWith(KerberosConstants.NEGOTIATE + " "));
+        Assertions.assertTrue(negotiateHeader.length() > KerberosConstants.NEGOTIATE.length() + 1);
+        response.close();
+    }
+
 
     // KEYCLOAK-2102
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
@@ -243,11 +243,7 @@ public abstract class AbstractKerberosTest extends AbstractAuthTest {
 
 
     protected Response spnegoLogin(String username, String password) {
-        String kcLoginPageLocation = oauth.loginForm().state("spnegoLogin").build();
-
-        // Request for SPNEGO login sent with Resteasy client
-        spnegoSchemeFactory.setCredentials(username, password);
-        Response response = client.target(kcLoginPageLocation).request().get();
+        Response response = spnegoLoginWithoutRedirect(username, password);
         if (response.getStatus() == 302) {
             if (response.getLocation() == null)
                 return response;
@@ -257,6 +253,15 @@ public abstract class AbstractKerberosTest extends AbstractAuthTest {
             }
         }
         return response;
+
+    }
+
+    protected Response spnegoLoginWithoutRedirect(String username, String password) {
+        String kcLoginPageLocation = oauth.loginForm().state("spnegoLogin").build();
+
+        // Request for SPNEGO login sent with Resteasy client
+        spnegoSchemeFactory.setCredentials(username, password);
+        return client.target(kcLoginPageLocation).request().get();
 
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KeycloakSPNegoSchemeFactory.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/KeycloakSPNegoSchemeFactory.java
@@ -47,6 +47,7 @@ public class KeycloakSPNegoSchemeFactory extends SPNegoSchemeFactory {
 
     private String username;
     private String password;
+    private GSSContext gssContext;
 
 
     public KeycloakSPNegoSchemeFactory(CommonKerberosConfig kerberosConfig, boolean credDelegEnabled) {
@@ -59,6 +60,10 @@ public class KeycloakSPNegoSchemeFactory extends SPNegoSchemeFactory {
     public void setCredentials(String username, String password) {
         this.username = username;
         this.password = password;
+    }
+
+    public GSSContext getGssContext() {
+        return gssContext;
     }
 
 
@@ -120,7 +125,7 @@ public class KeycloakSPNegoSchemeFactory extends SPNegoSchemeFactory {
                 GSSManager manager = getManager();
                 String httPrincipal = kerberosConfig.getServerPrincipal().replaceFirst("/.*@", "/" + authServer + "@");
                 GSSName serverName = manager.createName(httPrincipal, null);
-                GSSContext gssContext = manager.createContext(
+                gssContext = manager.createContext(
                         serverName.canonicalize(oid), oid, null, GSSContext.DEFAULT_LIFETIME);
                 gssContext.requestMutualAuth(true);
                 gssContext.requestCredDeleg(credDelegEnabled);


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

# Summary

Closes #51559 

Propagate the final SPNEGO response token when the GSS security context is established and return it in the `WWW-Authenticate` header of the authentication response.

Both the standalone Kerberos provider and the LDAP provider now include a generated response token in authenticated credential-validation state.
The browser SPNEGO authenticator extracts that transient protocol state, adds it to the HTTP response, and persists only the remaining credential state as user-session notes.

The GSS output token is optional.
`SPNEGOAuthenticator` now handles `null` and empty output tokens without failing authentication or generating a malformed empty `Negotiate` challenge.
It continues to use basic Base64 encoding because MIME Base64 can insert CRLF characters and is unsuitable for HTTP header values.

This allows clients that request SPNEGO mutual authentication to validate the Keycloak server and complete the exchange.

This follows [RFC 4178 section 3.2](https://www.rfc-editor.org/rfc/rfc4178#section-3.2), which requires a response mechanism token returned by the acceptor to be included in the SPNEGO response.
[RFC 4559 section 4.1](https://www.rfc-editor.org/rfc/rfc4559#section-4.1) and [section 5](https://www.rfc-editor.org/rfc/rfc4559#section-5) carry that final token as `gssapi-data` in the `WWW-Authenticate` header of the final HTTP response.

RFC 4559 illustrates a `200` final response rather than Keycloak's authorization-endpoint redirect.
Keycloak concludes successful browser authentication with a `302`, and [RFC 9110 section 11.6.1](https://www.rfc-editor.org/rfc/rfc9110#section-11.6.1) permits `WWW-Authenticate` on response statuses other than `401`.
The header is attached to the current HTTP response before the authentication flow continues because an authenticator does not own the flow's final JAX-RS response.

## Testing

Extended `spnegoMutualAuthenticationTest` in the shared Kerberos integration test class.
The test runs through both `KerberosStandaloneTest` and `KerberosLdapTest` and verifies that:

- The immediate successful redirect contains a non-empty `WWW-Authenticate: Negotiate <token>` header.
- Processing the returned token establishes the initiating GSS context with mutual authentication enabled.
- `SpnegoResponseToken` is not persisted as a user-session note or exposed through a configured session-note protocol mapper.

The header assertion failed against the original implementation because the final token was absent.

Verified with:

```bash
./mvnw -pl testsuite/integration-arquillian/tests/base -am install \
  -Dtest=org.keycloak.testsuite.federation.kerberos.KerberosStandaloneTest#spnegoMutualAuthenticationTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipProtoLock=true \
  -Dskip.installnodepnpm \
  -Dskip.pnpm \
  -Dmaven.antrun.skip=true

./mvnw -pl testsuite/integration-arquillian/tests/base -am install \
  -Dtest=org.keycloak.testsuite.federation.kerberos.KerberosLdapTest#spnegoMutualAuthenticationTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipProtoLock=true \
  -Dskip.installnodepnpm \
  -Dskip.pnpm \
  -Dmaven.antrun.skip=true

./mvnw spotless:check
```

## Documentation

No documentation changes are required because this corrects the existing SPNEGO protocol behavior and does not introduce configuration or user-facing options.
The observable addition of the final response header is described above for reviewers and release-note generation.

## AI disclosure

AI agents were used to help investigate the authentication flow, draft the implementation, and prepare the regression tests.
I reviewed and understand the complete change and am responsible for the submitted code.
