### PR TITLE
Remove .vale.ini file

### DIFF
--- a/docs/documentation/.vale.ini
+++ b/docs/documentation/.vale.ini
@@ -1,8 +1,0 @@
-StylesPath = /Users/bdooley/Documents/code/vale-boilerplate/styles
-MinAlertLevel = error
-
-Vocab = blog
-
-
-[*.adoc]
-BasedOnStyles = IBM, Vale, write-good


### PR DESCRIPTION
Removing the .vale.ini file as we don't use Vale. We can re-introduce an updated file later if this is a tool we at some point start using.

Closes: #48847
Signed-off-by: stianst <stianst@gmail.com>
