### PR TITLE
Integrate client secret rotation with client admin api v2

### DIFF
--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -22,6 +22,7 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.events.admin.v2.AdminEventV2Builder;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientSecretConstants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
@@ -33,6 +34,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocolFactory;
+import org.keycloak.protocol.oidc.OIDCClientSecretConfigWrapper;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
 import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
@@ -53,6 +55,8 @@ import org.keycloak.services.clientpolicy.context.AdminClientUnregisterContext;
 import org.keycloak.services.clientpolicy.context.AdminClientUpdateContext;
 import org.keycloak.services.clientpolicy.context.AdminClientUpdatedContext;
 import org.keycloak.services.clientpolicy.context.AdminClientViewContext;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
+import org.keycloak.services.clientpolicy.context.ClientSecretRotationContext;
 import org.keycloak.services.managers.ClientManager;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
@@ -315,7 +319,7 @@ public class DefaultClientService implements ClientService {
                         // Check permissions, execute validations and trigger client policies
                         permissions.clients().requireConfigure(model);
                         // Must run before bean validation: PutClient requires a non-blank secret for client-secret methods
-                        generateClientSecretIfNeeded(client, model, strategy, patchExplicitNullSecret);
+                        String currentSecret = generateClientSecretIfNeeded(client, model, strategy, patchExplicitNullSecret);
                         validator.validate(client, strategy.getValidationGroup(), Default.class);
                         var proposedRepresentation = getProposedOldRepresentation(realm, client, mapper);
                         session.clientPolicy().triggerOnEvent(new AdminClientUpdateContext(proposedRepresentation, model, permissions.adminAuth()));
@@ -331,7 +335,14 @@ public class DefaultClientService implements ClientService {
 
                         model.updateClient();
 
-                        session.clientPolicy().triggerOnEvent(new AdminClientUpdatedContext(proposedRepresentation, model, permissions.adminAuth()));
+                        ClientModelContext updatedContext = currentSecret != null
+                                ? new ClientSecretRotationContext(proposedRepresentation, model, currentSecret, permissions.adminAuth())
+                                : new AdminClientUpdatedContext(proposedRepresentation, model, permissions.adminAuth());
+                        session.clientPolicy().triggerOnEvent(updatedContext);
+
+                        if (!Boolean.TRUE.equals(session.removeAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED))) {
+                            OIDCClientSecretConfigWrapper.fromClientModel(model).removeClientSecretRotationInfo();
+                        }
                     }
                 }
             } else {
@@ -430,12 +441,14 @@ public class DefaultClientService implements ClientService {
         return proposedRepresentation;
     }
 
-    private void generateClientSecretIfNeeded(BaseClientRepresentation client, ClientModel model, CreateOrUpdateStrategy strategy, boolean patchExplicitNullSecret) {
+    private String generateClientSecretIfNeeded(BaseClientRepresentation client, ClientModel model, CreateOrUpdateStrategy strategy, boolean patchExplicitNullSecret) {
+        String currentSecret = null;
         if (client instanceof OIDCClientRepresentation oidcClient
                 && OIDCClientRepresentation.PROTOCOL.equals(client.getProtocol())) {
             var auth = oidcClient.getAuth();
             if (auth != null && isClientSecret(auth.getMethod()) && isBlank(auth.getSecret())) {
                 if (strategy == CreateOrUpdateStrategy.PATCH && patchExplicitNullSecret) {
+                    currentSecret = model.getSecret(); // return current password for rotation
                     auth.setSecret(KeycloakModelUtils.generateSecret(model));
                 } else {
                     // On PUT the client often omits the secret; reuse the persisted secret before bean validation (PutClient).
@@ -448,6 +461,7 @@ public class DefaultClientService implements ClientService {
                 }
             }
         }
+        return currentSecret;
     }
 
     protected void assertSameClientIds(String pathId, String payloadId) {

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2ClientSecretRotationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2ClientSecretRotationTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.client.v2;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
+import org.keycloak.common.Profile;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oidc.OIDCClientSecretConfigWrapper;
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
+import org.keycloak.services.clientpolicy.executor.ClientSecretRotationExecutor;
+import org.keycloak.services.clientpolicy.executor.ClientSecretRotationExecutorFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientPolicyBuilder;
+import org.keycloak.testframework.realm.ClientProfileBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Test client secret rotation and client admin api v2.
+ *
+ * @author rmartinc
+ */
+@KeycloakIntegrationTest(config = ClientApiV2ClientSecretRotationTest.TestServerConfig.class)
+public class ClientApiV2ClientSecretRotationTest extends AbstractClientApiV2Test {
+
+
+    @InjectRealm(config = TestRealmConfig.class, ref = "testRealm")
+    ManagedRealm realm;
+
+    @InjectRunOnServer(realmRef = "testRealm")
+    RunOnServerClient runOnServer;
+
+    @Override
+    public String getRealmName() {
+        return realm.getName();
+    }
+
+    @Test
+    public void testRotation() throws Exception {
+        var clientId = "other";
+        OIDCClientRepresentation rep = new OIDCClientRepresentation();
+        rep.setEnabled(true);
+        rep.setClientId(clientId);
+        rep.setDescription("I'm new");
+        rep.setAuth(new OIDCClientRepresentation.Auth());
+        rep.getAuth().setMethod(ClientIdAndSecretAuthenticator.PROVIDER_ID);
+        rep.getAuth().setSecret(null);
+
+        // create the client with auto-generated secret
+        OIDCClientRepresentation createdClient;
+        try (var response = getClientsApi().createClient(rep)) {
+            createdClient = response.readEntity(OIDCClientRepresentation.class);
+            assertThat(createdClient.getDescription(), is("I'm new"));
+            assertThat(createdClient.getAuth(), notNullValue());
+            assertThat(createdClient.getAuth().getSecret(), Matchers.not(emptyOrNullString()));
+            checkRotatedInfoOnlySecretPresent(createdClient.getUuid(), createdClient.getAuth().getSecret());
+        }
+
+        // update just description should not change the rotation info and keep the same secret
+        OIDCClientRepresentation updatedClient;
+        rep.setDescription("updated2");
+        try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
+            assertThat(response.getStatus(), is(200));
+            updatedClient = response.readEntity(OIDCClientRepresentation.class);
+            assertThat(updatedClient.getDescription(), is("updated2"));
+            assertThat(updatedClient.getAuth().getSecret(), is(createdClient.getAuth().getSecret()));
+            checkRotatedInfoOnlySecretPresent(updatedClient.getUuid(), createdClient.getAuth().getSecret());
+        }
+
+        // force new password not using patch changes the password without rotation
+        rep.setDescription("updated3");
+        rep.getAuth().setSecret("new-super-secure-secret");
+        try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
+            assertThat(response.getStatus(), is(200));
+            updatedClient = response.readEntity(OIDCClientRepresentation.class);
+            assertThat(updatedClient.getDescription(), is("updated3"));
+            assertThat(updatedClient.getAuth().getSecret(), is("new-super-secure-secret"));
+            checkRotatedInfoOnlySecretPresent(updatedClient.getUuid(), "new-super-secure-secret");
+        }
+
+        // update the password forcing the rotation using patch
+        String body = String.format(Locale.ROOT,
+                "{\"enabled\":true,\"clientId\":\"%s\",\"description\":\"updated4\",\"auth\":{\"method\":\"%s\",\"secret\":null}}",
+                clientId, ClientIdAndSecretAuthenticator.PROVIDER_ID);
+        updatedClient = (OIDCClientRepresentation) getClientsApi().client(clientId)
+                .patchClient(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        assertThat(updatedClient.getDescription(), is("updated4"));
+        assertThat(updatedClient.getAuth(), notNullValue());
+        String newlyGeneratedSecret = updatedClient.getAuth().getSecret();
+        assertThat(newlyGeneratedSecret, not(emptyOrNullString()));
+        assertThat(newlyGeneratedSecret, not(is("new-super-secure-secret")));
+        checkRotatedInfoBothPresent(updatedClient.getUuid(), newlyGeneratedSecret, "new-super-secure-secret");
+
+        // put again with no password should not change anything
+        rep.setDescription("updated5");
+        rep.getAuth().setSecret(null);
+        try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
+            updatedClient = response.readEntity(OIDCClientRepresentation.class);
+            assertThat(response.getStatus(), is(200));
+            assertThat(updatedClient.getDescription(), is("updated5"));
+            assertThat(updatedClient.getAuth().getSecret(), is(newlyGeneratedSecret));
+            checkRotatedInfoBothPresent(updatedClient.getUuid(), newlyGeneratedSecret, "new-super-secure-secret");
+        }
+
+        // disable the policy and check rotation data is removed and same password remains
+        disablePolicy();
+        rep.setDescription("updated6");
+        rep.getAuth().setSecret(null);
+        try (var response = getClientsApi().client(clientId).createOrUpdateClient(rep)) {
+            assertThat(response.getStatus(), is(200));
+            updatedClient = response.readEntity(OIDCClientRepresentation.class);
+            assertThat(updatedClient.getDescription(), is("updated6"));
+            assertThat(updatedClient.getAuth().getSecret(), is(newlyGeneratedSecret));
+            checkRotatedInfoRemoved(updatedClient.getUuid(), newlyGeneratedSecret);
+        }
+    }
+
+    private void checkRotatedInfoOnlySecretPresent(String uuid, String secret) {
+        runOnServer.run(session -> {
+            RealmModel realmModel = session.getContext().getRealm();
+            ClientModel clientModel = session.clients().getClientById(realmModel, uuid);
+            OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientModel(clientModel);
+            assertThat(wrapper.getSecret(), is(secret));
+            assertThat(wrapper.getClientRotatedSecret(session, false), nullValue());
+            assertThat(wrapper.getClientRotatedSecretCreationTime(), is(0L));
+            assertThat(wrapper.getClientRotatedSecretExpirationTime(), is(0L));
+            assertThat(wrapper.getClientSecretCreationTime(), greaterThan(0L));
+            assertThat(wrapper.getClientSecretExpirationTime(), greaterThan(0L));
+        });
+    }
+
+    private void checkRotatedInfoBothPresent(String uuid, String secret, String rotatedSecret) {
+        runOnServer.run(session -> {
+            RealmModel realmModel = session.getContext().getRealm();
+            ClientModel clientModel = session.clients().getClientById(realmModel, uuid);
+            OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientModel(clientModel);
+            assertThat(wrapper.getSecret(), is(secret));
+            assertThat(wrapper.getClientRotatedSecret(session), is(rotatedSecret));
+            assertThat(wrapper.getClientRotatedSecretCreationTime(), greaterThan(0L));
+            assertThat(wrapper.getClientRotatedSecretExpirationTime(), greaterThan(0L));
+            assertThat(wrapper.getClientSecretCreationTime(), greaterThan(0L));
+            assertThat(wrapper.getClientSecretExpirationTime(), greaterThan(0L));
+        });
+    }
+
+    private void checkRotatedInfoRemoved(String uuid, String secret) {
+        runOnServer.run(session -> {
+            RealmModel realmModel = session.getContext().getRealm();
+            ClientModel clientModel = session.clients().getClientById(realmModel, uuid);
+            OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientModel(clientModel);
+            assertThat(wrapper.getSecret(), is(secret));
+            assertThat(wrapper.getClientRotatedSecret(session), nullValue());
+            assertThat(wrapper.getClientRotatedSecretCreationTime(), is(0L));
+            assertThat(wrapper.getClientRotatedSecretExpirationTime(), is(0L));
+            assertThat(wrapper.getClientSecretCreationTime(), greaterThan(0L));
+            assertThat(wrapper.getClientSecretExpirationTime(), is(0L));
+        });
+    }
+
+    private void disablePolicy() {
+        realm.updateWithCleanup(r -> {
+            return r.resetClientPolicies()
+                    .clientPolicy(ClientPolicyBuilder.create()
+                            .name("ClientSecretRotationPolicy")
+                            .description("Policy for Client Secret Rotation")
+                            .condition(ClientAccessTypeConditionFactory.PROVIDER_ID, ClientPolicyBuilder.clientAccessTypeCondition(
+                                    false, ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL))
+                            .profile("ClientSecretRotationProfile")
+                            .enabled(false)
+                            .build());
+        });
+    }
+
+    public static class TestServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.CLIENT_ADMIN_API_V2, Profile.Feature.CLIENT_SECRET_ROTATION);
+        }
+    }
+
+    public static class TestRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            var profileConfig = new ClientSecretRotationExecutor.Configuration();
+            profileConfig.setExpirationPeriod(TimeUnit.HOURS.toSeconds(1));
+            profileConfig.setRotatedExpirationPeriod(TimeUnit.MINUTES.toSeconds(10));
+            profileConfig.setRemainExpirationPeriod(TimeUnit.MINUTES.toSeconds(30));
+
+            realm.clients(ClientBuilder.create("myclient")
+                    .secret("mysecret")
+                    .serviceAccountsEnabled(true));
+            realm.clientProfile(ClientProfileBuilder.create()
+                    .name("ClientSecretRotationProfile")
+                    .description("Enable Client Secret Rotation")
+                    .executor(ClientSecretRotationExecutorFactory.PROVIDER_ID, profileConfig)
+                    .build());
+            realm.clientPolicy(ClientPolicyBuilder.create()
+                    .name("ClientSecretRotationPolicy")
+                    .description("Policy for Client Secret Rotation")
+                    .condition(ClientAccessTypeConditionFactory.PROVIDER_ID, ClientPolicyBuilder.clientAccessTypeCondition(
+                            false, ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL))
+                    .profile("ClientSecretRotationProfile")
+                    .build());
+            return realm;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/ClientSecretRotationContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/ClientSecretRotationContext.java
@@ -2,11 +2,10 @@ package org.keycloak.services.clientpolicy.context;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.representations.idm.ClientRepresentation;
-import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.utils.StringUtil;
 
-public class ClientSecretRotationContext extends AdminClientUpdateContext {
+public class ClientSecretRotationContext extends AdminClientUpdatedContext {
 
     private final String currentSecret;
 
@@ -14,11 +13,6 @@ public class ClientSecretRotationContext extends AdminClientUpdateContext {
                                        ClientModel targetClient, String currentSecret, AdminAuth adminAuth) {
         super(proposedClientRepresentation, targetClient, adminAuth);
         this.currentSecret = currentSecret;
-    }
-
-    @Override
-    public ClientPolicyEvent getEvent() {
-        return ClientPolicyEvent.UPDATED;
     }
 
     public String getCurrentSecret() {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -157,7 +157,6 @@ public class ClientResource {
         auth.clients().requireConfigure(client);
 
         try {
-            session.setAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED,Boolean.FALSE);
             session.clientPolicy().triggerOnEvent(new AdminClientUpdateContext(rep, client, auth.adminAuth()));
 
             updateClientFromRep(rep, client, session);
@@ -172,11 +171,10 @@ public class ClientResource {
 
             session.clientPolicy().triggerOnEvent(new AdminClientUpdatedContext(rep, client, auth.adminAuth()));
 
-            if (!(boolean) session.getAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED)){
+            if (!Boolean.TRUE.equals(session.removeAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED))){
                 logger.debugv("Removing the previous rotation info for client {0}{1}, if there is",client.getClientId(),client.getName());
                 OIDCClientSecretConfigWrapper.fromClientModel(client).removeClientSecretRotationInfo();
             }
-            session.removeAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED);
 
             adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
             return Response.noContent().build();
@@ -303,7 +301,6 @@ public class ClientResource {
             auth.clients().requireConfigure(client);
 
             logger.debug("regenerateSecret");
-            session.setAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED,Boolean.FALSE);
 
             ClientRepresentation representation = ModelToRepresentation.toRepresentation(client, session);
             ClientSecretRotationContext secretRotationContext = new ClientSecretRotationContext(
@@ -317,13 +314,12 @@ public class ClientResource {
             rep.setType(CredentialRepresentation.SECRET);
             rep.setValue(secret);
 
-            if (!(boolean) session.getAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED)){
+            if (!Boolean.TRUE.equals(session.removeAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED))){
                 logger.debugv("Removing the previous rotation info for client {0}{1}, if there is",client.getClientId(),client.getName());
                 OIDCClientSecretConfigWrapper.fromClientModel(client).removeClientSecretRotationInfo();
             }
 
             adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).representation(rep).success();
-            session.removeAttribute(ClientSecretConstants.CLIENT_SECRET_ROTATION_ENABLED);
             rep.setValue(secret);
             return rep;
         } catch (ClientPolicyException cpe) {

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientPolicyBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientPolicyBuilder.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.keycloak.json.KeycloakJsonMapperFactory;
 import org.keycloak.json.RawJsonValue;
 import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientPolicyConditionRepresentation;
@@ -13,9 +14,7 @@ import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
 import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
 import org.keycloak.services.clientpolicy.condition.GrantTypeCondition;
 import org.keycloak.services.clientpolicy.condition.IdentityProviderCondition;
-import org.keycloak.util.JsonSerialization;
 
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  *
@@ -95,7 +94,8 @@ public class ClientPolicyBuilder extends Builder<ClientPolicyRepresentation> {
             config = new ClientPolicyConditionConfigurationRepresentation();
         }
         try {
-            condition.setConfiguration(RawJsonValue.of(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class)));
+            var mapper = KeycloakJsonMapperFactory.mapper();
+            condition.setConfiguration(mapper.readValue(mapper.writeValueAsBytes(config), RawJsonValue.class));
         } catch(IOException e) {
             throw new IllegalArgumentException("Invalid configuration", e);
         }

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientProfileBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientProfileBuilder.java
@@ -4,13 +4,12 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.keycloak.json.KeycloakJsonMapperFactory;
 import org.keycloak.json.RawJsonValue;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientPolicyExecutorRepresentation;
 import org.keycloak.representations.idm.ClientProfileRepresentation;
-import org.keycloak.util.JsonSerialization;
 
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  *
@@ -47,7 +46,8 @@ public class ClientProfileBuilder extends Builder<ClientProfileRepresentation> {
             config = new ClientPolicyExecutorConfigurationRepresentation();
         }
         try {
-            executor.setConfiguration(RawJsonValue.of(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class)));
+            var mapper = KeycloakJsonMapperFactory.mapper();
+            executor.setConfiguration(mapper.readValue(mapper.writeValueAsBytes(config), RawJsonValue.class));
         } catch (IOException e) {
             throw new IllegalArgumentException("Invalid configuration", e);
         }


### PR DESCRIPTION
Closes #51535
Closes #51527

Adding the client secret rotation bits for the admin API v2. I also needed to change the builders to make the test work with jackson3 (configuration for policies and profiles was not serialized OK). A simple test class added to check the rotation works OK with the admin API v2.
