### PR TITLE
Ignore Bootstrap CVEs as we are not affected by them since bootstrap javascript components are not distriburted or used

### DIFF
--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -70,6 +70,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
+          trivyignores: .trivy/trivyignore.yaml
           format: 'json'
           output: 'trivy-report.json'
           scanners: 'vuln'          

--- a/.trivy/trivyignore.yaml
+++ b/.trivy/trivyignore.yaml
@@ -1,0 +1,6 @@
+vulnerabilities:
+  - id: CVE-2024-6485
+    statement: Not affected, Bootstrap JavaScript component not distributed
+  - id: CVE-2025-1647
+    statement: Not affected, Bootstrap JavaScript component not distributed
+


### PR DESCRIPTION
Signed-off-by: stianst <stianst@gmail.com>
