### PR TITLE
fix: defer ClientCreationEvent to after transaction commit [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -60,6 +60,8 @@ import org.keycloak.models.GroupModel.GroupUpdatedEvent;
 import org.keycloak.models.GroupModel.Type;
 import org.keycloak.models.GroupProvider;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakTransaction;
+import org.keycloak.models.KeycloakTransactionManager;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.ModelValidationException;
@@ -936,15 +938,46 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
 
         resource = toClientModel(realm, entity);
 
-        session.getKeycloakSessionFactory().publish(new ClientModel.ClientCreationEvent() {
+        // Defer event publication to after the transaction commits so that the
+        // client representation (attributes, redirect URIs, protocol mappers, etc.)
+        // is fully populated before any on:client-created workflow resource conditions
+        // are evaluated.  See #51594.
+        session.getTransactionManager().enlistAfterCompletion(new KeycloakTransaction() {
             @Override
-            public ClientModel getCreatedClient() {
-                return resource;
+            public void begin() {
             }
 
             @Override
-            public KeycloakSession getKeycloakSession() {
-                return session;
+            public void commit() {
+                session.getKeycloakSessionFactory().publish(new ClientModel.ClientCreationEvent() {
+                    @Override
+                    public ClientModel getCreatedClient() {
+                        return resource;
+                    }
+
+                    @Override
+                    public KeycloakSession getKeycloakSession() {
+                        return session;
+                    }
+                });
+            }
+
+            @Override
+            public void rollback() {
+            }
+
+            @Override
+            public void setRollbackOnly() {
+            }
+
+            @Override
+            public boolean getRollbackOnly() {
+                return false;
+            }
+
+            @Override
+            public boolean isActive() {
+                return true;
             }
         });
         return resource;


### PR DESCRIPTION
## Fixes #51594

### Problem

The `ClientCreationEvent` was published synchronously inside `JpaRealmProvider.addClient`
before the client representation (attributes, redirect URIs, protocol mappers, etc.)
was fully populated by the caller. Any `on: client-created` workflow resource condition
that inspects client state (e.g., a custom `WorkflowConditionProvider` reading a client
attribute) always saw a half-initialized client and silently returned `false`, preventing
the workflow from ever activating.

### Root cause

`JpaRealmProvider.addClient` persists the bare `ClientEntity` (only `id`, `clientId`,
`enabled`, `standardFlowEnabled`, `realmId`) and immediately publishes the
`ClientCreationEvent`. The caller — typically `RepresentationToModel.createClient` —
applies attributes, redirect URIs, protocol mappers, etc. **after** `addClient` returns.

### Fix

Defer the event publication to after the outer transaction commits using
`enlistAfterCompletion`. By commit time the caller has finished applying the full
representation, so any workflow conditions evaluate against the complete client state.

### Verification

- The `enlistAfterCompletion` callback runs after the main transaction commits
  (in `DefaultKeycloakTransactionManager.commit()`), at which point the JPA
  persistence context is still open and the `ClientModel` entity is still managed.
- If the main transaction rolls back, the after-completion callback is skipped
  (rolled back), so no spurious event is published for a failed client creation.
- The existing pattern (`WorkflowExecutor.runTask` → `enlistAfterCompletion`) is
  already used elsewhere in the workflow subsystem.

### Related

- Issue #51594
- User side: `UserCreatedWorkflowEventProvider` reacts to `EventType.REGISTER`
  (user event) which fires after the user is fully populated — the fix makes the
  client side consistent with this pattern.