### PR TITLE
Skip resolving roles when processing transient tokens on FGAP requests

### DIFF
--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -72,21 +72,34 @@ mappings or group memberships, and not to users with admin roles mapped only thr
 
 ==== Multi-realm administration considerations
 
-When a user in the `master` realm is granted the `admin` role or realm-specific roles across many realms,
-the access token issued during authentication includes admin roles for every realm the user can administer.
-In deployments with a large number of realms, keep the following in mind.
+The `admin` role in the `master` realm is a composite role. For every realm in the deployment, it includes
+the full set of admin roles from that realm's `<realm name>-realm` client. For example, with 100 realms,
+the `admin` composite contains over 2,000 role mappings (approximately 21 roles per realm). This has
+implications for token size and performance.
 
 ===== Token size
 
-Each realm adds its `realm-management` client roles to the token. With hundreds of realms, the token
-can exceed HTTP header size limits enforced by load balancers or reverse proxies.
+When using full (non-lightweight) access tokens, all admin roles from the `admin` composite are included
+in the token. With hundreds of realms, the token can exceed HTTP header size limits enforced by load
+balancers or reverse proxies.
 
-To mitigate this, use lightweight access tokens. The `security-admin-console` and `admin-cli` clients
-use lightweight access tokens by default since {project_name} 26. Lightweight tokens do not carry roles
-over the wire — the server resolves them from the user session when needed.
+To mitigate this, use lightweight access tokens. The `security-admin-console` and `admin-cli` clients use
+lightweight access tokens by default since {project_name} 26. Lightweight tokens do not carry roles over
+the wire — the server resolves them from the user session when needed.
 
 ===== Cache sizing
 
-Deployments with many realms should size the `realms`, `users`, and `authorization` caches.
-See the server caching guide for guidance on tuning cache sizes.
+Deployments with many realms should ensure that the `realms`, `users`, and `authorization` local caches are
+properly sized. Undersized caches lead to frequent evictions and cache misses, resulting in additional
+database round-trips that degrade performance. See the link:{server_guide_base_link}/caching[server caching guide]
+for guidance on tuning cache sizes.
+
+===== Role policies and fine-grained admin permissions
+
+When using link:{adminguide_finegrained_link}[fine-grained admin permissions], role policies always resolve roles
+directly from the user rather than from the token. The *Fetch Roles* setting on role policies has no effect in
+this context and is disabled in the administration console.
+
+For regular authorization services outside the admin permissions scope, the *Fetch Roles* setting controls whether
+role policies check roles from the token or fetch them from the user's role mappings.
 

--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -74,40 +74,19 @@ mappings or group memberships, and not to users with admin roles mapped only thr
 
 When a user in the `master` realm is granted the `admin` role or realm-specific roles across many realms,
 the access token issued during authentication includes admin roles for every realm the user can administer.
-In deployments with a large number of realms, this has several implications.
+In deployments with a large number of realms, keep the following in mind.
 
 ===== Token size
 
-Access tokens grow with the number of realms the user can administer. Each realm adds its
-`realm-management` client roles to the token. With hundreds of realms, the resulting token can exceed
-HTTP `Authorization` header size limits enforced by load balancers, reverse proxies, or application servers,
-causing authentication failures.
+Each realm adds its `realm-management` client roles to the token. With hundreds of realms, the token
+can exceed HTTP header size limits enforced by load balancers or reverse proxies.
 
-Use lightweight access tokens to mitigate this. Since Keycloak 26, the `security-admin-console` and
-`admin-cli` clients use lightweight access tokens by default. Lightweight tokens do not carry roles over the
-wire — the server resolves them from the user session when processing admin API requests.
-
-===== Access control model
-
-When using the default role-based access control (RBAC), admin roles embedded in the token are not used
-for Admin API authorization decisions. The server checks the user's actual role assignments directly. In this
-model, the roles in the token are informational and their presence adds overhead without contributing to
-access control.
-
-When using fine-grained admin permissions (FGAP), role-based policies can be configured to resolve roles
-from the user's actual role assignments rather than from the token. Enable the *Fetch Roles* setting on
-role policies associated with permissions to avoid relying on roles embedded in the token.
+To mitigate this, use lightweight access tokens. The `security-admin-console` and `admin-cli` clients
+use lightweight access tokens by default since {project_name} 26. Lightweight tokens do not carry roles
+over the wire — the server resolves them from the user session when needed.
 
 ===== Cache sizing
 
-Deployments with many realms increase the working set of the `realms`, `users`, and `authorization` caches.
-Undersized caches lead to frequent evictions and cache misses, resulting in additional database round-trips
-that degrade admin API performance. Refer to the
-ifeval::[{project_community}==true]
-link:{adminguide_link}#_cache_configuration[cache configuration]
-endif::[]
-ifeval::[{project_product}==true]
-link:{adminguide_link}#_cache_configuration[cache configuration]
-endif::[]
-documentation for guidance on monitoring cache metrics and tuning cache sizes for your deployment.
+Deployments with many realms should size the `realms`, `users`, and `authorization` caches.
+See the server caching guide for guidance on tuning cache sizes.
 

--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -70,3 +70,44 @@ application access control.
 Effectively, access to the Admin API is only granted to users with admin roles explicitly assigned through direct role
 mappings or group memberships, and not to users with admin roles mapped only through client protocol mappers.
 
+==== Multi-realm administration considerations
+
+When a user in the `master` realm is granted the `admin` role or realm-specific roles across many realms,
+the access token issued during authentication includes admin roles for every realm the user can administer.
+In deployments with a large number of realms, this has several implications.
+
+===== Token size
+
+Access tokens grow with the number of realms the user can administer. Each realm adds its
+`realm-management` client roles to the token. With hundreds of realms, the resulting token can exceed
+HTTP `Authorization` header size limits enforced by load balancers, reverse proxies, or application servers,
+causing authentication failures.
+
+Use lightweight access tokens to mitigate this. Since Keycloak 26, the `security-admin-console` and
+`admin-cli` clients use lightweight access tokens by default. Lightweight tokens do not carry roles over the
+wire — the server resolves them from the user session when processing admin API requests.
+
+===== Access control model
+
+When using the default role-based access control (RBAC), admin roles embedded in the token are not used
+for Admin API authorization decisions. The server checks the user's actual role assignments directly. In this
+model, the roles in the token are informational and their presence adds overhead without contributing to
+access control.
+
+When using fine-grained admin permissions (FGAP), role-based policies can be configured to resolve roles
+from the user's actual role assignments rather than from the token. Enable the *Fetch Roles* setting on
+role policies associated with permissions to avoid relying on roles embedded in the token.
+
+===== Cache sizing
+
+Deployments with many realms increase the working set of the `realms`, `users`, and `authorization` caches.
+Undersized caches lead to frequent evictions and cache misses, resulting in additional database round-trips
+that degrade admin API performance. Refer to the
+ifeval::[{project_community}==true]
+link:{adminguide_link}#_cache_configuration[cache configuration]
+endif::[]
+ifeval::[{project_product}==true]
+link:{adminguide_link}#_cache_configuration[cache configuration]
+endif::[]
+documentation for guidance on monitoring cache metrics and tuning cache sizes for your deployment.
+

--- a/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
@@ -2,7 +2,7 @@ import { HelpItem, useFetch } from "@keycloak/keycloak-ui-shared";
 import { Button, Checkbox, FormGroup } from "@patternfly/react-core";
 import { MinusCircleIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../../admin-client";
@@ -13,16 +13,32 @@ import {
   FilterType,
 } from "../../../components/role-mapping/AddRoleMappingModal";
 import { Row, ServiceRole } from "../../../components/role-mapping/RoleMapping";
+import { NewPermissionPolicyDetailsParams } from "../../../permissions-configuration/routes/NewPermissionPolicy";
+import { useIsAdminPermissionsClient } from "../../../utils/useIsAdminPermissionsClient";
+import { useParams } from "../../../utils/useParams";
+import type { PolicyDetailsParams } from "../../routes/PolicyDetails";
 import type { RequiredIdValue } from "./ClientScope";
 
 export const Role = () => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
+  const { id } = useParams<PolicyDetailsParams>();
+  const { permissionClientId } = useParams<NewPermissionPolicyDetailsParams>();
+  const isAdminPermissionsClient = useIsAdminPermissionsClient(
+    permissionClientId || id,
+  );
   const { control, getValues, setValue } = useFormContext<{
     roles?: RequiredIdValue[];
     fetchRoles?: boolean;
   }>();
+
+  useEffect(() => {
+    if (isAdminPermissionsClient) {
+      setValue("fetchRoles", true);
+    }
+  }, [isAdminPermissionsClient, setValue]);
+
   const values = getValues("roles");
 
   const [open, setOpen] = useState(false);
@@ -156,6 +172,7 @@ export const Role = () => {
         name="fetchRoles"
         label={t("fetchRoles")}
         labelIcon={t("fetchRolesHelp")}
+        isDisabled={isAdminPermissionsClient}
       />
     </>
   );

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -37,9 +37,11 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessToken.Access;
@@ -66,6 +68,7 @@ public class KeycloakIdentity implements Identity {
     protected final Attributes attributes;
     private final boolean resourceServer;
     private final String id;
+    private UserModel user;
 
     public KeycloakIdentity(KeycloakSession keycloakSession) {
         this(Tokens.getAccessToken(keycloakSession), keycloakSession);
@@ -185,10 +188,10 @@ public class KeycloakIdentity implements Identity {
     }
 
     public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession) {
-        this(accessToken, keycloakSession, keycloakSession.getContext().getRealm());
+        this(accessToken, keycloakSession, keycloakSession.getContext().getRealm(), false);
     }
 
-    public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession, RealmModel realm) {
+    public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession, RealmModel realm, boolean ignoreTokenRoles) {
         if (accessToken == null) {
             throw new ErrorResponseException("invalid_bearer_token", "Could not obtain bearer access_token from request.", Status.FORBIDDEN);
         }
@@ -248,7 +251,11 @@ public class KeycloakIdentity implements Identity {
                 throw new IllegalArgumentException("User from token not found");
             }
 
-            addRolesAsAttributes(accessToken, realm, user, attributes);
+            if (!ignoreTokenRoles) {
+                addRolesAsAttributes(accessToken, realm, user, attributes);
+            } else {
+                this.user = user;
+            }
 
             if (clientUser != null && user.getId().equals(clientUser.getId())) {
                 AuthorizationProvider provider = keycloakSession.getProvider(AuthorizationProvider.class);
@@ -281,6 +288,36 @@ public class KeycloakIdentity implements Identity {
         return this.attributes;
     }
 
+    @Override
+    public boolean hasClientRole(String clientId, String roleName) {
+        if (user == null) {
+            return Identity.super.hasClientRole(clientId, roleName);
+        }
+
+        RoleModel role = KeycloakModelUtils.getRoleByName(realm, clientId, roleName);
+
+        if (role == null) {
+            return false;
+        }
+
+        return user.hasRole(role);
+    }
+
+    @Override
+    public boolean hasRealmRole(String roleName) {
+        if (user == null) {
+            return Identity.super.hasRealmRole(roleName);
+        }
+
+        RoleModel role = KeycloakModelUtils.getRoleByName(realm, null, roleName);
+
+        if (role == null) {
+            return false;
+        }
+
+        return user.hasRole(role);
+    }
+
     public AccessToken getAccessToken() {
         return this.accessToken;
     }
@@ -303,6 +340,9 @@ public class KeycloakIdentity implements Identity {
     }
 
     private UserModel getUserFromToken() {
+        if (user != null) {
+            return user;
+        }
         if (accessToken.getSessionState() == null) {
             return TokenManager.lookupUserFromStatelessToken(keycloakSession, realm, accessToken);
         }

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -53,6 +53,7 @@ import org.keycloak.util.JsonSerialization;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import static org.keycloak.models.utils.KeycloakModelUtils.removeTransientAdminRoles;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -153,6 +154,12 @@ public class KeycloakIdentity implements Identity {
 
             ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionScopeParameter(clientSessionModel, keycloakSession);
             this.accessToken = new TokenManager().createClientAccessToken(keycloakSession, realm, client, userSession.getUser(), userSession, clientSessionCtx, clientSessionCtx.isOfflineTokenRequested());
+            UserModel tokenUser = userSession.getUser();
+            removeTransientAdminRoles(realm, null, tokenUser, this.accessToken.getRealmAccess());
+            Map<String, Access> resourceAccess = this.accessToken.getResourceAccess();
+            if (resourceAccess != null) {
+                resourceAccess.forEach((cId, access) -> removeTransientAdminRoles(realm, cId, tokenUser, access));
+            }
         }
 
         ClientModel clientModel = getTargetClient();

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -53,7 +53,6 @@ import org.keycloak.util.JsonSerialization;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static org.keycloak.models.utils.KeycloakModelUtils.removeTransientAdminRoles;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -323,7 +322,6 @@ public class KeycloakIdentity implements Identity {
         Access realmAccess = accessToken.getRealmAccess();
 
         if (realmAccess != null) {
-            removeTransientAdminRoles(realm, null, user, realmAccess);
             attributes.put("kc.realm.roles", realmAccess.getRoles());
         }
 
@@ -331,7 +329,6 @@ public class KeycloakIdentity implements Identity {
 
         if (resourceAccess != null) {
             resourceAccess.forEach((clientId, access) -> {
-                removeTransientAdminRoles(realm, clientId, user, access);
                 attributes.put("kc.client." + clientId + ".roles", access.getRoles());
             });
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
@@ -49,7 +49,6 @@ import org.keycloak.models.cache.CacheRealmProvider;
 import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.Permission;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 
@@ -106,8 +105,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
 
     private void initIdentity(KeycloakSession session, AdminAuth auth) {
         AccessToken accessToken = auth.getToken();
-        AuthenticationManager.resolveLightweightAccessTokenRoles(session, accessToken, adminsRealm);
-        this.identity = new KeycloakIdentity(accessToken, session, adminsRealm);
+        this.identity = new KeycloakIdentity(accessToken, session, adminsRealm, true);
     }
 
     MgmtPermissions(KeycloakSession session, RealmModel adminsRealm, UserModel admin) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/UMAGrantTypeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/UMAGrantTypeTest.java
@@ -1,0 +1,120 @@
+package org.keycloak.tests.admin.authz;
+
+import java.util.Set;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.Constants;
+import org.keycloak.protocol.oidc.mappers.HardcodedRole;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.tests.common.BasicUserConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.models.utils.ModelToRepresentation.toRepresentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest
+public class UMAGrantTypeTest {
+
+    @InjectRealm(lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @InjectUser(config = BasicUserConfig.class)
+    ManagedUser user;
+
+    @InjectClient(config = AuthzResourceServerConfig.class)
+    ManagedClient resourceServer;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @Test
+    public void testAdminRolesIgnoredWhenUsingIdTokenAsClaimToken() {
+        ClientResource clientResource = resourceServer.admin();
+        String clientId = resourceServer.getClientId();
+        String clientSecret = resourceServer.getSecret();
+
+        ProtocolMapperRepresentation mapper = toRepresentation(
+                HardcodedRole.create("inject-view-clients",
+                        Constants.REALM_MANAGEMENT_CLIENT_ID + "." + AdminRoles.VIEW_CLIENTS)
+        );
+        clientResource.getProtocolMappers().createMapper(mapper).close();
+
+        ClientRepresentation realmMgmt = realm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation viewClientsRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.VIEW_CLIENTS).toRepresentation();
+
+        RolePolicyRepresentation rolePolicy = new RolePolicyRepresentation();
+        rolePolicy.setName("require-view-clients");
+        rolePolicy.addRole(viewClientsRole.getId(), true);
+        try (Response response = clientResource.authorization().policies().role().create(rolePolicy)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        rolePolicy = clientResource.authorization().policies().role().findByName("require-view-clients");
+
+        ResourceRepresentation resource = new ResourceRepresentation();
+        resource.setName("protected-resource");
+        try (Response response = clientResource.authorization().resources().create(resource)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        resource = clientResource.authorization().resources().findByName("protected-resource").get(0);
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        permission.setName("protect-resource");
+        permission.setResources(Set.of(resource.getId()));
+        permission.setPolicies(Set.of(rolePolicy.getId()));
+        try (Response response = clientResource.authorization().permissions().resource().create(permission)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+
+        AccessTokenResponse tokenResponse = oauth.client(clientId, clientSecret)
+                .doPasswordGrantRequest(user.getUsername(), user.getPassword());
+        String idToken = tokenResponse.getIdToken();
+        assertNotNull(idToken);
+
+        tokenResponse = oauth.client(clientId, clientSecret)
+                .permissionGrantRequest()
+                .claimToken(idToken)
+                .send();
+        assertNull(tokenResponse.getAccessToken(),
+                "Authorization should be denied when admin role is only mapper-injected via IDToken claim_token");
+        assertNotNull(tokenResponse.getError(),
+                "Response should contain an error when admin role is only mapper-injected");
+    }
+
+    public static class AuthzResourceServerConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .directAccessGrantsEnabled(true);
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminMasterRealmTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminMasterRealmTest.java
@@ -115,19 +115,12 @@ public class FineGrainedAdminMasterRealmTest extends AbstractFineGrainedAdminTes
             newClient.setProtocol("openid-connect");
             newClient.setPublicClient(false);
             newClient.setEnabled(true);
+            // FGAP resolves roles server-side, so the admin has immediate permissions on a newly created realm without needing a token refresh
             Response response = realmClient.realm("anotherRealm").clients().create(newClient);
-            Assertions.assertEquals(403, response.getStatus());
-            response.close();
-
-            realmClient.close();
-            //creating new client to refresh token
-            realmClient = adminClientFactory.create().realm("master")
-                    .username("admin").password("admin").clientId("fullScopedClient").clientSecret("618268aa-51e6-4e64-93c4-3c0bc65b8171").build();
-            assertThat(realmClient.realms().findAll().stream().map(RealmRepresentation::getRealm).collect(Collectors.toSet()),
-                    hasItem("anotherRealm"));
-            response = realmClient.realm("anotherRealm").clients().create(newClient);
             Assertions.assertEquals(201, response.getStatus());
             response.close();
+            assertThat(realmClient.realms().findAll().stream().map(RealmRepresentation::getRealm).collect(Collectors.toSet()),
+                    hasItem("anotherRealm"));
         } finally {
             adminClient.realm("anotherRealm").remove();
             realmClient.close();


### PR DESCRIPTION
## Description

Closes #51554
Closes #51523
Closes #51707

### Root Cause

The `addRolesAsAttributes` method in `KeycloakIdentity.java` calls `removeTransientAdminRoles` for every role in the access token, on every request. When lightweight admin tokens are expanded to include roles across all realms, this results in **O(n) database lookups** per request where n = number of realms.

With 400 realms, each admin API request takes 9–19 seconds (vs. 5–24ms without the redundant calls), as measured by the reporter.

### Fix

Remove the two `removeTransientAdminRoles` calls from `addRolesAsAttributes`. The admin role validation is already performed at token creation time by `AdminRoleTokenPostProcessor.process()` — the roles are stripped of transient entries before the token reaches the client. Re-validating at request time is redundant and causes the O(n) performance regression.

### Performance Impact

| Realms | Before | After | Ratio |
|--------|--------|-------|-------|
| 10 | 7 ms | 5 ms | 1x |
| 50 | 40 ms | 6 ms | 7x |
| 100 | 141 ms | 6 ms | 24x |
| 200 | 551 ms | 11 ms | 50x |
| 250 | 3628 ms | 15 ms | 242x |
| 300 | 11367 ms | 18 ms | 632x |
| 350 | 19157 ms | 24 ms | 798x |

### Security

Safe to remove because `AdminRoleTokenPostProcessor.process()` already validates transient admin roles during token creation. The `addRolesAsAttributes` method is only populating attributes for the authorization context from an already-validated token.

### Related

- Introduced by commit `200e65568dcd` (CVE-2026-4629)
- Also reported in #51523 (sustained high CPU on all nodes after upgrade)