### PR TITLE
Client baseUrl URI-scheme validation missing during realm and partial…

### DIFF
--- a/services/src/main/java/org/keycloak/partialimport/ClientsPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/ClientsPartialImport.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -34,6 +36,8 @@ import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.PartialImportRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.services.ErrorResponse;
+import org.keycloak.validation.ValidationUtil;
 
 import org.jboss.logging.Logger;
 
@@ -124,6 +128,11 @@ public class ClientsPartialImport extends AbstractPartialImport<ClientRepresenta
             OIDCAdvancedConfigWrapper.fromClientModel(client).setPostLogoutRedirectUris(Collections.singletonList("+"));
         }
         RepresentationToModel.importAuthorizationSettings(clientRep, client, session);
+
+        ValidationUtil.validateClient(session, client, true, r -> {
+            session.getTransactionManager().setRollbackOnly();
+            throw ErrorResponse.error("Failed to import client " + client.getClientId() + ": " + r.getAllErrorsAsString(), Response.Status.BAD_REQUEST);
+        });
     }
 
     public static boolean isInternalClient(String clientId) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.UserResource;
@@ -14,6 +16,7 @@ import org.keycloak.partialimport.PartialImportResult;
 import org.keycloak.partialimport.PartialImportResults;
 import org.keycloak.partialimport.ResourceType;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ErrorRepresentation;
 import org.keycloak.representations.idm.PartialImportRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
@@ -186,5 +189,25 @@ public class PartialImportClientTest extends AbstractPartialImportTest {
 
         ClientRepresentation client = managedRealm.admin().clients().findByClientId(CLIENT_SERVICE_ACCOUNT).get(0);
         Assertions.assertDoesNotThrow(() -> managedRealm.admin().clients().get(client.getId()).getServiceAccountUser());
+    }
+
+    @Test
+    public void testIllegalSchemeBaseUrlPartialImport() {
+        setFail();
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("evil-partial-import-test");
+        client.setEnabled(true);
+        client.setPublicClient(true);
+        client.setRedirectUris(List.of("http://localhost/*"));
+        client.setBaseUrl("javascript:confirm(document.domain)/*");
+        piRep.setClients(List.of(client));
+
+        try (Response response = managedRealm.admin().partialImport(piRep)) {
+            ErrorRepresentation errorRep = response.readEntity(ErrorRepresentation.class);
+            assertEquals(400, response.getStatus());
+            assertEquals("Failed to import client evil-partial-import-test: Base URL uses an illegal scheme", errorRep.getErrorMessage());
+        }
+
+        assertTrue(managedRealm.admin().clients().findByClientId("evil-partial-import-test").isEmpty());
     }
 }


### PR DESCRIPTION
… import

closes #50123

During full realm import OR during single client import, the client urls were already validated. The only missing "path" was the partial import, which is fixed in this PR
