### PR TITLE
[ABCA] Add replay protection for Client Attestation PoP JWTs

### DIFF
--- a/core/src/main/java/org/keycloak/OAuthErrorException.java
+++ b/core/src/main/java/org/keycloak/OAuthErrorException.java
@@ -65,6 +65,7 @@ public class OAuthErrorException extends Exception {
     // Others
     public static final String INVALID_CLIENT = "invalid_client";
     public static final String INVALID_CLIENT_ATTESTATION = "invalid_client_attestation";
+    public static final String USE_ATTESTATION_CHALLENGE = "use_attestation_challenge";
     public static final String INVALID_GRANT = "invalid_grant";
     public static final String UNSUPPORTED_GRANT_TYPE = "unsupported_grant_type";
     public static final String UNSUPPORTED_TOKEN_TYPE = "unsupported_token_type";

--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -121,6 +121,9 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("client_attestation_pop_signing_alg_values_supported")
     private List<String> clientAttestationPopSigningAlgValuesSupported;
 
+    @JsonProperty("challenge_endpoint")
+    private String challengeEndpoint;
+
     @JsonProperty("introspection_endpoint_auth_methods_supported")
     private List<String> introspectionEndpointAuthMethodsSupported;
 
@@ -430,6 +433,14 @@ public class OIDCConfigurationRepresentation {
 
     public void setClientAttestationPopSigningAlgValuesSupported(List<String> clientAttestationPopSigningAlgValuesSupported) {
         this.clientAttestationPopSigningAlgValuesSupported = clientAttestationPopSigningAlgValuesSupported;
+    }
+
+    public String getChallengeEndpoint() {
+        return challengeEndpoint;
+    }
+
+    public void setChallengeEndpoint(String challengeEndpoint) {
+        this.challengeEndpoint = challengeEndpoint;
     }
 
     public List<String> getIntrospectionEndpointAuthMethodsSupported() {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
@@ -521,6 +521,9 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         if (cNonceHandler == null) {
             throw new TokenVerificationException(attestationPoPJwt, "Client attestation challenge validation is not available");
         }
+        if (!cNonceHandler.supportsCNonceConsumption()) {
+            throw new TokenVerificationException(attestationPoPJwt, "Client attestation challenge consumption is not available");
+        }
 
         WellKnownProvider oidcProvider = session.getProvider(WellKnownProvider.class, OIDCWellKnownProviderFactory.PROVIDER_ID);
         OIDCConfigurationRepresentation oidcConfig = (OIDCConfigurationRepresentation) oidcProvider.getConfig();
@@ -532,11 +535,10 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
             if (cNonceHandler.supportsCNonceTokenRetrieval()) {
                 JsonWebToken challengeToken = cNonceHandler.verifyCNonceAndGetToken(challenge,
                         challengeAudiences, challengeDetails);
-                if (cNonceHandler.supportsCNonceConsumption()) {
-                    cNonceHandler.consumeCNonce(challenge, challengeToken);
-                }
+                cNonceHandler.consumeCNonce(challenge, challengeToken);
             } else {
                 cNonceHandler.verifyCNonce(challenge, challengeAudiences, challengeDetails);
+                cNonceHandler.consumeCNonce(challenge);
             }
         } catch (Exception ex) {
             throw new ClientAttestationChallengeException(

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
@@ -51,8 +51,11 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandler;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtCNonceHandler;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCWellKnownProviderFactory;
+import org.keycloak.protocol.oidc.endpoints.ClientAttestationChallengeEndpoint;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -71,6 +74,7 @@ import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 
 import static org.keycloak.OAuth2Constants.CLIENT_ID;
 import static org.keycloak.OAuthErrorException.INVALID_CLIENT_ATTESTATION;
+import static org.keycloak.OAuthErrorException.USE_ATTESTATION_CHALLENGE;
 
 
 /**
@@ -87,6 +91,7 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
     public static final String PROVIDER_ID = "attestation-based";
     public static final String OAUTH_CLIENT_ATTESTATION_HEADER = "OAuth-Client-Attestation";
     public static final String OAUTH_CLIENT_ATTESTATION_POP_HEADER = "OAuth-Client-Attestation-PoP";
+    public static final String OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER = "OAuth-Client-Attestation-Challenge";
 
     public static final String OAUTH_CLIENT_ATTESTATION_JWT_TYPE = "oauth-client-attestation+jwt";
     public static final String OAUTH_CLIENT_ATTESTATION_POP_JWT_TYPE = "oauth-client-attestation-pop+jwt";
@@ -135,6 +140,12 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
             ClientModel clientModel = context.getClient();
             abcaResult.setAttestedClient(clientModel);
 
+        } catch (ClientAttestationChallengeException ex) {
+            ServicesLogger.LOGGER.errorValidatingAssertion(ex);
+            Response response = Response.fromResponse(ClientAuthUtil.errorResponse(BAD_REQUEST.getStatusCode(), USE_ATTESTATION_CHALLENGE, ex.getMessage()))
+                    .header(OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER, ex.getChallenge())
+                    .build();
+            context.failure(AuthenticationFlowError.INVALID_CLIENT_ATTESTATION, response);
         } catch (Exception ex) {
             ServicesLogger.LOGGER.errorValidatingAssertion(ex);
             Response response = ClientAuthUtil.errorResponse(BAD_REQUEST.getStatusCode(), INVALID_CLIENT_ATTESTATION, ex.getMessage());
@@ -142,7 +153,6 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         }
 
         // Error Message specifically related to the use of client attestations
-        // [TODO] use_attestation_challenge MUST be used when the Client Attestation PoP JWT is not using an expected server-provided challenge.
         // [TODO] use_fresh_attestation MUST be used when the Client Attestation JWT is deemed to be not fresh enough to be acceptable by the server.
         // [TODO] invalid_client_attestation MAY be used in addition to the more general invalid_client error code as defined in [RFC6749] if the attestation or its proof of possession could not be successfully verified
     }
@@ -490,13 +500,64 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
             throw new TokenSignatureInvalidException(attestationPoPJwt, "Invalid token signature");
         }
 
+        validateClientAttestationChallenge(session, attestationPoPJwt);
+
         abcaResult.setAttestationPoPJwt(attestationPoPJwt);
 
         // [TODO] The authorization server can utilize the jti value for replay attack detection
         // [TODO] The authorization server may reject JWTs with an "iat" claim value that is unreasonably far in the past
 
-        // [TODO] If the server provided a challenge value to the client, the challenge claim is present in the Client Attestation PoP JWT and matches the server-provided challenge value.
         // [TODO] Additional checks to guarantee replay protection for the Client Attestation PoP JWT might need to be applied
+    }
+
+    private void validateClientAttestationChallenge(KeycloakSession session, ClientAttestationPoPJwt attestationPoPJwt)
+            throws ClientAttestationChallengeException, TokenVerificationException {
+        String challenge = attestationPoPJwt.getChallenge();
+        if (Strings.isEmpty(challenge)) {
+            return;
+        }
+
+        CNonceHandler cNonceHandler = session.getProvider(CNonceHandler.class);
+        if (cNonceHandler == null) {
+            throw new TokenVerificationException(attestationPoPJwt, "Client attestation challenge validation is not available");
+        }
+
+        WellKnownProvider oidcProvider = session.getProvider(WellKnownProvider.class, OIDCWellKnownProviderFactory.PROVIDER_ID);
+        OIDCConfigurationRepresentation oidcConfig = (OIDCConfigurationRepresentation) oidcProvider.getConfig();
+
+        try {
+            Map<String, Object> challengeDetails = Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                    ClientAttestationChallengeEndpoint.getChallengeEndpoint(session.getContext()));
+            List<String> challengeAudiences = List.of(oidcConfig.getIssuer());
+            if (cNonceHandler.supportsCNonceTokenRetrieval()) {
+                JsonWebToken challengeToken = cNonceHandler.verifyCNonceAndGetToken(challenge,
+                        challengeAudiences, challengeDetails);
+                if (cNonceHandler.supportsCNonceConsumption()) {
+                    cNonceHandler.consumeCNonce(challenge, challengeToken);
+                }
+            } else {
+                cNonceHandler.verifyCNonce(challenge, challengeAudiences, challengeDetails);
+            }
+        } catch (Exception ex) {
+            throw new ClientAttestationChallengeException(
+                    "Client Attestation PoP JWT challenge is invalid: " + ex.getMessage(),
+                    ClientAttestationChallengeEndpoint.buildChallenge(session),
+                    ex);
+        }
+    }
+
+    private static class ClientAttestationChallengeException extends Exception {
+
+        private final String challenge;
+
+        private ClientAttestationChallengeException(String message, String challenge, Throwable cause) {
+            super(message, cause);
+            this.challenge = challenge;
+        }
+
+        private String getChallenge() {
+            return challenge;
+        }
     }
 
     public static class ABCAResult {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,6 +39,7 @@ import org.keycloak.broker.provider.TrustMaterialRequest;
 import org.keycloak.broker.provider.TrustMaterialResolver;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.Time;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
@@ -47,10 +49,12 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandler;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtCNonceHandler;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -95,6 +99,8 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
 
     public static final String OAUTH_CLIENT_ATTESTATION_JWT_TYPE = "oauth-client-attestation+jwt";
     public static final String OAUTH_CLIENT_ATTESTATION_POP_JWT_TYPE = "oauth-client-attestation-pop+jwt";
+    private static final int CLIENT_ATTESTATION_POP_REPLAY_WINDOW_SECONDS = 300;
+    private static final int CLIENT_ATTESTATION_POP_ALLOWED_CLOCK_SKEW_SECONDS = 15;
 
     /**
      * Comma-separated aliases of trust-material identity providers that expose the trusted attester keys.
@@ -457,7 +463,7 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         };
 
         TokenVerifier.Predicate<JsonWebToken> iatCheck = (t) -> {
-            if (t.getIat() == 0)
+            if (t.getIat() == null || t.getIat() == 0)
                 throw new TokenVerificationException(t, "The iat (issued at) claim MUST specify the time at which the Client Attestation PoP was issued.");
             return true;
         };
@@ -500,14 +506,63 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
             throw new TokenSignatureInvalidException(attestationPoPJwt, "Invalid token signature");
         }
 
+        ensureClientAttestationPoPNotReplayed(session, attestationJwt, attestationPoPJwt, clientKey);
         validateClientAttestationChallenge(session, attestationPoPJwt);
+        markClientAttestationPoPAsUsed(session, attestationJwt, attestationPoPJwt, clientKey);
 
         abcaResult.setAttestationPoPJwt(attestationPoPJwt);
+    }
 
-        // [TODO] The authorization server can utilize the jti value for replay attack detection
-        // [TODO] The authorization server may reject JWTs with an "iat" claim value that is unreasonably far in the past
+    private void ensureClientAttestationPoPNotReplayed(KeycloakSession session, ClientAttestationJwt attestationJwt,
+            ClientAttestationPoPJwt attestationPoPJwt, KeyWrapper clientKey) throws TokenVerificationException {
+        getClientAttestationPoPReplayEntryLifespan(attestationPoPJwt);
 
-        // [TODO] Additional checks to guarantee replay protection for the Client Attestation PoP JWT might need to be applied
+        String cacheKey = getClientAttestationPoPReplayCacheKey(attestationJwt, attestationPoPJwt, clientKey);
+        if (session.singleUseObjects().contains(cacheKey)) {
+            throw new TokenVerificationException(attestationPoPJwt, "Client Attestation PoP JWT has already been used");
+        }
+    }
+
+    private void markClientAttestationPoPAsUsed(KeycloakSession session, ClientAttestationJwt attestationJwt,
+            ClientAttestationPoPJwt attestationPoPJwt, KeyWrapper clientKey) throws TokenVerificationException {
+        long lifespan = getClientAttestationPoPReplayEntryLifespan(attestationPoPJwt);
+        String cacheKey = getClientAttestationPoPReplayCacheKey(attestationJwt, attestationPoPJwt, clientKey);
+
+        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
+        if (!singleUseStore.putIfAbsent(cacheKey, lifespan)) {
+            throw new TokenVerificationException(attestationPoPJwt, "Client Attestation PoP JWT has already been used");
+        }
+    }
+
+    private long getClientAttestationPoPReplayEntryLifespan(ClientAttestationPoPJwt attestationPoPJwt)
+            throws TokenVerificationException {
+        long now = Time.currentTime();
+        Long issuedAt = attestationPoPJwt.getIat();
+        if (issuedAt == null || issuedAt == 0) {
+            throw new TokenVerificationException(attestationPoPJwt, "The iat (issued at) claim MUST specify the time at which the Client Attestation PoP was issued.");
+        }
+        if (issuedAt > now + CLIENT_ATTESTATION_POP_ALLOWED_CLOCK_SKEW_SECONDS) {
+            throw new TokenVerificationException(attestationPoPJwt, "Client Attestation PoP JWT was issued in the future");
+        }
+
+        long lifespan = issuedAt + CLIENT_ATTESTATION_POP_REPLAY_WINDOW_SECONDS
+                + CLIENT_ATTESTATION_POP_ALLOWED_CLOCK_SKEW_SECONDS - now;
+        if (lifespan <= 0) {
+            throw new TokenVerificationException(attestationPoPJwt, "Client Attestation PoP JWT was issued too far in the past");
+        }
+        return lifespan;
+    }
+
+    private String getClientAttestationPoPReplayCacheKey(ClientAttestationJwt attestationJwt,
+            ClientAttestationPoPJwt attestationPoPJwt, KeyWrapper clientKey) {
+        String clientInstanceKeyHash = HashUtils.sha256UrlEncodedHash(
+                Base64Url.encode(clientKey.getPublicKey().getEncoded()), StandardCharsets.UTF_8);
+        String replayKeyMaterial = String.join("\n", attestationJwt.getSubject(), clientInstanceKeyHash,
+                attestationPoPJwt.getId());
+        String replayKeyHash = HashUtils.sha256UrlEncodedHash(replayKeyMaterial, StandardCharsets.UTF_8);
+
+        // Scope the jti cache key to the attested client instance key, so unrelated instances can choose the same jti.
+        return AttestationBasedClientAuthenticator.class.getName().toLowerCase(Locale.ROOT) + ".pop-replay." + replayKeyHash;
     }
 
     private void validateClientAttestationChallenge(KeycloakSession session, ClientAttestationPoPJwt attestationPoPJwt)

--- a/services/src/main/java/org/keycloak/protocol/oidc/ClientAttestationChallengeResponse.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/ClientAttestationChallengeResponse.java
@@ -1,0 +1,25 @@
+package org.keycloak.protocol.oidc;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Challenge response for OAuth 2.0 Attestation-Based Client Authentication.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-attestation-based-client-auth-10#section-6.1">Challenge endpoint</a>
+ * @author <a href="mailto:ogenbertrand@gmail.com">Bertrand Ogen</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ClientAttestationChallengeResponse {
+
+    @JsonProperty("attestation_challenge")
+    private String attestationChallenge;
+
+    public String getAttestationChallenge() {
+        return attestationChallenge;
+    }
+
+    public void setAttestationChallenge(String attestationChallenge) {
+        this.attestationChallenge = attestationChallenge;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolService.java
@@ -40,6 +40,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
+import org.keycloak.protocol.oidc.endpoints.ClientAttestationChallengeEndpoint;
 import org.keycloak.protocol.oidc.endpoints.LoginStatusIframeEndpoint;
 import org.keycloak.protocol.oidc.endpoints.LogoutEndpoint;
 import org.keycloak.protocol.oidc.endpoints.ThirdPartyCookiesIframeEndpoint;
@@ -116,6 +117,10 @@ public class OIDCLoginProtocolService {
         return uriBuilder.path(OIDCLoginProtocolService.class, "token");
     }
 
+    public static UriBuilder clientAttestationChallengeUrl(UriBuilder baseUriBuilder) {
+        return ClientAttestationChallengeEndpoint.challengeUrl(baseUriBuilder);
+    }
+
     public static UriBuilder certsUrl(UriBuilder baseUriBuilder) {
         UriBuilder uriBuilder = tokenServiceBaseUrl(baseUriBuilder);
         return uriBuilder.path(OIDCLoginProtocolService.class, "certs");
@@ -177,6 +182,14 @@ public class OIDCLoginProtocolService {
     @Path("token")
     public Object token() {
         return new TokenEndpoint(session, tokenManager, event);
+    }
+
+    /**
+     * Attestation-Based Client Authentication challenge endpoint
+     */
+    @Path(ClientAttestationChallengeEndpoint.PATH)
+    public Object clientAttestationChallenge() {
+        return new ClientAttestationChallengeEndpoint(session);
     }
 
     @Path("login-status-iframe.html")

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -47,6 +47,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
+import org.keycloak.protocol.oidc.endpoints.ClientAttestationChallengeEndpoint;
 import org.keycloak.protocol.oidc.endpoints.TokenEndpoint;
 import org.keycloak.protocol.oidc.grants.OAuth2GrantType;
 import org.keycloak.protocol.oidc.grants.ciba.CibaGrantType;
@@ -166,6 +167,8 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         if (clientAuthMethodsSupported.contains(ATTEST_JWT_CLIENT_AUTH)) {
             config.setClientAttestationSigningAlgValuesSupported(getSupportedSigningAlgorithms(false));
             config.setClientAttestationPopSigningAlgValuesSupported(getSupportedSigningAlgorithms(false));
+            config.setChallengeEndpoint(ClientAttestationChallengeEndpoint.challengeUrl(backendUriInfo.getBaseUriBuilder())
+                    .build(realm.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL).toString());
         }
 
         config.setAuthorizationSigningAlgValuesSupported(getSupportedSigningAlgorithms(false));

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/ClientAttestationChallengeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/ClientAttestationChallengeEndpoint.java
@@ -1,0 +1,108 @@
+package org.keycloak.protocol.oidc.endpoints;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator;
+import org.keycloak.common.ClientConnection;
+import org.keycloak.common.Profile;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandler;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtCNonceHandler;
+import org.keycloak.protocol.oidc.ClientAttestationChallengeResponse;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
+import org.keycloak.services.CorsErrorResponseException;
+import org.keycloak.services.cors.Cors;
+import org.keycloak.services.Urls;
+import org.keycloak.urls.UrlType;
+import org.keycloak.utils.ProfileHelper;
+
+/**
+ * OAuth 2.0 Attestation-Based Client Authentication challenge endpoint.
+ *
+ * @author <a href="mailto:ogenbertrand@gmail.com">Bertrand Ogen</a>
+ */
+public class ClientAttestationChallengeEndpoint {
+
+    public static final String PATH = "attestation/challenge";
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+    private final HttpRequest request;
+    private final ClientConnection clientConnection;
+
+    public ClientAttestationChallengeEndpoint(KeycloakSession session) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
+        this.request = session.getContext().getHttpRequest();
+        this.clientConnection = session.getContext().getConnection();
+    }
+
+    public static UriBuilder challengeUrl(UriBuilder baseUriBuilder) {
+        return OIDCLoginProtocolService.tokenServiceBaseUrl(baseUriBuilder)
+                .path(OIDCLoginProtocolService.class, "clientAttestationChallenge");
+    }
+
+    public static String getChallengeEndpoint(KeycloakContext context) {
+        return challengeUrl(context.getUri(UrlType.BACKEND).getBaseUriBuilder())
+                .build(context.getRealm().getName(), OIDCLoginProtocol.LOGIN_PROTOCOL)
+                .toString();
+    }
+
+    public static String buildChallenge(KeycloakSession session) {
+        CNonceHandler cNonceHandler = session.getProvider(CNonceHandler.class);
+        if (cNonceHandler == null) {
+            throw new IllegalStateException("Client attestation challenge handler is not configured");
+        }
+
+        String issuer = Urls.realmIssuer(session.getContext().getUri(UrlType.FRONTEND).getBaseUri(),
+                session.getContext().getRealm().getName());
+        return cNonceHandler.buildCNonce(
+                List.of(issuer),
+                Map.of(JwtCNonceHandler.SOURCE_ENDPOINT, getChallengeEndpoint(session.getContext())));
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response requestChallenge() {
+        ProfileHelper.requireFeature(Profile.Feature.CLIENT_AUTH_ABCA);
+        checkSsl();
+
+        String challenge = buildChallenge(session);
+        ClientAttestationChallengeResponse challengeResponse = new ClientAttestationChallengeResponse();
+        challengeResponse.setAttestationChallenge(challenge);
+
+        return Response.ok(challengeResponse)
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .header("Pragma", "no-cache")
+                .header(HttpHeaders.DATE, DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneOffset.UTC)))
+                .header(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER, challenge)
+                .build();
+    }
+
+    private void checkSsl() {
+        if (!session.getContext().getUri().getBaseUri().getScheme().equals("https")
+                && realm.getSslRequired().isRequired(clientConnection)) {
+            Cors cors = Cors.builder().auth().allowedMethods(request.getHttpMethod()).auth()
+                    .exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS,
+                            AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER);
+            throw new CorsErrorResponseException(cors.allowAllOrigins(), OAuthErrorException.INVALID_REQUEST,
+                    "HTTPS required", Response.Status.FORBIDDEN);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/ClientAttestationChallengeEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/ClientAttestationChallengeEndpoint.java
@@ -27,8 +27,8 @@ import org.keycloak.protocol.oidc.ClientAttestationChallengeResponse;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.cors.Cors;
 import org.keycloak.services.Urls;
+import org.keycloak.services.cors.Cors;
 import org.keycloak.urls.UrlType;
 import org.keycloak.utils.ProfileHelper;
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -231,6 +231,11 @@ public class OID4VCBasicWallet {
     }
 
     public String buildClientAttestationPoPJWT(OID4VCTestContext ctx, KeyWrapper walletKey, String challenge) {
+        return buildClientAttestationPoPJWT(ctx, walletKey, challenge, null, Time.currentTime());
+    }
+
+    public String buildClientAttestationPoPJWT(OID4VCTestContext ctx, KeyWrapper walletKey, String challenge,
+            String jwtId, long issuedAt) {
         var issuer = getIssuerMetadata(ctx).getCredentialIssuer();
 
         // Build Client Attestation PoP JWT
@@ -238,9 +243,15 @@ public class OID4VCBasicWallet {
         String clientId = ctx.getClient().getClientId();
         ClientAttestationPoPJwt body = new ClientAttestationPoPJwt()
                 .audience(issuer)
-                .issuer(clientId)
-                .issuedNowWithTTL(300) // 5min
-                .randomId();
+                .issuer(clientId);
+        body.iat(issuedAt)
+                .nbf(issuedAt)
+                .exp(issuedAt + 300); // 5min
+        if (jwtId == null) {
+            body.randomId();
+        } else {
+            body.id(jwtId);
+        }
         if (challenge != null) {
             body.challenge(challenge);
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -227,6 +227,10 @@ public class OID4VCBasicWallet {
     }
 
     public String buildClientAttestationPoPJWT(OID4VCTestContext ctx, KeyWrapper walletKey) {
+        return buildClientAttestationPoPJWT(ctx, walletKey, null);
+    }
+
+    public String buildClientAttestationPoPJWT(OID4VCTestContext ctx, KeyWrapper walletKey, String challenge) {
         var issuer = getIssuerMetadata(ctx).getCredentialIssuer();
 
         // Build Client Attestation PoP JWT
@@ -237,6 +241,9 @@ public class OID4VCBasicWallet {
                 .issuer(clientId)
                 .issuedNowWithTTL(300) // 5min
                 .randomId();
+        if (challenge != null) {
+            body.challenge(challenge);
+        }
 
         String attestationPoPJwt = new JWSBuilder()
                 .type(OAUTH_CLIENT_ATTESTATION_POP_JWT_TYPE)

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
@@ -32,6 +32,7 @@ import org.keycloak.authentication.authenticators.client.AttestationBasedClientA
 import org.keycloak.broker.trust.DefaultTrustIdentityProviderConfig;
 import org.keycloak.broker.trust.DefaultTrustIdentityProviderFactory;
 import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
@@ -292,7 +293,8 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         var kw = wallet.getRSAKeyPair(ctx);
         String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
         String challenge = oauth.clientAttestationChallengeRequest().send().getAttestationChallenge();
-        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, challenge);
+        String firstAttestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, challenge);
+        String secondAttestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, challenge);
 
         KeyWrapper ecKey = wallet.getECKeyPair(ctx);
         String tokenEndpoint = oauth.getEndpoints().getToken();
@@ -305,7 +307,7 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
 
         AccessTokenResponse firstTokenResponse = wallet.accessTokenRequest(ctx, firstAuthResponse.getCode())
                 .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
-                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, firstAttestationPoPJwt)
                 .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
                 .send();
         assertTrue(firstTokenResponse.isSuccess(), "Token request error: " + firstTokenResponse.getErrorDescription());
@@ -318,12 +320,68 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
 
         AccessTokenResponse secondTokenResponse = wallet.accessTokenRequest(ctx, secondAuthResponse.getCode())
                 .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
-                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, secondAttestationPoPJwt)
                 .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
                 .send();
 
         assertFalse(secondTokenResponse.isSuccess());
         assertEquals(OAuthErrorException.USE_ATTESTATION_CHALLENGE, secondTokenResponse.getError());
         assertNotNull(secondTokenResponse.getHeader(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER));
+    }
+
+    @Test
+    public void testClientAttestationPoPJWTCannotBeReused() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var kw = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw);
+
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+
+        AccessTokenResponse firstTokenResponse = requestToken(ctx, attestationJwt, attestationPoPJwt, ecKey, tokenEndpoint);
+        assertTrue(firstTokenResponse.isSuccess(), "Token request error: " + firstTokenResponse.getErrorDescription());
+
+        AccessTokenResponse secondTokenResponse = requestToken(ctx, attestationJwt, attestationPoPJwt, ecKey, tokenEndpoint);
+        assertFalse(secondTokenResponse.isSuccess());
+        assertEquals(OAuthErrorException.INVALID_CLIENT_ATTESTATION, secondTokenResponse.getError());
+    }
+
+    @Test
+    public void testClientAttestationPoPJWTIssuedTooFarInPastIsRejected() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var kw = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, null, "old-pop-jti",
+                Time.currentTime() - 360);
+
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+
+        AccessTokenResponse tokenResponse = requestToken(ctx, attestationJwt, attestationPoPJwt, ecKey, tokenEndpoint);
+        assertFalse(tokenResponse.isSuccess());
+        assertEquals(OAuthErrorException.INVALID_CLIENT_ATTESTATION, tokenResponse.getError());
+    }
+
+    private AccessTokenResponse requestToken(OID4VCTestContext ctx, String attestationJwt, String attestationPoPJwt,
+            KeyWrapper ecKey, String tokenEndpoint) {
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(ctx.getHolder(), TEST_PASSWORD);
+
+        assertNull(authResponse.getErrorDescription(), "Authorization error: " + authResponse.getErrorDescription());
+        assertNotNull(authResponse.getCode(), "No auth code");
+
+        return wallet.accessTokenRequest(ctx, authResponse.getCode())
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
+                .send();
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
@@ -106,7 +106,7 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
     }
 
     @Test
-    public void testClientAttestationChallengeEndpoint() {
+    public void testClientAttestationChallengeEndpoint() throws VerificationException {
         var response = oauth.clientAttestationChallengeRequest().send();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
@@ -17,10 +17,16 @@
 package org.keycloak.tests.oid4vc.abca;
 
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.OAuthErrorException;
 import org.keycloak.TokenVerifier;
+import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator;
 import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ClientAttestationJwt;
 import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ClientAttestationPoPJwt;
 import org.keycloak.broker.trust.DefaultTrustIdentityProviderConfig;
@@ -31,9 +37,11 @@ import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtCNonceHandler;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
@@ -51,6 +59,7 @@ import static org.keycloak.protocol.oidc.OIDCLoginProtocol.ATTEST_JWT_CLIENT_AUT
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -93,6 +102,25 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         OIDCConfigurationRepresentation oidcConfiguration = oauth.doWellKnownRequest();
         List<String> tokenAuthMethodsSupported = oidcConfiguration.getTokenEndpointAuthMethodsSupported();
         assertTrue(tokenAuthMethodsSupported.contains(ATTEST_JWT_CLIENT_AUTH), "Should contain: " + ATTEST_JWT_CLIENT_AUTH);
+        assertEquals(oauth.getEndpoints().getClientAttestationChallenge(), oidcConfiguration.getChallengeEndpoint());
+    }
+
+    @Test
+    public void testClientAttestationChallengeEndpoint() {
+        var response = oauth.clientAttestationChallengeRequest().send();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode());
+
+        String challenge = response.getAttestationChallenge();
+        assertNotNull(challenge);
+        assertEquals(challenge, response.getHeader(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER));
+        assertEquals("no-store", response.getHeader(HttpHeaders.CACHE_CONTROL));
+
+        TokenVerifier<JsonWebToken> verifier = TokenVerifier.create(challenge, JsonWebToken.class);
+        JsonWebToken challengeToken = verifier.getToken();
+        assertEquals(testRealm.getBaseUrl(), challengeToken.getIssuer());
+        assertEquals(List.of(testRealm.getBaseUrl()), Arrays.asList(challengeToken.getAudience()));
+        assertEquals(oauth.getEndpoints().getClientAttestationChallenge(),
+                challengeToken.getOtherClaims().get(JwtCNonceHandler.SOURCE_ENDPOINT));
     }
 
     @Test
@@ -193,5 +221,109 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
                 .send().getCredentialResponse();
 
         assertFalse(credResponse.getCredentials().isEmpty(), "No credential");
+    }
+
+    @Test
+    public void testClientAttestationChallengeHappyFlow() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var kw = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
+        String challenge = oauth.clientAttestationChallengeRequest().send().getAttestationChallenge();
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, challenge);
+
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(ctx.getHolder(), TEST_PASSWORD);
+
+        assertNull(authResponse.getErrorDescription(), "Authorization error: " + authResponse.getErrorDescription());
+        assertNotNull(authResponse.getCode(), "No auth code");
+
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authResponse.getCode())
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
+                .send();
+
+        assertTrue(tokenResponse.isSuccess(), "Token request error: " + tokenResponse.getErrorDescription());
+        assertNotNull(tokenResponse.getAccessToken(), "No access token");
+    }
+
+    @Test
+    public void testInvalidClientAttestationChallengeReturnsFreshChallenge() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var kw = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, "invalid-challenge");
+
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(ctx.getHolder(), TEST_PASSWORD);
+
+        assertNull(authResponse.getErrorDescription(), "Authorization error: " + authResponse.getErrorDescription());
+        assertNotNull(authResponse.getCode(), "No auth code");
+
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authResponse.getCode())
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
+                .send();
+
+        assertFalse(tokenResponse.isSuccess());
+        assertEquals(OAuthErrorException.USE_ATTESTATION_CHALLENGE, tokenResponse.getError());
+        assertNotNull(tokenResponse.getHeader(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER));
+    }
+
+    @Test
+    public void testClientAttestationChallengeCannotBeReused() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var kw = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
+        String challenge = oauth.clientAttestationChallengeRequest().send().getAttestationChallenge();
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw, challenge);
+
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+
+        AuthorizationEndpointResponse firstAuthResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(ctx.getHolder(), TEST_PASSWORD);
+        assertNull(firstAuthResponse.getErrorDescription(), "Authorization error: " + firstAuthResponse.getErrorDescription());
+        assertNotNull(firstAuthResponse.getCode(), "No auth code");
+
+        AccessTokenResponse firstTokenResponse = wallet.accessTokenRequest(ctx, firstAuthResponse.getCode())
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
+                .send();
+        assertTrue(firstTokenResponse.isSuccess(), "Token request error: " + firstTokenResponse.getErrorDescription());
+
+        AuthorizationEndpointResponse secondAuthResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(ctx.getHolder(), TEST_PASSWORD);
+        assertNull(secondAuthResponse.getErrorDescription(), "Authorization error: " + secondAuthResponse.getErrorDescription());
+        assertNotNull(secondAuthResponse.getCode(), "No auth code");
+
+        AccessTokenResponse secondTokenResponse = wallet.accessTokenRequest(ctx, secondAuthResponse.getCode())
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
+                .send();
+
+        assertFalse(secondTokenResponse.isSuccess());
+        assertEquals(OAuthErrorException.USE_ATTESTATION_CHALLENGE, secondTokenResponse.getError());
+        assertNotNull(secondTokenResponse.getHeader(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CHALLENGE_HEADER));
     }
 }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
@@ -182,6 +182,10 @@ public abstract class AbstractOAuthClient<T> {
         return wellknownRequest().send().getOidcConfiguration();
     }
 
+    public ClientAttestationChallengeRequest clientAttestationChallengeRequest() {
+        return new ClientAttestationChallengeRequest(this);
+    }
+
     public UserInfoRequest userInfoRequest(String accessToken) {
         return new UserInfoRequest(accessToken, this);
     }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/ClientAttestationChallengeRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/ClientAttestationChallengeRequest.java
@@ -1,0 +1,29 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+/**
+ * @author <a href="mailto:ogenbertrand@gmail.com">Bertrand Ogen</a>
+ */
+public class ClientAttestationChallengeRequest extends AbstractHttpPostRequest<ClientAttestationChallengeRequest, ClientAttestationChallengeResponse> {
+
+    public ClientAttestationChallengeRequest(AbstractOAuthClient<?> client) {
+        super(client);
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return client.getEndpoints().getClientAttestationChallenge();
+    }
+
+    @Override
+    protected void initRequest() {
+    }
+
+    @Override
+    protected ClientAttestationChallengeResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new ClientAttestationChallengeResponse(response);
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/ClientAttestationChallengeResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/ClientAttestationChallengeResponse.java
@@ -1,0 +1,35 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+/**
+ * @author <a href="mailto:ogenbertrand@gmail.com">Bertrand Ogen</a>
+ */
+public class ClientAttestationChallengeResponse extends AbstractHttpResponse {
+
+    private ObjectNode challengeResponse;
+
+    public ClientAttestationChallengeResponse(CloseableHttpResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void parseContent() throws IOException {
+        challengeResponse = asJson();
+    }
+
+    public String getAttestationChallenge() {
+        return Optional.ofNullable(challengeResponse)
+                .filter(json -> json.hasNonNull("attestation_challenge"))
+                .map(json -> json.get("attestation_challenge").asText())
+                .orElseThrow(() -> new IllegalStateException(String.format("[%s] %s", getError(), getErrorDescription())));
+    }
+
+    public ObjectNode getChallengeResponse() {
+        return challengeResponse;
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/Endpoints.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/Endpoints.java
@@ -39,7 +39,7 @@ public class Endpoints {
     }
 
     public String getClientAttestationChallenge() {
-        return asString(getBase().path(RealmsResource.class).path("{realm}/protocol/openid-connect/attestation/challenge"));
+        return asString(OIDCLoginProtocolService.clientAttestationChallengeUrl(getBase()));
     }
 
     public String getIntrospection() {

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/Endpoints.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/Endpoints.java
@@ -38,6 +38,10 @@ public class Endpoints {
         return asString(OIDCLoginProtocolService.tokenUrl(getBase()));
     }
 
+    public String getClientAttestationChallenge() {
+        return asString(getBase().path(RealmsResource.class).path("{realm}/protocol/openid-connect/attestation/challenge"));
+    }
+
     public String getIntrospection() {
         return asString(OIDCLoginProtocolService.tokenIntrospectionUrl(getBase()));
     }


### PR DESCRIPTION
Implements replay attack protection for Attestation-Based Client Authentication by tracking used PoP JWT jti values per attested client instance within an iat-based sliding window. Also adds regression coverage for PoP JWT reuse, stale PoP JWTs, and preserves challenge reuse detection behavior.

Closes: https://github.com/keycloak/keycloak/issues/44770