### PR TITLE
fix: add admin-permissions client to isInternal denylist (FGAP V2) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissions.java
@@ -721,6 +721,10 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             return false;
         }
 
+        if (Constants.ADMIN_PERMISSIONS_CLIENT_ID.equals(client.getClientId())) {
+            return true;
+        }
+
         if (realm.getName().equals(Config.getAdminRealm())) {
             return client.getClientId().endsWith(AdminRoles.APP_SUFFIX);
         }


### PR DESCRIPTION
## Summary

`ClientPermissions.isInternal` only denylisted the `realm-management` client (and, in the master realm, client IDs ending in `-realm`). The `admin-permissions` client — the resource server holding the realm's entire FGAP V2 model — was not in that list.

## Fix

Added a `Constants.ADMIN_PERMISSIONS_CLIENT_ID` check before the existing realm-specific branches so `admin-permissions` is treated as internal in **all** realms (both admin/master and non-admin).

## Why this works

- `isInternal` is called from `canManage(ClientModel)` and `canConfigure(ClientModel)` — both return `false` for internal clients, preventing FGAP `Clients:manage` from overriding the block.
- The `getAccess` method already special-cases `admin-permissions` (returns `manage: false`), but `canManage` did not agree — this fix aligns enforcement with the access report.

## Testing

- Existing `PermissionRESTTest` already validates that users with `manage-clients` **cannot** create permissions on `admin-permissions` client.
- This is a minimal one-line-add change (4 lines with guard) matching the pattern already used for `REALM_MANAGEMENT_CLIENT_ID`.

Closes #51630