### PR TITLE
[OID4VP] Introduce SD-JWT User Attribute / Session mappers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProvider.java
@@ -86,10 +86,13 @@ public class OID4VPIdentityProvider extends AbstractIdentityProvider<OID4VPIdent
     // object and the presentation.
     public static final String CONTEXT_PREFIX = "oid4vp.context.";
     // The deferred object is written once the presentation is verified and read when the browser
-    // returns to complete-auth. It marks that a verified identity, serialized under IDENTITY_NOTE in
-    // the authentication session, is waiting to finish the broker login.
+    // returns to complete-auth. It marks that verified credential claims, stored under
+    // VERIFIED_CLAIMS_NOTE in the authentication session, are waiting to finish the broker login.
     public static final String DEFERRED_PREFIX = "oid4vp.deferred.";
-    public static final String IDENTITY_NOTE = "OID4VP_IDENTITY";
+    public static final String VERIFIED_CLAIMS_NOTE = "OID4VP_VERIFIED_CLAIMS";
+    // Key in BrokeredIdentityContext#getContextData() holding the disclosed claims of the verified
+    // credential presentation, consumed by the OID4VP identity provider mappers.
+    public static final String CREDENTIAL_CLAIMS = "OID4VP_CREDENTIAL_CLAIMS";
     public static final String KEY_ROOT_SESSION_ID = "rootSessionId";
     public static final String KEY_TAB_ID = "tabId";
     public static final String KEY_STATE = "state";

--- a/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/OID4VPIdentityProviderEndpoint.java
@@ -39,8 +39,6 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.OID4VCConstants;
-import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
-import org.keycloak.broker.oidc.mappers.AbstractJsonUserAttributeMapper;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.UserAuthenticationIdentityProvider.AuthenticationCallback;
 import org.keycloak.common.VerificationException;
@@ -199,10 +197,10 @@ public class OID4VPIdentityProviderEndpoint {
                     "Authentication session not found", Errors.INVALID_REQUEST);
         }
 
-        BrokeredIdentityContext context;
+        String claimsJson;
         try {
             SdJwtVpVerificationResult result = verifyPresentation(vpToken, requestContext.nonce());
-            context = toBrokeredContext(result, authSession);
+            claimsJson = JsonSerialization.writeValueAsString(result.getClaims());
         } catch (Exception e) {
             logger.warnf("OID4VP presentation rejected: %s", e.getMessage());
             return loginError(Response.Status.BAD_REQUEST, OAuthErrorException.ACCESS_DENIED, e.getMessage(),
@@ -216,13 +214,15 @@ public class OID4VPIdentityProviderEndpoint {
                     "Unknown or expired state", Errors.INVALID_REQUEST);
         }
 
-        // The wallet cannot finish the browser login, so hand the verified identity to the browser.
-        // Stash it in the authentication session and add the deferred marker with a fresh response_code.
-        // The state may have leaked through the request_uri. The browser gets the response_code
-        // only from this direct_post response (OID4VP session fixation defense).
+        // The wallet cannot finish the browser login. Stash the verified claims for complete-auth,
+        // where the browser turns them into the brokered identity, and mark the login as deferred
+        // under a fresh response_code. Deliberately only the claims and not a serialized identity
+        // context: deserializing and later reserializing a context restores stale user property
+        // entries over whatever the identity provider mappers set in between. The state may have
+        // leaked through the request_uri, so only this direct_post response reveals the
+        // response_code (OID4VP session fixation defense).
         String responseCode = UUID.randomUUID().toString();
-        SerializedBrokeredIdentityContext.serialize(context)
-                .saveToAuthenticationSession(authSession, OID4VPIdentityProvider.IDENTITY_NOTE);
+        authSession.setAuthNote(OID4VPIdentityProvider.VERIFIED_CLAIMS_NOTE, claimsJson);
         session.singleUseObjects().put(
                 OID4VPIdentityProvider.DEFERRED_PREFIX + state,
                 realm.getAccessCodeLifespanLogin(),
@@ -312,19 +312,22 @@ public class OID4VPIdentityProviderEndpoint {
             return loginErrorPage(authSession, Messages.SESSION_NOT_ACTIVE);
         }
 
-        SerializedBrokeredIdentityContext serialized = SerializedBrokeredIdentityContext.readFromAuthenticationSession(
-                authSession, OID4VPIdentityProvider.IDENTITY_NOTE);
-        if (serialized == null) {
+        String claimsJson = authSession.getAuthNote(OID4VPIdentityProvider.VERIFIED_CLAIMS_NOTE);
+        if (claimsJson == null) {
             return loginErrorPage(authSession, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
         }
-        authSession.removeAuthNote(OID4VPIdentityProvider.IDENTITY_NOTE);
+        authSession.removeAuthNote(OID4VPIdentityProvider.VERIFIED_CLAIMS_NOTE);
 
         session.getContext().setAuthenticationSession(authSession);
         session.getContext().setClient(authSession.getClient());
 
-        BrokeredIdentityContext context = serialized.deserialize(session, authSession);
-        context.setAuthenticationSession(authSession);
-
+        BrokeredIdentityContext context;
+        try {
+            context = toBrokeredContext(JsonSerialization.readValue(claimsJson, JsonNode.class), authSession);
+        } catch (IllegalStateException | IOException e) {
+            logger.warnf("OID4VP login not completed: %s", e.getMessage());
+            return loginErrorPage(authSession, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR);
+        }
         return callback.authenticated(context);
     }
 
@@ -452,7 +455,10 @@ public class OID4VPIdentityProviderEndpoint {
                 .build();
 
         // TODO bind the presentation to the requested credential type and claims, so that not any
-        // credential from a trusted issuer satisfies the login.
+        // credential from a trusted issuer satisfies the login. Planned for the DCQL generation
+        // task: derive PresentationRequirements from the configured identity provider mappers
+        // (required or optional per mapper) and enforce them here. The principal check in
+        // requirePrincipalClaim then becomes just another required claim.
         PresentationRequirements noAdditionalRequirements = disclosedPayload -> {
         };
         TrustedSdJwtIssuer trustedIssuer = provider.trustedIssuerResolver().resolve(sdJwtVP.getIssuerSignedJWT());
@@ -496,8 +502,8 @@ public class OID4VPIdentityProviderEndpoint {
         return presentation.textValue();
     }
 
-    protected BrokeredIdentityContext toBrokeredContext(SdJwtVpVerificationResult result, AuthenticationSessionModel authSession) {
-        JsonNode claims = result.getClaims();
+    // The principal claim becomes the brokered subject. Rejects presentations without a usable value.
+    protected String requirePrincipalClaim(JsonNode claims) {
         JsonNode principal = claims.get(provider.getConfig().getPrincipalAttribute());
         if (principal == null || principal.isNull() || !principal.isValueNode()
                 || StringUtil.isBlank(principal.asText())) {
@@ -505,7 +511,11 @@ public class OID4VPIdentityProviderEndpoint {
                     "Credential does not contain a usable value for the configured principal attribute '"
                             + provider.getConfig().getPrincipalAttribute() + "'");
         }
-        String subject = principal.asText();
+        return principal.asText();
+    }
+
+    protected BrokeredIdentityContext toBrokeredContext(JsonNode claims, AuthenticationSessionModel authSession) {
+        String subject = requirePrincipalClaim(claims);
 
         BrokeredIdentityContext context = new BrokeredIdentityContext(subject, provider.getConfig());
         context.setIdp(provider);
@@ -519,8 +529,8 @@ public class OID4VPIdentityProviderEndpoint {
             context.setEmail(email.asText());
         }
 
-        // Expose disclosed claims so identity provider attribute mappers can consume them.
-        AbstractJsonUserAttributeMapper.storeUserProfileForMapper(context, claims, provider.getConfig().getAlias());
+        // Expose disclosed claims so the OID4VP identity provider mappers can consume them.
+        context.getContextData().put(OID4VPIdentityProvider.CREDENTIAL_CLAIMS, claims);
         return context;
     }
 

--- a/services/src/main/java/org/keycloak/broker/oid4vp/mappers/AbstractOID4VPClaimMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/mappers/AbstractOID4VPClaimMapper.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProvider;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderFactory;
+import org.keycloak.broker.provider.AbstractIdentityProviderMapper;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.common.Profile;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
+
+/**
+ * Base for OID4VP identity provider mappers that read a claim of the verified credential
+ * presentation, addressed by a {@link ClaimPath} over the claims JSON. Subclasses decide where the
+ * resolved values go. Not tied to a credential format: any format whose verification yields claims
+ * JSON under {@link OID4VPIdentityProvider#CREDENTIAL_CLAIMS} can build on it.
+ */
+public abstract class AbstractOID4VPClaimMapper extends AbstractIdentityProviderMapper
+        implements EnvironmentDependentProviderFactory {
+
+    protected static final Logger logger = Logger.getLogger(AbstractOID4VPClaimMapper.class);
+
+    public static final String CLAIM = "claim";
+
+    private static final String[] COMPATIBLE_PROVIDERS = {OID4VPIdentityProviderFactory.PROVIDER_ID};
+
+    protected static ProviderConfigProperty claimProperty() {
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setName(CLAIM);
+        property.setLabel("Claim");
+        property.setHelpText("Path of the claim in the presented credential. Use dot notation for nested claims, "
+                + "i.e. 'address.locality', [] to select all array elements, i.e. 'nationalities[]', and [0] to select the first element of the presented array. "
+                + "To use dot (.) literally, escape it with backslash (\\.)");
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        return property;
+    }
+
+    @Override
+    public String[] getCompatibleProviders() {
+        return COMPATIBLE_PROVIDERS;
+    }
+
+    @Override
+    public boolean supportsSyncMode(IdentityProviderSyncMode syncMode) {
+        return true;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.OID4VC_VP);
+    }
+
+    protected JsonNode credentialClaims(BrokeredIdentityContext context) {
+        Object claims = context.getContextData().get(OID4VPIdentityProvider.CREDENTIAL_CLAIMS);
+        if (claims == null) {
+            return null;
+        }
+        if (claims instanceof JsonNode node) {
+            return node;
+        }
+        // The brokered context may have been serialized into the authentication session in
+        // between, for example while the first broker login shows the review profile page.
+        return JsonSerialization.mapper.valueToTree(claims);
+    }
+
+    // Null when the claim is absent or the mapper is misconfigured.
+    protected List<String> claimValues(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        String claimPath = mapperModel.getConfig().get(CLAIM);
+        if (StringUtil.isBlank(claimPath)) {
+            logger.warnf("No claim configured for mapper %s", mapperModel.getName());
+            return null;
+        }
+        ClaimPath path = ClaimPath.parse(claimPath.trim());
+        if (path == null) {
+            logger.warnf("Invalid claim path '%s' in mapper %s", claimPath, mapperModel.getName());
+            return null;
+        }
+        List<JsonNode> matches = path.select(credentialClaims(context));
+        if (matches.isEmpty()) {
+            return null;
+        }
+        Iterable<JsonNode> selected = matches.size() == 1 && matches.get(0).isArray()
+                ? matches.get(0)
+                : matches;
+        // The values end up in the brokered context, whose serialization restores lists by their
+        // concrete class, so they must stay plain ArrayLists.
+        List<String> values = new ArrayList<>();
+        for (JsonNode node : selected) {
+            if (!node.isNull()) {
+                values.add(value(node));
+            }
+        }
+        return values;
+    }
+
+    protected String value(JsonNode node) {
+        if (node.isValueNode()) {
+            return node.asText();
+        }
+        try {
+            return JsonSerialization.writeValueAsString(node);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to serialize the claim value", e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/mappers/ClaimPath.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/mappers/ClaimPath.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.utils.JsonUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * A path locating claims in the claims JSON of a presented credential, configured in dot notation
+ * with optional array selectors: {@code address.locality} selects a nested claim,
+ * {@code nationalities[]} selects all array elements, {@code nationalities[0]} selects the first
+ * element, and a literal dot in a claim name is escaped as {@code \.}.
+ *
+ * <p>Field and all element steps correspond to the object key (string) and all elements (null)
+ * kinds of a DCQL claims path pointer as defined by
+ * <a href="https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-6.3">
+ * OID4VP 1.0, Section 6.3</a>. The pointer's array index kind is not supported beyond {@code [0]}:
+ * the verifier removes undisclosed array elements from the presented payload, so positions from
+ * the issued credential do not survive selective disclosure, and an index read against the
+ * compacted array would silently select a different element than the one the position named at
+ * issuance. {@code [0]} therefore means the first element of the presentation, which under
+ * selective disclosure is the first disclosed element and not necessarily the first issued one.
+ */
+public class ClaimPath {
+
+    /**
+     * One path step. The field name is set for {@link Kind#FIELD} steps only.
+     */
+    public record Step(String field, Kind kind) {
+
+        public enum Kind {
+            FIELD,
+            ALL_ELEMENTS,
+            FIRST_ELEMENT
+        }
+    }
+
+    private final List<Step> steps;
+
+    protected ClaimPath(List<Step> steps) {
+        this.steps = List.copyOf(steps);
+    }
+
+    /**
+     * The parsed steps, for consumers that transform the path rather than resolve it.
+     */
+    public List<Step> steps() {
+        return steps;
+    }
+
+    /**
+     * Parses the dot notation path, returning {@code null} if it is not well formed.
+     */
+    public static ClaimPath parse(String path) {
+        // The splitting below would silently drop a trailing separator, so a path ending in a
+        // dot is always malformed, even an escaped one.
+        if (path == null || path.endsWith(".")) {
+            return null;
+        }
+        List<Step> steps = new ArrayList<>();
+        for (String segment : JsonUtils.splitClaimPath(path)) {
+            int bracket = segment.indexOf('[');
+            String field = bracket < 0 ? segment : segment.substring(0, bracket);
+            if (field.isEmpty()) {
+                return null;
+            }
+            steps.add(new Step(field, Step.Kind.FIELD));
+            String selectors = bracket < 0 ? "" : segment.substring(bracket);
+            while (!selectors.isEmpty()) {
+                if (selectors.startsWith("[]")) {
+                    steps.add(new Step(null, Step.Kind.ALL_ELEMENTS));
+                    selectors = selectors.substring(2);
+                } else if (selectors.startsWith("[0]")) {
+                    steps.add(new Step(null, Step.Kind.FIRST_ELEMENT));
+                    selectors = selectors.substring(3);
+                } else {
+                    return null;
+                }
+            }
+        }
+        return steps.isEmpty() ? null : new ClaimPath(steps);
+    }
+
+    /**
+     * Selects the claims this path points to. An all elements step fans out into every array
+     * element, so the result may hold several nodes. Null nodes and dead ends select nothing.
+     */
+    public List<JsonNode> select(JsonNode claims) {
+        List<JsonNode> current = new ArrayList<>();
+        if (claims != null) {
+            current.add(claims);
+        }
+        for (Step step : steps) {
+            List<JsonNode> next = new ArrayList<>();
+            for (JsonNode node : current) {
+                switch (step.kind()) {
+                    case FIELD -> {
+                        if (node.isObject() && node.get(step.field()) != null) {
+                            next.add(node.get(step.field()));
+                        }
+                    }
+                    case ALL_ELEMENTS -> {
+                        if (node.isArray()) {
+                            node.forEach(next::add);
+                        }
+                    }
+                    case FIRST_ELEMENT -> {
+                        if (node.isArray() && !node.isEmpty()) {
+                            next.add(node.get(0));
+                        }
+                    }
+                }
+            }
+            next.removeIf(JsonNode::isNull);
+            current = next;
+        }
+        return current;
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapper.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.common.util.CollectionUtil;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Maps a claim of the presented SD JWT credential to a user property or attribute. A single mapper
+ * covers the credential value types: string, number and boolean claims become a single text value,
+ * arrays become a multivalued attribute, and object values are imported as their JSON
+ * representation.
+ */
+public class OID4VPSdJwtUserAttributeMapper extends AbstractOID4VPClaimMapper {
+
+    public static final String PROVIDER_ID = "oid4vp-sd-jwt-user-attribute-idp-mapper";
+
+    public static final String USER_ATTRIBUTE = "user.attribute";
+
+    public static final String USERNAME = "username";
+    public static final String EMAIL = "email";
+    public static final String FIRST_NAME = "firstName";
+    public static final String LAST_NAME = "lastName";
+
+    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
+            .property(claimProperty())
+            .property()
+                .name(USER_ATTRIBUTE)
+                .label("User Attribute Name")
+                .helpText("User attribute name to store the claim. Use username, email, firstName and lastName "
+                        + "to map to those predefined user properties.")
+                .type(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE)
+                .add()
+            .build();
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return CONFIG_PROPERTIES;
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "Attribute Importer";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "SD-JWT Attribute Importer";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Import the configured claim of the presented SD-JWT credential into the specified user property or "
+                + "attribute. String, number and boolean claims are imported as a single value, arrays as a "
+                + "multivalued attribute, and object values as their JSON representation.";
+    }
+
+    @Override
+    public void preprocessFederatedIdentity(KeycloakSession session, RealmModel realm,
+            IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        String attribute = attribute(mapperModel);
+        if (attribute == null) {
+            return;
+        }
+        List<String> values = claimValues(mapperModel, context);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        switch (attribute) {
+            case USERNAME -> context.setModelUsername(values.get(0));
+            case EMAIL -> context.setEmail(values.get(0));
+            case FIRST_NAME -> context.setFirstName(values.get(0));
+            case LAST_NAME -> context.setLastName(values.get(0));
+            default -> context.setUserAttribute(attribute, values);
+        }
+    }
+
+    @Override
+    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user,
+            IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        String attribute = attribute(mapperModel);
+        if (attribute == null) {
+            return;
+        }
+        List<String> values = claimValues(mapperModel, context);
+        switch (attribute) {
+            case USERNAME -> setIfPresent(values, user::setUsername);
+            case EMAIL -> setIfPresent(values, user::setEmail);
+            case FIRST_NAME -> setIfPresent(values, user::setFirstName);
+            case LAST_NAME -> setIfPresent(values, user::setLastName);
+            default -> {
+                if (values == null || values.isEmpty()) {
+                    user.removeAttribute(attribute);
+                } else if (!CollectionUtil.collectionEquals(values, user.getAttributeStream(attribute).toList())) {
+                    user.setAttribute(attribute, values);
+                }
+            }
+        }
+    }
+
+    protected void setIfPresent(List<String> values, Consumer<String> setter) {
+        if (values != null && !values.isEmpty() && StringUtil.isNotBlank(values.get(0))) {
+            setter.accept(values.get(0));
+        }
+    }
+
+    protected String attribute(IdentityProviderMapperModel mapperModel) {
+        String attribute = mapperModel.getConfig().get(USER_ATTRIBUTE);
+        if (StringUtil.isBlank(attribute)) {
+            logger.warnf("No user attribute configured for mapper %s", mapperModel.getName());
+            return null;
+        }
+        return attribute.trim();
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapper.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.broker.oid4vp.mappers;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -93,15 +94,12 @@ public class OID4VPSdJwtUserAttributeMapper extends AbstractOID4VPClaimMapper {
             return;
         }
         List<String> values = claimValues(mapperModel, context);
-        if (values == null || values.isEmpty()) {
-            return;
-        }
         switch (attribute) {
-            case USERNAME -> context.setModelUsername(values.get(0));
-            case EMAIL -> context.setEmail(values.get(0));
-            case FIRST_NAME -> context.setFirstName(values.get(0));
-            case LAST_NAME -> context.setLastName(values.get(0));
-            default -> context.setUserAttribute(attribute, values);
+            case USERNAME -> setIfPresent(values, context::setModelUsername);
+            case EMAIL -> setIfPresent(values, context::setEmail);
+            case FIRST_NAME -> setIfPresent(values, context::setFirstName);
+            case LAST_NAME -> setIfPresent(values, context::setLastName);
+            default -> context.setUserAttribute(attribute, values == null ? new ArrayList<>() : values);
         }
     }
 

--- a/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapper.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.util.List;
+
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Imports a claim of the presented SD JWT credential into a user session attribute, so it can be
+ * surfaced in tokens through the user session note protocol mappers. Session notes hold one string
+ * value: multivalued selections are joined with a comma and object values are stored as their JSON
+ * representation.
+ */
+public class OID4VPSdJwtUserSessionAttributeMapper extends AbstractOID4VPClaimMapper {
+
+    public static final String PROVIDER_ID = "oid4vp-sd-jwt-user-session-attribute-idp-mapper";
+
+    public static final String ATTRIBUTE = "attribute";
+
+    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = ProviderConfigurationBuilder.create()
+            .property(claimProperty())
+            .property()
+                .name(ATTRIBUTE)
+                .label("User Session Attribute")
+                .helpText("Name of the user session attribute to store the claim in.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+            .build();
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return CONFIG_PROPERTIES;
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return "User Session";
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "SD-JWT User Session Attribute Importer";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Import the configured claim of the presented SD-JWT credential into the specified user session "
+                + "attribute. Use together with the 'User Session Note' protocol mapper on your client or client "
+                + "scope to make the claim available in tokens.";
+    }
+
+    /**
+     * The note is per login state, so it is also set during preprocessing, which runs for every
+     * login. The user centric hooks below never run for an existing user whose effective sync
+     * mode is IMPORT.
+     */
+    @Override
+    public void preprocessFederatedIdentity(KeycloakSession session, RealmModel realm,
+            IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        addSessionNote(mapperModel, context);
+    }
+
+    @Override
+    public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user,
+            IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        addSessionNote(mapperModel, context);
+    }
+
+    @Override
+    public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user,
+            IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        addSessionNote(mapperModel, context);
+    }
+
+    protected void addSessionNote(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+        String attribute = mapperModel.getConfig().get(ATTRIBUTE);
+        if (StringUtil.isBlank(attribute)) {
+            logger.warnf("No user session attribute configured for mapper %s", mapperModel.getName());
+            return;
+        }
+        List<String> values = claimValues(mapperModel, context);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        context.setSessionNote(attribute.trim(), String.join(",", values));
+    }
+}

--- a/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapper.java
@@ -85,31 +85,30 @@ public class OID4VPSdJwtUserSessionAttributeMapper extends AbstractOID4VPClaimMa
     @Override
     public void preprocessFederatedIdentity(KeycloakSession session, RealmModel realm,
             IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        addSessionNote(mapperModel, context);
+        applySessionNote(mapperModel, context);
     }
 
     @Override
     public void importNewUser(KeycloakSession session, RealmModel realm, UserModel user,
             IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        addSessionNote(mapperModel, context);
+        applySessionNote(mapperModel, context);
     }
 
     @Override
     public void updateBrokeredUser(KeycloakSession session, RealmModel realm, UserModel user,
             IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
-        addSessionNote(mapperModel, context);
+        applySessionNote(mapperModel, context);
     }
 
-    protected void addSessionNote(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
+    protected void applySessionNote(IdentityProviderMapperModel mapperModel, BrokeredIdentityContext context) {
         String attribute = mapperModel.getConfig().get(ATTRIBUTE);
         if (StringUtil.isBlank(attribute)) {
             logger.warnf("No user session attribute configured for mapper %s", mapperModel.getName());
             return;
         }
         List<String> values = claimValues(mapperModel, context);
-        if (values == null || values.isEmpty()) {
-            return;
-        }
-        context.setSessionNote(attribute.trim(), String.join(",", values));
+        // A null note value means removal, so a claim that disappeared from the presentation does
+        // not leave a stale note on the session.
+        context.setSessionNote(attribute.trim(), values == null || values.isEmpty() ? null : String.join(",", values));
     }
 }

--- a/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -26,6 +26,8 @@ org.keycloak.broker.oidc.mappers.ClaimToUserSessionNoteMapper
 org.keycloak.broker.oidc.mappers.ExternalKeycloakRoleToRoleMapper
 org.keycloak.broker.oidc.mappers.UserAttributeMapper
 org.keycloak.broker.oidc.mappers.UsernameTemplateMapper
+org.keycloak.broker.oid4vp.mappers.OID4VPSdJwtUserAttributeMapper
+org.keycloak.broker.oid4vp.mappers.OID4VPSdJwtUserSessionAttributeMapper
 org.keycloak.broker.saml.mappers.AdvancedAttributeToRoleMapper
 org.keycloak.broker.saml.mappers.AdvancedAttributeToGroupMapper
 org.keycloak.broker.saml.mappers.AttributeToRoleMapper

--- a/services/src/test/java/org/keycloak/broker/oid4vp/mappers/ClaimPathTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/mappers/ClaimPathTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.util.List;
+
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class ClaimPathTest {
+
+    @Test
+    public void parsesFieldSteps() {
+        List<ClaimPath.Step> steps = ClaimPath.parse("address.locality").steps();
+
+        assertEquals(List.of(fieldStep("address"), fieldStep("locality")), steps);
+    }
+
+    @Test
+    public void parsesSelectorSteps() {
+        assertEquals(List.of(fieldStep("degrees"), allElementsStep(), fieldStep("type")),
+                ClaimPath.parse("degrees[].type").steps());
+        assertEquals(List.of(fieldStep("degrees"), firstElementStep(), fieldStep("type")),
+                ClaimPath.parse("degrees[0].type").steps());
+        assertEquals(List.of(fieldStep("matrix"), allElementsStep(), allElementsStep()),
+                ClaimPath.parse("matrix[][]").steps());
+    }
+
+    @Test
+    public void parsesEscapedDotAsLiteralFieldName() {
+        assertEquals(List.of(fieldStep("org.example")), ClaimPath.parse("org\\.example").steps());
+    }
+
+    @Test
+    public void rejectsMalformedPaths() {
+        assertNull(ClaimPath.parse(null));
+        assertNull(ClaimPath.parse(""));
+        assertNull(ClaimPath.parse("[0]"));
+        assertNull(ClaimPath.parse("degrees[x]"));
+        assertNull(ClaimPath.parse("degrees[1]"));
+        assertNull(ClaimPath.parse("degrees[2]"));
+        assertNull(ClaimPath.parse("degrees[10]"));
+        assertNull(ClaimPath.parse("degrees[-1]"));
+        assertNull(ClaimPath.parse("degrees[00]"));
+        assertNull(ClaimPath.parse("degrees[*]"));
+        assertNull(ClaimPath.parse("degrees["));
+        assertNull(ClaimPath.parse("degrees[]x"));
+        assertNull(ClaimPath.parse("degrees[]]"));
+        assertNull(ClaimPath.parse("degrees[[]]"));
+        assertNull(ClaimPath.parse("address."));
+        assertNull(ClaimPath.parse("degrees[]."));
+        assertNull(ClaimPath.parse("org\\."));
+        assertNull(ClaimPath.parse("org\\\\."));
+    }
+
+    @Test
+    public void gibberishNeverThrowsAndSelectsNothing() throws Exception {
+        List<String> gibberish = List.of(
+                ".", "..", "a..b", "*", "***", "\\", "a\\", "§$%&!?", "🔥💥",
+                "[[[]]]", "]][[", "a[b]c[d]", "[*]", "*[*]*", "a]b[c", " ");
+        for (String path : gibberish) {
+            ClaimPath parsed = ClaimPath.parse(path);
+            if (parsed != null) {
+                assertTrue("Gibberish '" + path + "' must select nothing",
+                        parsed.select(claims()).isEmpty());
+            }
+        }
+    }
+
+    @Test
+    public void stepsAreImmutable() {
+        List<ClaimPath.Step> steps = ClaimPath.parse("email").steps();
+
+        assertThrows(UnsupportedOperationException.class, () -> steps.add(fieldStep("more")));
+    }
+
+    @Test
+    public void selectsScalarAndNestedClaims() throws Exception {
+        assertEquals("alice@email.cz", selectSingle("email").textValue());
+        assertEquals("London", selectSingle("address.locality").textValue());
+    }
+
+    @Test
+    public void selectsWholeArrayAsOneMatch() throws Exception {
+        JsonNode match = selectSingle("nationalities");
+
+        assertTrue(match.isArray());
+        assertEquals(2, match.size());
+    }
+
+    @Test
+    public void allElementsSelectorFansOutAndSkipsNullValues() throws Exception {
+        List<JsonNode> matches = ClaimPath.parse("degrees[].type").select(claims());
+
+        assertEquals(List.of("BSc", "MSc"), matches.stream().map(JsonNode::textValue).toList());
+    }
+
+    @Test
+    public void firstElementSelectorTakesTheFirstPresentedElement() throws Exception {
+        assertEquals("DE", selectSingle("nationalities[0]").textValue());
+        assertEquals("BSc", selectSingle("degrees[0].type").textValue());
+        assertTrue(ClaimPath.parse("none[0]").select(claims()).isEmpty());
+    }
+
+    @Test
+    public void deadEndsSelectNothing() throws Exception {
+        assertTrue(ClaimPath.parse("missing").select(claims()).isEmpty());
+        assertTrue(ClaimPath.parse("empty").select(claims()).isEmpty());
+        assertTrue(ClaimPath.parse("email.nested").select(claims()).isEmpty());
+        assertTrue(ClaimPath.parse("email[]").select(claims()).isEmpty());
+        assertTrue(ClaimPath.parse("address[]").select(claims()).isEmpty());
+        assertTrue(ClaimPath.parse("email").select(null).isEmpty());
+    }
+
+    private static JsonNode selectSingle(String path) throws Exception {
+        List<JsonNode> matches = ClaimPath.parse(path).select(claims());
+        assertEquals("Expected exactly one match for " + path, 1, matches.size());
+        return matches.get(0);
+    }
+
+    private static ClaimPath.Step fieldStep(String name) {
+        return new ClaimPath.Step(name, ClaimPath.Step.Kind.FIELD);
+    }
+
+    private static ClaimPath.Step allElementsStep() {
+        return new ClaimPath.Step(null, ClaimPath.Step.Kind.ALL_ELEMENTS);
+    }
+
+    private static ClaimPath.Step firstElementStep() {
+        return new ClaimPath.Step(null, ClaimPath.Step.Kind.FIRST_ELEMENT);
+    }
+
+    private static JsonNode claims() throws Exception {
+        return JsonSerialization.readValue("""
+                {
+                  "email": "alice@email.cz",
+                  "empty": null,
+                  "address": {"locality": "London"},
+                  "nationalities": ["DE", "CZ"],
+                  "degrees": [{"type": "BSc"}, {"type": "MSc"}, {"type": null}],
+                  "none": [],
+                  "org.example": "literal"
+                }""", JsonNode.class);
+    }
+}

--- a/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapperTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapperTest.java
@@ -143,6 +143,18 @@ public class OID4VPSdJwtUserAttributeMapperTest {
     }
 
     @Test
+    public void blankClaimLeavesUserPropertiesUntouched() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"sub": " ", "given_name": ""}""");
+
+        preprocess(context, "sub", "username");
+        preprocess(context, "given_name", "firstName");
+
+        assertNull(context.getModelUsername());
+        assertNull(context.getFirstName());
+    }
+
+    @Test
     public void blankConfigurationMapsNothing() throws Exception {
         BrokeredIdentityContext context = contextWithClaims("""
                 {"email": "alice@email.cz"}""");

--- a/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapperTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserAttributeMapperTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.broker.oid4vp.OID4VPIdentityProvider;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers value conversion and target application. Claim path semantics are covered by
+ * {@link ClaimPathTest}.
+ */
+public class OID4VPSdJwtUserAttributeMapperTest {
+
+    private final OID4VPSdJwtUserAttributeMapper mapper = new OID4VPSdJwtUserAttributeMapper();
+
+    @Test
+    public void mapsStringClaimToSingleValuedAttribute() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"email": "alice@email.cz"}""");
+
+        preprocess(context, "email", "emailAttribute");
+
+        assertEquals("alice@email.cz", context.getUserAttribute("emailAttribute"));
+    }
+
+    @Test
+    public void mapsNumberAndBooleanClaimsAsText() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"age": 42, "adult": true}""");
+
+        preprocess(context, "age", "age");
+        preprocess(context, "adult", "adult");
+
+        assertEquals("42", context.getUserAttribute("age"));
+        assertEquals("true", context.getUserAttribute("adult"));
+    }
+
+    @Test
+    public void mapsArrayOfStringsToMultivaluedAttribute() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"degrees": ["BSc", "MSc"]}""");
+
+        preprocess(context, "degrees", "degrees");
+
+        assertEquals(List.of("BSc", "MSc"), attributeValues(context, "degrees"));
+    }
+
+    @Test
+    public void mapsArrayOfObjectsToJsonElements() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"nationalities": [{"country": "DE"}, {"country": "CZ"}]}""");
+
+        preprocess(context, "nationalities", "nationalities");
+
+        assertEquals(List.of("{\"country\":\"DE\"}", "{\"country\":\"CZ\"}"),
+                attributeValues(context, "nationalities"));
+    }
+
+    @Test
+    public void mapsFannedOutMatchesToMultivaluedAttribute() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"degrees": [{"type": "BSc"}, {"type": "MSc"}]}""");
+
+        preprocess(context, "degrees[].type", "degreeTypes");
+
+        assertEquals(List.of("BSc", "MSc"), attributeValues(context, "degreeTypes"));
+    }
+
+    @Test
+    public void mapsObjectClaimToJsonAttribute() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"address": {"street_address": "221B Baker Street", "locality": "London"}}""");
+
+        preprocess(context, "address", "addressJson");
+
+        assertEquals("{\"street_address\":\"221B Baker Street\",\"locality\":\"London\"}",
+                context.getUserAttribute("addressJson"));
+    }
+
+    @Test
+    public void missingClaimSetsNoAttribute() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"email": "alice@email.cz"}""");
+
+        preprocess(context, "phone", "phone");
+
+        assertNull(context.getUserAttribute("phone"));
+    }
+
+    @Test
+    public void invalidClaimPathMapsNothing() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"degrees": ["BSc"]}""");
+
+        preprocess(context, "degrees[x]", "notAnIndex");
+
+        assertNull(context.getUserAttribute("notAnIndex"));
+    }
+
+    @Test
+    public void mapsSpecialTargetsToUserProperties() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"sub": "alice", "email": "alice@email.cz", "given_name": "Alice", "family_name": "Wonder"}""");
+
+        preprocess(context, "sub", "username");
+        preprocess(context, "email", "email");
+        preprocess(context, "given_name", "firstName");
+        preprocess(context, "family_name", "lastName");
+
+        assertEquals("alice", context.getModelUsername());
+        assertEquals("alice@email.cz", context.getEmail());
+        assertEquals("Alice", context.getFirstName());
+        assertEquals("Wonder", context.getLastName());
+    }
+
+    @Test
+    public void blankConfigurationMapsNothing() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"email": "alice@email.cz"}""");
+
+        preprocess(context, "", "emailAttribute");
+        preprocess(context, "email", "");
+
+        assertNull(context.getUserAttribute("emailAttribute"));
+        assertNull(context.getEmail());
+    }
+
+    @Test
+    public void mapsClaimsRestoredFromSerializedContext() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"address": {"locality": "London"}}""");
+        Object restored = JsonSerialization.readValue(
+                JsonSerialization.writeValueAsString(
+                        context.getContextData().get(OID4VPIdentityProvider.CREDENTIAL_CLAIMS)),
+                Map.class);
+        context.getContextData().put(OID4VPIdentityProvider.CREDENTIAL_CLAIMS, restored);
+
+        preprocess(context, "address.locality", "locality");
+
+        assertEquals("London", context.getUserAttribute("locality"));
+    }
+
+    @Test
+    public void supportsAllSyncModes() {
+        for (IdentityProviderSyncMode syncMode : IdentityProviderSyncMode.values()) {
+            assertTrue(mapper.supportsSyncMode(syncMode));
+        }
+    }
+
+    @Test
+    public void isCompatibleWithTheOid4vpProvider() {
+        assertEquals(List.of("oid4vp"), List.of(mapper.getCompatibleProviders()));
+    }
+
+    private void preprocess(BrokeredIdentityContext context, String claim, String attribute) {
+        IdentityProviderMapperModel model = new IdentityProviderMapperModel();
+        model.setName("test-mapper");
+        model.setConfig(Map.of(
+                OID4VPSdJwtUserAttributeMapper.CLAIM, claim,
+                OID4VPSdJwtUserAttributeMapper.USER_ATTRIBUTE, attribute));
+        mapper.preprocessFederatedIdentity(null, null, model, context);
+    }
+
+    private static BrokeredIdentityContext contextWithClaims(String claimsJson) throws Exception {
+        JsonNode claims = JsonSerialization.readValue(claimsJson, JsonNode.class);
+        OID4VPIdentityProviderConfig config = new OID4VPIdentityProviderConfig();
+        config.setAlias("oid4vp");
+        config.setEnabled(true);
+        BrokeredIdentityContext context = new BrokeredIdentityContext("test-user", config);
+        context.getContextData().put(OID4VPIdentityProvider.CREDENTIAL_CLAIMS, claims);
+        return context;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> attributeValues(BrokeredIdentityContext context, String attribute) {
+        return (List<String>) context.getContextData().get("user.attributes." + attribute);
+    }
+}

--- a/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapperTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapperTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.broker.oid4vp.mappers;
+
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.broker.oid4vp.OID4VPIdentityProvider;
+import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.Constants;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class OID4VPSdJwtUserSessionAttributeMapperTest {
+
+    private final OID4VPSdJwtUserSessionAttributeMapper mapper = new OID4VPSdJwtUserSessionAttributeMapper();
+
+    @Test
+    public void importsStringClaimAsSessionNote() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"vct": "https://credentials.example.com/identity"}""");
+
+        importNewUser(context, "vct", "credential_vct");
+
+        assertEquals("https://credentials.example.com/identity", sessionNote(context, "credential_vct"));
+    }
+
+    @Test
+    public void importsNestedAndArrayClaims() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"address": {"locality": "London"}, "nationalities": ["DE", "CZ"]}""");
+
+        importNewUser(context, "address.locality", "locality");
+        importNewUser(context, "nationalities", "nationalities");
+
+        assertEquals("London", sessionNote(context, "locality"));
+        assertEquals("DE,CZ", sessionNote(context, "nationalities"));
+    }
+
+    @Test
+    public void importsObjectClaimAsJson() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"address": {"locality": "London"}}""");
+
+        importNewUser(context, "address", "addressJson");
+
+        assertEquals("{\"locality\":\"London\"}", sessionNote(context, "addressJson"));
+    }
+
+    @Test
+    public void missingClaimSetsNoNote() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"vct": "identity"}""");
+
+        importNewUser(context, "phone", "phone");
+
+        assertNull(sessionNote(context, "phone"));
+    }
+
+    @Test
+    public void blankConfigurationSetsNoNote() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"vct": "identity"}""");
+
+        importNewUser(context, "", "note");
+        importNewUser(context, "vct", "");
+
+        assertNull(sessionNote(context, "note"));
+        assertNull(sessionNote(context, ""));
+    }
+
+    @Test
+    public void updateBrokeredUserAlsoSetsTheNote() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"vct": "identity"}""");
+
+        mapper.updateBrokeredUser(null, null, null, model("vct", "credential_vct"), context);
+
+        assertEquals("identity", sessionNote(context, "credential_vct"));
+    }
+
+    // The note is per login state, so it must also be set on the preprocess path that runs for
+    // existing users whose effective sync mode skips updateBrokeredUser.
+    @Test
+    public void preprocessFederatedIdentityAlsoSetsTheNote() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"vct": "identity"}""");
+
+        mapper.preprocessFederatedIdentity(null, null, model("vct", "credential_vct"), context);
+
+        assertEquals("identity", sessionNote(context, "credential_vct"));
+    }
+
+    @Test
+    public void supportsAllSyncModes() {
+        for (IdentityProviderSyncMode syncMode : IdentityProviderSyncMode.values()) {
+            assertTrue(mapper.supportsSyncMode(syncMode));
+        }
+    }
+
+    @Test
+    public void isCompatibleWithTheOid4vpProvider() {
+        assertEquals(List.of("oid4vp"), List.of(mapper.getCompatibleProviders()));
+    }
+
+    private void importNewUser(BrokeredIdentityContext context, String claimPath, String attribute) {
+        mapper.importNewUser(null, null, null, model(claimPath, attribute), context);
+    }
+
+    private static IdentityProviderMapperModel model(String claimPath, String attribute) {
+        IdentityProviderMapperModel model = new IdentityProviderMapperModel();
+        model.setName("test-mapper");
+        model.setConfig(Map.of(
+                OID4VPSdJwtUserSessionAttributeMapper.CLAIM, claimPath,
+                OID4VPSdJwtUserSessionAttributeMapper.ATTRIBUTE, attribute));
+        return model;
+    }
+
+    // Without an authentication session the context stores session notes in its context data.
+    @SuppressWarnings("unchecked")
+    private static String sessionNote(BrokeredIdentityContext context, String name) {
+        Map<String, String> notes =
+                (Map<String, String>) context.getContextData().get(Constants.MAPPER_SESSION_NOTES);
+        return notes == null ? null : notes.get(name);
+    }
+
+    private static BrokeredIdentityContext contextWithClaims(String claimsJson) throws Exception {
+        JsonNode claims = JsonSerialization.readValue(claimsJson, JsonNode.class);
+        OID4VPIdentityProviderConfig config = new OID4VPIdentityProviderConfig();
+        config.setAlias("oid4vp");
+        config.setEnabled(true);
+        BrokeredIdentityContext context = new BrokeredIdentityContext("test-user", config);
+        context.getContextData().put(OID4VPIdentityProvider.CREDENTIAL_CLAIMS, claims);
+        return context;
+    }
+}

--- a/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapperTest.java
+++ b/services/src/test/java/org/keycloak/broker/oid4vp/mappers/OID4VPSdJwtUserSessionAttributeMapperTest.java
@@ -82,6 +82,17 @@ public class OID4VPSdJwtUserSessionAttributeMapperTest {
     }
 
     @Test
+    public void missingClaimClearsAPreviouslySetNote() throws Exception {
+        BrokeredIdentityContext context = contextWithClaims("""
+                {"vct": "identity"}""");
+        context.setSessionNote("phone", "12345");
+
+        importNewUser(context, "phone", "phone");
+
+        assertNull(sessionNote(context, "phone"));
+    }
+
+    @Test
     public void blankConfigurationSetsNoNote() throws Exception {
         BrokeredIdentityContext context = contextWithClaims("""
                 {"vct": "identity"}""");

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPVerifierTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPVerifierTestBase.java
@@ -25,6 +25,7 @@ import java.security.KeyPairGenerator;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -47,14 +48,23 @@ import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.keys.Attributes;
 import org.keycloak.keys.GeneratedEcdsaKeyProviderFactory;
 import org.keycloak.keys.KeyProvider;
+import org.keycloak.models.IdentityProviderMapperModel;
+import org.keycloak.models.IdentityProviderMapperSyncMode;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.KeysMetadataRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AbstractHttpResponse;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vpRequestObjectResponse;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.KeyWrapperUtil;
@@ -70,12 +80,18 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
 
     protected static final String IDP_ALIAS = "oid4vp";
     protected static final String REDIRECT_URI = "http://127.0.0.1:8500/callback";
+
+    protected static final String USER_ATTRIBUTE_MAPPER_ID = "oid4vp-sd-jwt-user-attribute-idp-mapper";
+    protected static final String USER_SESSION_ATTRIBUTE_MAPPER_ID = "oid4vp-sd-jwt-user-session-attribute-idp-mapper";
+    protected static final String VCT_SESSION_NOTE = "credential_vct";
+    protected static final String VCT_TOKEN_CLAIM = "credential_vct";
 
     @InjectHttpClient
     protected CloseableHttpClient httpClient;
@@ -88,9 +104,12 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
     public void configureTestRealm() {
         super.configureTestRealm();
         addVerifierSigningKey();
-        // The verifier enforces ES256, so the issued credential must be signed with it.
+        // The verifier enforces ES256, so the issued credential must be signed with it. Tests may
+        // present the same credential more than once, so it must outlive the default 15 second
+        // test expiry.
         setCredentialScopeAttributes(requireExistingCredentialScope(sdJwtTypeCredentialScopeName),
-                Map.of(VC_SIGNING_ALG, Algorithm.ES256));
+                Map.of(VC_SIGNING_ALG, Algorithm.ES256,
+                        CredentialScopeModel.VC_EXPIRY_IN_SECONDS, "300"));
     }
 
     private void addVerifierSigningKey() {
@@ -141,7 +160,14 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
     }
 
     protected OID4VCTestContext issueCredential() {
+        return issueCredential(null);
+    }
+
+    protected OID4VCTestContext issueCredential(String holder) {
         OID4VCTestContext ctx = new OID4VCTestContext(client, sdJwtTypeCredentialScope);
+        if (holder != null) {
+            ctx.setHolder(holder);
+        }
         wallet.fetchCredentialByScope(ctx, ctx.getScope());
         assertNotNull(ctx.getCredentialResponse().getCredentials().get(0).getCredential(),
                 "No SD-JWT VC issued");
@@ -156,9 +182,64 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
         idp.setAlias(IDP_ALIAS);
         idp.setProviderId(OID4VPIdentityProviderFactory.PROVIDER_ID);
         idp.setEnabled(true);
-        idp.setConfig(config);
+        Map<String, String> effective = new HashMap<>(config);
+        effective.putIfAbsent(IdentityProviderModel.SYNC_MODE, IdentityProviderSyncMode.FORCE.name());
+        idp.setConfig(effective);
         try (Response response = testRealm.admin().identityProviders().create(idp)) {
             assertEquals(201, response.getStatus(), "Failed to create OID4VP identity provider");
+        }
+        createVerifierMappers();
+    }
+
+    // One canonical mapper configuration shared by all verifier tests: user properties, a nested
+    // claim, an object as JSON and a session attribute surfaced in tokens.
+    protected void createVerifierMappers() {
+        addUserAttributeMapper("email", "email");
+        addUserAttributeMapper("firstName", "firstName");
+        addUserAttributeMapper("lastName", "lastName");
+        addUserAttributeMapper("address.locality", "locality");
+        addUserAttributeMapper("address", "addressJson");
+        addUserSessionAttributeMapper("vct", VCT_SESSION_NOTE);
+        addSessionNoteProtocolMapper();
+    }
+
+    protected void addUserAttributeMapper(String claimPath, String attribute) {
+        addIdpMapper(attribute + "-mapper", USER_ATTRIBUTE_MAPPER_ID,
+                Map.of("claim", claimPath, "user.attribute", attribute));
+    }
+
+    protected void addUserSessionAttributeMapper(String claimPath, String attribute) {
+        addIdpMapper(attribute + "-session-mapper", USER_SESSION_ATTRIBUTE_MAPPER_ID,
+                Map.of("claim", claimPath, "attribute", attribute));
+    }
+
+    protected void addIdpMapper(String name, String mapperId, Map<String, String> config) {
+        IdentityProviderMapperRepresentation mapper = new IdentityProviderMapperRepresentation();
+        mapper.setName(name);
+        mapper.setIdentityProviderAlias(IDP_ALIAS);
+        mapper.setIdentityProviderMapper(mapperId);
+        // Follows the admin console default. Without it the mapper falls back to LEGACY, which
+        // updates the user on every login regardless of the sync mode of the identity provider.
+        Map<String, String> effective = new HashMap<>(config);
+        effective.putIfAbsent(IdentityProviderMapperModel.SYNC_MODE, IdentityProviderMapperSyncMode.INHERIT.name());
+        mapper.setConfig(effective);
+        try (Response response = testRealm.admin().identityProviders().get(IDP_ALIAS).addMapper(mapper)) {
+            assertEquals(201, response.getStatus(), "Failed to create the identity provider mapper " + name);
+        }
+    }
+
+    protected void addSessionNoteProtocolMapper() {
+        ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+        mapper.setName("credential-vct-note");
+        mapper.setProtocol("openid-connect");
+        mapper.setProtocolMapper("oidc-usersessionmodel-note-mapper");
+        mapper.setConfig(Map.of(
+                "user.session.note", VCT_SESSION_NOTE,
+                "claim.name", VCT_TOKEN_CLAIM,
+                "access.token.claim", "true",
+                "jsonType.label", "String"));
+        try (Response response = managedClient.admin().getProtocolMappers().createMapper(mapper)) {
+            assertEquals(201, response.getStatus(), "Failed to create the session note protocol mapper");
         }
     }
 
@@ -170,16 +251,56 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
                       "id": "identity",
                       "format": "dc+sd-jwt",
                       "meta": { "vct_values": ["%s"] },
-                      "claims": [{ "path": ["email"] }, { "path": ["lastName"] }]
+                      "claims": [
+                        { "path": ["email"] },
+                        { "path": ["firstName"] },
+                        { "path": ["lastName"] },
+                        { "path": ["address"] }
+                      ]
                     }
                   ]
                 }""".formatted(sdJwtTypeCredentialVct);
     }
 
     protected void assertLoginContinued() {
-        // TODO assert the presented claims (email, given and family name) were mapped to the user
         assertTrue(driver.driver().getCurrentUrl().contains("login-actions"),
                 "Expected to continue into the login flow, was: " + driver.driver().getCurrentUrl());
+    }
+
+    protected void assertLoginCompleted() {
+        String currentUrl = driver.driver().getCurrentUrl();
+        assertTrue(currentUrl.startsWith(REDIRECT_URI) && currentUrl.contains("code="),
+                "Expected the completed login redirect to the client, was: " + currentUrl);
+    }
+
+    protected String accessTokenClaim(String claim) throws Exception {
+        String currentUrl = driver.driver().getCurrentUrl();
+        Matcher matcher = Pattern.compile("[?&]code=([^&]+)").matcher(currentUrl);
+        assertTrue(matcher.find(), "No code in the redirect url: " + currentUrl);
+
+        AccessTokenResponse response = oauth.accessTokenRequest(matcher.group(1))
+                .redirectUri(REDIRECT_URI)
+                .send();
+        assertNull(response.getErrorDescription(), "Token exchange failed: " + response.getErrorDescription());
+
+        String payload = new String(Base64.getUrlDecoder()
+                .decode(response.getAccessToken().split("\\.")[1]), StandardCharsets.UTF_8);
+        return JsonSerialization.readValue(payload, JsonNode.class).path(claim).asText(null);
+    }
+
+    protected void deleteRealmUser(UserRepresentation user) {
+        try (Response response = testRealm.admin().users().delete(user.getId())) {
+            assertEquals(204, response.getStatus(), "Failed to delete user " + user.getUsername());
+        }
+    }
+
+    // The principal attribute is the email, so the federated user is created under it.
+    protected UserRepresentation federatedUser(String username) {
+        String userId = testRealm.admin().users().search(username, true).stream()
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("The federated user was not created"))
+                .getId();
+        return testRealm.admin().users().get(userId).toRepresentation();
     }
 
     protected String realmSigningJwks() {
@@ -190,6 +311,22 @@ public abstract class OID4VPVerifierTestBase extends OID4VCIssuerTestBase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    protected void relogin(OID4VCTestContext credential, UserRepresentation user) throws Exception {
+        endBrowserSession(user.getId());
+        JsonNode request = requestObject();
+        driver.open(wallet.directPost(request, wallet.present(credential, request)).getRedirectUri());
+        assertLoginCompleted();
+    }
+
+    // The browser still points at the client callback, so its cookies cannot be cleared for the
+    // Keycloak origin. Ending the SSO session server side forces a fresh wallet login and keeps
+    // the tests order independent.
+    protected void endBrowserSession(String userId) {
+        testRealm.admin().users().get(userId).logout();
+        driver.open(testRealm.getBaseUrl());
+        driver.cookies().deleteAll();
     }
 
     protected JsonNode requestObject() {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPX509HashDirectPostTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/presentation/OID4VPX509HashDirectPostTest.java
@@ -18,11 +18,15 @@
 package org.keycloak.tests.oid4vc.presentation;
 
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.OID4VCConstants;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.broker.oid4vp.OID4VPIdentityProviderConfig;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
@@ -32,6 +36,12 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
@@ -47,6 +57,7 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SIGNING_ALG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -65,6 +76,9 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
                 OID4VPIdentityProviderConfig.TRUSTED_ISSUER_JWKS, realmSigningJwks(),
                 OID4VPIdentityProviderConfig.DCQL_QUERY, dcqlQuery(),
                 OID4VPIdentityProviderConfig.PRINCIPAL_ATTRIBUTE, "email"));
+        createCompletionHolder("bob");
+        createCompletionHolder("carol");
+        createCompletionHolder("dave");
     }
 
     @Test
@@ -243,18 +257,151 @@ public class OID4VPX509HashDirectPostTest extends OID4VPVerifierTestBase {
     }
 
     @Test
-    public void directPostRejectsNonScalarPrincipal() throws Exception {
-        // address is an object claim, so configuring it as the principal must be rejected rather than
-        // mapped onto an empty user id.
+    public void completeAuthRejectsNonScalarPrincipal() throws Exception {
+        // address is an object claim, so configuring it as the principal must fail the login rather
+        // than map onto an empty user id. The principal is resolved when the browser completes the
+        // login, so the wallet post succeeds and the browser sees the error page.
         updatePrincipalAttribute("address");
         OID4VCTestContext credential = issueCredential();
         JsonNode request = requestObject();
 
         Oid4vpDirectPostResponse response = wallet.directPost(request, wallet.present(credential, request));
-        assertEquals(400, response.getStatusCode());
-        assertEquals("access_denied", response.getError());
-        assertTrue(response.getErrorDescription().contains("principal attribute"),
-                "Expected a principal attribute error, was: " + response.getErrorDescription());
+        assertEquals(200, response.getStatusCode());
+
+        driver.open(response.getRedirectUri());
+        assertTrue(driver.driver().getPageSource().contains("kc-error-message"),
+                "Expected the login error page, was: " + driver.driver().getCurrentUrl());
+    }
+
+    @Test
+    public void credentialClaimsAreMappedOnCompletedLogin() throws Exception {
+        OID4VCTestContext credential = issueCredential("bob");
+        UserRepresentation holder = deleteHolder("bob");
+        String street = holder.getAttributes().get("address_street_address").get(0);
+        String locality = holder.getAttributes().get("address_locality").get(0);
+
+        UserRepresentation user = completeFirstLogin(credential, holder);
+
+        assertEquals(holder.getEmail(), user.getEmail());
+        assertEquals(holder.getFirstName(), user.getFirstName());
+        assertEquals(holder.getLastName(), user.getLastName());
+        assertEquals(List.of(locality), user.getAttributes().get("locality"));
+        JsonNode address = JsonSerialization.readValue(user.getAttributes().get("addressJson").get(0), JsonNode.class);
+        assertEquals(street, address.path("street_address").asText());
+        assertEquals(locality, address.path("locality").asText());
+        assertEquals(sdJwtTypeCredentialVct, accessTokenClaim(VCT_TOKEN_CLAIM));
+
+        endBrowserSession(user.getId());
+    }
+
+    @Test
+    public void forceSyncModeHealsTamperedClaimsOnRelogin() throws Exception {
+        OID4VCTestContext credential = issueCredential("carol");
+        UserRepresentation holder = deleteHolder("carol");
+        String street = holder.getAttributes().get("address_street_address").get(0);
+        String locality = holder.getAttributes().get("address_locality").get(0);
+        UserRepresentation user = completeFirstLogin(credential, holder);
+
+        tamperMappedValues(user, holder.getEmail());
+        relogin(credential, user);
+
+        UserRepresentation healed = federatedUser(holder.getEmail());
+        assertEquals(holder.getFirstName(), healed.getFirstName());
+        assertEquals(List.of(locality), healed.getAttributes().get("locality"));
+        JsonNode healedAddress = JsonSerialization.readValue(healed.getAttributes().get("addressJson").get(0), JsonNode.class);
+        assertEquals(street, healedAddress.path("street_address").asText());
+
+        endBrowserSession(healed.getId());
+    }
+
+    // The session note is per login state, so it must survive an existing user login whose IMPORT
+    // sync mode skips the user updates.
+    @Test
+    public void importSyncModeKeepsSessionNoteButSkipsUserUpdatesOnRelogin() throws Exception {
+        OID4VCTestContext credential = issueCredential("dave");
+        UserRepresentation holder = deleteHolder("dave");
+        UserRepresentation user = completeFirstLogin(credential, holder);
+
+        updateIdpSyncMode(IdentityProviderSyncMode.IMPORT);
+        try {
+            tamperMappedValues(user, holder.getEmail());
+            relogin(credential, user);
+
+            assertEquals(sdJwtTypeCredentialVct, accessTokenClaim(VCT_TOKEN_CLAIM));
+            UserRepresentation untouched = federatedUser(holder.getEmail());
+            assertEquals("Tampered", untouched.getFirstName());
+            assertNull(untouched.getAttributes().get("addressJson"));
+            endBrowserSession(untouched.getId());
+        } finally {
+            updateIdpSyncMode(IdentityProviderSyncMode.FORCE);
+        }
+    }
+
+    // The mapped claims originate from the holder user, so its representation is kept as the
+    // expectation. The holder is deleted because the first broker login would otherwise stop at
+    // the duplicate user check instead of creating the account.
+    private UserRepresentation deleteHolder(String username) {
+        UserRepresentation holder = testRealm.admin().users()
+                .get(requireExistingUser(username).getId()).toRepresentation();
+        deleteRealmUser(holder);
+        return holder;
+    }
+
+    private UserRepresentation completeFirstLogin(OID4VCTestContext credential, UserRepresentation holder) throws Exception {
+        JsonNode request = requestObject();
+        driver.open(wallet.directPost(request, wallet.present(credential, request)).getRedirectUri());
+        assertLoginCompleted();
+        return federatedUser(holder.getEmail());
+    }
+
+    private void updateIdpSyncMode(IdentityProviderSyncMode syncMode) {
+        IdentityProviderResource idp = testRealm.admin().identityProviders().get(IDP_ALIAS);
+        IdentityProviderRepresentation rep = idp.toRepresentation();
+        rep.getConfig().put(IdentityProviderModel.SYNC_MODE, syncMode.name());
+        idp.update(rep);
+    }
+
+    // Dedicated credential holder per completed login test: completing a broker login for a
+    // holder changes how every later wallet login of that holder behaves, so the shared users stay
+    // untouched and the tests are order independent. Same profile shape as the shared users.
+    private void createCompletionHolder(String username) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        user.setEnabled(true);
+        user.setEmail(username + "@email.cz");
+        user.setEmailVerified(true);
+        user.setFirstName("Bob");
+        user.setLastName("Baumeister");
+        user.setAttributes(Map.of(
+                "address_street_address", List.of("221B Baker Street"),
+                "address_locality", List.of("London")));
+        CredentialRepresentation password = new CredentialRepresentation();
+        password.setType(CredentialRepresentation.PASSWORD);
+        password.setValue(TEST_PASSWORD);
+        password.setTemporary(false);
+        user.setCredentials(List.of(password));
+        String id;
+        try (Response response = testRealm.admin().users().create(user)) {
+            assertEquals(201, response.getStatus(), "Failed to create the completion holder");
+            String location = response.getHeaderString("Location");
+            id = location.substring(location.lastIndexOf('/') + 1);
+        }
+        UserVerifiableCredentialRepresentation grant = new UserVerifiableCredentialRepresentation();
+        grant.setCredentialScopeName(sdJwtTypeCredentialScopeName);
+        testRealm.admin().users().get(id).verifiableCredentials().createCredential(grant);
+    }
+
+    private void tamperMappedValues(UserRepresentation user, String username) {
+        user.setFirstName("Tampered");
+        Map<String, List<String>> attributes = new HashMap<>(user.getAttributes());
+        attributes.remove("addressJson");
+        attributes.put("locality", List.of("Nowhere"));
+        user.setAttributes(attributes);
+        testRealm.admin().users().get(user.getId()).update(user);
+
+        UserRepresentation tampered = federatedUser(username);
+        assertEquals("Tampered", tampered.getFirstName());
+        assertNull(tampered.getAttributes().get("addressJson"));
     }
 
     private void assertLoginRejected() {


### PR DESCRIPTION
Closes #51427

@rmartinc @vaceksimon @mabartos Could you please review?

Note that we do not support to select array indices other than 0 (or the whole array), because we a) do not know if the whole array or just the element will be disclosed (depends on how the data in the requested credential is modeled) and b) in case of selectively disclosing array elements, the other elements are not present at all... so adding two mappers for the same array but different indices would never work (at least not without synchronization between the mappers which is messy). Furthermore i really can't think of a good reason to select for example the 3rd index of an array... you generally don't even know how much elements an array has or how they are ordered.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
