### PR TITLE
Parse SCIM filter once per request instead of twice

### DIFF
--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ScimBackedClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ScimBackedClientService.java
@@ -53,7 +53,13 @@ public class ScimBackedClientService implements ClientService {
                                                        ClientProjectionOptions projectionOptions,
                                                        ClientSearchOptions searchOptions,
                                                        ClientSortAndSliceOptions sortAndSliceOptions) {
-        if (!canUseJpaQuery(realm, searchOptions)) {
+        FilterContext filterContext;
+        try {
+            filterContext = parseQuery(searchOptions);
+        } catch (ClientQueryException e) {
+            return delegate.getClients(realm, projectionOptions, searchOptions, sortAndSliceOptions);
+        }
+        if (!canUseJpaQuery(realm, filterContext)) {
             return delegate.getClients(realm, projectionOptions, searchOptions, sortAndSliceOptions);
         }
 
@@ -64,9 +70,7 @@ public class ScimBackedClientService implements ClientService {
         int limit = sortAndSliceOptions.limit();
 
         try {
-            FilterContext filterContext = null;
-            if (searchOptions != null && !StringUtil.isBlank(searchOptions.query())) {
-                filterContext = QueryParseUtils.parse(searchOptions.query());
+            if (filterContext != null) {
                 QueryParseUtils.validate(filterContext);
             }
 
@@ -83,24 +87,26 @@ public class ScimBackedClientService implements ClientService {
         }
     }
 
+    private FilterContext parseQuery(ClientSearchOptions searchOptions) {
+        if (searchOptions == null || StringUtil.isBlank(searchOptions.query())) {
+            return null;
+        }
+        return QueryParseUtils.parse(searchOptions.query());
+    }
+
     private boolean canViewAll(RealmModel realm) {
         return AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm) || permissions.clients().canView();
     }
 
-    private boolean canUseJpaQuery(RealmModel realm, ClientSearchOptions searchOptions) {
+    private boolean canUseJpaQuery(RealmModel realm, FilterContext filterContext) {
         if (!canViewAll(realm)) {
             return false;
         }
-        if (searchOptions == null || StringUtil.isBlank(searchOptions.query())) {
+        if (filterContext == null) {
             return true;
         }
-        try {
-            var filterContext = QueryParseUtils.parse(searchOptions.query());
-            Set<String> queryFields = QueryFieldExtractor.extractFields(filterContext);
-            return ClientJpaQuerySchema.JPA_FIELDS.containsAll(queryFields);
-        } catch (ClientQueryException e) {
-            return false;
-        }
+        Set<String> queryFields = QueryFieldExtractor.extractFields(filterContext);
+        return ClientJpaQuerySchema.JPA_FIELDS.containsAll(queryFields);
     }
 
     private void validateProjectionFields(ClientProjectionOptions projectionOptions) {

--- a/scim/core/src/main/java/org/keycloak/scim/protocol/request/SearchRequest.java
+++ b/scim/core/src/main/java/org/keycloak/scim/protocol/request/SearchRequest.java
@@ -3,6 +3,11 @@ package org.keycloak.scim.protocol.request;
 import java.util.List;
 import java.util.Set;
 
+import org.keycloak.scim.filter.FilterUtils;
+import org.keycloak.scim.filter.ScimFilterParser;
+import org.keycloak.utils.StringUtil;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -37,6 +42,9 @@ public class SearchRequest {
     @JsonProperty("count")
     private Integer count;
 
+    @JsonIgnore
+    private transient ScimFilterParser.FilterContext filterContext;
+
     // Getters and setters
 
     public Set<String> getSchemas() {
@@ -69,6 +77,15 @@ public class SearchRequest {
 
     public void setFilter(String filter) {
         this.filter = filter;
+        this.filterContext = null;
+    }
+
+    @JsonIgnore
+    public ScimFilterParser.FilterContext getFilterContext() {
+        if (filterContext == null && StringUtil.isNotBlank(filter)) {
+            filterContext = FilterUtils.parseFilter(filter);
+        }
+        return filterContext;
     }
 
     public String getSortBy() {

--- a/scim/core/src/test/java/org/keycloak/scim/protocol/request/SearchRequestTest.java
+++ b/scim/core/src/test/java/org/keycloak/scim/protocol/request/SearchRequestTest.java
@@ -1,0 +1,77 @@
+package org.keycloak.scim.protocol.request;
+
+import org.keycloak.scim.filter.ScimFilterParser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class SearchRequestTest {
+
+    @Test
+    public void testGetFilterContextReturnsNullWhenNoFilter() {
+        SearchRequest request = new SearchRequest();
+        assertNull(request.getFilterContext());
+    }
+
+    @Test
+    public void testGetFilterContextReturnsNullWhenBlankFilter() {
+        SearchRequest request = new SearchRequest();
+        request.setFilter("  ");
+        assertNull(request.getFilterContext());
+    }
+
+    @Test
+    public void testGetFilterContextParsesValidFilter() {
+        SearchRequest request = new SearchRequest();
+        request.setFilter("userName eq \"john\"");
+        ScimFilterParser.FilterContext ctx = request.getFilterContext();
+        assertNotNull(ctx);
+        assertNotNull(ctx.expression());
+    }
+
+    @Test
+    public void testGetFilterContextCachesResult() {
+        SearchRequest request = new SearchRequest();
+        request.setFilter("userName eq \"john\"");
+        ScimFilterParser.FilterContext first = request.getFilterContext();
+        ScimFilterParser.FilterContext second = request.getFilterContext();
+        assertSame(first, second);
+    }
+
+    @Test
+    public void testSetFilterInvalidatesCache() {
+        SearchRequest request = new SearchRequest();
+        request.setFilter("userName eq \"john\"");
+        ScimFilterParser.FilterContext first = request.getFilterContext();
+
+        request.setFilter("displayName co \"doe\"");
+        ScimFilterParser.FilterContext second = request.getFilterContext();
+        assertNotNull(second);
+        assertNotSame(first, second);
+    }
+
+    @Test
+    public void testSetFilterToNullClearsCache() {
+        SearchRequest request = new SearchRequest();
+        request.setFilter("userName eq \"john\"");
+        assertNotNull(request.getFilterContext());
+
+        request.setFilter(null);
+        assertNull(request.getFilterContext());
+    }
+
+    @Test
+    public void testBuilderPreservesFilterContextCaching() {
+        SearchRequest request = SearchRequest.builder()
+                .withFilter("userName eq \"john\"")
+                .build();
+        ScimFilterParser.FilterContext first = request.getFilterContext();
+        ScimFilterParser.FilterContext second = request.getFilterContext();
+        assertSame(first, second);
+    }
+
+}

--- a/scim/model/src/main/java/org/keycloak/scim/model/group/GroupResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/group/GroupResourceTypeProvider.java
@@ -36,7 +36,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.jpa.GroupAdapter;
 import org.keycloak.models.jpa.entities.GroupEntity;
 import org.keycloak.models.jpa.entities.UserGroupMembershipEntity;
-import org.keycloak.scim.filter.FilterUtils;
 import org.keycloak.scim.filter.ScimFilterParser;
 import org.keycloak.scim.model.filter.ScimAttributeJpaExpressionResolver;
 import org.keycloak.scim.model.filter.ScimJPAPredicateEvaluator;
@@ -45,7 +44,6 @@ import org.keycloak.scim.resource.group.Group;
 import org.keycloak.scim.resource.group.Member;
 import org.keycloak.scim.resource.schema.attribute.Attribute;
 import org.keycloak.scim.resource.spi.AbstractScimResourceTypeProvider;
-import org.keycloak.utils.StringUtil;
 
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
@@ -124,11 +122,9 @@ public class GroupResourceTypeProvider extends AbstractScimResourceTypeProvider<
         Integer maxResults = searchRequest.getCount();
         maxResults = maxResults != null ? Math.max(0, Math.min(maxResults, DEFAULT_MAX_RESULTS)) : DEFAULT_MAX_RESULTS;
 
-        if (StringUtil.isNotBlank(searchRequest.getFilter())) {
-            // parse filter into AST
-            ScimFilterParser.FilterContext filterContext = FilterUtils.parseFilter(searchRequest.getFilter());
+        ScimFilterParser.FilterContext filterContext = searchRequest.getFilterContext();
 
-            // execute JPA query with filter
+        if (filterContext != null) {
             EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<GroupEntity> query = cb.createQuery(GroupEntity.class);
@@ -138,7 +134,6 @@ public class GroupResourceTypeProvider extends AbstractScimResourceTypeProvider<
             // apply distinct and order by name to ensure consistency with no-filter case
             query.where(predicates).distinct(true).orderBy(cb.asc(root.get("name")));
 
-            // execute query and convert to UserModel stream
             return closing(paginateQuery(em.createQuery(query), firstResult, maxResults).getResultStream()
                     .map(entity -> new GroupAdapter(session, realm, em, entity)));
         } else {
@@ -149,11 +144,9 @@ public class GroupResourceTypeProvider extends AbstractScimResourceTypeProvider<
     @Override
     public Long count(SearchRequest searchRequest) {
         RealmModel realm = session.getContext().getRealm();
-        if (StringUtil.isNotBlank(searchRequest.getFilter())) {
-            // parse filter into AST
-            ScimFilterParser.FilterContext filterContext = FilterUtils.parseFilter(searchRequest.getFilter());
+        ScimFilterParser.FilterContext filterContext = searchRequest.getFilterContext();
 
-            // execute JPA query with filter
+        if (filterContext != null) {
             EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Long> query = cb.createQuery(Long.class);

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserResourceTypeProvider.java
@@ -27,7 +27,6 @@ import org.keycloak.models.UserProvider;
 import org.keycloak.models.jpa.UserAdapter;
 import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.jpa.entities.UserGroupMembershipEntity;
-import org.keycloak.scim.filter.FilterUtils;
 import org.keycloak.scim.filter.ScimFilterParser;
 import org.keycloak.scim.filter.ScimFilterParser.FilterContext;
 import org.keycloak.scim.model.filter.ScimAttributeJpaExpressionResolver;
@@ -41,7 +40,6 @@ import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.userprofile.ValidationException;
 import org.keycloak.userprofile.ValidationException.Error;
-import org.keycloak.utils.StringUtil;
 
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
@@ -139,11 +137,9 @@ public class UserResourceTypeProvider extends AbstractScimResourceTypeProvider<U
         Integer maxResults = searchRequest.getCount();
         maxResults = maxResults != null ? Math.max(0, Math.min(maxResults, DEFAULT_MAX_RESULTS)) : DEFAULT_MAX_RESULTS;
 
-        if (StringUtil.isNotBlank(searchRequest.getFilter())) {
-            // parse filter into AST
-            ScimFilterParser.FilterContext filterContext = FilterUtils.parseFilter(searchRequest.getFilter());
+        ScimFilterParser.FilterContext filterContext = searchRequest.getFilterContext();
 
-            // execute JPA query with filter
+        if (filterContext != null) {
             EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<UserEntity> query = cb.createQuery(UserEntity.class);
@@ -154,7 +150,6 @@ public class UserResourceTypeProvider extends AbstractScimResourceTypeProvider<U
             // apply distinct and order by username to ensure consistency with no-filter case
             query.where(predicates).distinct(true).orderBy(cb.asc(root.get("username")));
 
-            // execute query and convert to UserModel stream
             return closing(paginateQuery(em.createQuery(query), firstResult, maxResults).getResultStream()
                     .map(entity -> new UserAdapter(session, realm, em, entity)));
         } else {
@@ -165,11 +160,9 @@ public class UserResourceTypeProvider extends AbstractScimResourceTypeProvider<U
     @Override
     public Long count(SearchRequest searchRequest) {
         RealmModel realm = session.getContext().getRealm();
-        if (StringUtil.isNotBlank(searchRequest.getFilter())) {
-            // parse filter into AST
-            ScimFilterParser.FilterContext filterContext = FilterUtils.parseFilter(searchRequest.getFilter());
+        ScimFilterParser.FilterContext filterContext = searchRequest.getFilterContext();
 
-            // execute JPA count query with filter
+        if (filterContext != null) {
             EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
             CriteriaBuilder cb = em.getCriteriaBuilder();
             CriteriaQuery<Long> query = cb.createQuery(Long.class);


### PR DESCRIPTION
- cache the parsed FilterContext on SearchRequest

Closes #51403

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
