### PR TITLE
Report OID4VCI credential request errors

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -1769,7 +1769,7 @@ public class OID4VCIssuerEndpoint {
         VCIssuanceContext vcIssuanceContext = getVCToSign(protocolMappers, credentialConfig, authResult, authDetail, credentialRequestVO, credentialScopeModel, eventBuilder);
 
         // Enforce key binding prior to signing if necessary
-        enforceKeyBindingIfProofProvided(vcIssuanceContext);
+        enforceKeyBindingIfProofProvided(vcIssuanceContext, eventBuilder);
 
         return vcIssuanceContext;
     }
@@ -1893,7 +1893,7 @@ public class OID4VCIssuerEndpoint {
     /**
      * Enforce key binding: Validate proof and bind associated key to credential in issuance context.
      */
-    private void enforceKeyBindingIfProofProvided(VCIssuanceContext vcIssuanceContext) {
+    private void enforceKeyBindingIfProofProvided(VCIssuanceContext vcIssuanceContext, EventBuilder eventBuilder) {
         Proofs proofs = vcIssuanceContext.getCredentialRequest().getProofs();
         if (proofs == null) {
             LOGGER.debugf("No proofs provided, skipping key binding");
@@ -1902,11 +1902,11 @@ public class OID4VCIssuerEndpoint {
 
         // Validate each proof type that is present
         for (String proofType : proofs.getPresentProofTypes()) {
-            validateProofs(vcIssuanceContext, proofType);
+            validateProofs(vcIssuanceContext, proofType, eventBuilder);
         }
     }
 
-    private void validateProofs(VCIssuanceContext vcIssuanceContext, String proofType) {
+    private void validateProofs(VCIssuanceContext vcIssuanceContext, String proofType, EventBuilder eventBuilder) {
         ProofValidator proofValidator = session.getProvider(ProofValidator.class, proofType);
         if (proofValidator == null) {
             throw new BadRequestException(String.format("Unable to validate proofs of type %s", proofType));
@@ -1920,6 +1920,8 @@ public class OID4VCIssuerEndpoint {
                 vcIssuanceContext.getCredentialBody().addKeyBinding(jwks.get(0));
             }
         } catch (VCIssuerException e) {
+            eventBuilder.detail(Details.REASON, e.getMessage())
+                    .error(e.getErrorType().getValue());
             switch (e.getErrorType()) {
                 case INVALID_NONCE:
                     throw new ErrorResponseException(INVALID_NONCE.getValue(), e.getMessage(), Response.Status.BAD_REQUEST);
@@ -1957,8 +1959,10 @@ public class OID4VCIssuerEndpoint {
     private void validateRequestedClaimsArePresent(Map<String, Object> allClaims, SupportedCredentialConfiguration credentialConfig,
                                                    UserModel user, OID4VCAuthorizationDetail authzDetail, String scope, EventBuilder eventBuilder) {
         // Protocol mappers from configuration
-        Map<List<Object>, ClaimsDescription> claimsConfig = credentialConfig.getCredentialMetadata().getClaims()
+        Map<List<Object>, ClaimsDescription> claimsConfig = Optional.ofNullable(credentialConfig.getCredentialMetadata())
+                .map(metadata -> metadata.getClaims())
                 .stream()
+                .flatMap(claims -> claims.stream())
                 .map(claim -> {
                     List<Object> pathObj = new ArrayList<>(claim.getPath());
                     return new ClaimsDescription(pathObj, claim.isMandatory());

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -40,6 +40,8 @@ import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.models.Constants;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
@@ -73,6 +75,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.services.managers.AppAuthManager.BearerTokenAuthenticator;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testsuite.util.AccountHelper;
@@ -1041,6 +1044,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .setCredentialIdentifier(credentialIdentifier)
                 .setProofs(new Proofs().setJwt(List.of(futureIatProof)));
 
+        events.clear();
         Oid4vcCredentialResponse response = oauth.oid4vc()
                 .credentialRequest(request)
                 .bearerToken(token)
@@ -1049,6 +1053,11 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Proof iat is in the future"));
+        EventAssertion.assertError(events.poll())
+                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
+                .clientId(OID4VCI_CLIENT_ID)
+                .error(ErrorType.INVALID_PROOF.getValue())
+                .details(Details.REASON, "Proof iat is in the future beyond allowed clock skew");
     }
 
     @Test
@@ -1496,6 +1505,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 VCFormat.JWT_VC,
                 null, null
         );
+        optionalScope.setProtocolMappers(List.of());
 
         optionalScope = registerOptionalClientScope(optionalScope);
         ClientRepresentation testClient = testRealm.admin().clients().findByClientId(OID4VCI_CLIENT_ID).get(0);
@@ -1526,6 +1536,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         CredentialRequest credentialRequest = new CredentialRequest()
                 .setCredentialIdentifier(credentialIdentifier);
 
+        events.clear();
         Oid4vcCredentialResponse response = oauth.oid4vc()
                 .credentialRequest(credentialRequest)
                 .bearerToken(token)
@@ -1538,6 +1549,10 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
         assertNotNull(credentialResponseVO.getCredentials(), "Credentials array should not be null");
         assertFalse(credentialResponseVO.getCredentials().isEmpty(), "Credentials array should not be empty");
+        EventAssertion.assertSuccess(events.poll())
+                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST)
+                .clientId(OID4VCI_CLIENT_ID)
+                .details(Details.CREDENTIAL_TYPE, configId);
     }
 
     @Test


### PR DESCRIPTION
Closes #51692.

## What changed

- Treat missing OID4VCI credential claims metadata as an empty claim set. This lets a client scope with no protocol mappers issue a credential instead of failing with a null-pointer exception.
- Record proof-validation failures on the `VERIFIABLE_CREDENTIAL_REQUEST_ERROR` event, including the OID4VCI error type and the failure reason.
- Extend the existing endpoint tests to cover a mapper-free optional scope and the event generated for a future-`iat` proof.

## Verification

- On the unmodified issue base, the mapper-free scenario returned HTTP 500 and the proof-error scenario produced no event.
- The two focused tests pass with this change.
- The complete `OID4VCJWTIssuerEndpointTest` class passes: 55 tests, 0 failures, 0 errors.
- The affected `services` and `tests/base` Spotless checks pass.
- A reactor package build completed successfully across 82 modules.

## AI assistance disclosure

I used an AI coding assistant to help investigate the issue, implement the change, and run the verification. I reviewed the resulting diff and test evidence before submitting it.
