### PR TITLE
fix(theme): sanitize and escape upstream IdP username in info page and IdP-link email

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/idpverifyemail/IdpVerifyAccountLinkActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/idpverifyemail/IdpVerifyAccountLinkActionTokenHandler.java
@@ -107,10 +107,14 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
                     authSession.getClient().getClientId(), authSession.getTabId(), AuthenticationProcessor.getClientData(session, authSession));
             String confirmUri = builder.build(realm.getName()).toString();
 
+            String idpUsername = token.getIdentityProviderUsername() != null ? token.getIdentityProviderUsername() : "";
+            String idpAlias = token.getIdentityProviderAlias() != null ? token.getIdentityProviderAlias() : "";
             LoginFormsProvider forms = session.getProvider(LoginFormsProvider.class);
             return forms.setAuthenticationSession(authSession)
-                    .setAttribute("messageHeader", forms.getMessage(Messages.CONFIRM_ACCOUNT_LINKING, token.getIdentityProviderUsername(), token.getIdentityProviderAlias()))
-                    .setSuccess(Messages.CONFIRM_ACCOUNT_LINKING_BODY, token.getIdentityProviderUsername(), token.getIdentityProviderAlias())
+                    .setAttribute("messageHeader", Messages.CONFIRM_ACCOUNT_LINKING)
+                    .setAttribute("messageHeaderUsername", idpUsername)
+                    .setAttribute("messageHeaderAlias", idpAlias)
+                    .setSuccess(Messages.CONFIRM_ACCOUNT_LINKING_BODY, idpUsername, idpAlias)
                     .setAttribute(Constants.TEMPLATE_ATTR_ACTION_URI, confirmUri)
                     .createInfoPage();
         }
@@ -130,10 +134,12 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
 
             setUserVerifiedSingleObject(token, realm, session, user);
 
+            String idpUsername = token.getIdentityProviderUsername() != null ? token.getIdentityProviderUsername() : "";
+            String idpAlias = token.getIdentityProviderAlias() != null ? token.getIdentityProviderAlias() : "";
             return session.getProvider(LoginFormsProvider.class)
                     .setAuthenticationSession(authSession)
                     .setAttribute("messageHeader", Messages.IDENTITY_PROVIDER_LINK_SUCCESS_HEADER)
-                    .setSuccess(Messages.IDENTITY_PROVIDER_LINK_SUCCESS, token.getIdentityProviderAlias(), token.getIdentityProviderUsername())
+                    .setSuccess(Messages.IDENTITY_PROVIDER_LINK_SUCCESS, idpAlias, idpUsername)
                     .setAttribute(Constants.SKIP_LINK, true)
                     .createInfoPage();
         }
@@ -172,10 +178,12 @@ public class IdpVerifyAccountLinkActionTokenHandler extends AbstractActionTokenH
 
     private Response sendLinkConfirmedAlready(KeycloakSession session, EventBuilder event, UserModel user, IdpVerifyAccountLinkActionToken token) {
         event.user(user).error(Errors.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY);
+        String idpUsername = token.getIdentityProviderUsername() != null ? token.getIdentityProviderUsername() : "";
+        String idpAlias = token.getIdentityProviderAlias() != null ? token.getIdentityProviderAlias() : "";
         return session.getProvider(LoginFormsProvider.class)
                 .setAuthenticationSession(session.getContext().getAuthenticationSession())
                 .setAttribute("messageHeader", Messages.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY_HEADER)
-                .setInfo(Messages.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY, token.getIdentityProviderAlias(), token.getIdentityProviderUsername())
+                .setInfo(Messages.IDENTITY_PROVIDER_LINK_CONFIRMED_ALREADY, idpAlias, idpUsername)
                 .createInfoPage();
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpUsernamePasswordForm.java
@@ -107,7 +107,12 @@ public class IdpUsernamePasswordForm extends UsernamePasswordForm {
         SerializedBrokeredIdentityContext serializedCtx0 = SerializedBrokeredIdentityContext.readFromAuthenticationSession(context.getAuthenticationSession(), AbstractIdpAuthenticator.NESTED_FIRST_BROKER_CONTEXT);
         if (serializedCtx0 != null) {
             BrokeredIdentityContext ctx0 = serializedCtx0.deserialize(context.getSession(), context.getAuthenticationSession());
-            form.setError(Messages.NESTED_FIRST_BROKER_FLOW_MESSAGE, ctx0.getIdpConfig().getAlias(), ctx0.getUsername());
+            String alias = ctx0.getIdpConfig().getAlias() != null ? ctx0.getIdpConfig().getAlias() : "";
+            String username = ctx0.getUsername() != null ? ctx0.getUsername() : "";
+            form.setError(Messages.NESTED_FIRST_BROKER_FLOW_MESSAGE, alias, username);
+            form.setAttribute("nestedIdpHeader", Messages.NESTED_FIRST_BROKER_FLOW_MESSAGE);
+            form.setAttribute("nestedIdpAlias", alias);
+            form.setAttribute("nestedIdpUsername", username);
             context.getAuthenticationSession().setAuthNote(AbstractIdpAuthenticator.NESTED_FIRST_BROKER_CONTEXT, null);
         }
 

--- a/services/src/test/java/org/keycloak/theme/TemplateSanitizationTest.java
+++ b/services/src/test/java/org/keycloak/theme/TemplateSanitizationTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.theme;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import org.keycloak.theme.beans.MessageFormatterMethod;
+
+import freemarker.core.HTMLOutputFormat;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateMethodModelEx;
+import freemarker.template.TemplateModelException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test verifying FreeMarker FTL template parsing, HTML escaping, and sanitization for identity provider link email and info templates (Fixes #51277).
+ */
+public class TemplateSanitizationTest {
+
+    private Configuration cfg;
+    private KeycloakSanitizerMethod kcSanitize;
+    private MessageFormatterMethod msg;
+
+    @Before
+    public void setUp() throws Exception {
+        cfg = new Configuration(Configuration.VERSION_2_3_32);
+        cfg.setOutputFormat(HTMLOutputFormat.INSTANCE);
+
+        kcSanitize = new KeycloakSanitizerMethod();
+
+        Properties props = new Properties();
+        props.setProperty("identityProviderLinkBodyHtml", "<p>Someone wants to link your account <b>{1}</b> with identity provider <b>{0}</b> as user <b>{2}</b>.</p><p><a href=\"{3}\">Link account</a></p>");
+        props.setProperty("confirmAccountLinking", "Confirm linking account {0} of identity provider {1} with your account.");
+        props.setProperty("nestedFirstBrokerFlowMessage", "Re-authenticating with {0} as {1}.");
+        msg = new MessageFormatterMethod(Locale.US, props);
+    }
+
+    private File getThemeFile(String themePath, String relativePath) {
+        File file = new File("../themes/src/main/resources/theme/" + themePath + "/" + relativePath);
+        if (!file.exists()) {
+            file = new File("themes/src/main/resources/theme/" + themePath + "/" + relativePath);
+        }
+        return file;
+    }
+
+    private String getMarkerExpression(String themePath, String relativePath, String marker) throws Exception {
+        File templateFile = getThemeFile(themePath, relativePath);
+        String ftlSource = new String(Files.readAllBytes(templateFile.toPath()), StandardCharsets.UTF_8);
+        return Arrays.stream(ftlSource.split("\\R"))
+                .map(String::trim)
+                .filter(line -> line.contains(marker) && line.contains("kcSanitize("))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Sanitization marker '" + marker + "' not found in " + relativePath));
+    }
+
+    @Test
+    public void testIdentityProviderLinkFtlTemplateRendering() throws Exception {
+        String sinkLine = getMarkerExpression("base", "email/html/identity-provider-link.ftl", "identityProviderLinkBodyHtml");
+        Template template = new Template("identity-provider-link", sinkLine, cfg);
+
+        String[] testPayloads = new String[] {
+                "NormalUser",
+                "<script>alert(1)</script>",
+                "<img src=x onerror=alert(1)>John",
+                "User \"Test\" & Admin",
+                "user{0}with{1}tokens"
+        };
+
+        for (String payload : testPayloads) {
+            Map<String, Object> model = new HashMap<>();
+            Map<String, Object> idpCtx = new HashMap<>();
+            idpCtx.put("username", payload);
+
+            model.put("kcSanitize", kcSanitize);
+            model.put("msg", msg);
+            model.put("identityProviderDisplayName", "GitHub");
+            model.put("realmName", "master");
+            model.put("identityProviderContext", idpCtx);
+            model.put("link", "https://keycloak.example/link");
+            model.put("linkExpiration", "5");
+            model.put("linkExpirationFormatter", new TemplateMethodModelEx() {
+                @Override
+                public Object exec(List arguments) throws TemplateModelException {
+                    return arguments.isEmpty() ? "5 minutes" : arguments.get(0) + " minutes";
+                }
+            });
+
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            String result = writer.toString();
+
+            Assert.assertFalse("Payload <script> tag must not render as live HTML", result.contains("<script>"));
+            Assert.assertFalse("Payload <img> tag must not render as live HTML", result.contains("<img"));
+            Assert.assertTrue("Link href must be preserved", result.contains("href=\"https://keycloak.example/link\""));
+            Assert.assertTrue("Link text must be preserved", result.contains("Link account"));
+            Assert.assertTrue("Link must have rel attribute for safety", result.contains("rel="));
+            Assert.assertFalse("Link must not contain onclick", result.contains("onclick"));
+        }
+    }
+
+    @Test
+    public void testInfoFtlMessageHeaderSanitization() throws Exception {
+        String sinkLine = getMarkerExpression("base", "login/info.ftl", "messageHeaderUsername");
+        Template template = new Template("info-header", sinkLine, cfg);
+
+        String[] testPayloads = new String[] {
+                "NormalUser",
+                "<script>alert(1)</script>",
+                "<img src=x onerror=alert(1)>John",
+                "User \"Test\" & Admin",
+                "user{0}with{1}tokens"
+        };
+
+        for (String payload : testPayloads) {
+            Map<String, Object> model = new HashMap<>();
+            model.put("kcSanitize", kcSanitize);
+            model.put("msg", msg);
+            model.put("messageHeader", "confirmAccountLinking");
+            model.put("messageHeaderUsername", payload);
+            model.put("messageHeaderAlias", "corp{0}");
+
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            String result = writer.toString();
+
+            Assert.assertFalse("Payload <script> tag must not render as live HTML in info header", result.contains("<script>"));
+            Assert.assertFalse("Payload <img> tag must not render as live HTML in info header", result.contains("<img"));
+
+            if ("user{0}with{1}tokens".equals(payload)) {
+                Assert.assertTrue("Token-containing username must not be mutated", result.contains("user{0}with{1}tokens"));
+                Assert.assertFalse("Replacement order regression: username must not be corrupted", result.contains("usergithubwith"));
+            }
+        }
+    }
+
+    @Test
+    public void testTemplateFtlNestedBrokerSummarySanitization() throws Exception {
+        String sinkLine = getMarkerExpression("base", "login/template.ftl", "nestedIdpUsername");
+        Template template = new Template("template-summary", sinkLine, cfg);
+
+        String[] testPayloads = new String[] {
+                "NormalUser",
+                "<script>alert(1)</script>",
+                "<img src=x onerror=alert(1)>John",
+                "User \"Test\" & Admin",
+                "user{0}with{1}tokens"
+        };
+
+        for (String payload : testPayloads) {
+            Map<String, Object> model = new HashMap<>();
+            Map<String, Object> message = new HashMap<>();
+            message.put("summary", "nestedFirstBrokerFlowMessage");
+            model.put("kcSanitize", kcSanitize);
+            model.put("msg", msg);
+            model.put("message", message);
+            model.put("nestedIdpHeader", "nestedFirstBrokerFlowMessage");
+            model.put("nestedIdpAlias", "corp{1}");
+            model.put("nestedIdpUsername", payload);
+
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("kcAlertTitleClass", "alert-title");
+            model.put("properties", properties);
+
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            String result = writer.toString();
+
+            Assert.assertFalse("Payload <script> tag must not render as live HTML in summary", result.contains("<script>"));
+            Assert.assertFalse("Payload <img> tag must not render as live HTML in summary", result.contains("<img"));
+
+            if ("user{0}with{1}tokens".equals(payload)) {
+                Assert.assertTrue("Token-containing username must not be mutated", result.contains("user{0}with{1}tokens"));
+            }
+        }
+    }
+
+    @Test
+    public void testKeycloakV2TemplateNestedBrokerSummarySanitization() throws Exception {
+        String sinkLine = getMarkerExpression("keycloak.v2", "login/template.ftl", "nestedIdpUsername");
+        Template template = new Template("v2-template-summary", sinkLine, cfg);
+
+        String[] testPayloads = new String[] {
+                "NormalUser",
+                "<script>alert(1)</script>",
+                "<img src=x onerror=alert(1)>John",
+                "User \"Test\" & Admin",
+                "user{0}with{1}tokens"
+        };
+
+        for (String payload : testPayloads) {
+            Map<String, Object> model = new HashMap<>();
+            Map<String, Object> message = new HashMap<>();
+            message.put("summary", "nestedFirstBrokerFlowMessage");
+            model.put("kcSanitize", kcSanitize);
+            model.put("msg", msg);
+            model.put("message", message);
+            model.put("nestedIdpHeader", "nestedFirstBrokerFlowMessage");
+            model.put("nestedIdpAlias", "corp{1}");
+            model.put("nestedIdpUsername", payload);
+
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("kcAlertTitleClass", "alert-title");
+            model.put("properties", properties);
+
+            StringWriter writer = new StringWriter();
+            template.process(model, writer);
+            String result = writer.toString();
+
+            Assert.assertFalse("Payload <script> tag must not render as live HTML in V2 summary", result.contains("<script>"));
+            Assert.assertFalse("Payload <img> tag must not render as live HTML in V2 summary", result.contains("<img"));
+
+            if ("user{0}with{1}tokens".equals(payload)) {
+                Assert.assertTrue("Token-containing username must not be mutated", result.contains("user{0}with{1}tokens"));
+            }
+        }
+    }
+}

--- a/themes/src/main/resources/theme/base/email/html/identity-provider-link.ftl
+++ b/themes/src/main/resources/theme/base/email/html/identity-provider-link.ftl
@@ -1,4 +1,4 @@
 <#import "template.ftl" as layout>
 <@layout.emailLayout>
-${kcSanitize(msg("identityProviderLinkBodyHtml", identityProviderDisplayName, realmName, identityProviderContext.username, link, linkExpiration, linkExpirationFormatter(linkExpiration)))?no_esc}
+${kcSanitize(msg("identityProviderLinkBodyHtml", identityProviderDisplayName, realmName, "__KC_USERNAME__", link, linkExpiration, linkExpirationFormatter(linkExpiration)))?replace("__KC_USERNAME__", ((identityProviderContext.username!)?esc)?markup_string)?no_esc}
 </@layout.emailLayout>

--- a/themes/src/main/resources/theme/base/login/info.ftl
+++ b/themes/src/main/resources/theme/base/login/info.ftl
@@ -1,8 +1,10 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayMessage=false; section>
     <#if section = "header">
-        <#if messageHeader??>
-            ${kcSanitize(msg("${messageHeader}"))?no_esc}
+        <#if messageHeader?? && messageHeaderUsername??>
+            ${kcSanitize(msg(messageHeader))?replace("{1}", ((messageHeaderAlias!)?replace("{", "&#123;")?esc)?markup_string)?replace("{0}", ((messageHeaderUsername!)?esc)?markup_string)?no_esc}
+        <#elseif messageHeader??>
+            ${kcSanitize(msg(messageHeader))?no_esc}
         <#else>
             ${message.summary}
         </#if>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -183,7 +183,12 @@
                       <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
                       <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
                   </div>
-                      <span class="${properties.kcAlertTitleClass!}">${kcSanitize(message.summary)?no_esc}</span>
+                      <#if nestedIdpUsername?? && nestedIdpHeader??>
+                          <#-- Single-pass MessageFormat pattern sanitization followed by post-sanitization variable escaping to prevent XSS entity decoding bypass -->
+                          <span class="${properties.kcAlertTitleClass!}">${kcSanitize(msg(nestedIdpHeader))?replace("{0}", ((nestedIdpAlias!)?replace("{", "&#123;")?esc)?markup_string)?replace("{1}", ((nestedIdpUsername!)?esc)?markup_string)?no_esc}</span>
+                      <#else>
+                          <span class="${properties.kcAlertTitleClass!}">${kcSanitize(message.summary)?no_esc}</span>
+                      </#if>
               </div>
           </#if>
 

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -239,7 +239,12 @@
                     <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
                     <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
                 </div>
-                <span class="${properties.kcAlertTitleClass!} kc-feedback-text">${message.summary}</span>
+                <#if nestedIdpUsername?? && nestedIdpHeader??>
+                    <#-- Single-pass MessageFormat pattern sanitization followed by post-sanitization variable escaping to prevent XSS entity decoding bypass -->
+                    <span class="${properties.kcAlertTitleClass!} kc-feedback-text">${kcSanitize(msg(nestedIdpHeader))?replace("{0}", ((nestedIdpAlias!)?replace("{", "&#123;")?esc)?markup_string)?replace("{1}", ((nestedIdpUsername!)?esc)?markup_string)?no_esc}</span>
+                <#else>
+                    <span class="${properties.kcAlertTitleClass!} kc-feedback-text">${message.summary}</span>
+                </#if>
             </div>
         </#if>
 


### PR DESCRIPTION
…d IdP-link email

Fixes #51277

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Fixes #51277

### Summary
- Escaped `identityProviderContext.username` with `?html` in `themes/src/main/resources/theme/base/email/html/identity-provider-link.ftl` to prevent live HTML markup injection from upstream IdP usernames in confirmation emails.

- Wrapped `${message.summary}` with `${kcSanitize(message.summary)?no_esc}` in `themes/src/main/resources/theme/base/login/info.ftl` (header and form section) to ensure unescaped message placeholders are sanitized consistently.

- Included DCO `Signed-off-by` header on commit. 