### PR TITLE
Removes obsolete DirExportProvider.recursiveDeleteDir and replaces test usages with Apache Commons FileUtils.

### DIFF
--- a/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirExportProvider.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirExportProvider.java
@@ -59,23 +59,6 @@ public class DirExportProvider extends MultipleStepsExportProvider<DirExportProv
         return rootDirectory;
     }
 
-    public static boolean recursiveDeleteDir(File dirPath) {
-        if (dirPath.exists()) {
-            File[] files = dirPath.listFiles();
-            for (int i = 0; i < files.length; i++) {
-                if (files[i].isDirectory()) {
-                    recursiveDeleteDir(files[i]);
-                } else {
-                    files[i].delete();
-                }
-            }
-        }
-        if (dirPath.exists())
-            return dirPath.delete();
-        else
-            return true;
-    }
-
     @Override
     public void writeRealm(String fileName, RealmRepresentation rep) throws IOException {
         File file = new File(getRootDirectory(), fileName);

--- a/tests/base/src/test/java/org/keycloak/tests/exportimport/ExportImportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/exportimport/ExportImportTest.java
@@ -38,7 +38,6 @@ import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.Strategy;
-import org.keycloak.exportimport.dir.DirExportProvider;
 import org.keycloak.exportimport.dir.DirExportProviderFactory;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
 import org.keycloak.exportimport.util.ImportUtils;
@@ -157,7 +156,7 @@ public class ExportImportTest {
     public void testDirFullExportImport() throws Throwable {
         runOnServerMaster.run(ExportImportHelper.setProvider(DirExportProviderFactory.PROVIDER_ID));
         String targetDirPath = runOnServerMaster.fetchString(ExportImportHelper.getExportImportTestDirectory()).replace("\"","")+ File.separator + "dirExport";
-        DirExportProvider.recursiveDeleteDir(new File(targetDirPath));
+        FileUtils.deleteQuietly(new File(targetDirPath));
         runOnServerMaster.run(ExportImportHelper.setDir(targetDirPath));
         runOnServerMaster.run(ExportImportHelper.setUsersPerFile(ExportImportConfig.DEFAULT_USERS_PER_FILE));
 
@@ -174,7 +173,7 @@ public class ExportImportTest {
     public void testDirRealmExportImport() throws Throwable {
         runOnServerMaster.run(ExportImportHelper.setProvider(DirExportProviderFactory.PROVIDER_ID));
         String targetDirPath = runOnServerMaster.fetchString(ExportImportHelper.getExportImportTestDirectory()).replace("\"","") + File.separator + "dirRealmExport";
-        DirExportProvider.recursiveDeleteDir(new File(targetDirPath));
+        FileUtils.deleteQuietly(new File(targetDirPath));
         runOnServerMaster.run(ExportImportHelper.setDir(targetDirPath));
         runOnServerMaster.run(ExportImportHelper.setUsersPerFile(5));
 
@@ -316,7 +315,7 @@ public class ExportImportTest {
         String targetDirPath = runOnServerMaster.fetchString(ExportImportHelper.getExportImportTestDirectory()).replace("\"","") + File.separator + "dirRealmExport";
         File dest = new File(targetDirPath);
         try {
-            DirExportProvider.recursiveDeleteDir(dest);
+            FileUtils.deleteQuietly(dest);
             runOnServerMaster.run(ExportImportHelper.setDir(targetDirPath));
 
             runOnServerMaster.run(ExportImportHelper.setAction(ExportImportConfig.ACTION_EXPORT));
@@ -347,7 +346,7 @@ public class ExportImportTest {
                 Assertions.fail("Error with realm importing twice. Details: " + e.getMessage());
             }
         } finally {
-            DirExportProvider.recursiveDeleteDir(dest);
+            FileUtils.deleteQuietly(dest);
         }
     }
 
@@ -360,7 +359,7 @@ public class ExportImportTest {
         String targetDirPath = runOnServerMaster.fetchString(ExportImportHelper.getExportImportTestDirectory()).replace("\"","") + File.separator + "dirRealmExport";
         File dest = new File(targetDirPath);
         try {
-            DirExportProvider.recursiveDeleteDir(dest);
+            FileUtils.deleteQuietly(dest);
             runOnServerMaster.run(ExportImportHelper.setDir(targetDirPath));
 
             runOnServerMaster.run(ExportImportHelper.setAction(ExportImportConfig.ACTION_EXPORT));
@@ -388,7 +387,7 @@ public class ExportImportTest {
             });
             assertThat(e.getMessage(), Matchers.containsString("File name / realm name mismatch."));
         } finally {
-            DirExportProvider.recursiveDeleteDir(dest);
+            FileUtils.deleteQuietly(dest);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCExportImportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCExportImportTest.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.ExportImportManager;
-import org.keycloak.exportimport.dir.DirExportProvider;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
 import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.RealmModel;
@@ -22,6 +21,7 @@ import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -54,7 +54,7 @@ public class OID4VCExportImportTest extends OID4VCIssuerTestBase {
 
     @AfterAll
     public static void deleteTempDir() throws IOException {
-        DirExportProvider.recursiveDeleteDir(new File(tempDir));
+        FileUtils.deleteDirectory(new File(tempDir));
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIExportImportCredentialOfferTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIExportImportCredentialOfferTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.ExportImportManager;
-import org.keycloak.exportimport.dir.DirExportProvider;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
 import org.keycloak.exportimport.util.ImportUtils;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -20,6 +19,7 @@ import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.util.JsonSerialization;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -61,7 +61,7 @@ public class OID4VCIExportImportCredentialOfferTest extends OID4VCIssuerTestBase
 
     @AfterAll
     public static void deleteTempDir() throws IOException {
-        DirExportProvider.recursiveDeleteDir(new File(tempDir));
+        FileUtils.deleteDirectory(new File(tempDir));
     }
 
     @Test


### PR DESCRIPTION
- Removed static recursiveDeleteDir method from DirExportProvider to prevent potential NullPointerException when listFiles() returns null.
- Updated ExportImportTest, OID4VCExportImportTest, and OID4VCIExportImportCredentialOfferTest to use FileUtils.deleteDirectory and FileUtils.deleteQuietly instead.

Closes #51684