### PR TITLE
Enable HTTP optimized serializers by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,11 +160,10 @@ jobs:
         uses: ./.github/actions/integration-test-setup
 
       - name: Run base tests
-        # enable the http-optimized-serializers feature for the old testsuite to verify it works as expected
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/base-suite.sh ${{ matrix.group }}`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dauth.server.feature=http-optimized-serializers -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - uses: ./.github/actions/upload-flaky-tests
         name: Upload flaky tests

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -176,7 +176,7 @@ public class Profile {
 
         SSF("Shared Signals Framework", Type.EXPERIMENTAL),
 
-        HTTP_OPTIMIZED_SERIALIZERS("Optimized JSON serializers for better performance of the HTTP layer", Type.PREVIEW),
+        HTTP_OPTIMIZED_SERIALIZERS("Optimized JSON serializers for better performance of the HTTP layer", Type.DEFAULT),
 
         OPENAPI("OpenAPI specification served at runtime", Type.EXPERIMENTAL, CLIENT_ADMIN_API_V2),
 

--- a/docs/documentation/release_notes/topics/26_8_0.adoc
+++ b/docs/documentation/release_notes/topics/26_8_0.adoc
@@ -16,3 +16,10 @@ Additionally, tokens issued from impersonation sessions now include the `act` (a
 The social identity provider section on the login page has been refreshed with updated icons, a new divider layout, and improved button labels.
 
 If you have a custom login theme, see the link:{upgradingguide_link}[{upgradingguide_name}] for details on what changed.
+
+== Enhanced HTTP performance
+
+The `http-optimized-serializers` feature is now supported and enabled by default.
+This improves how {project_name} handles JSON in the HTTP layer, increasing throughput by about 5%, stabilizing response times, and reducing resource usage.
+
+If you need to disable it, use the `--features-disabled=http-optimized-serializers` server option.

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -30,6 +30,13 @@ When calling {project_name}'s experimental AuthZEN endpoints, the caller now nee
 
 The Admin REST API endpoints for listing client sessions (`GET /admin/realms/\{realm}/clients/\{id}/user-sessions` and `GET /admin/realms/\{realm}/clients/\{id}/offline-sessions`) now filter out sessions belonging to users that the caller does not have permission to view. Previously, any caller with the `view-clients` role could see all user sessions for a client, potentially exposing user identities to callers without the `view-users` role. After upgrading, callers without `view-users` permission will see fewer results from these endpoints.
 
+=== HTTP optimized serializers enabled by default
+
+The `http-optimized-serializers` feature is now enabled by default.
+If you enabled it explicitly in a previous release, the `--features=http-optimized-serializers` option is no longer required.
+
+If needed, you can disable it with `--features-disabled=http-optimized-serializers`.
+
 === Redesigned identity provider buttons on the login page
 
 The social identity provider section on the login page has been redesigned with updated icons and layout.

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -107,8 +107,7 @@ export JAVA_OPTS_APPEND="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6A
 
 See <@links.server id="caching" anchor="network-bind-address"/> for more details.
 
-== Preview of enhanced HTTP performance
-<@features.techpreview feature="http-optimized-serializers" additionalCommunityText="We gather more feedback on this feature to promote it to supported. Please, share your feedback about any issue in https://github.com/keycloak/keycloak/discussions/43484[this discussion]."/>
+== Enhanced HTTP performance
 
 In production environments, the performance of the HTTP layer is critical.
 Every request passes through it, making it a key factor in overall system responsiveness, scalability, and user experience.
@@ -124,8 +123,9 @@ These improvements help ensure smoother, more predictable performance at scale w
 
 The only known tradeoff is that build time increases by ~6% as certain actions were moved to the build time instead of runtime.
 
-You can enable this feature as follows:
+This feature is enabled by default.
+If needed, you can disable it as follows:
 
-<@kc.start parameters="--features=http-optimized-serializers"/>
+<@kc.start parameters="--features-disabled=http-optimized-serializers"/>
 
 </@tmpl.guide>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -36,6 +36,7 @@ import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.config.WildcardOptionsUtil;
+import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.ShortErrorMessageHandler;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
@@ -613,17 +614,20 @@ public class PropertyMapper<T> {
     /**
      * Create a property mapper from a feature.
      * The mapper maps to external properties the state of the feature.
-     * <p>
-     * If the feature is enabled, it returns {@code true}. Otherwise {@code null}.
      */
     public static PropertyMapper.Builder<Boolean> fromFeature(Profile.Feature feature) {
         final var option = new OptionBuilder<>(feature.getKey() + "-hidden-mapper", Boolean.class)
                 .buildTime(true)
-                .defaultValue(Boolean.TRUE)
                 .synthetic()
                 .build();
         return new Builder<>(option)
-                .isEnabled(() -> Profile.isFeatureEnabled(feature));
+                .transformer((value, context) -> {
+                    if (Profile.getInstance() == null) {
+                        // can be null when running during augmentation
+                        Environment.getCurrentOrCreateFeatureProfile();
+                    }
+                    return Profile.isFeatureEnabled(feature) ? "true" : "false";
+                });
     }
 
     public void validate(ConfigValue value) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -1083,12 +1083,12 @@ public class PicocliTest extends AbstractConfigurationTest {
     public void httpOptimizedSerializers() {
         var nonRunningPicocli = pseudoLaunch("start-dev");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertExternalConfigNull("quarkus.rest.jackson.optimization.enable-reflection-free-serializers");
+        assertExternalConfig("quarkus.rest.jackson.optimization.enable-reflection-free-serializers", "true");
         onAfter();
 
-        nonRunningPicocli = pseudoLaunch("start-dev", "--features=http-optimized-serializers");
+        nonRunningPicocli = pseudoLaunch("start-dev", "--features-disabled=http-optimized-serializers");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertExternalConfig("quarkus.rest.jackson.optimization.enable-reflection-free-serializers", "true");
+        assertExternalConfigNull("quarkus.rest.jackson.optimization.enable-reflection-free-serializers");
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -1088,7 +1088,7 @@ public class PicocliTest extends AbstractConfigurationTest {
 
         nonRunningPicocli = pseudoLaunch("start-dev", "--features-disabled=http-optimized-serializers");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertExternalConfigNull("quarkus.rest.jackson.optimization.enable-reflection-free-serializers");
+        assertExternalConfig("quarkus.rest.jackson.optimization.enable-reflection-free-serializers", "false");
     }
 
     @Test


### PR DESCRIPTION
closes: #50166

This promotes http-optimized-serializers from preview to default behavior in 26.8. The change aligns the feature model, docs, and runtime expectations around opt-out rather than opt-in.

Mark HTTP_OPTIMIZED_SERIALIZERS as Type.DEFAULT in Profile
Keep the existing feature flag as the backdoor for disabling the optimization
Documentation

Update the production guide to describe enhanced HTTP performance as enabled by default
Replace enablement guidance with opt-out guidance
Add 26.8 release notes and upgrading notes for the default-on change
Runtime and compatibility

Update the CLI test to assert the Quarkus serializer optimization is active by default
Verify disabling via --features-disabled=http-optimized-serializers
Remove the CI override that explicitly enabled the feature so coverage reflects the new default
bin/kc.sh start --features-disabled=http-optimized-serializers

created initially with copilot
