### PR TITLE
Surface Kubernetes IdP key-loading failures and fix a resulting NPE

### DIFF
--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProvider.java
@@ -48,7 +48,16 @@ public class KubernetesIdentityProvider implements ClientAssertionIdentityProvid
 
             String modelKey = PublicKeyStorageUtils.getIdpModelCacheKey(validator.getContext().getRealm().getId(), config.getInternalId());
             PublicKeyStorageProvider keyStorage = session.getProvider(PublicKeyStorageProvider.class);
-            KeyWrapper publicKey = keyStorage.getPublicKey(modelKey, kid, alg, new KubernetesJwksEndpointLoader(session, config.getIssuer()));
+
+            KeyWrapper publicKey;
+            try {
+                publicKey = keyStorage.getPublicKey(modelKey, kid, alg, new KubernetesJwksEndpointLoader(session, config.getIssuer()));
+            } catch (Exception e) {
+                // Indicative of an infrastructure/configuration and can't be
+                // triggered by a client - worth WARN visibility.
+                LOGGER.warnf(e, "Failed to load public keys for Kubernetes IdP '%s' with issuer '%s'", config.getAlias(), config.getIssuer());
+                return false;
+            }
 
             SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, alg);
             if (signatureProvider == null) {

--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesJwksEndpointLoader.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesJwksEndpointLoader.java
@@ -1,6 +1,7 @@
 package org.keycloak.broker.kubernetes;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.keycloak.crypto.PublicKeysWrapper;
@@ -46,6 +47,9 @@ public class KubernetesJwksEndpointLoader implements PublicKeyLoader {
             wellKnownReqest.auth(token);
         }
         String jwksUri = wellKnownReqest.asJson(OIDCConfigurationRepresentation.class).getJwksUri();
+        if (jwksUri == null) {
+            throw new IOException("OIDC discovery document from " + wellKnownEndpoint + " did not include a jwks_uri");
+        }
 
         SimpleHttpRequest jwksRequest = simpleHttp.doGet(jwksUri).header(HttpHeaders.ACCEPT, "application/jwk-set+json");
         if (token != null) {


### PR DESCRIPTION
`KubernetesIdentityProvider.verifySignature()` logged any caught exception from loading the JWKS at `DEBUG` only, indistinguishable from a routine signature mismatch and invisible without enabling `DEBUG` logging.

Split the two: a failure to load the keys themselves (an infra/config problem, not something a client can trigger) now logs at `WARN`, while a routine bad-signature/malformed token stays at `DEBUG` so spoofing attempts don't spam the log.

Separately, `KubernetesJwksEndpointLoader` silently let a null `jwks_uri` propagate into request-building code, surfacing several calls later as an opaque `NullPointerException` deep inside `java.net.URI`. It now fails fast with a descriptive `IOException` instead.

This PR was written with the help of AI.

Fixes #51682

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
