### PR TITLE
fix: add admin-permissions client to isInternal denylist

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/ClientPermissions.java
@@ -725,6 +725,7 @@ class ClientPermissions implements ClientPermissionEvaluator,  ClientPermissionM
             return client.getClientId().endsWith(AdminRoles.APP_SUFFIX);
         }
 
-        return Constants.REALM_MANAGEMENT_CLIENT_ID.equals(client.getClientId());
+        return Constants.REALM_MANAGEMENT_CLIENT_ID.equals(client.getClientId())
+                || Constants.ADMIN_PERMISSIONS_CLIENT_ID.equals(client.getClientId());
     }
 }


### PR DESCRIPTION
## Description

The `ClientPermissions.isInternal` method denylists only the `realm-management` client (and, in the master realm, client IDs ending in the `-realm` suffix). The `admin-permissions` client — the resource server holding the realm's entire FGAP V2 model — is not in that list.

As a result, a delegated administrator holding a FGAP `Clients:manage` permission (and no realm-management roles) can update and disable the `admin-permissions` client through the Admin API, even though `getAccess()` correctly returns `manage: false` for this client.

## Fix

Added `Constants.ADMIN_PERMISSIONS_CLIENT_ID` to the `isInternal` predicate, making the enforcement path consistent with the access report.

## Root Cause

`ClientPermissions.isInternal` (line 719) checks only for `realm-management` and `-realm` suffix clients. `Constants.ADMIN_PERMISSIONS_CLIENT_ID` was missing from the predicate.

## How Has This Been Tested?

- Code inspection confirmed the fix aligns with how `realm-management` is handled
- The `getAccess()` method already special-cases this client at line 676; the fix makes `isInternal` consistent with that check

Closes #51630