### PR TITLE
Disable user federation enabled toggle for users without manage-realm

### DIFF
--- a/js/apps/admin-ui/src/user-federation/shared/Header.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/Header.tsx
@@ -11,6 +11,7 @@ import { useAdminClient } from "../../admin-client";
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
 import { useConfirmDialog } from "../../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../../components/view-header/ViewHeader";
+import { useAccess } from "../../context/access/Access";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { CustomUserFederationRouteParams } from "../routes/CustomUserFederation";
 import { toUserFederation } from "../routes/UserFederation";
@@ -36,6 +37,8 @@ export const Header = ({
 
   const { addAlert, addError } = useAlerts();
   const { realm } = useRealm();
+  const { hasAccess } = useAccess();
+  const isManager = hasAccess("manage-realm");
 
   const { control, setValue } = useFormContext();
 
@@ -95,6 +98,7 @@ export const Header = ({
                   {t("deleteProvider")}
                 </DropdownItem>,
               ]}
+              isReadOnly={!isManager}
               isEnabled={field.value?.[0] === "true" || field.value === "true"}
               onToggle={(value) => {
                 if (!value) {

--- a/js/apps/admin-ui/test/user-federation/ldap.spec.ts
+++ b/js/apps/admin-ui/test/user-federation/ldap.spec.ts
@@ -209,3 +209,63 @@ test.describe.serial("User Federation LDAP tests", () => {
     });
   });
 });
+
+test.describe.serial("User Federation LDAP enabled toggle access", () => {
+  const realmName = `user-federation-ldap-access-${uuid()}`;
+  const viewOnlyUser = `ldap-view-only-${uuid()}`;
+  const password = "password";
+
+  test.beforeAll(async () => {
+    await adminClient.createRealm(realmName);
+    await adminClient.createUserFederation(realmName, {
+      providerId: provider,
+      name: firstLdapName,
+      config: {
+        vendor: [firstLdapVendor],
+        connectionUrl: [connectionUrlValid],
+        bindType: [bindTypeSimple],
+        bindDn: [bindDnCnDc],
+        bindCredential: [bindCredsValid],
+        editMode: [editModeReadOnly],
+        usersDn: [firstUsersDn],
+        usernameLDAPAttribute: [firstUserLdapAtt],
+        rdnLDAPAttribute: [firstRdnLdapAtt],
+      },
+    });
+    const user = await adminClient.createUser({
+      username: viewOnlyUser,
+      enabled: true,
+      credentials: [{ type: "password", value: password }],
+    });
+    await adminClient.addClientRoleToUser(user.id!, `${realmName}-realm`, [
+      "view-realm",
+    ]);
+  });
+
+  test.afterAll(async () => {
+    await adminClient.deleteUser(viewOnlyUser);
+    await adminClient.deleteRealm(realmName);
+  });
+
+  test("Should disable the enabled toggle for a view-realm only user", async ({
+    page,
+  }) => {
+    await login(page, { username: viewOnlyUser, password });
+    await goToRealm(page, realmName);
+    await goToUserFederation(page);
+    await clickLdapCard(page, firstLdapName);
+
+    await expect(page.getByTestId("LDAP-switch")).toBeDisabled();
+  });
+
+  test("Should enable the enabled toggle for a manage-realm user", async ({
+    page,
+  }) => {
+    await login(page);
+    await goToRealm(page, realmName);
+    await goToUserFederation(page);
+    await clickLdapCard(page, firstLdapName);
+
+    await expect(page.getByTestId("LDAP-switch")).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Description

The enabled/disabled toggle in the user federation provider header (`Header.tsx`, used by both LDAP and Kerberos providers) was always interactive, even for administrators who only have `view-realm` access. The rest of the provider settings form is already gated behind `manage-realm` via `FormAccess`, so the toggle was an inconsistency: a view-only admin could still enable/disable the provider.

This change gates the toggle with the same `manage-realm` check by passing `isReadOnly={!isManager}` to `ViewHeader` (which already supports rendering the switch as disabled).

## Testing

Added Playwright integration tests in `ldap.spec.ts` that:
- create a `view-realm`-only user and assert the Enabled toggle is **disabled** for them, and
- assert the toggle remains **enabled** for a `manage-realm` user.

Verified test-first: the negative test fails against the current code and passes with the fix. The full `ldap.spec.ts` suite passes (8/8).

## AI usage disclosure

This contribution was developed with the assistance of an AI agent (Claude Code). I have reviewed and understand all of the changes, and I am able to explain and revise them in response to review feedback. The output is licensed under the Apache License 2.0.

Closes #51269
