### PR TITLE
Create the changelog table in the manual migration export for an empty database

### DIFF
--- a/docs/documentation/upgrading/topics/migrate_db.adoc
+++ b/docs/documentation/upgrading/topics/migrate_db.adoc
@@ -69,6 +69,16 @@ kc.[sh|bat] start --spi-connections-jpa--quarkus--migration-export=<path>/<file.
 
 After the changes have been written to the file, the server exits.
 
+For an empty database the script also creates the Liquibase `DATABASECHANGELOG` table, which it records the applied
+changesets in. It does not create the `DATABASECHANGELOGLOCK` table: {project_name} creates that one itself on
+startup, so it is missing from a database that was only ever set up by running the script.
+
+Keep this in mind when the database user is not allowed to create tables. Even with the manual strategy,
+{project_name} creates both Liquibase bookkeeping tables, `DATABASECHANGELOG` and `DATABASECHANGELOGLOCK`, on the
+database it is started against. Have an administrator create them up front, both on the database used to generate
+the script and on the database the script is applied to. When they already exist, the generated script contains no
+`CREATE TABLE` for them, so it can also be applied to the database it was generated from.
+
 For further details on how to run the statements in the file against the database, see the documentation for your relational database.
 
 Once you have run the statements, you can start the new {project_name} version.

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/LiquibaseJpaUpdaterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/LiquibaseJpaUpdaterProvider.java
@@ -53,6 +53,7 @@ import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddColumnStatement;
+import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
 import liquibase.statement.core.SetNullableStatement;
 import liquibase.statement.core.UpdateStatement;
 import liquibase.structure.core.Column;
@@ -68,10 +69,14 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
     private static final Logger logger = Logger.getLogger(LiquibaseJpaUpdaterProvider.class);
 
     public static final String CHANGELOG = "META-INF/jpa-changelog-master.xml";
+    private static final String MASTER_CHANGELOG_TABLE = "DATABASECHANGELOG";
 
     public static final String DEPLOYMENT_ID_COLUMN = "DEPLOYMENT_ID";
 
     private final KeycloakSession session;
+    // Did the master changelog table already exist when this server started, before validation created it?
+    // Only the master table is relevant: Liquibase still writes the DDL of custom provider changelog tables itself.
+    private Boolean masterChangelogTablePreExisted;
 
     public LiquibaseJpaUpdaterProvider(KeycloakSession session) {
         this.session = session;
@@ -136,6 +141,11 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
         String changelog = liquibase.getChangeLogFile();
         Database database = liquibase.getDatabase();
         Table changelogTable = SnapshotGeneratorFactory.getInstance().getDatabaseChangeLogTable(new SnapshotControl(database, false, Table.class, Column.class), database);
+        // Validation is not always run before an update, and nothing has touched the changelog table yet at this
+        // point, so record its state here as well.
+        if (masterChangelogTablePreExisted == null && isMasterChangelogTable(database)) {
+            masterChangelogTablePreExisted = changelogTable != null;
+        }
 
         if (changelogTable != null) {
             boolean hasDeploymentIdColumn = changelogTable.getColumn(DEPLOYMENT_ID_COLUMN) != null;
@@ -210,10 +220,22 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
         loggingExecutor.comment("* Keycloak database creation script - apply this script to empty DB *");
         loggingExecutor.comment("*********************************************************************" + StreamUtil.getLineSeparator());
 
-        // DatabaseChangeLogTable is automatically added to the script by Liquibase
+        // Liquibase adds the changelog table DDL to the script itself, but only while the table does not exist yet.
+        // Since Liquibase 4.33 parsing a changelog initializes the change log history service (DatabaseChangeLog
+        // creates the table on the live connection), so by the time the export is written the table is already
+        // there and Liquibase no longer emits it - leaving a script that inserts into a table it never creates,
+        // even though its header offers it as a creation script for an empty database. Emit the statement here
+        // instead, but only when the table was absent before this server started: an administrator may have
+        // pre-created it so that a user without DDL rights could produce the script at all, and in that case the
+        // target database already has the table and the DDL would fail the script with "already exists".
         // DatabaseChangeLogLockTable is created before this code is executed and recreated if it does not exist automatically
         // in org.keycloak.connections.jpa.updater.liquibase.lock.CustomLockService.init() called indirectly from
         // KeycloakApplication constructor (search for waitForLock() call). Hence it is not included in the creation script.
+        if (isMasterChangelogTable(database) && Boolean.FALSE.equals(masterChangelogTablePreExisted)) {
+            // Same comment Liquibase emits when it writes this statement itself
+            loggingExecutor.comment("Create Database Change Log Table");
+            loggingExecutor.execute(new CreateDatabaseChangeLogTableStatement());
+        }
 
         // For MySQL, add primary key to DATABASECHANGELOG table (handled by MySQLCustomChangeLogHistoryService at runtime)
         ChangeLogHistoryService changeLogHistoryService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
@@ -270,6 +292,7 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
 
     protected Status validateChangeSet(KeycloakLiquibase liquibase, String changelog) throws LiquibaseException {
         final Status result;
+        recordWhetherMasterChangelogTablePreExisted(liquibase.getDatabase());
         List<ChangeSet> changeSets = getLiquibaseUnrunChangeSets(liquibase);
 
         if (!changeSets.isEmpty()) {
@@ -294,6 +317,18 @@ public class LiquibaseJpaUpdaterProvider implements JpaUpdaterProvider {
     private void resetLiquibaseServices(KeycloakLiquibase liquibase) {
         liquibase.resetServices();
         ChangeLogHistoryServiceFactory.getInstance().register(new MySQLCustomChangeLogHistoryService());
+    }
+
+    private void recordWhetherMasterChangelogTablePreExisted(Database database) throws LiquibaseException {
+        if (masterChangelogTablePreExisted == null && isMasterChangelogTable(database)) {
+            Table table = SnapshotGeneratorFactory.getInstance()
+                    .getDatabaseChangeLogTable(new SnapshotControl(database, false, Table.class, Column.class), database);
+            masterChangelogTablePreExisted = table != null;
+        }
+    }
+
+    private static boolean isMasterChangelogTable(Database database) {
+        return MASTER_CHANGELOG_TABLE.equalsIgnoreCase(database.getDatabaseChangeLogTableName());
     }
 
     private List<ChangeSet> getLiquibaseUnrunChangeSets(Liquibase liquibase) throws LiquibaseException {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusJpaUpdaterProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusJpaUpdaterProvider.java
@@ -56,6 +56,7 @@ import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddColumnStatement;
+import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
 import liquibase.statement.core.SetNullableStatement;
 import liquibase.statement.core.UpdateStatement;
 import liquibase.structure.core.Column;
@@ -68,11 +69,15 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
     private static final Logger logger = Logger.getLogger(QuarkusJpaUpdaterProvider.class);
 
     public static final String CHANGELOG = "META-INF/jpa-changelog-master.xml";
+    private static final String MASTER_CHANGELOG_TABLE = "DATABASECHANGELOG";
     private static final String DEPLOYMENT_ID_COLUMN = "DEPLOYMENT_ID";
     public static final String VERIFY_AND_RUN_MASTER_CHANGELOG = "VERIFY_AND_RUN_MASTER_CHANGELOG";
 
     private final KeycloakSession session;
     private Map<String, List<ChangeSet>> changeSets = new HashMap<>();
+    // Did the master changelog table already exist when this server started, before validation created it?
+    // Only the master table is relevant: Liquibase still writes the DDL of custom provider changelog tables itself.
+    private Boolean masterChangelogTablePreExisted;
 
     public QuarkusJpaUpdaterProvider(KeycloakSession session) {
         this.session = session;
@@ -139,6 +144,11 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
         String changelog = liquibase.getChangeLogFile();
         Database database = liquibase.getDatabase();
         Table changelogTable = SnapshotGeneratorFactory.getInstance().getDatabaseChangeLogTable(new SnapshotControl(database, false, Table.class, Column.class), database);
+        // Validation is not always run before an update, and nothing has touched the changelog table yet at this
+        // point, so record its state here as well.
+        if (masterChangelogTablePreExisted == null && isMasterChangelogTable(database)) {
+            masterChangelogTablePreExisted = changelogTable != null;
+        }
 
         if (changelogTable != null) {
             boolean hasDeploymentIdColumn = changelogTable.getColumn(DEPLOYMENT_ID_COLUMN) != null;
@@ -213,10 +223,22 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
         loggingExecutor.comment("* Keycloak database creation script - apply this script to empty DB *");
         loggingExecutor.comment("*********************************************************************" + StreamUtil.getLineSeparator());
 
-        // DatabaseChangeLogTable is automatically added to the script by Liquibase
+        // Liquibase adds the changelog table DDL to the script itself, but only while the table does not exist yet.
+        // Since Liquibase 4.33 parsing a changelog initializes the change log history service (DatabaseChangeLog
+        // creates the table on the live connection), so by the time the export is written the table is already
+        // there and Liquibase no longer emits it - leaving a script that inserts into a table it never creates,
+        // even though its header offers it as a creation script for an empty database. Emit the statement here
+        // instead, but only when the table was absent before this server started: an administrator may have
+        // pre-created it so that a user without DDL rights could produce the script at all, and in that case the
+        // target database already has the table and the DDL would fail the script with "already exists".
         // DatabaseChangeLogLockTable is created before this code is executed and recreated if it does not exist automatically
         // in org.keycloak.connections.jpa.updater.liquibase.lock.CustomLockService.init() called indirectly from
         // KeycloakApplication constructor (search for waitForLock() call). Hence it is not included in the creation script.
+        if (isMasterChangelogTable(database) && Boolean.FALSE.equals(masterChangelogTablePreExisted)) {
+            // Same comment Liquibase emits when it writes this statement itself
+            loggingExecutor.comment("Create Database Change Log Table");
+            loggingExecutor.execute(new CreateDatabaseChangeLogTableStatement());
+        }
 
         // For MySQL, add primary key to DATABASECHANGELOG table (handled by MySQLCustomChangeLogHistoryService at runtime)
         ChangeLogHistoryService changeLogHistoryService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
@@ -268,6 +290,7 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
 
     protected Status validateChangeSet(KeycloakLiquibase liquibase, String changelog) throws LiquibaseException {
         final Status result;
+        recordWhetherMasterChangelogTablePreExisted(liquibase.getDatabase());
         List<ChangeSet> changeSets = getLiquibaseUnrunChangeSets(liquibase);
 
         if (!changeSets.isEmpty()) {
@@ -296,6 +319,18 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
 
     private ChangeLogHistoryServiceFactory getChangeLogHistoryService() {
         return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
+    }
+
+    private void recordWhetherMasterChangelogTablePreExisted(Database database) throws LiquibaseException {
+        if (masterChangelogTablePreExisted == null && isMasterChangelogTable(database)) {
+            Table table = SnapshotGeneratorFactory.getInstance()
+                    .getDatabaseChangeLogTable(new SnapshotControl(database, false, Table.class, Column.class), database);
+            masterChangelogTablePreExisted = table != null;
+        }
+    }
+
+    private static boolean isMasterChangelogTable(Database database) {
+        return MASTER_CHANGELOG_TABLE.equalsIgnoreCase(database.getDatabaseChangeLogTableName());
     }
 
     private List<ChangeSet> getLiquibaseUnrunChangeSets(Liquibase liquibase) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManualMigrationCustomProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManualMigrationCustomProviderDistTest.java
@@ -33,7 +33,9 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DistributionTest
@@ -66,5 +68,14 @@ public class ManualMigrationCustomProviderDistTest {
         }
 
         assertThat(output, containsString("MIGRATION_TEST_ENTITY"));
+
+        // The custom provider gets its own changelog table, which the script inserts into, so it has to create
+        // it as well - exactly once, and before the first insert.
+        String createTable = "CREATE TABLE PUBLIC.DATABASECHANGELOG_MIGRATION_ (";
+        String insertInto = "INSERT INTO PUBLIC.DATABASECHANGELOG_MIGRATION_ (";
+        assertThat("custom changelog table must be created exactly once",
+                output.split(java.util.regex.Pattern.quote(createTable), -1).length - 1, is(1));
+        assertThat("custom changelog table must be created before it is inserted into",
+                output.indexOf(createTable), lessThan(output.indexOf(insertInto)));
     }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManualMigrationEmptyDatabaseDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManualMigrationEmptyDatabaseDistTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.regex.Pattern;
+
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.KeycloakRunner;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.utils.RawDistRootPath;
+import org.keycloak.it.utils.RawKeycloakDistribution;
+
+import io.quarkus.deployment.util.FileUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DistributionTest
+@RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SLOW)
+public class ManualMigrationEmptyDatabaseDistTest {
+
+    private static final String CREATE_CHANGELOG_TABLE = "CREATE TABLE PUBLIC.DATABASECHANGELOG (";
+    private static final String INSERT_INTO_CHANGELOG = "INSERT INTO PUBLIC.DATABASECHANGELOG (";
+
+    /**
+     * The manual migration strategy exists for database users without DDL privileges. On an empty
+     * database the generated script announces itself as a creation script to be applied to an empty
+     * database, so it has to contain the DDL of the Liquibase changelog table it inserts into.
+     */
+    @Test
+    void testEmptyDatabaseExportContainsChangelogTableDdl(KeycloakRunner runner, RawDistRootPath rawDistRootPath) throws IOException {
+        // force a completely empty database
+        RawKeycloakDistribution rawDist = runner.getDistribution(RawKeycloakDistribution.class);
+        FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
+
+        CLIResult result = runner.run("start-dev",
+                "--spi-connections-jpa-quarkus-migration-strategy=manual",
+                "--spi-connections-jpa-quarkus-initialize-empty=false");
+
+        result.assertMessage("Database not initialized, please initialize database with");
+
+        File script = rawDistRootPath.getDistRootPath().resolve("bin").resolve("keycloak-database-update.sql").toFile();
+        assertTrue(script.isFile(), "Export file must exist when migration-strategy=manual");
+
+        String output = FileUtils.readFileToString(script, Charset.defaultCharset());
+
+        assertThat(output, containsString("Keycloak database creation script - apply this script to empty DB"));
+
+        // The script inserts into the changelog table, so it has to create it as well. Exactly once:
+        // emitting it twice makes the script fail with "table already exists" instead.
+        assertThat("changelog table must be created exactly once",
+                countOccurrences(output, CREATE_CHANGELOG_TABLE), is(1));
+
+        // ... and it has to be created before the first row is inserted into it.
+        assertThat("changelog table must be created before it is inserted into",
+                output.indexOf(CREATE_CHANGELOG_TABLE), lessThan(output.indexOf(INSERT_INTO_CHANGELOG)));
+
+        // changeSetExecuted preconditions are resolved against the changelog table, so it must still exist while
+        // the script is generated. Were it missing, they would all resolve to "not executed" and changesets that
+        // should be marked as ran would be emitted instead - this one carries MySQL-only index syntax.
+        assertThat(output, not(containsString("VALUE(255)")));
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        return haystack.split(Pattern.quote(needle), -1).length - 1;
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/BasicDatabaseTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.utils.RawDistRootPath;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -93,6 +95,13 @@ public abstract class BasicDatabaseTest {
 
         assertThat(output, notNullValue());
         assertThat(output, containsString("Keycloak database creation script - apply this script to empty DB"));
+        assertThat(output, containsString("Create Database Change Log Table"));
+
+        // The script inserts into the changelog table, so it has to create it - once, or applying it fails
+        var outputLowerCase = output.toLowerCase(Locale.ROOT);
+        var count = countMatches(outputLowerCase, "create table public.databasechangelog (")
+                + countMatches(outputLowerCase, "create table keycloak.databasechangelog (");
+        assertThat(count, is(1));
         assertThat(output, containsString("Change Log: META-INF/jpa-changelog-master.xml"));
         assertThat(output, containsString("Changeset META-INF/jpa-changelog-26.2.6.xml"));
 


### PR DESCRIPTION
Closes #51729

## What

With `migration-strategy=manual` against an empty database, the generated script offers itself as a creation
script for an empty database but inserts into `DATABASECHANGELOG` without creating it, so it cannot be applied.

Liquibase writes that DDL into the script only while the table does not exist. Since Liquibase 4.33 parsing a
changelog initializes the change log history service (`DatabaseChangeLog`), which creates the table on the live
connection, so by the time the export is written Liquibase no longer emits it.

This restores the guarantee added in #32535 / PR #37204, together with the two assertions that were dropped from
`BasicDatabaseTest` in #41299 / PR #41490.

## How

`outputChangeLogTableCreationScript` emits `CreateDatabaseChangeLogTableStatement` explicitly, guarded on two
conditions:

* the table did **not** exist before this server started — an administrator may have created the bookkeeping
  tables up front so a user without DDL rights can produce the script at all, and in that case the target
  database already has the table and the DDL would break the script with `already exists`. This is the case
  PR #37204 was originally fixing, so the guard is what keeps that fix intact;
* it is the master changelog table — custom `JpaEntityProvider` changelog tables are still emitted by Liquibase
  itself (verified: `DATABASECHANGELOG_MIGRATION_` appears exactly once on `main`), so emitting them here too
  would duplicate.

Whether the table pre-existed is recorded in `validateChangeSet` and in `updateChangeSet`; the latter is needed
because validation returns as soon as one changelog is out of date, so custom providers may not be seen there.

The same change is applied to the legacy `LiquibaseJpaUpdaterProvider`, as in fe40730aed.

## Testing

New `ManualMigrationEmptyDatabaseDistTest` (H2, raw dist, empty database) asserts the script:

* contains the changelog table DDL — **exactly once**, since emitting it twice breaks the script just as badly;
* creates the table **before** the first insert into it;
* still marks `client-attributes-string-accomodation-fixed-post-create-index` as `MARK_RAN` (asserted as the
  absence of its MySQL-only `VALUE(255)` index syntax). `changeSetExecuted` preconditions with
  `onSqlOutput="TEST"` are resolved against the physical changelog table, so this pins that the fix does not
  remove it.

`ManualMigrationCustomProviderDistTest` gains the same once/ordering assertions for a custom provider's
bookkeeping table.

The two assertions removed in PR #41490 are restored in `BasicDatabaseTest.assertManualDbInitialization`, so
`PostgreSQLDistTest`, `MySQLDistTest` and `MariaDBDistTest` guard this again.

Verified end to end on PostgreSQL 17 with an empty schema — the generated script applies with
`psql -v ON_ERROR_STOP=1` (exit 0, 99 tables), after which the server starts with `migration-strategy=validate`.
Applying to a database whose bookkeeping tables were pre-created still works, i.e. no `already exists`.

Run against PostgreSQL (7 tests), MySQL (3) and MariaDB (3) through the `test-database` profile, which is where
the restored `assertManualDbInitialization` assertions apply. The MySQL path matters here because
`MySQLCustomChangeLogHistoryService` adds the changelog table's primary key to the script; the `CREATE TABLE`
is emitted before that `ALTER TABLE`.

The upgrade path is unaffected, which I checked separately on PostgreSQL: with an already migrated database
rolled back by one release, the generated script contains the 23 pending changesets and no `CREATE TABLE` for
either bookkeeping table — `outputChangeLogTableCreationScript` is only reached when no changeset has run yet.

### Out of scope

`DATABASECHANGELOGLOCK` remains absent from the script — it is created by `CustomLockService` on startup, which
is why it was excluded in the first place, and that is unchanged here. So a database populated only by running
the script still lacks the lock table, and the first server start against it needs the privilege to create that
one table (in the run above the server was started with an owner role, which has it). The documentation change
in this PR states that; making manual mode work for a database user with no DDL privileges at all is a larger
question I would rather raise separately.

## Documentation

`docs/documentation/upgrading/topics/migrate_db.adoc` — the "Manual relational database migration" section did
not mention `initialize-empty=false`, although manual mode is silently skipped without it on an empty database.
Added, together with a note that the two Liquibase bookkeeping tables are still created on startup, so a user
without DDL rights needs them created up front.

## Note on AI assistance

AI agents were used while investigating this and while drafting the change, tests and documentation. I have
reviewed and understand every line, ran the verification described above myself, and will handle review feedback
directly.
