### PR TITLE
SSF: Fix NPE in transmitter on RP-initiated logout without details (#51571)

### DIFF
--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -864,7 +864,12 @@ public class SecurityEventTokenMapper {
     }
 
     protected boolean shouldIgnoreLogout(Event event) {
-        String reason = event.getDetails().get(Details.REASON);
+        // details can be null, e.g. for RP-initiated logouts without a post_logout_redirect_uri
+        Map<String, String> details = event.getDetails();
+        if (details == null) {
+            return false;
+        }
+        String reason = details.get(Details.REASON);
         return Details.USER_SESSION_EXPIRED_REASON.equals(reason) || Details.INVALID_USER_SESSION_REMEMBER_ME_REASON.equals(reason);
     }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -397,9 +397,17 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
     }
 
     protected boolean isUserSessionExpiration(Event event) {
-        return EventType.USER_SESSION_DELETED.equals(event.getType()) &&
-               (Details.INVALID_USER_SESSION_REMEMBER_ME_REASON.equals(event.getDetails().get(Details.REASON))
-               || Details.USER_SESSION_EXPIRED_REASON.equals(event.getDetails().get(Details.REASON)));
+        if (!EventType.USER_SESSION_DELETED.equals(event.getType())) {
+            return false;
+        }
+        // details can be null depending on how the event was constructed
+        Map<String, String> details = event.getDetails();
+        if (details == null) {
+            return false;
+        }
+        String reason = details.get(Details.REASON);
+        return Details.INVALID_USER_SESSION_REMEMBER_ME_REASON.equals(reason)
+               || Details.USER_SESSION_EXPIRED_REASON.equals(reason);
     }
 
     @Override

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
@@ -146,6 +146,39 @@ class SecurityEventTokenMapperTest {
         assertEquals(InitiatingEntity.ADMIN, ((RiscAccountEnabled) payload).getInitiatingEntity());
     }
 
+    @Test
+    void logoutWithoutDetails_isNotIgnored() {
+        Event event = new Event();
+        event.setType(EventType.LOGOUT);
+        // details intentionally left null, which is the RP-initiated logout path
+        // without post_logout_redirect_uri never calls detail()
+
+        assertFalse(mapper.shouldIgnoreLogout(event),
+                "a real user logout without details must be propagated, not dropped or NPE");
+        assertTrue(mapper.canConvert(event),
+                "canConvert must survive a LOGOUT event with null details");
+    }
+
+    @Test
+    void logoutWithExpiredSessionReason_isIgnored() {
+        Event event = new Event();
+        event.setType(EventType.LOGOUT);
+        event.setDetails(Map.of(Details.REASON, Details.USER_SESSION_EXPIRED_REASON));
+
+        assertTrue(mapper.shouldIgnoreLogout(event),
+                "expired session cleanup is not a real logout and must not emit a SET");
+    }
+
+    @Test
+    void logoutWithUnrelatedDetails_isNotIgnored() {
+        Event event = new Event();
+        event.setType(EventType.LOGOUT);
+        event.setDetails(Map.of(Details.REDIRECT_URI, "https://rp.example.com/logged-out"));
+
+        assertFalse(mapper.shouldIgnoreLogout(event),
+                "details without a REASON entry must be treated like a real logout");
+    }
+
     private StreamConfig streamConfig() {
         return new StreamConfig();
     }

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerTest.java
@@ -141,6 +141,17 @@ class SsfTransmitterEventListenerTest {
         throw new IllegalArgumentException("Test fixture only covers CAEP session-revoked / credential-change. Add a branch when extending.");
     }
 
+    @Test
+    void userSessionDeletedWithoutDetails_isNotExpiration() {
+        Event event = new Event();
+        event.setType(org.keycloak.events.EventType.USER_SESSION_DELETED);
+        // details intentionally left null — EventBuilder creates the map
+        // lazily, so events without any detail() call carry null here
+
+        assertFalse(listener.isUserSessionExpiration(event),
+                "a USER_SESSION_DELETED event without details must not NPE and not count as expiration");
+    }
+
     // ----- auto-notify-on-login read-only handling -----
 
     private static final String RECEIVER_CLIENT_ID = "receiver";


### PR DESCRIPTION
The non-browser RP-initiated logout path emits a success LOGOUT event without any details when no post_logout_redirect_uri is given, so Event.getDetails() is null. SecurityEventTokenMapper.shouldIgnoreLogout and SsfTransmitterEventListener.isUserSessionExpiration dereferenced the details map unconditionally, crashing the SSF event listener. Treat missing details as a real logout / non-expiration.

Fixes #51571

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
