### PR TITLE
Add client attribute condition and client activity event workflow providers

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/workflow/JpaWorkflowStateProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/JpaWorkflowStateProvider.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.workflow;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
@@ -78,12 +77,12 @@ public class JpaWorkflowStateProvider implements WorkflowStateProvider {
             entity.setWorkflowId(workflow.getId());
             entity.setExecutionId(executionId);
             entity.setScheduledStepId(step.getId());
-            entity.setScheduledStepTimestamp(Instant.now().plus(duration).toEpochMilli());
+            entity.setScheduledStepTimestamp(Time.currentTimeMillis() + duration.toMillis());
             em.persist(entity);
             return ScheduleResult.CREATED;
         } else {
             entity.setScheduledStepId(step.getId());
-            entity.setScheduledStepTimestamp(Instant.now().plus(duration).toEpochMilli());
+            entity.setScheduledStepTimestamp(Time.currentTimeMillis() + duration.toMillis());
             return ScheduleResult.UPDATED;
         }
     }

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.models.workflow.conditions;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.WorkflowConditionProviderFactory;
+
+public class ClientAttributeWorkflowConditionFactory implements WorkflowConditionProviderFactory<ClientAttributeWorkflowConditionProvider> {
+
+    public static final String ID = "has-client-attribute";
+
+    @Override
+    public ClientAttributeWorkflowConditionProvider create(KeycloakSession session, String keyValuePair) {
+        return new ClientAttributeWorkflowConditionProvider(session, keyValuePair);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionProvider.java
@@ -1,0 +1,126 @@
+package org.keycloak.models.workflow.conditions;
+
+import java.util.Objects;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.jpa.entities.ClientAttributeEntity;
+import org.keycloak.models.workflow.ResourceType;
+import org.keycloak.models.workflow.WorkflowConditionProvider;
+import org.keycloak.models.workflow.WorkflowExecutionContext;
+import org.keycloak.models.workflow.WorkflowInvalidStateException;
+
+import org.hibernate.Session;
+
+import static org.keycloak.models.workflow.conditions.UserAttributeWorkflowConditionProvider.parseKeyValuePair;
+
+public class ClientAttributeWorkflowConditionProvider implements WorkflowConditionProvider {
+
+    private final String expectedAttribute;
+    private final KeycloakSession session;
+
+    public ClientAttributeWorkflowConditionProvider(KeycloakSession session, String expectedAttribute) {
+        this.session = session;
+        this.expectedAttribute = expectedAttribute;
+    }
+
+    @Override
+    public ResourceType getSupportedResourceType() {
+        return ResourceType.CLIENTS;
+    }
+
+    @Override
+    public boolean evaluate(WorkflowExecutionContext context) {
+        validate();
+
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel client = session.clients().getClientById(realm, context.getResourceId());
+
+        if (client == null) {
+            return false;
+        }
+
+        String[] parsedKeyValuePair = parseKeyValuePair(expectedAttribute);
+        String key = parsedKeyValuePair[0];
+        String valuePart = parsedKeyValuePair[1];
+
+        // Presence-only: "key" -> true if the client has the attribute, regardless of its value
+        if (valuePart.isEmpty()) {
+            return client.getAttributes().containsKey(key);
+        }
+
+        // Client attributes are single-valued, so the expected value is compared literally
+        return Objects.equals(valuePart, client.getAttribute(key));
+    }
+
+    @Override
+    public Predicate toPredicate(CriteriaBuilder cb, CriteriaQuery<String> query, Root<?> path) {
+        validate();
+
+        String[] parsedKeyValuePair = parseKeyValuePair(expectedAttribute);
+        String attributeName = parsedKeyValuePair[0];
+        String valuePart = parsedKeyValuePair[1];
+
+        // Subquery to find if an attribute with this name (and value, if one is expected) exists for the client
+        Subquery<Integer> subquery = query.subquery(Integer.class);
+        Root<ClientAttributeEntity> attrRoot = subquery.from(ClientAttributeEntity.class);
+        subquery.select(cb.literal(1));
+
+        Predicate clientPredicate = cb.equal(attrRoot.get("client").get("id"), path.get("id"));
+        Predicate namePredicate = cb.equal(attrRoot.get("name"), attributeName);
+
+        // Presence-only: require the attribute to exist for the client, regardless of its value
+        if (valuePart.isEmpty()) {
+            subquery.where(cb.and(clientPredicate, namePredicate));
+            return cb.exists(subquery);
+        }
+
+        subquery.where(cb.and(clientPredicate, namePredicate, createValuePredicate(cb, attrRoot, valuePart)));
+        return cb.exists(subquery);
+    }
+
+    private Predicate createValuePredicate(CriteriaBuilder cb, Root<ClientAttributeEntity> attrRoot, String expectedValue) {
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+
+        //noinspection resource
+        String dbProductName = em.unwrap(Session.class).doReturningWork(connection -> connection.getMetaData().getDatabaseProductName());
+
+        if (dbProductName.equals("Oracle")) {
+            // Oracle is not able to compare a CLOB with a VARCHAR unless it being converted with TO_CHAR
+            // But for this all values in the table need to be smaller than 4K, otherwise the cast will fail with
+            // "ORA-22835: Buffer too small for CLOB to CHAR" (even if it is in another row).
+            // This leaves DBMS_LOB.COMPARE as the option to compare the CLOB with the value.
+            return cb.equal(cb.function("DBMS_LOB.COMPARE", Integer.class, attrRoot.get("value"), cb.literal(expectedValue)), 0);
+        } else if (dbProductName.equals("PostgreSQL")) {
+            // use the substr comparison and the full comparison in postgresql
+            return cb.and(
+                    cb.equal(
+                            cb.function("substr", Integer.class, attrRoot.get("value"), cb.literal(1), cb.literal(255)),
+                            cb.function("substr", Integer.class, cb.literal(expectedValue), cb.literal(1), cb.literal(255))),
+                    cb.equal(attrRoot.get("value"), expectedValue));
+        }
+
+        return cb.equal(attrRoot.get("value"), expectedValue);
+    }
+
+    @Override
+    public void validate() {
+        if (expectedAttribute == null) {
+            throw new WorkflowInvalidStateException("workflowConditionAttributeNotSet");
+        }
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/ClientActivityWorkflowEventFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/ClientActivityWorkflowEventFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.models.workflow.events;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.WorkflowEventProvider;
+import org.keycloak.models.workflow.WorkflowEventProviderFactory;
+
+public class ClientActivityWorkflowEventFactory implements WorkflowEventProviderFactory<WorkflowEventProvider> {
+
+    public static final String ID = "client-activity";
+
+    @Override
+    public WorkflowEventProvider create(KeycloakSession session, String configParameter) {
+        return new ClientActivityWorkflowEventProvider(session, configParameter, this.getId());
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/ClientActivityWorkflowEventProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/ClientActivityWorkflowEventProvider.java
@@ -1,0 +1,31 @@
+package org.keycloak.models.workflow.events;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.AbstractWorkflowEventProvider;
+import org.keycloak.models.workflow.ResourceType;
+
+public class ClientActivityWorkflowEventProvider extends AbstractWorkflowEventProvider {
+
+    // User events that indicate a client is actively being used on behalf of a user. Unlike CLIENT_LOGIN,
+    // these events are also sent for public clients, which cannot authenticate on their own.
+    private static final Set<EventType> ACTIVITY_EVENT_TYPES = EnumSet.of(EventType.LOGIN, EventType.CODE_TO_TOKEN, EventType.REFRESH_TOKEN);
+
+    public ClientActivityWorkflowEventProvider(final KeycloakSession session, final String configParameter, final String providerId) {
+        super(session, configParameter, providerId);
+    }
+
+    @Override
+    public ResourceType getSupportedResourceType() {
+        return ResourceType.CLIENTS;
+    }
+
+    @Override
+    public boolean supports(Event event) {
+        return ACTIVITY_EVENT_TYPES.contains(event.getType());
+    }
+}

--- a/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowConditionProviderFactory
+++ b/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowConditionProviderFactory
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+org.keycloak.models.workflow.conditions.ClientAttributeWorkflowConditionFactory
 org.keycloak.models.workflow.conditions.GroupMembershipWorkflowConditionFactory
 org.keycloak.models.workflow.conditions.IdentityProviderWorkflowConditionFactory
 org.keycloak.models.workflow.conditions.UserAttributeWorkflowConditionFactory

--- a/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowEventProviderFactory
+++ b/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowEventProviderFactory
@@ -9,5 +9,6 @@ org.keycloak.models.workflow.events.UserRoleGrantedWorkflowEventFactory
 org.keycloak.models.workflow.events.UserRoleRevokedWorkflowEventFactory
 
 # client event providers
+org.keycloak.models.workflow.events.ClientActivityWorkflowEventFactory
 org.keycloak.models.workflow.events.ClientAuthenticatedWorkflowEventFactory
 org.keycloak.models.workflow.events.ClientCreatedWorkflowEventFactory

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/activation/ClientActivityWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/activation/ClientActivityWorkflowTest.java
@@ -1,0 +1,112 @@
+package org.keycloak.tests.workflow.activation;
+
+import java.time.Duration;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.workflow.client.DisableClientStepProviderFactory;
+import org.keycloak.models.workflow.events.ClientActivityWorkflowEventFactory;
+import org.keycloak.representations.workflows.WorkflowRepresentation;
+import org.keycloak.representations.workflows.WorkflowStepRepresentation;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
+import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
+import org.keycloak.tests.workflow.AbstractWorkflowTest;
+import org.keycloak.tests.workflow.config.WorkflowsBlockingServerConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests activation of client workflows based on user-driven activity (login) events.
+ */
+@KeycloakIntegrationTest(config = WorkflowsBlockingServerConfig.class)
+public class ClientActivityWorkflowTest extends AbstractWorkflowTest {
+
+    @InjectUser(ref = "alice", config = DefaultUserConfig.class, lifecycle = LifeCycle.METHOD, realmRef = DEFAULT_REALM_NAME)
+    private ManagedUser userAlice;
+
+    @InjectTimeOffSet
+    TimeOffSet timeOffSet;
+
+    @Test
+    public void testActivateWorkflowOnClientActivity() {
+        managedRealm.admin().workflows().create(WorkflowRepresentation.withName("myworkflow")
+                .onEvent(ClientActivityWorkflowEventFactory.ID)
+                .concurrency().restartInProgress("true") // this setting enables restarting the workflow
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(DisableClientStepProviderFactory.ID)
+                                .after(Duration.ofDays(5))
+                                .build()
+                ).build()).close();
+
+        // login with alice - the login event carries the client, so this attaches the workflow to the
+        // client used for the login and schedules the first step
+        login();
+
+        // running the scheduled tasks now shouldn't pick up any step as none are due to run yet
+        runScheduledSteps(Duration.ZERO);
+
+        assertClientEnabled(true, "phase1: nothing due yet");
+
+        // move the clock 4 days ahead and login again - the activity resets the workflow, so the
+        // disable step is now due 9 days after the first login
+        timeOffSet.set(Duration.ofDays(4));
+        try {
+            login();
+        } finally {
+            timeOffSet.set(0);
+        }
+
+        // without the reset the disable step would be due now
+        runScheduledSteps(Duration.ofDays(6));
+
+        assertClientEnabled(true, "phase2: reset moved the step past day 6");
+
+        // setting the offset past the reset schedule should disable the client
+        runScheduledSteps(Duration.ofDays(10));
+
+        assertClientEnabled(false, "phase3: step due after day 9");
+    }
+
+    private void login() {
+        oauth.openLoginForm();
+        loginPage.fillLogin(userAlice.getUsername(), userAlice.getPassword());
+        loginPage.submit();
+        Assertions.assertTrue(oauth.parseLoginResponse().isSuccess());
+    }
+
+    private void assertClientEnabled(boolean expectedEnabled, String phase) {
+        String clientId = oauth.getClientId();
+
+        runOnServer.run((session -> {
+            RealmModel realm = session.getContext().getRealm();
+            ClientModel client = session.clients().getClientByClientId(realm, clientId);
+            if (expectedEnabled) {
+                assertTrue(client.isEnabled(), phase);
+            } else {
+                assertFalse(client.isEnabled(), phase);
+            }
+        }));
+    }
+
+    private static class DefaultUserConfig implements UserConfig {
+
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            user.username("alice");
+            user.password("alice");
+            user.name("alice", "alice");
+            user.email("alice@example.org");
+            return user;
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/activation/ClientActivityWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/activation/ClientActivityWorkflowTest.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.workflow.WorkflowProvider;
+import org.keycloak.models.workflow.WorkflowStateProvider;
 import org.keycloak.models.workflow.client.DisableClientStepProviderFactory;
 import org.keycloak.models.workflow.events.ClientActivityWorkflowEventFactory;
 import org.keycloak.representations.workflows.WorkflowRepresentation;
@@ -22,6 +24,8 @@ import org.keycloak.tests.workflow.config.WorkflowsBlockingServerConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,14 +43,7 @@ public class ClientActivityWorkflowTest extends AbstractWorkflowTest {
 
     @Test
     public void testActivateWorkflowOnClientActivity() {
-        managedRealm.admin().workflows().create(WorkflowRepresentation.withName("myworkflow")
-                .onEvent(ClientActivityWorkflowEventFactory.ID)
-                .concurrency().restartInProgress("true") // this setting enables restarting the workflow
-                .withSteps(
-                        WorkflowStepRepresentation.create().of(DisableClientStepProviderFactory.ID)
-                                .after(Duration.ofDays(5))
-                                .build()
-                ).build()).close();
+        createWorkflow();
 
         // login with alice - the login event carries the client, so this attaches the workflow to the
         // client used for the login and schedules the first step
@@ -75,6 +72,35 @@ public class ClientActivityWorkflowTest extends AbstractWorkflowTest {
         runScheduledSteps(Duration.ofDays(10));
 
         assertClientEnabled(false, "phase3: step due after day 9");
+    }
+
+    @Test
+    public void testFailedLoginDoesNotActivateWorkflow() {
+        createWorkflow();
+
+        // a failed attempt carries the client on the error event but must not activate the workflow -
+        // otherwise spamming bad credentials against a dormant client would keep its idle clock alive
+        oauth.openLoginForm();
+        loginPage.fillLogin(userAlice.getUsername(), "wrong-password");
+        loginPage.submit();
+
+        runOnServer.run((session -> {
+            WorkflowProvider provider = session.getProvider(WorkflowProvider.class);
+            WorkflowStateProvider stateProvider = session.getProvider(WorkflowStateProvider.class);
+            provider.getWorkflows().forEach(workflow ->
+                    assertThat(stateProvider.getScheduledStepsByWorkflow(workflow.getId()).toList(), empty()));
+        }));
+    }
+
+    private void createWorkflow() {
+        managedRealm.admin().workflows().create(WorkflowRepresentation.withName("myworkflow")
+                .onEvent(ClientActivityWorkflowEventFactory.ID)
+                .concurrency().restartInProgress("true") // this setting enables restarting the workflow
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(DisableClientStepProviderFactory.ID)
+                                .after(Duration.ofDays(5))
+                                .build()
+                ).build()).close();
     }
 
     private void login() {

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/condition/ClientAttributeWorkflowConditionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/condition/ClientAttributeWorkflowConditionTest.java
@@ -1,0 +1,134 @@
+package org.keycloak.tests.workflow.condition;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.workflow.Workflow;
+import org.keycloak.models.workflow.WorkflowProvider;
+import org.keycloak.models.workflow.WorkflowStateProvider;
+import org.keycloak.models.workflow.WorkflowStateProvider.ScheduledStep;
+import org.keycloak.models.workflow.client.DisableClientStepProviderFactory;
+import org.keycloak.models.workflow.conditions.ClientAttributeWorkflowConditionFactory;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.workflows.WorkflowRepresentation;
+import org.keycloak.representations.workflows.WorkflowScheduleRepresentation;
+import org.keycloak.representations.workflows.WorkflowStepRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.providers.runonserver.RunOnServer;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.workflow.AbstractWorkflowTest;
+import org.keycloak.tests.workflow.config.WorkflowsBlockingServerConfig;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest(config = WorkflowsBlockingServerConfig.class)
+public class ClientAttributeWorkflowConditionTest extends AbstractWorkflowTest {
+
+    @Test
+    public void testConditionForAnyValuedAttribute() {
+        createWorkflow(ClientAttributeWorkflowConditionFactory.ID + "(attribute)");
+
+        String matching1 = createClient("client-1", Map.of("attribute", "singleValue"));
+        String matching2 = createClient("client-2", Map.of("attribute", "otherValue"));
+        createClient("client-3", Map.of());
+
+        awaitActivationFor(matching1, matching2);
+
+        runScheduledSteps(Duration.ofDays(6));
+
+        assertClientEnabled("client-1", false);
+        assertClientEnabled("client-2", false);
+        assertClientEnabled("client-3", true);
+    }
+
+    @Test
+    public void testConditionForExactValue() {
+        createWorkflow(ClientAttributeWorkflowConditionFactory.ID + "(attribute:valid)");
+
+        String matching = createClient("client-1", Map.of("attribute", "valid"));
+        createClient("client-2", Map.of("attribute", "not-valid"));
+        createClient("client-3", Map.of());
+
+        awaitActivationFor(matching);
+
+        runScheduledSteps(Duration.ofDays(6));
+
+        assertClientEnabled("client-1", false);
+        assertClientEnabled("client-2", true);
+        assertClientEnabled("client-3", true);
+    }
+
+    private void createWorkflow(String condition) {
+        // the clients are picked up by the scheduled activation - the client-created event cannot be used
+        // to activate attribute-based workflows because it is published before the attributes are set
+        // (see https://github.com/keycloak/keycloak/issues/51594)
+        WorkflowRepresentation workflow = WorkflowRepresentation.withName("myworkflow")
+                .schedule(WorkflowScheduleRepresentation.create().after("1s").build())
+                .onCondition(condition)
+                .withSteps(
+                        WorkflowStepRepresentation.create()
+                                .of(DisableClientStepProviderFactory.ID)
+                                .after(Duration.ofDays(5))
+                                .build()
+                ).build();
+
+        try (Response response = managedRealm.admin().workflows().create(workflow)) {
+            assertThat(response.getStatus(), is(Status.CREATED.getStatusCode()));
+        }
+    }
+
+    private String createClient(String clientId, Map<String, String> attributes) {
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setClientId(clientId);
+        rep.setProtocol("openid-connect");
+        rep.setEnabled(true);
+        rep.setAttributes(attributes);
+        try (Response response = managedRealm.admin().clients().create(rep)) {
+            assertThat(response.getStatus(), is(Status.CREATED.getStatusCode()));
+            return ApiUtil.getCreatedId(response);
+        }
+    }
+
+    private void awaitActivationFor(String... expectedClientUuids) {
+        Awaitility.await()
+                .timeout(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofSeconds(1))
+                .untilAsserted(() -> runOnServer.run((RunOnServer) session -> {
+                    WorkflowProvider provider = session.getProvider(WorkflowProvider.class);
+                    List<Workflow> workflows = provider.getWorkflows().toList();
+                    assertThat(workflows, hasSize(1));
+
+                    WorkflowStateProvider stateProvider = session.getProvider(WorkflowStateProvider.class);
+                    List<String> scheduledResources = stateProvider.getScheduledStepsByWorkflow(workflows.get(0).getId())
+                            .map(ScheduledStep::resourceId)
+                            .toList();
+                    assertThat(scheduledResources, containsInAnyOrder(expectedClientUuids));
+                }));
+    }
+
+    private void assertClientEnabled(String clientId, boolean expectedEnabled) {
+        runOnServer.run((session -> {
+            RealmModel realm = session.getContext().getRealm();
+            ClientModel client = session.clients().getClientByClientId(realm, clientId);
+            if (expectedEnabled) {
+                assertTrue(client.isEnabled());
+            } else {
+                assertFalse(client.isEnabled());
+            }
+        }));
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/execution/BrokeredUserLifecycleWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/execution/BrokeredUserLifecycleWorkflowTest.java
@@ -177,10 +177,11 @@ public class BrokeredUserLifecycleWorkflowTest extends AbstractWorkflowTest {
         // workflow should have been restarted due to reauthentication
         assertScheduledWorkflows(federatedUser.getId(), NotifyUserStepProviderFactory.ID, 3);
 
-        // now simulate the workflow to its end - alice should be deleted
-        runScheduledSteps(Duration.ofDays(5)); // notify
-        runScheduledSteps(Duration.ofDays(10)); // disable
-        runScheduledSteps(Duration.ofDays(10)); // delete
+        // now simulate the workflow to its end - alice should be deleted. The offsets are cumulative: each
+        // step is scheduled relative to the (offset) time the previous step ran.
+        runScheduledSteps(Duration.ofDays(5)); // notify (due on day 3)
+        runScheduledSteps(Duration.ofDays(15)); // disable (due 10 days after notify ran on day 5)
+        runScheduledSteps(Duration.ofDays(25)); // delete (due 10 days after disable ran on day 15)
 
         runOnServer.run((session -> {
             RealmModel realm = session.getContext().getRealm();


### PR DESCRIPTION
Closes #51595

Adds the two client-scoped Workflows providers proposed in #51595, so client lifecycle workflows can select clients by attribute and track user-driven activity on public clients:

- **`has-client-attribute` condition** — mirrors `has-user-attribute` for `CLIENTS` resources, taking `key` (presence-only) or `key:value` config. `evaluate` checks the client attribute map; `toPredicate` builds an EXISTS subquery over `ClientAttributeEntity` so scheduled activation picks up eligible clients directly in the JPA query. Since client attributes are single-valued, the expected value is compared literally (no multi-value set semantics). The value comparison reuses the per-database handling from `JpaRealmProvider.searchClientsByAttributes` (Oracle `DBMS_LOB.COMPARE`, PostgreSQL `substr` + full comparison).
- **`client-activity` event** — complements `client-authenticated` (which only sees `CLIENT_LOGIN`, an event public clients can never produce) by treating `LOGIN`, `CODE_TO_TOKEN` and `REFRESH_TOKEN` user events as activity on the event's client. Combined with `restart-in-progress`, this lets a disable/delete workflow keep actively used clients out of the steps while dormant ones progress.

The motivating use case (detailed in #51595) is lifecycle management of dynamically registered OAuth clients (MCP clients registering via RFC 7591): flag them with an attribute at registration, disable after N days of inactivity, delete after M more.

Also includes a small consistency fix this work surfaced: `JpaWorkflowStateProvider.scheduleStep` stamped `scheduledStepTimestamp` with `Instant.now()` while `getDueScheduledSteps` compares it against `Time.currentTimeMillis()` in the same class. Production behavior is identical (`Time` delegates to the system clock), but under a test time offset a workflow restart schedules against the wrong clock, which made the activity-reset scenario untestable — `ClientActivityWorkflowTest` acts as the regression test. With the fix, steps scheduled *during* an offset run are scheduled relative to the simulated clock (cumulative), so `BrokeredUserLifecycleWorkflowTest`'s tail offsets were adjusted from `5/10/10` to cumulative `5/15/25` days — arguably what the simulated timeline meant all along. `ScheduleWorkflowTask`/`RunWorkflowTask` have the same `System.currentTimeMillis()` pattern for the informational `scheduledTime` event payload; left untouched to keep the diff minimal. Full `org.keycloak.tests.workflow` package passes locally (103 tests).

### Notes for reviewers

- The condition test activates via the schedule rather than `on: client-created`, because the client creation event is currently published before attributes are persisted and can never match an attribute condition — that is #51594 (fix in flight at #51598). Once that lands, event-based activation works with this condition unchanged.
- `ClientAttributeWorkflowConditionProvider` reuses `UserAttributeWorkflowConditionProvider.parseKeyValuePair` so the two conditions keep one config grammar. Worth knowing that this inherits two `Properties`-syntax edge cases (affecting `has-user-attribute` equally today): a `#`-prefixed key parses as a comment and is silently dropped, and multi-line input produces multiple entries with `stringPropertyNames().iterator().next()` picking one non-deterministically. Kept as-is here for grammar consistency between the two conditions; happy to harden the shared parser (single-entry check, or a first-colon split) in this PR or a follow-up, whichever you prefer.
- Failed attempts (`LOGIN_ERROR`, `CODE_TO_TOKEN_ERROR`, `REFRESH_TOKEN_ERROR`) also carry the client id but are deliberately excluded from the activity set — otherwise spamming bad credentials against a dormant client would keep resetting its idle clock. `ClientActivityWorkflowTest#testFailedLoginDoesNotActivateWorkflow` pins this.
- Naming is open to bikeshedding: `client-activity` vs. extending `client-authenticated` to cover the user-driven events. A separate provider avoids changing the semantics of existing `client-authenticated` workflows.

This implementation is ported from providers we run out-of-tree in production against 26.6.4, adapted to the current SPI (`getSupportedResourceType`/`validate`/`Root`-based `toPredicate`).

### AI disclosure

Per the contributing guidelines: AI agents were used to generate this port and its tests (adapted from our out-of-tree implementation). The changes have been reviewed and are understood and owned by the submitter.
