### PR TITLE
Fix UnknownError parsing Kerberos principal with escaped '@'

### DIFF
--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosPrincipal.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/KerberosPrincipal.java
@@ -24,18 +24,50 @@ package org.keycloak.federation.kerberos;
  */
 public class KerberosPrincipal {
 
+    private static final char REALM_SEPARATOR = '@';
+    private static final char ESCAPE_CHAR = '\\';
+
     // Full principal name like "john@KEYCLOAK.ORG"
     private final String kerberosPrincipal;
     private final String prefix; // Something like "john"
     private final String realm; // Something like "KEYCLOAK.ORG"
     public KerberosPrincipal(String kerberosPrincipal) {
-        String[] parts = kerberosPrincipal.split("@");
-        if (parts.length != 2) {
+        int separatorIndex = findRealmSeparatorIndex(kerberosPrincipal);
+        if (separatorIndex < 0 || separatorIndex == kerberosPrincipal.length() - 1) {
             throw new IllegalArgumentException("Kerberos principal '" + kerberosPrincipal + "' not valid");
         }
-        this.prefix = parts[0];
-        this.realm = parts[1].toUpperCase();
-        this.kerberosPrincipal = prefix + "@" + realm;
+        this.prefix = kerberosPrincipal.substring(0, separatorIndex);
+        this.realm = kerberosPrincipal.substring(separatorIndex + 1).toUpperCase();
+        this.kerberosPrincipal = prefix + REALM_SEPARATOR + realm;
+    }
+
+    /**
+     * Finds the index of the single unescaped '{@code @}' separating the principal name from the
+     * realm. An '{@code @}' inside the principal name is escaped as "{@code \@}" (RFC 1964, section
+     * 2.1.1) and is not treated as the realm separator. Returns {@code -1} when the principal does
+     * not contain exactly one unescaped '{@code @}', i.e. it is not a valid {@code name@REALM}.
+     */
+    private static int findRealmSeparatorIndex(String principal) {
+        int separatorIndex = -1;
+        for (int i = 0; i < principal.length(); i++) {
+            if (principal.charAt(i) == REALM_SEPARATOR && !isEscaped(principal, i)) {
+                if (separatorIndex != -1) {
+                    // more than one unescaped '@' -> ambiguous, not a valid principal
+                    return -1;
+                }
+                separatorIndex = i;
+            }
+        }
+        return separatorIndex;
+    }
+
+    // A character is escaped when preceded by an odd number of consecutive escape characters.
+    private static boolean isEscaped(String value, int index) {
+        int backslashes = 0;
+        for (int i = index - 1; i >= 0 && value.charAt(i) == ESCAPE_CHAR; i--) {
+            backslashes++;
+        }
+        return backslashes % 2 != 0;
     }
 
     public String getKerberosPrincipal() {

--- a/federation/kerberos/src/test/java/org/keycloak/federation/kerberos/KerberosPrincipalTest.java
+++ b/federation/kerberos/src/test/java/org/keycloak/federation/kerberos/KerberosPrincipalTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.federation.kerberos;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link KerberosPrincipal} name/realm parsing.
+ */
+public class KerberosPrincipalTest {
+
+    @Test
+    public void testStandardPrincipal() {
+        KerberosPrincipal principal = new KerberosPrincipal("john@KEYCLOAK.ORG");
+
+        Assert.assertEquals("john", principal.getPrefix());
+        Assert.assertEquals("KEYCLOAK.ORG", principal.getRealm());
+        Assert.assertEquals("john@KEYCLOAK.ORG", principal.getKerberosPrincipal());
+        Assert.assertEquals("john@KEYCLOAK.ORG", principal.toString());
+    }
+
+    @Test
+    public void testRealmIsUpperCased() {
+        KerberosPrincipal principal = new KerberosPrincipal("john@keycloak.org");
+
+        Assert.assertEquals("john", principal.getPrefix());
+        Assert.assertEquals("KEYCLOAK.ORG", principal.getRealm());
+    }
+
+    // An '@' inside the principal name is escaped as "\@" (RFC 1964, section 2.1.1) and
+    // must not be treated as the realm separator.
+    @Test
+    public void testEscapedAtInPrincipalName() {
+        KerberosPrincipal principal = new KerberosPrincipal("ssiemel\\@a.com@KEYCLOAK.ORG");
+
+        Assert.assertEquals("ssiemel\\@a.com", principal.getPrefix());
+        Assert.assertEquals("KEYCLOAK.ORG", principal.getRealm());
+        Assert.assertEquals("ssiemel\\@a.com@KEYCLOAK.ORG", principal.getKerberosPrincipal());
+    }
+
+    // A '@' preceded by an escaped backslash ("\\@") is a real, unescaped realm separator.
+    @Test
+    public void testEscapedBackslashBeforeSeparator() {
+        KerberosPrincipal principal = new KerberosPrincipal("a\\\\@KEYCLOAK.ORG");
+
+        Assert.assertEquals("a\\\\", principal.getPrefix());
+        Assert.assertEquals("KEYCLOAK.ORG", principal.getRealm());
+    }
+
+    // More than one unescaped '@' is ambiguous and not a valid name@REALM principal.
+    @Test
+    public void testMultipleUnescapedAtIsInvalid() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new KerberosPrincipal("a@b@KEYCLOAK.ORG"));
+    }
+
+    @Test
+    public void testMissingRealmIsInvalid() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new KerberosPrincipal("john"));
+    }
+
+    @Test
+    public void testEmptyRealmIsInvalid() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new KerberosPrincipal("john@"));
+    }
+}


### PR DESCRIPTION
## Description

`KerberosPrincipal(String)` split the incoming principal on **every** `@` and required exactly two parts:

```java
String[] parts = kerberosPrincipal.split("@");
if (parts.length != 2) {
    throw new IllegalArgumentException("Kerberos principal '" + kerberosPrincipal + "' not valid");
}
```

A Kerberos principal may legally contain an escaped `@` (written `\@`) inside its name component — see RFC 1964, section 2.1.1. For such a principal, e.g. `ssiemel\@a.com@KEYCLOAK.ORG`, `split("@")` yields three parts and the constructor throws `IllegalArgumentException`. On the LDAP user-sync path (`LDAPStorageProvider` → `new KerberosPrincipal(...)`) this is not handled gracefully and surfaces as `Could not sync users: 'UnknownError'` in the admin console (with nothing in the server log), exactly as reported in the issue.

## Fix

Parse the realm as the part after the **single unescaped** `@`, treating an escaped `\@` inside the name as a literal (escape detection via backslash parity). Behaviour is otherwise unchanged:

| Input | Result |
| --- | --- |
| `john@KEYCLOAK.ORG` | prefix `john`, realm `KEYCLOAK.ORG` (unchanged) |
| `ssiemel\@a.com@KEYCLOAK.ORG` | prefix `ssiemel\@a.com`, realm `KEYCLOAK.ORG` (**fixed** — previously threw) |
| `a@b@KEYCLOAK.ORG` (multiple unescaped `@`) | still rejected as invalid |
| `john` / `john@` (no realm / empty realm) | still rejected as invalid |

All four production callers (`LDAPStorageProvider`, `KerberosFederationProvider`, `SPNEGOAuthenticator`, `KerberosUsernamePasswordAuthenticator`) route through this one constructor, so fixing the shared parser repairs every path, including the reported LDAP-sync reproducer. The change is intentionally limited to `KerberosPrincipal` and preserves the original exception message.

## Test verification (RED → GREEN)

New unit test `KerberosPrincipalTest` (plain JUnit, no running server required).

**RED** — on unmodified `main`, before the production change:

```
[ERROR] org.keycloak.federation.kerberos.KerberosPrincipalTest.testEscapedAtInPrincipalName -- Time elapsed: 0.005 s <<< ERROR!
java.lang.IllegalArgumentException: Kerberos principal 'ssiemel\@a.com@KEYCLOAK.ORG' not valid
	at org.keycloak.federation.kerberos.KerberosPrincipal.<init>(KerberosPrincipal.java:34)
[ERROR] Tests run: 6, Failures: 0, Errors: 1, Skipped: 0
```

**GREEN** — with the fix:

```
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 -- in org.keycloak.federation.kerberos.KerberosPrincipalTest
[INFO] BUILD SUCCESS
```

`./mvnw -pl federation/kerberos spotless:check` and the module's full test suite (`KerberosFederationProviderFactoryTest` + `KerberosPrincipalTest`, 10 tests) also pass.

## Note on AI usage

AI agents were used to assist with investigating and implementing this change. I understand every line of the change and can explain and revise it.

Closes #29316
