### PR TITLE
Fix refresh token introspection audience validation

### DIFF
--- a/docs/documentation/server_admin/topics/clients/oidc/con-audience.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-audience.adoc
@@ -186,4 +186,6 @@ NOTE: Both the _Audience_ and _Audience Resolve_ protocol mappers add the audien
 
 The OAuth2 token introspection endpoint validates that the authenticated client is present in the token's audience (`aud`) claim before allowing introspection. This prevents clients from introspecting tokens that were not intended for them.
 
+For refresh and offline tokens, audience protocol mappers do not apply. Instead, only the client the token was issued for (`azp`) is allowed to introspect the token. Refresh and offline tokens are automatically detected from the token even when `token_type_hint` is not provided.
+
 If you need to disable this validation during migration, you can enable a backwards compatibility option in *OpenID Connect Compatibility Modes* by enabling *Allow token introspection without audience check* on the client that performs the introspection. See link:https://www.keycloak.org/server/all-provider-config#_openid_connect[OpenID Connect provider configuration] for the server-wide option.

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_2.adoc
@@ -31,6 +31,8 @@ WARNING: Both server-wide and per-client options are deprecated and will be remo
 
 NOTE: For lightweight access tokens, the audience claim may only be present in the introspection response (not in the token itself). The audience check validates the transformed token returned by introspection, ensuring proper validation for both standard and lightweight tokens.
 
+NOTE: For refresh and offline tokens, the audience check validates that the authenticated client matches the client the token was issued for (`azp`). Audience protocol mappers do not apply to refresh tokens. These tokens are automatically detected from the token even when `token_type_hint` is not provided.
+
 === UserInfo endpoint rejects lightweight access tokens
 
 The UserInfo endpoint now rejects lightweight access tokens by default. Lightweight access tokens contain minimal claims and are designed for token introspection.

--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -65,7 +65,7 @@ public class AccessTokenIntrospectionProvider<T extends AccessToken> implements 
     protected final TokenManager tokenManager;
     protected final RealmModel realm;
     private static final Logger logger = Logger.getLogger(AccessTokenIntrospectionProvider.class);
-    protected EventBuilder eventBuilder;
+    protected EventBuilder  eventBuilder;
 
     // Those are set after successfully verified
     protected T token;

--- a/services/src/main/java/org/keycloak/protocol/oidc/RefreshTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/RefreshTokenIntrospectionProvider.java
@@ -83,7 +83,15 @@ public class RefreshTokenIntrospectionProvider extends AccessTokenIntrospectionP
     protected boolean verifyAudience() {
         ClientModel authenticatedClient = session.getContext().getClient();
 
-        return authenticatedClient.getClientId().equals(token.getIssuedFor());
+        if (authenticatedClient.getClientId().equals(token.getIssuedFor())) {
+            return true;
+        }
+
+        logger.debugf("Introspection denied: client '%s' is not the client the %s token was issued for '%s'",
+                authenticatedClient.getClientId(), token.getType(), token.getIssuedFor());
+        eventBuilder.detail(Details.REASON, String.format("Client '%s' is not authorized to introspect this token", authenticatedClient.getClientId()));
+        eventBuilder.error(Errors.INVALID_TOKEN);
+        return false;
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/RefreshTokenIntrospectionProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/RefreshTokenIntrospectionProviderFactory.java
@@ -24,7 +24,7 @@ import org.keycloak.models.KeycloakSession;
  */
 public class RefreshTokenIntrospectionProviderFactory extends AccessTokenIntrospectionProviderFactory {
 
-    private static final String REFRESH_TOKEN_TYPE = "refresh_token";
+    public static final String REFRESH_TOKEN_TYPE = "refresh_token";
 
     @Override
     public TokenIntrospectionProvider create(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -36,10 +36,15 @@ import org.keycloak.http.HttpRequest;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.protocol.oidc.AccessTokenIntrospectionProviderFactory;
+import org.keycloak.protocol.oidc.RefreshTokenIntrospectionProviderFactory;
 import org.keycloak.protocol.oidc.TokenIntrospectionProvider;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.util.TokenUtil;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenIntrospectContext;
@@ -87,17 +92,13 @@ public class TokenIntrospectionEndpoint {
 
         checkParameterDuplicated(formParams);
 
-        String tokenTypeHint = formParams.getFirst(PARAM_TOKEN_TYPE_HINT);
-
-        if (tokenTypeHint == null) {
-            tokenTypeHint = AccessTokenIntrospectionProviderFactory.ACCESS_TOKEN_TYPE;
-        }
-
         String token = formParams.getFirst(PARAM_TOKEN);
 
         if (token == null) {
             throw throwErrorResponseException(Errors.INVALID_REQUEST, "Token not provided.", Status.BAD_REQUEST);
         }
+
+        String tokenTypeHint = resolveTokenTypeHint(formParams.getFirst(PARAM_TOKEN_TYPE_HINT), token);
 
         TokenIntrospectionProvider provider = this.session.getProvider(TokenIntrospectionProvider.class, tokenTypeHint);
 
@@ -180,5 +181,33 @@ public class TokenIntrospectionEndpoint {
     private ErrorResponseException throwErrorResponseException(String error, String detail, Status status) {
         this.event.detail("detail", detail).error(error);
         return new ErrorResponseException(error, detail, status);
+    }
+
+    /**
+     * Resolves the introspection provider to use. Refresh and offline tokens are routed to the refresh-token
+     * provider based on the token type claim, even when no token_type_hint is provided or access_token is hinted.
+     */
+    private String resolveTokenTypeHint(String tokenTypeHint, String token) {
+        if (RefreshTokenIntrospectionProviderFactory.REFRESH_TOKEN_TYPE.equals(tokenTypeHint)) {
+            return tokenTypeHint;
+        }
+
+        if (tokenTypeHint == null || AccessTokenIntrospectionProviderFactory.ACCESS_TOKEN_TYPE.equals(tokenTypeHint)) {
+            try {
+                JsonWebToken tokenRepresentation = new JWSInput(token).readJsonContent(JsonWebToken.class);
+                String tokenType = tokenRepresentation.getType();
+                if (TokenUtil.TOKEN_TYPE_REFRESH.equals(tokenType) || TokenUtil.TOKEN_TYPE_OFFLINE.equals(tokenType)) {
+                    return RefreshTokenIntrospectionProviderFactory.REFRESH_TOKEN_TYPE;
+                }
+            } catch (JWSInputException e) {
+                // Fall through to default provider selection
+            }
+
+            if (tokenTypeHint == null) {
+                return AccessTokenIntrospectionProviderFactory.ACCESS_TOKEN_TYPE;
+            }
+        }
+
+        return tokenTypeHint;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -269,6 +269,26 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void testIntrospectRefreshTokenWithoutTokenTypeHint() throws Exception {
+        oauth.doLogin("test-user@localhost", "password");
+        String code = oauth.parseLoginResponse().getCode();
+        EventRepresentation loginEvent = EventAssertion.expectLoginSuccess(events.poll()).getEvent();
+        AccessTokenResponse accessTokenResponse = oauth.doAccessTokenRequest(code);
+        oauth.client("test-app", "password");
+        events.clear();
+
+        // test-app has an audience mapper adding test-app to access tokens, but refresh tokens do not include aud
+        JsonNode jsonNode = oauth.introspectionRequest(accessTokenResponse.getRefreshToken()).send().asJsonNode();
+
+        EventAssertion.assertSuccess(events.poll()).type(EventType.INTROSPECT_TOKEN)
+                .clientId("test-app")
+                .sessionId(loginEvent.getSessionId());
+        Assertions.assertNull(events.poll());
+        assertTrue(jsonNode.get("active").asBoolean());
+        assertEquals("test-app", jsonNode.get("client_id").asText());
+    }
+
+    @Test
     public void testIntrospectRefreshTokenDeniedForNotIssuedFor() throws Exception {
         oauth.doLogin("test-user@localhost", "password");
         String code = oauth.parseLoginResponse().getCode();
@@ -693,6 +713,9 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
 
             oauth.client("test-app", "password");
             jsonNode = oauth.doIntrospectionRefreshTokenRequest(oldRefreshToken).asJsonNode();
+            assertFalse(jsonNode.get("active").asBoolean());
+
+            jsonNode = oauth.introspectionRequest(oldRefreshToken).send().asJsonNode();
             assertFalse(jsonNode.get("active").asBoolean());
         } finally {
             realm.setRevokeRefreshToken(false);


### PR DESCRIPTION
## Summary

Fixes refresh and offline token introspection returning `{"active": false}` since 26.6.2 when `token_type_hint` is not provided.

Closes #51552

## Problem

Since #49113 (26.6.2), token introspection checks that the authenticated client is in the token's `aud` claim.

Audience protocol mappers add clients to `aud` on access tokens only — not on refresh or offline tokens.

When introspection is called without `token_type_hint`, the endpoint defaults to the access-token provider and applies the `aud` check. Refresh tokens don't have the client in `aud`, so introspection incorrectly returns `{"active": false}` even for the issuing client.

## Solution

- Auto-detect token type: `TokenIntrospectionEndpoint` reads the `typ` claim and routes refresh/offline tokens to `RefreshTokenIntrospectionProvider`, even when `token_type_hint` is missing or set to `access_token`.
- Validate using `azp`: `RefreshTokenIntrospectionProvider` checks that the authenticated client matches the client the token was issued for (`azp` / `issuedFor`), not `aud`.
-  Other `token_type_hint` values are left unchanged (e.g. unknown hints still return `Unsupported token type.`).
- Docs: document that refresh/offline token introspection uses `azp` and works without `token_type_hint`.

## Test plan

- [x] `testIntrospectRefreshToken` — introspection with `token_type_hint=refresh_token` (client with audience mapper)
- [x] `testIntrospectRefreshTokenWithoutTokenTypeHint` — introspection without hint returns `active: true`
- [x] `testIntrospectRefreshTokenDeniedForNotIssuedFor` — wrong client returns `active: false`
- [x] `testIntrospectRefreshTokenAfterRefreshTokenRequest` — used refresh token returns `active: false` (with and without hint)