### PR TITLE
Align SCIM attribute schema caseExact defaults with RFC 7643

### DIFF
--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/scim/BaseClientModelSchema.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/scim/BaseClientModelSchema.java
@@ -46,6 +46,7 @@ public abstract class BaseClientModelSchema<R extends BaseClientRepresentation>
             BiConsumer<BaseClientRepresentation, String> repSetter,
             BiConsumer<ClientModel, String> modelSetter) {
         return Attribute.<ClientModel, R>simple(name)
+                .caseExact()
                 .modelAttributeResolver(a -> entityField)
                 .withModelSetter(
                         modelSetter != null ? (TriConsumer<ClientModel, String, String>) (model, n, v) -> modelSetter.accept(model, v) : null,

--- a/scim/core/src/main/java/org/keycloak/scim/resource/schema/attribute/Attribute.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/schema/attribute/Attribute.java
@@ -355,7 +355,7 @@ public class Attribute<M extends Model, R> {
         private TriConsumer<M, String, Set<?>> modelRemover;
         private TriConsumer<M, String, Set<?>> modelAdder;
         private boolean required;
-        private boolean caseExact = true;
+        private boolean caseExact = false;
         private boolean storedLowerCase;
         private String uniqueness = "none";
 
@@ -397,7 +397,7 @@ public class Attribute<M extends Model, R> {
             String subName = this.name + "." + name;
             Attribute<M, R> attribute = assembleAttribute(subName, this.name, alias,
                     new AttributeMapper<>(modelSetter, new ComplexAttributeSetter<>(this.name, name, complexType)),
-                    modelAttributeResolver, "string", null, returned, false, false, true, false, null, null);
+                    modelAttributeResolver, "string", null, returned, false, false, false, false, null, null);
             attributes.add(attribute);
             return this;
         }
@@ -491,6 +491,11 @@ public class Attribute<M extends Model, R> {
 
         public Builder<M, R> notCaseExact() {
             this.caseExact = false;
+            return this;
+        }
+
+        public Builder<M, R> caseExact() {
+            this.caseExact = true;
             return this;
         }
 

--- a/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateProvider.java
@@ -167,7 +167,7 @@ public class ScimJPAPredicateProvider {
             basePredicate = cb.equal(join.get("name"), modelAttributeName);
         }
 
-        if (value != null && (attrInfo.isStoredLowerCase() || !attrInfo.isCaseExact())) {
+        if (value instanceof String && (attrInfo.isStoredLowerCase() || !attrInfo.isCaseExact())) {
             value = value.toString().toLowerCase();
             if (!attrInfo.isStoredLowerCase()) {
                 expression = cb.lower((Expression<String>) expression);

--- a/scim/model/src/main/java/org/keycloak/scim/model/group/GroupCoreModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/group/GroupCoreModelSchema.java
@@ -93,7 +93,6 @@ public final class GroupCoreModelSchema extends AbstractModelSchema<GroupModel, 
     @Override
     protected Map<String, Attribute<GroupModel, Group>> getAttributeMappers() {
         List<Attribute<GroupModel, Group>> attributes = new ArrayList<>(Attribute.<GroupModel, Group>simple("displayName")
-                    .notCaseExact()
                     .modelAttributeResolver((attribute) -> {
                         if (attribute.getName().equals("displayName")) {
                             return "name";
@@ -107,6 +106,7 @@ public final class GroupCoreModelSchema extends AbstractModelSchema<GroupModel, 
                     })
                     .build());
         attributes.addAll(Attribute.<GroupModel, Group>simple("externalId")
+                .caseExact()
                 .immutable()
                 .string()
                 .withModelSetter(GroupModel::setSingleAttribute)

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
@@ -57,7 +57,6 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
 
         attributes.addAll(Attribute.<UserModel, User>simple("userName")
                 .required()
-                .notCaseExact()
                 .storedLowerCase()
                 .serverUnique()
                 .modelAttributeResolver(this::createModelAttributeResolver)
@@ -65,7 +64,6 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
                 .build());
         attributes.addAll(Attribute.<UserModel, User>complex("emails", Email.class)
                 .modelAttributeResolver(this::createModelAttributeResolver)
-                .notCaseExact()
                 .storedLowerCase()
                 .globalUnique()
                 .multivalued()
@@ -108,6 +106,7 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
                 .withModelSetter(UserModel::setSingleAttribute)
                 .build());
         attributes.addAll(Attribute.<UserModel, User>simple("externalId")
+                .caseExact()
                 .modelAttributeResolver(this::createModelAttributeResolver)
                 .withModelSetter(UserModel::setSingleAttribute)
                 .build());

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -487,6 +487,53 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
+    public void testFilterCaseInsensitiveByName() {
+        User bob = createUser("bob", "Robert", "Johnson", "bob@keycloak.org", true);
+        createUser("alice", "Alice", "Smith", "alice@keycloak.org", true);
+
+        String filter = ResourceFilter.filter().eq("name.givenName", "ROBERT").build();
+        ListResponse<User> response = client.users().getAll(filter);
+        assertSingleResult(response, bob.getUserName());
+
+        filter = ResourceFilter.filter().eq("name.familyName", "johnson").build();
+        response = client.users().getAll(filter);
+        assertSingleResult(response, bob.getUserName());
+    }
+
+    @Test
+    public void testFilterCaseInsensitiveByEnterpriseAttributes() {
+        addEnterpriseUserUserProfileAttributes();
+
+        User user1 = createEnterpriseUser("user1", "Engineering", "E1234", "Bruce Wayne");
+        createEnterpriseUser("user2", "QE", "E7763", "Lucius Fox");
+
+        String filter = ResourceFilter.filter().eq(ENTERPRISE_USER_SCHEMA + ":department", "engineering").build();
+        ListResponse<User> response = client.users().getAll(filter);
+        assertSingleResult(response, user1.getUserName());
+
+        filter = ResourceFilter.filter().sw(ENTERPRISE_USER_SCHEMA + ":costCenter", "amer").build();
+        response = client.users().getAll(filter);
+        assertThat(response.getTotalResults(), is(2));
+    }
+
+    @Test
+    public void testFilterExternalIdRemainsCaseExact() {
+        addOrReplaceUPAttribute("externalId");
+
+        User user = new User();
+        user.setUserName("bob");
+        user.setExternalId("EXT-Bob-01");
+        user = client.users().create(user);
+        userIdsToRemove.add(user.getId());
+
+        String filter = ResourceFilter.filter().eq("externalId", "ext-bob-01").build();
+        assertNoResults(client.users().getAll(filter));
+
+        filter = ResourceFilter.filter().eq("externalId", "EXT-Bob-01").build();
+        assertSingleResult(client.users().getAll(filter), user.getUserName());
+    }
+
+    @Test
     public void testFilterByEmail() {
         User bob = createUser("bob", "Robert", "Johnson", "bob@keycloak.org", true);
         User alice = createUser("alice", "Alice", "Smith", "alice@keycloak.org", true);

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/SchemaTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/SchemaTest.java
@@ -98,18 +98,18 @@ public class SchemaTest extends AbstractScimTest {
 
         assertAttribute(findAttribute(schema, "userName"), "string", false, true, false, "readWrite", "server");
         assertAttribute(findAttribute(schema, "emails"), "complex", true, false, false, "readWrite", "global");
-        assertAttribute(findAttribute(schema, "name"), "complex", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "displayName"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "title"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "name"), "complex", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "displayName"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "title"), "string", false, false, false, "readWrite", "none");
         assertAttribute(findAttribute(schema, "externalId"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "userType"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "nickName"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "locale"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "timezone"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "preferredLanguage"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "profileUrl"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "active"), "boolean", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "groups"), "complex", true, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "userType"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "nickName"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "locale"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "timezone"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "preferredLanguage"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "profileUrl"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "active"), "boolean", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "groups"), "complex", true, false, false, "readWrite", "none");
 
         // Verify name sub-attributes
         Schema.Attribute name = findAttribute(schema, "name");
@@ -146,7 +146,7 @@ public class SchemaTest extends AbstractScimTest {
 
         assertAttribute(findAttribute(schema, "displayName"), "string", false, false, false, "readWrite", "none");
         assertAttribute(findAttribute(schema, "externalId"), "string", false, false, true, "immutable", "none");
-        assertAttribute(findAttribute(schema, "members"), "complex", true, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "members"), "complex", true, false, false, "readWrite", "none");
     }
 
     @Test
@@ -167,11 +167,11 @@ public class SchemaTest extends AbstractScimTest {
         assertEquals(6, attributeNames.size(), "Enterprise User schema should have exactly 6 attributes");
 
         // Simple string attributes
-        assertAttribute(findAttribute(schema, "employeeNumber"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "costCenter"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "organization"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "division"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "department"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "employeeNumber"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "costCenter"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "organization"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "division"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "department"), "string", false, false, false, "readWrite", "none");
 
         // Manager is a complex attribute with sub-attributes
         assertAttribute(findAttribute(schema, "manager"), "complex", false, false, false, "readWrite", "none");
@@ -206,8 +206,8 @@ public class SchemaTest extends AbstractScimTest {
                 .map(Schema.Attribute::getName)
                 .collect(Collectors.toSet());
         assertEquals(2, attributeNames.size());
-        assertAttribute(findAttribute(schema, "myattribute"), "string", false, false, true, "readWrite", "none");
-        assertAttribute(findAttribute(schema, "team"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "myattribute"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "team"), "string", false, false, false, "readWrite", "none");
 
         schema = client.schemas().get(barSchema);
         attributeNames = schema.getAttributes().stream()
@@ -215,7 +215,7 @@ public class SchemaTest extends AbstractScimTest {
                 .collect(Collectors.toSet());
         assertEquals(1, attributeNames.size());
         // Simple string attributes
-        assertAttribute(findAttribute(schema, "other"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "other"), "string", false, false, false, "readWrite", "none");
     }
 
     @Test


### PR DESCRIPTION
Closes #51593

The SCIM attribute schemas defaulted `caseExact` to `true`, while RFC 7643 defines `false` as the default and marks every User, Group and EnterpriseUser string attribute as case insensitive. 

Filters on attributes like `name.givenName` or `department` therefore only matched exact case values, deviating from the Admin API's search semantics.

This flips the schema builder default to `false` per the RFC and pins `externalId` as `caseExact=true` (RFC 7643 section 3.1). The predicate lowering now only applies to string values, so timestamp and boolean attributes are unaffected by the new default. The admin-v2 client schema keeps its string attributes case-exact, since clientId matching is case sensitive everywhere else in Keycloak. The `/Schemas` endpoint reads the same definitions, so its metadata is corrected as well.

New filter tests cover mixed case matching on name sub attributes and enterprise attributes, plus one asserting `externalId` remains case exact; schema test expectations updated to the RFC values. The new tests fail without the fix, and the full SCIM testsuite passes with it.