### PR TITLE
fix: prevent SMTP credential forwarding to unintended

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -930,6 +931,18 @@ public class DefaultExportImportManager implements ExportImportManager {
         if (rep.getSmtpServer() != null) {
 
             Map<String, String> config = new HashMap<>(rep.getSmtpServer());
+            Map<String, String> existingConfig = realm.getSmtpConfig() != null ? realm.getSmtpConfig() : Map.of();
+
+            boolean destinationUnchanged =
+                    Objects.equals(config.getOrDefault("host", ""), existingConfig.getOrDefault("host", ""))
+                            && Objects.equals(config.getOrDefault("port", "25"), existingConfig.getOrDefault("port", "25"))
+                            && Objects.equals(config.getOrDefault("ssl", "false"), existingConfig.getOrDefault("ssl", "false"))
+                            && Objects.equals(config.getOrDefault("starttls", "false"), existingConfig.getOrDefault("starttls", "false"))
+                            && Objects.equals(config.getOrDefault("from", ""), existingConfig.getOrDefault("from", ""))
+                            && Objects.equals(config.getOrDefault("user", ""), existingConfig.getOrDefault("user", ""))
+                            && Objects.equals(config.getOrDefault("authTokenUrl", ""), existingConfig.getOrDefault("authTokenUrl", ""))
+                            && Objects.equals(config.getOrDefault("authTokenClientId", ""), existingConfig.getOrDefault("authTokenClientId", ""))
+                            && Objects.equals(config.getOrDefault("authTokenScope", ""), existingConfig.getOrDefault("authTokenScope", ""));
 
             if (!Boolean.parseBoolean(config.get("auth"))) {
                 config.remove("authTokenUrl");
@@ -941,8 +954,12 @@ public class DefaultExportImportManager implements ExportImportManager {
                 config.remove("authType");
             } else if (config.get("authType") == null || "basic".equals(config.get("authType"))) {
                 if (ComponentRepresentation.SECRET_VALUE.equals(config.get("password"))) {
-                    String passwordValue = realm.getSmtpConfig() != null ? realm.getSmtpConfig().get("password") : null;
-                    config.put("password", passwordValue);
+                    if (destinationUnchanged) {
+                        config.put("password", existingConfig.get("password"));
+                    } else {
+                        // Destination changed — reject the masked value; require explicit credential
+                        config.remove("password");
+                    }
                 }
                 config.remove("authTokenUrl");
                 config.remove("authTokenScope");
@@ -950,8 +967,11 @@ public class DefaultExportImportManager implements ExportImportManager {
                 config.remove("authTokenClientSecret");
             } else if ("token".equals(config.get("authType"))) {
                 if (ComponentRepresentation.SECRET_VALUE.equals(config.get("authTokenClientSecret"))) {
-                    String authTokenClientSecretValue = realm.getSmtpConfig() != null ? realm.getSmtpConfig().get("authTokenClientSecret") : null;
-                    config.put("authTokenClientSecret", authTokenClientSecretValue);
+                    if (destinationUnchanged) {
+                        config.put("authTokenClientSecret", existingConfig.get("authTokenClientSecret"));
+                    } else {
+                        config.remove("authTokenClientSecret");
+                    }
                 }
                 config.remove("password");
             }

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/StripSecretsUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/StripSecretsUtilsTest.java
@@ -187,7 +187,15 @@ public class StripSecretsUtilsTest {
 
         rep.setSmtpServer(new HashMap<>());
         rep.getSmtpServer().put("password", "secret");
+        rep.getSmtpServer().put("authTokenClientSecret", "tokenSecret");
         rep.getSmtpServer().put("user", "smtpUser");
+        rep.getSmtpServer().put("host", "mail.example.org");
+        rep.getSmtpServer().put("port", "587");
+        rep.getSmtpServer().put("ssl", "true");
+        rep.getSmtpServer().put("starttls", "false");
+        rep.getSmtpServer().put("from", "keycloak@example.org");
+        rep.getSmtpServer().put("replyTo", "noreply@example.org");
+        rep.getSmtpServer().put("envelopeFrom", "bounce@example.org");
 
         ClientRepresentation client = new ClientRepresentation();
         client.setId("clientId");
@@ -244,9 +252,17 @@ public class StripSecretsUtilsTest {
 
         assertEquals("Master", rep.getRealm());
         assertEquals("realmId", rep.getId());
-        assertEquals(2, rep.getSmtpServer().size());
+        assertEquals(10, rep.getSmtpServer().size());
         assertEquals(ComponentRepresentation.SECRET_VALUE, rep.getSmtpServer().get("password"));
+        assertEquals(ComponentRepresentation.SECRET_VALUE, rep.getSmtpServer().get("authTokenClientSecret"));
         assertEquals("smtpUser", rep.getSmtpServer().get("user"));
+        assertEquals("mail.example.org", rep.getSmtpServer().get("host"));
+        assertEquals("587", rep.getSmtpServer().get("port"));
+        assertEquals("true", rep.getSmtpServer().get("ssl"));
+        assertEquals("false", rep.getSmtpServer().get("starttls"));
+        assertEquals("keycloak@example.org", rep.getSmtpServer().get("from"));
+        assertEquals("noreply@example.org", rep.getSmtpServer().get("replyTo"));
+        assertEquals("bounce@example.org", rep.getSmtpServer().get("envelopeFrom"));
 
         assertEquals(1, rep.getClients().size());
         assertEquals("clientId", rep.getClients().get(0).getId());

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -1200,7 +1200,15 @@ public class RealmAdminResource {
                 && realm.getSmtpConfig().getOrDefault("authType", EmailAuthenticator.AuthenticatorType.BASIC.name()).equalsIgnoreCase(type.name())
                 && Objects.equals(Optional.ofNullable(settings.get("host")).orElse(""), realm.getSmtpConfig().getOrDefault("host", ""))
                 && Objects.equals(Optional.ofNullable(settings.get("port")).orElse("25"), realm.getSmtpConfig().getOrDefault("port", "25"))
-                && Objects.equals(Optional.ofNullable(settings.get("user")).orElse(""), realm.getSmtpConfig().getOrDefault("user", ""));
+                && Objects.equals(Optional.ofNullable(settings.get("user")).orElse(""), realm.getSmtpConfig().getOrDefault("user", ""))
+                && Objects.equals(Optional.ofNullable(settings.get("ssl")).orElse("false"), realm.getSmtpConfig().getOrDefault("ssl", "false"))
+                && Objects.equals(Optional.ofNullable(settings.get("starttls")).orElse("false"), realm.getSmtpConfig().getOrDefault("starttls", "false"))
+                && Objects.equals(Optional.ofNullable(settings.get("from")).orElse(""), realm.getSmtpConfig().getOrDefault("from", ""))
+                && Objects.equals(Optional.ofNullable(settings.get("replyTo")).orElse(""), realm.getSmtpConfig().getOrDefault("replyTo", ""))
+                && Objects.equals(Optional.ofNullable(settings.get("envelopeFrom")).orElse(""), realm.getSmtpConfig().getOrDefault("envelopeFrom", ""))
+                && Objects.equals(Optional.ofNullable(settings.get("authTokenUrl")).orElse(""), realm.getSmtpConfig().getOrDefault("authTokenUrl", ""))
+                && Objects.equals(Optional.ofNullable(settings.get("authTokenClientId")).orElse(""), realm.getSmtpConfig().getOrDefault("authTokenClientId", ""))
+                && Objects.equals(Optional.ofNullable(settings.get("authTokenScope")).orElse(""), realm.getSmtpConfig().getOrDefault("authTokenScope", ""));
     }
 
     @Path("identity-provider")

--- a/tests/base/src/test/java/org/keycloak/tests/admin/SMTPConnectionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/SMTPConnectionTest.java
@@ -138,6 +138,18 @@ public class SMTPConnectionTest {
         response = realm.testSMTPConnection(settings("localhost", "3025", "auto@keycloak.org", "true", null, null,
                 "admin@localhost", SECRET_VALUE));
         assertStatus(response, 500);
+
+        // from address changed — guard must reject reuse even though host/port/user match
+        mailServer.credentials("admin@localhost", password);
+        response = realm.testSMTPConnection(smtpMap("127.0.0.1", "3025", "attacker@evil.example", "true", null, null,
+                "admin@localhost", SECRET_VALUE, null, null, null));
+        assertStatus(response, 500);
+
+        // all fields match including the newly-checked ones — reuse must succeed
+        mailServer.credentials("admin@localhost", password);
+        response = realm.testSMTPConnection(smtpMap("127.0.0.1", "3025", "auto@keycloak.org", "true", null, null,
+                "admin@localhost", SECRET_VALUE, "", "", null));
+        assertStatus(response, 204);
     }
 
     @Test
@@ -175,6 +187,10 @@ public class SMTPConnectionTest {
         final var thirdResponse = realm.testSMTPConnection(settings("localhost", "3025", "auto@keycloak.org", "true", null, null,
                 "admin@localhost", keycloakUrls.getToken(managedRealm.getName()), "test-smtp-client-I", SECRET_VALUE, "basic"));
         assertStatus(thirdResponse, 500);
+
+        final var fourthResponse = realm.testSMTPConnection(smtpMapForTokenAuth("127.0.0.1", "3025", "auto@keycloak.org", "true", null, null,
+                "admin@localhost", "http://attacker.evil.example/steal", "test-smtp-client-I", SECRET_VALUE, "basic", null, null));
+        assertStatus(fourthResponse, 500);
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmDefaultConfigTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmDefaultConfigTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -115,6 +116,56 @@ public class RealmDefaultConfigTest extends AbstractRealmTest {
 
         realm = smtpRealm.admin().toRepresentation();
         assertEquals(ComponentRepresentation.SECRET_VALUE, realm.getSmtpServer().get("password"));
+    }
+
+    @Test
+    public void smtpPasswordNotSubstitutedWhenDestinationChanged() {
+        smtpRealm.updateWithCleanup(r -> r.smtp("localhost", 3025, "smtp_realm@local"));
+        RealmRepresentation rep = smtpRealm.admin().toRepresentation();
+        rep.getSmtpServer().put("auth", "true");
+        rep.getSmtpServer().put("user", "user");
+        rep.getSmtpServer().put("password", "secret");
+        smtpRealm.admin().update(rep);
+
+        RealmRepresentation internal = smtpRealmRunOnServer.fetch(RunHelpers.internalRealm());
+        assertEquals("secret", internal.getSmtpServer().get("password"));
+
+        // Attack: change host to attacker's server, keep password=SECRET_VALUE
+        rep = smtpRealm.admin().toRepresentation();
+        rep.getSmtpServer().put("host", "attacker.evil.example");
+        rep.getSmtpServer().put("password", ComponentRepresentation.SECRET_VALUE);
+        smtpRealm.admin().update(rep);
+
+        // Real password must NOT be substituted — it must be cleared
+        internal = smtpRealmRunOnServer.fetch(RunHelpers.internalRealm());
+        assertNull(internal.getSmtpServer().get("password"),
+                "Credential must not be forwarded to a changed SMTP host");
+
+        smtpRealm.updateWithCleanup(r -> r.smtp("localhost", 3025, "smtp_realm@local"));
+        rep = smtpRealm.admin().toRepresentation();
+        rep.getSmtpServer().put("auth", "true");
+        rep.getSmtpServer().put("authType", "token");
+        rep.getSmtpServer().put("user", "user");
+        rep.getSmtpServer().put("authTokenUrl", "http://localhost/token");
+        rep.getSmtpServer().put("authTokenClientId", "smtp-client");
+        rep.getSmtpServer().put("authTokenClientSecret", "real-token-secret");
+        rep.getSmtpServer().put("authTokenScope", "email");
+        smtpRealm.admin().update(rep);
+
+        internal = smtpRealmRunOnServer.fetch(RunHelpers.internalRealm());
+        assertEquals("real-token-secret", internal.getSmtpServer().get("authTokenClientSecret"));
+
+        // Now change only authTokenUrl — host/port/user remain unchanged
+        rep = smtpRealm.admin().toRepresentation();
+        rep.getSmtpServer().put("authTokenUrl", "http://attacker.evil.example/steal");
+        rep.getSmtpServer().put("authTokenClientSecret", ComponentRepresentation.SECRET_VALUE);
+        smtpRealm.admin().update(rep);
+
+        // Secret must NOT be substituted — persisting it would cause the next email
+        // to POST client_secret=real-token-secret to the attacker's token endpoint
+        internal = smtpRealmRunOnServer.fetch(RunHelpers.internalRealm());
+        assertNull(internal.getSmtpServer().get("authTokenClientSecret"),
+                "Token secret must not be forwarded to a changed authTokenUrl");
     }
 
     @Test


### PR DESCRIPTION
destination

The masked credential substitution (SECRET_VALUE) did not fully validate destination fields before reusing stored SMTP credentials.

  - testSMTPConnection: extend guard to also check ssl, starttls, from, replyTo, and envelopeFrom before substituting credentials
  - updateRealm: add destinationUnchanged check where none existed; clear the credential instead of forwarding it when destination fields change

Closes #49242

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
