### PR TITLE
Admin client: bump Jackson 3 RESTEasy provider to 1.0.0.Beta1

### DIFF
--- a/integration/admin-client-jackson3/pom.xml
+++ b/integration/admin-client-jackson3/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <version.tools.jackson>3.1.5</version.tools.jackson>
-        <version.resteasy.jackson.provider>1.0.0.Alpha1</version.resteasy.jackson.provider>
+        <version.resteasy.jackson.provider>1.0.0.Beta1</version.resteasy.jackson.provider>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
https://github.com/resteasy/resteasy-jackson-provider/releases/tag/v1.0.0.Beta1 was released, moving us closer to more stable version for Jackson 3-based RESTEasy Jackson provider.
