### PR TITLE
Fix scope selector filtering attributes in Account context

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -92,6 +92,14 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
                 .anyMatch(configuredScopes::contains);
     }
 
+    private static boolean shouldEvaluateScopeSelector(UserProfileContext context) {
+        if (UserProfileContext.ACCOUNT.equals(context)) {
+            return false;
+        }
+
+        return context.canBeAuthFlowContext();
+    }
+
     private final KeycloakSession session;
     private final String providerId;
     private final Map<UserProfileContext, UserProfileMetadata> contextualMetadataRegistry;
@@ -341,7 +349,7 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
 
             Predicate<AttributeContext> selector = AttributeMetadata.ALWAYS_TRUE;
             UPAttributeSelector sc = attrConfig.getSelector();
-            if (sc != null && !isBuiltInAttribute(context, attributeName) && context.canBeAuthFlowContext() && sc.getScopes() != null && !sc.getScopes().isEmpty()) {
+            if (sc != null && !isBuiltInAttribute(context, attributeName) && shouldEvaluateScopeSelector(context) && sc.getScopes() != null && !sc.getScopes().isEmpty()) {
                 // for contexts executed from auth flow and with configured scopes selector
                 // we have to create correct predicate
                 selector = (c) -> requestedScopePredicate(c, sc.getScopes());

--- a/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceWithUserProfileTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceWithUserProfileTest.java
@@ -134,6 +134,38 @@ public class AccountRestServiceWithUserProfileTest extends AbstractRestServiceTe
     }
 
     @Test
+    public void testScopeSelectorBypassedInAccountContext() throws IOException {
+        managedRealm.cleanup().add(r -> UserProfileUtil.setUserProfileConfiguration(r, null));
+
+        String upConfigScopeSelector = "{\"attributes\": ["
+                + "{\"name\": \"firstName\"," + PERMISSIONS_ALL + ", \"required\": {}},"
+                + "{\"name\": \"lastName\"," + PERMISSIONS_ALL + ", \"required\": {}},"
+                + "{\"name\": \"attr_scope_profile\"," + PERMISSIONS_ALL + ", \"selector\": {\"scopes\": [\"profile\"]}},"
+                + "{\"name\": \"attr_scope_address\"," + PERMISSIONS_ALL + ", \"selector\": {\"scopes\": [\"address\"]}},"
+                + "{\"name\": \"attr_scope_multiple\"," + PERMISSIONS_ALL + ", \"selector\": {\"scopes\": [\"profile\", \"phone\"]}},"
+                + "{\"name\": \"attr_no_selector\"," + PERMISSIONS_ALL + "},"
+                + "{\"name\": \"attr_scope_admin_only\"," + PERMISSIONS_ADMIN_ONLY + ", \"selector\": {\"scopes\": [\"profile\"]}}"
+                + "]}";
+
+        setUserProfileConfiguration(upConfigScopeSelector);
+
+        String token = oauth.client("direct-grant", "password").doPasswordGrantRequest("test-user@localhost", "password").getAccessToken();
+        UserRepresentation user = getUser(token);
+        Assertions.assertNotNull(user.getUserProfileMetadata());
+
+        // scope selectors are bypassed in account context — all attributes with selector.scopes are visible
+        assertUserProfileAttributeMetadata(user, "attr_scope_profile", "attr_scope_profile", false, false);
+        assertUserProfileAttributeMetadata(user, "attr_scope_address", "attr_scope_address", false, false);
+        assertUserProfileAttributeMetadata(user, "attr_scope_multiple", "attr_scope_multiple", false, false);
+
+        // attribute without selector is also visible
+        assertUserProfileAttributeMetadata(user, "attr_no_selector", "attr_no_selector", false, false);
+
+        // permissions still restrict visibility independently of scope selector
+        Assertions.assertNull(getUserProfileAttributeMetadata(user, "attr_scope_admin_only"));
+    }
+
+    @Test
     public void testGetUserProfileMetadata_NoAccessToNameFields() throws IOException {
         managedRealm.cleanup().add(r -> UserProfileUtil.setUserProfileConfiguration(r, null));
         managedRealm.updateWithCleanup(r -> r.editUsernameAllowed(false));


### PR DESCRIPTION
Attributes configured with selector.scopes were incorrectly filtered in the Account context, causing them to disappear from Account Console metadata. This adds a shouldEvaluateScopeSelector() helper that explicitly bypasses scope selector evaluation for the ACCOUNT context.

Closes #38113

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
