### PR TITLE
Do not expose organization groups through the SCIM Users groups attribute

### DIFF
--- a/scim/model/src/main/java/org/keycloak/scim/model/user/AbstractUserModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/AbstractUserModelSchema.java
@@ -70,6 +70,7 @@ public abstract class AbstractUserModelSchema extends AbstractModelSchema<UserMo
 
             if (permissions.hasPermission(model, AdminPermissionsSchema.USERS_RESOURCE_TYPE, AdminPermissionsSchema.VIEW)) {
                 return model.getGroupsStream()
+                        .filter(group -> !isOrganizationGroup(group))
                         .filter(this::canViewGroup)
                         .toList();
             }
@@ -121,5 +122,12 @@ public abstract class AbstractUserModelSchema extends AbstractModelSchema<UserMo
 
     protected boolean canViewGroup(GroupModel group) {
         return session.getContext().getPermissions().hasPermission(group, AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, AdminPermissionsSchema.VIEW);
+    }
+
+    /**
+     * Organization groups are only accessible through the Organization API and must not be exposed through SCIM.
+     */
+    protected static boolean isOrganizationGroup(GroupModel group) {
+        return GroupModel.Type.ORGANIZATION.equals(group.getType()) && group.getOrganization() != null;
     }
 }

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
@@ -255,7 +255,7 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
     }
 
     private static void checkGroupMembershipPermission(Permissions permissions, GroupModel group) {
-        if (GroupModel.Type.ORGANIZATION.equals(group.getType()) && group.getOrganization() != null) {
+        if (isOrganizationGroup(group)) {
             throw new ModelValidationException("Cannot access organization related group via non Organization API.");
         }
         if (permissions.isAdminGroup(group)) {

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.GroupResource;
+import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.http.simple.SimpleHttp;
@@ -21,6 +22,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPAttribute;
@@ -1323,6 +1326,50 @@ public class UserTest extends AbstractScimTest {
         } finally {
             client.users().delete(user.getId());
         }
+    }
+
+    @Test
+    public void testOrganizationGroupsNotExposedOnUser() {
+        realm.updateWithCleanup(realm -> realm.organizationsEnabled(true));
+
+        OrganizationRepresentation orgRep = new OrganizationRepresentation();
+        String orgName = KeycloakModelUtils.generateId();
+        orgRep.setName(orgName);
+        orgRep.setAlias(orgName);
+        orgRep.addDomain(new OrganizationDomainRepresentation(orgName + ".org"));
+        try (Response response = realm.admin().organizations().create(orgRep)) {
+            orgRep.setId(ApiUtil.getCreatedId(response));
+        }
+        realm.cleanup().add(realm -> realm.organizations().get(orgRep.getId()).delete().close());
+
+        OrganizationResource orgResource = realm.admin().organizations().get(orgRep.getId());
+
+        GroupRepresentation orgGroup = new GroupRepresentation();
+        orgGroup.setName(KeycloakModelUtils.generateId());
+        try (Response response = orgResource.groups().addTopLevelGroup(orgGroup)) {
+            orgGroup.setId(ApiUtil.getCreatedId(response));
+        }
+
+        GroupRepresentation realmGroup = createGroup(KeycloakModelUtils.generateId());
+
+        User user = createUser();
+        user.addGroup(realmGroup.getId());
+        User expected = client.users().create(user);
+
+        // organization membership is itself a membership in the organization's internal group
+        try (Response response = orgResource.members().addMember(expected.getId())) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        orgResource.groups().group(orgGroup.getId()).addMember(expected.getId());
+
+        User actual = client.users().get(expected.getId(), List.of("groups"));
+        List<GroupMembership> groups = actual.getGroups();
+
+        assertNotNull(groups);
+        assertTrue(groups.stream().anyMatch(g -> realmGroup.getId().equals(g.getValue())));
+        assertTrue(groups.stream().noneMatch(g -> orgGroup.getId().equals(g.getValue())));
+        // neither the organization group nor the organization's internal group are exposed
+        assertEquals(1, groups.size());
     }
 
     private static void assertGroup(List<GroupMembership> groups, GroupRepresentation group, String type) {


### PR DESCRIPTION
Closes #51590

Organization groups — and the organization's internal backing group — were exposed through the `groups` attribute of the SCIM `Users` resource.

`AbstractUserModelSchema.getAttributeValue` returned `model.getGroupsStream()` filtered only by `canViewGroup`, which resolves to `GroupPermissionsV2.canView(group)` and short-circuits to `true` for any caller holding `view-users` or `manage-users`. There was no group-type check on that path. Since organization membership is itself a membership in the organization's internal group, both that group and any organization groups were returned.

The same boundary is already enforced for the `Groups` resource (#50310 / #50311) and on the SCIM user write path in `UserCoreModelSchema.checkGroupMembershipPermission`, which throws `"Cannot access organization related group via non Organization API."`. This aligns the read path with those.

The predicate used by the write path is extracted into `AbstractUserModelSchema.isOrganizationGroup` and reused on both sides, so the two cannot drift apart. It matches the existing behaviour exactly (`Type.ORGANIZATION` and a non-null organization); both the internal group and organization groups carry the organization relationship, set in `JpaOrganizationProvider` on organization creation and in `createGroup` respectively.

Added `UserTest#testOrganizationGroupsNotExposedOnUser`, which puts a user in a realm group, an organization, and an organization group, then asserts that only the realm group is returned by `GET /Users/{id}?attributes=groups`.

Note for reviewers: `UserResourceTypeProvider.getAttributeExpression` maps the SCIM `groups` filter onto `UserGroupMembershipEntity.groupId` without a type restriction, so a user can still be filtered by a known organization group id. That is a separate surface from serialization and is left out of this change — happy to follow up if you would like it covered here or in its own issue.
