### PR TITLE
Validate unrecognized SCIM attributes and schemas

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/resource/ResourceTypeRepresentation.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/ResourceTypeRepresentation.java
@@ -53,6 +53,18 @@ public abstract class ResourceTypeRepresentation {
         this.schemas = schemas;
     }
 
+    /**
+     * Returns the {@code schemas} array exactly as submitted by the client, without the subclass normalization
+     * applied by {@link #getSchemas()} (e.g. {@link org.keycloak.scim.resource.group.Group} pinning the value to
+     * the core Group schema, or the User representation injecting the enterprise schema). Used for request
+     * validation so that unrecognized submitted schema URIs are rejected regardless of how {@link #getSchemas()}
+     * is overridden. Returns {@code null} when the client omitted {@code schemas}.
+     */
+    @JsonIgnore
+    public Set<String> getSubmittedSchemas() {
+        return schemas;
+    }
+
     public String getId() {
         return id;
     }

--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
@@ -17,8 +18,11 @@ import org.keycloak.scim.protocol.request.PatchRequest.PatchOperation;
 import org.keycloak.scim.resource.ResourceTypeRepresentation;
 import org.keycloak.scim.resource.schema.ModelSchema;
 import org.keycloak.scim.resource.schema.attribute.Attribute;
+import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 
 import static java.util.function.Predicate.not;
 
@@ -32,6 +36,12 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
      * This limit is not advertised via {@code /ServiceProviderConfig}.
      */
     public static final int MAX_PATCH_OPERATIONS = 100;
+
+    /**
+     * Cache of the canonical sub-attribute names of a complex attribute's backing Java type, keyed by that
+     * type. Populated lazily via Jackson bean introspection (see {@link #getComplexSubAttributes(Class)}).
+     */
+    private static final Map<Class<?>, Set<String>> COMPLEX_SUB_ATTRIBUTES = new ConcurrentHashMap<>();
 
     private final ModelSchema<M, R> schema;
     private final List<ModelSchema<M, R>> schemaExtensions;
@@ -161,8 +171,13 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
     /**
      * Validates that a PATCH operation path targets a recognized attribute. The path is first normalized
      * by stripping any filter expressions (e.g. {@code emails[type eq "work"].value} becomes {@code emails.value}),
-     * then checked against recognized schema URIs, attribute paths, and attribute name prefixes. Throws
+     * then checked against recognized schema URIs and attribute paths. Throws
      * {@link ScimNoTargetException} (HTTP 400, {@code scimType=noTarget}) if the path is not recognized.
+     *
+     * <p>A sub-attribute path such as {@code emails.type} or {@code name.givenName} is only accepted when the
+     * sub-attribute actually exists: either it is individually declared (e.g. {@code name.givenName}) or it is a
+     * canonical member of the complex attribute's backing type (e.g. {@code emails.type}). An unknown descendant
+     * such as {@code emails.bogus} or {@code name.bogus} is rejected rather than accepted by a loose prefix match.
      */
     private void validatePatchPath(String rawPath) {
         String normalizedPath = normalizePath(rawPath);
@@ -173,23 +188,56 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
         }
 
         for (ModelSchema<M, R> s : schemas) {
+            // resolves simple attributes, individually declared sub-attributes (e.g. name.givenName), the
+            // synthesized "<attr>.value" of a multi-valued complex attribute, and all extension path forms
             if (s.getAttributeByPath(normalizedPath) != null) {
                 return;
             }
             for (Attribute<M, R> attr : s.getAttributes().values()) {
                 String attrName = attr.getName();
                 String parentName = attr.getParentName();
+
+                // exact match on an attribute name, or on the bare parent of a declared complex attribute
+                // whose sub-attributes are individually registered (e.g. the bare "name" of "name.givenName")
                 if (normalizedPath.equalsIgnoreCase(attrName)
-                        || normalizedPath.toLowerCase().startsWith(attrName.toLowerCase() + ".")
-                        || (parentName != null && (normalizedPath.equalsIgnoreCase(parentName)
-                            || normalizedPath.toLowerCase().startsWith(parentName.toLowerCase() + ".")))) {
+                        || (parentName != null && normalizedPath.equalsIgnoreCase(parentName))) {
                     return;
+                }
+
+                // a canonical sub-attribute of a complex attribute that is not individually declared, such as
+                // "emails.type"/"emails.primary" for the multi-valued "emails" (backed by Email). Only genuine
+                // canonical members are accepted; unknown descendants fall through and are rejected below.
+                Class<?> complexType = attr.getComplexType();
+                if (complexType != null) {
+                    for (String sub : getComplexSubAttributes(complexType)) {
+                        if (normalizedPath.equalsIgnoreCase(attrName + "." + sub)) {
+                            return;
+                        }
+                    }
                 }
             }
         }
 
         throw new ScimNoTargetException(
                 "The path '" + rawPath + "' does not target a recognized attribute");
+    }
+
+    /**
+     * Returns the canonical sub-attribute names of a complex attribute's backing Java type (e.g. for the SCIM
+     * {@code emails} attribute, backed by {@code Email}, this yields {@code value}, {@code display}, {@code type},
+     * {@code primary} and {@code $ref}). Names are derived via Jackson bean introspection so that {@code @JsonProperty}
+     * overrides (such as {@code $ref}) are honored, and cached per type since the mapping is static.
+     */
+    private static Set<String> getComplexSubAttributes(Class<?> complexType) {
+        return COMPLEX_SUB_ATTRIBUTES.computeIfAbsent(complexType, type -> {
+            Set<String> subs = new HashSet<>();
+            BeanDescription description = JsonSerialization.mapper.getSerializationConfig()
+                    .introspect(JsonSerialization.mapper.constructType(type));
+            for (BeanPropertyDefinition property : description.findProperties()) {
+                subs.add(property.getName());
+            }
+            return subs;
+        });
     }
 
     /**

--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
@@ -1,8 +1,8 @@
 package org.keycloak.scim.resource.spi;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -13,16 +13,24 @@ import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.Model;
 import org.keycloak.models.ModelValidationException;
+import org.keycloak.scim.filter.FilterUtils;
+import org.keycloak.scim.filter.ScimFilterException;
+import org.keycloak.scim.filter.ScimFilterParser;
+import org.keycloak.scim.filter.ScimFilterParserBaseVisitor;
 import org.keycloak.scim.protocol.ForbiddenException;
 import org.keycloak.scim.protocol.request.PatchRequest.PatchOperation;
 import org.keycloak.scim.resource.ResourceTypeRepresentation;
+import org.keycloak.scim.resource.group.Member;
 import org.keycloak.scim.resource.schema.ModelSchema;
 import org.keycloak.scim.resource.schema.attribute.Attribute;
+import org.keycloak.scim.resource.user.Email;
+import org.keycloak.scim.resource.user.GroupMembership;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import org.antlr.v4.runtime.tree.ParseTree;
 
 import static java.util.function.Predicate.not;
 
@@ -43,6 +51,29 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
      */
     private static final Map<Class<?>, Set<String>> COMPLEX_SUB_ATTRIBUTES = new ConcurrentHashMap<>();
 
+    /**
+     * Sub-attributes that a backing Java type inherits (from {@link org.keycloak.scim.resource.common.MultiValuedAttribute})
+     * but that are not part of the SCIM definition of the attributes it backs, and therefore must not be accepted.
+     * For example, {@code Member} (SCIM Group {@code members}) and {@code GroupMembership} (SCIM User {@code groups})
+     * are reference-style multi-valued attributes that do not define a {@code primary} sub-attribute, even though the
+     * shared bean declares one; conversely {@code Email} (SCIM User {@code emails}) does not define a {@code $ref}
+     * sub-attribute, even though it inherits one.
+     */
+    private static final Map<Class<?>, Set<String>> NON_SCHEMA_SUB_ATTRIBUTES = Map.of(
+            Member.class, Set.of("primary"),
+            GroupMembership.class, Set.of("primary"),
+            Email.class, Set.of("$ref"));
+
+    /**
+     * Common SCIM resource attributes ({@code id}, {@code schemas}, {@code meta}, {@code meta.resourceType},
+     * {@code meta.location}, {@code meta.version}) that are not backed by a {@link ModelSchema} {@link Attribute} - they are populated
+     * directly on the resource representation or computed by the service layer rather than mapped from the model.
+     * They are nonetheless recognized attribute paths so a PATCH targeting one of them is treated as a no-op
+     * (read-only attributes are ignored, not rejected) instead of failing with {@code noTarget}.
+     */
+    private static final Set<String> COMMON_READ_ONLY_PATHS = Set.of(
+            "id", "schemas", "meta", "meta.resourcetype", "meta.location", "meta.version");
+
     private final ModelSchema<M, R> schema;
     private final List<ModelSchema<M, R>> schemaExtensions;
 
@@ -55,7 +86,7 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
     public AbstractScimResourceTypeProvider(KeycloakSession session, ModelSchema<M, R> schema) {
         this(session, schema, List.of());
     }
-    
+
     @Override
     protected String getModelId(R resource) {
         return resource.getId();
@@ -77,6 +108,9 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
             throw new ForbiddenException();
         }
 
+        // computed once per request rather than per operation/field, as the recognized set is invariant
+        Set<String> recognized = getRecognizedSchemaUris();
+
         for (PatchOperation operation : operations) {
             String op = operation.getOp();
 
@@ -87,17 +121,39 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
             String path = operation.getPath();
             JsonNode value = operation.getValue();
 
-            if (!isBlank(path)) {
-                validatePatchPath(path);
-            } else if (value != null && value.isObject()) {
-                validatePatchValue(value);
+            if (isBlank(path)) {
+                // a blank (whitespace-only or empty) path is not a valid attribute path; treat it the same as an
+                // absent one so validation and application agree on this being a pathless operation
+                path = null;
+            }
+
+            if (path != null) {
+                if (value == null && !"remove".equalsIgnoreCase(op)) {
+                    // per RFC 7644 section 3.5.2, "add" and "replace" require a value; without this check a
+                    // missing/null value reaches the schema layer's own null check as an uncaught NPE (HTTP 500)
+                    // rather than a clean 400 response
+                    throw new ModelValidationException(
+                            "A '" + op + "' operation with an explicit path requires a value");
+                }
+                validateFilterAttributes(path, recognized);
+                validatePatchMember(path, value, recognized);
+            } else if (value != null && value.isObject() && !value.isEmpty()) {
+                validatePatchValue(value, recognized);
+            } else {
+                // per RFC 7644 section 3.5.2, a pathless add/replace must carry the attributes to modify as
+                // members of the value object; a scalar, null, array or empty value provides no target
+                throw new ModelValidationException("A pathless patch operation requires a non-empty object value");
             }
 
             for (ModelSchema<M, R> schema : schemas) {
-                switch (op.toLowerCase()) {
-                    case "add" -> schema.add(model, path, value);
-                    case "replace" -> schema.replace(existing, model, path, value);
-                    case "remove" -> schema.remove(existing, model, path);
+                // core attributes are stored unqualified; a fully-qualified core path must be stripped before
+                // being applied, mirroring the stripping already done for recognition in isRecognizedPath
+                String schemaPath = stripCorePrefix(schema, path);
+
+                switch (op.toLowerCase(Locale.ROOT)) {
+                    case "add" -> schema.add(model, schemaPath, value);
+                    case "replace" -> schema.replace(existing, model, schemaPath, value);
+                    case "remove" -> schema.remove(existing, model, schemaPath);
                     default -> throw new ModelValidationException("Unsupported patch operation " + op);
                 }
             }
@@ -108,7 +164,7 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
     public String getSchema() {
         return schema.getId();
     }
-    
+
     @Override
     public List<String> getSchemaExtensions() {
         return schemaExtensions.stream().filter(not(ModelSchema::isInternal)).map(ModelSchema::getId).toList();
@@ -138,16 +194,17 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
     }
 
     /**
-     * Validates that all schema URIs in the request's {@code schemas} array and all keys in the
-     * {@code extensions} map are recognized by at least one registered schema. Throws
-     * {@link ScimInvalidValueException} (HTTP 400, {@code scimType=invalidValue}) if any are not.
+     * Validates that all schema URIs in the request's {@code schemas} array and every attribute carried by the
+     * {@code extensions} map (including nested sub-attributes of complex extension attributes) are recognized by
+     * at least one registered schema. Throws {@link ScimInvalidValueException} (HTTP 400,
+     * {@code scimType=invalidValue}) if any are not.
      *
      * <p>Called from {@link #populate(Model, ResourceTypeRepresentation)} to validate POST and PUT requests.
      */
     private void validateSchemas(R resource) {
         Set<String> recognized = getRecognizedSchemaUris();
 
-        Set<String> requestSchemas = resource.getSchemas();
+        Set<String> requestSchemas = resource.getSubmittedSchemas();
         if (requestSchemas != null) {
             for (String uri : requestSchemas) {
                 if (!recognized.contains(uri)) {
@@ -163,36 +220,70 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
                 String key = entry.getKey();
                 if (!recognized.contains(key)) {
                     throw new ScimInvalidValueException(
-                            "Unrecognized attribute '" + key + "'");
+                            "Unrecognized schema URI '" + key + "'");
                 }
 
-                // the schema URI is recognized; validate the nested attributes it carries so that e.g.
-                // {"urn:custom:schema:User": {"bogus": "x"}} is rejected rather than silently ignored
-                Object value = entry.getValue();
-                if (value instanceof Map<?, ?> nested) {
-                    for (Object nestedKey : nested.keySet()) {
-                        String qualified = key + ":" + nestedKey;
-                        if (!isRecognizedPath(qualified)) {
-                            throw new ScimInvalidValueException(
-                                    "Unrecognized attribute '" + qualified + "'");
-                        }
+                // the schema URI is recognized; validate the attributes it carries, recursing into complex values,
+                // so that e.g. {"urn:custom:schema:User": {"bogus": "x"}} or an undeclared descendant of a complex
+                // attribute is rejected rather than silently ignored
+                JsonNode extension = JsonSerialization.mapper.valueToTree(entry.getValue());
+                if (extension.isObject()) {
+                    for (Map.Entry<String, JsonNode> member : extension.properties()) {
+                        validateExtensionMember(key + ":" + member.getKey(), member.getValue(), recognized, false);
                     }
+                } else {
+                    // a schema URI is a namespace that must carry an object of attributes; a scalar or array value
+                    // (e.g. {"urn:custom:schema:User": "x"}) targets no attribute and is rejected
+                    throw new ScimInvalidValueException(
+                            "Schema '" + key + "' must be a JSON object of attributes");
                 }
             }
         }
     }
 
     /**
-     * Validates that a PATCH operation path targets a recognized attribute, throwing
-     * {@link ScimNoTargetException} (HTTP 400, {@code scimType=noTarget}) if it does not.
-     *
-     * @see #isRecognizedPath(String)
+     * Validates a single PATCH member, i.e. an explicit operation {@code path}/{@code value} pair or a member of a
+     * pathless {@code value} object. When {@code name} is a recognized schema URI carrying a JSON object, its members
+     * are validated as schema-qualified attributes (e.g. {@code {"urn:...:User": {"bogus": "x"}}} is rejected because
+     * {@code urn:...:User:bogus} is unknown). Otherwise {@code name} is treated as an attribute path and validated
+     * together with the descendants of its {@code value}, so an object value carrying an unknown sub-attribute (e.g.
+     * {@code path="name", value={"bogus":"x"}}) is rejected rather than silently ignored. Throws
+     * {@link ScimNoTargetException} (HTTP 400, {@code scimType=noTarget}) for anything that does not target a
+     * recognized attribute.
      */
-    private void validatePatchPath(String rawPath) {
-        if (!isRecognizedPath(rawPath)) {
-            throw new ScimNoTargetException(
-                    "The path '" + rawPath + "' does not target a recognized attribute");
+    private void validatePatchMember(String name, JsonNode value, Set<String> recognized) {
+        if (recognized.contains(name)) {
+            // a recognized schema URI is a namespace, not an attribute: it must carry a non-empty object of
+            // attributes. A scalar, array or empty object value (e.g. {"urn:...:User": "x"} or {"urn:...:User": {}})
+            // targets no attribute and is rejected.
+            if (value == null || !value.isObject() || value.isEmpty()) {
+                throw new ScimNoTargetException(
+                        "The path '" + name + "' is a schema URI and must carry a non-empty object of attributes");
+            }
+            for (Map.Entry<String, JsonNode> nested : value.properties()) {
+                validateExtensionMember(name + ":" + nested.getKey(), nested.getValue(), recognized, true);
+            }
+        } else {
+            validateExtensionMember(name, value, recognized, true);
         }
+    }
+
+    /**
+     * Strips a fully-qualified core schema prefix (e.g. {@code urn:ietf:params:scim:schemas:core:2.0:User:}) from
+     * {@code path} when {@code s} is the core schema and {@code path} starts with that prefix; {@code path} is
+     * returned unchanged otherwise. Core attribute names are stored unqualified, so both attribute recognition
+     * ({@link #isRecognizedPath}) and application ({@link ModelSchema#add}/{@code replace}/{@code remove}) must
+     * resolve the same, unqualified form.
+     */
+    private static String stripCorePrefix(ModelSchema<?, ?> s, String path) {
+        if (path == null || !s.isCore()) {
+            return path;
+        }
+        String prefix = s.getId() + ":";
+        if (path.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            return path.substring(prefix.length());
+        }
+        return path;
     }
 
     /**
@@ -200,24 +291,39 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
      * by stripping any filter expressions (e.g. {@code emails[type eq "work"].value} becomes {@code emails.value}),
      * then checked against recognized schema URIs and attribute paths.
      *
+     * <p>Core attribute names are stored unqualified, so a fully-qualified core path such as
+     * {@code urn:ietf:params:scim:schemas:core:2.0:User:nickName} has its (core) schema prefix stripped before the
+     * attribute lookup - {@code getAttributeByPath} only strips the prefix for non-core schemas.
+     *
      * <p>A sub-attribute path such as {@code emails.type} or {@code name.givenName} is only recognized when the
      * sub-attribute actually exists: either it is individually declared (e.g. {@code name.givenName}) or it is a
      * canonical member of the complex attribute's backing type (e.g. {@code emails.type}). An unknown descendant
      * such as {@code emails.bogus} or {@code name.bogus} is not recognized (rather than accepted by a loose
      * prefix match).
      */
-    private boolean isRecognizedPath(String rawPath) {
+    private boolean isRecognizedPath(String rawPath, Set<String> recognized) {
         String normalizedPath = normalizePath(rawPath);
 
-        Set<String> recognized = getRecognizedSchemaUris();
+        if (COMMON_READ_ONLY_PATHS.contains(normalizedPath.toLowerCase(Locale.ROOT))) {
+            return true;
+        }
+
         if (recognized.contains(normalizedPath)) {
             return true;
         }
 
         for (ModelSchema<M, R> s : schemas) {
+            String localPath = stripCorePrefix(s, normalizedPath);
+
+            // a common read-only path may also be submitted with the (optional) core schema prefix, e.g.
+            // "urn:ietf:params:scim:schemas:core:2.0:User:id" - recheck against the stripped form too
+            if (COMMON_READ_ONLY_PATHS.contains(localPath.toLowerCase(Locale.ROOT))) {
+                return true;
+            }
+
             // resolves simple attributes, individually declared sub-attributes (e.g. name.givenName), the
             // synthesized "<attr>.value" of a multi-valued complex attribute, and all extension path forms
-            if (s.getAttributeByPath(normalizedPath) != null) {
+            if (s.getAttributeByPath(localPath) != null) {
                 return true;
             }
             for (Attribute<M, R> attr : s.getAttributes().values()) {
@@ -226,8 +332,8 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
 
                 // exact match on an attribute name, or on the bare parent of a declared complex attribute
                 // whose sub-attributes are individually registered (e.g. the bare "name" of "name.givenName")
-                if (normalizedPath.equalsIgnoreCase(attrName)
-                        || (parentName != null && normalizedPath.equalsIgnoreCase(parentName))) {
+                if (localPath.equalsIgnoreCase(attrName)
+                        || (parentName != null && localPath.equalsIgnoreCase(parentName))) {
                     return true;
                 }
 
@@ -237,7 +343,7 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
                 Class<?> complexType = attr.getComplexType();
                 if (complexType != null) {
                     for (String sub : getComplexSubAttributes(complexType)) {
-                        if (normalizedPath.equalsIgnoreCase(attrName + "." + sub)) {
+                        if (localPath.equalsIgnoreCase(attrName + "." + sub)) {
                             return true;
                         }
                     }
@@ -252,7 +358,8 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
      * Returns the canonical sub-attribute names of a complex attribute's backing Java type (e.g. for the SCIM
      * {@code emails} attribute, backed by {@code Email}, this yields {@code value}, {@code display}, {@code type},
      * {@code primary} and {@code $ref}). Names are derived via Jackson bean introspection so that {@code @JsonProperty}
-     * overrides (such as {@code $ref}) are honored, and cached per type since the mapping is static.
+     * overrides (such as {@code $ref}) are honored, minus any {@link #NON_SCHEMA_SUB_ATTRIBUTES inherited-but-undefined}
+     * sub-attributes, and cached per type since the mapping is static.
      */
     private static Set<String> getComplexSubAttributes(Class<?> complexType) {
         return COMPLEX_SUB_ATTRIBUTES.computeIfAbsent(complexType, type -> {
@@ -262,7 +369,8 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
             for (BeanPropertyDefinition property : description.findProperties()) {
                 subs.add(property.getName());
             }
-            return subs;
+            subs.removeAll(NON_SCHEMA_SUB_ATTRIBUTES.getOrDefault(type, Set.of()));
+            return Set.copyOf(subs);
         });
     }
 
@@ -271,43 +379,165 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
      * {@code add} and {@code replace} operations may omit {@code path} and instead carry the attributes to
      * modify as members of the {@code value} object. Each top-level member is treated as an attribute path
      * (or extension schema URI) and validated the same way as an explicit operation path. When a member is a
-     * recognized extension schema URI whose value is itself an object, its nested members are validated as
-     * schema-qualified attributes of that URI (e.g. {@code {"urn:...:enterprise:2.0:User": {"bogus": "x"}}} is
-     * rejected because {@code urn:...:enterprise:2.0:User:bogus} is not a recognized attribute). Throws
-     * {@link ScimNoTargetException} for any member that does not target a recognized attribute.
+     * recognized extension schema URI whose value is itself an object, its (possibly nested) members are validated
+     * as schema-qualified attributes of that URI (e.g. {@code {"urn:...:User": {"bogus": "x"}}} is rejected because
+     * {@code urn:...:User:bogus} is not a recognized attribute). Throws {@link ScimNoTargetException} for any member
+     * that does not target a recognized attribute.
      */
-    private void validatePatchValue(JsonNode value) {
-        Set<String> recognizedUris = getRecognizedSchemaUris();
+    private void validatePatchValue(JsonNode value, Set<String> recognized) {
         for (Map.Entry<String, JsonNode> member : value.properties()) {
-            String name = member.getKey();
-            JsonNode memberValue = member.getValue();
-
-            if (recognizedUris.contains(name) && memberValue != null && memberValue.isObject()) {
-                validateExtensionMembers(name, memberValue);
-            } else {
-                validatePatchPath(name);
-            }
+            validateFilterAttributes(member.getKey(), recognized);
+            validatePatchMember(member.getKey(), member.getValue(), recognized);
         }
     }
 
     /**
-     * Validates the members of a value object nested under a recognized extension schema URI. Each nested member
-     * is checked as the schema-qualified attribute {@code schemaUri:memberName}, throwing
-     * {@link ScimNoTargetException} for any member that does not target a recognized attribute of that schema.
+     * Validates the attributes referenced inside a value-path filter of a PATCH path (for example the {@code type}
+     * in {@code emails[type eq "work"].value}). Each such attribute must be a recognized sub-attribute of the
+     * multi-valued attribute the filter is applied to; otherwise {@link #normalizePath(String) normalization} would
+     * silently drop the filter, causing the operation to match nothing or - for {@code add}, which strips rather than
+     * evaluates the filter - to mutate the whole attribute instead of the targeted element. Both an unrecognized
+     * filter attribute and an unparseable filter expression propagate as {@link ScimFilterException} (HTTP 400,
+     * {@code scimType=invalidFilter}), consistent with RFC 7644 Table 9, which classifies PATCH path filter
+     * problems under {@code invalidFilter} rather than {@code noTarget}.
+     *
+     * <p>Only paths that actually contain a filter (a {@code '['}) are parsed, so this adds no overhead to
+     * unfiltered PATCH operations or to any read/search request.
+     *
+     * <p>The filter's attributes are only checked once the filtered attribute itself ({@code parent}) is confirmed
+     * to be recognized; otherwise this defers to the normal path-recognition check on the (filter-stripped) full
+     * path, so that e.g. {@code bogus[type eq "work"].value} is reported as {@code noTarget} (the "bogus" attribute
+     * does not exist at all) rather than {@code invalidFilter} (which would incorrectly suggest the filter itself,
+     * as opposed to the attribute it is applied to, is the problem).
      */
-    private void validateExtensionMembers(String schemaUri, JsonNode object) {
-        for (Iterator<String> names = object.fieldNames(); names.hasNext(); ) {
-            String qualified = schemaUri + ":" + names.next();
-            if (!isRecognizedPath(qualified)) {
-                throw new ScimNoTargetException(
-                        "The path '" + qualified + "' does not target a recognized attribute");
+    private void validateFilterAttributes(String rawPath, Set<String> recognized) {
+        int filterStart = rawPath.indexOf('[');
+        if (filterStart <= 0) {
+            return;
+        }
+        int filterEnd = rawPath.lastIndexOf(']');
+        if (filterEnd <= filterStart) {
+            // a missing or out-of-order closing ']' is a malformed filter, not a "target does not exist" condition
+            throw new ScimFilterException("Unbalanced filter delimiters in path '" + rawPath + "'");
+        }
+
+        String parent = rawPath.substring(0, filterStart);
+        if (!isRecognizedPath(parent, recognized)) {
+            return;
+        }
+
+        String filterExpression = rawPath.substring(filterStart + 1, filterEnd);
+
+        // let a malformed filter surface as ScimFilterException (-> invalidFilter); it is not a noTarget condition
+        ScimFilterParser.FilterContext filter = FilterUtils.parseFilter(filterExpression);
+
+        validateFilterScope(parent, filter, recognized, rawPath);
+    }
+
+    /**
+     * Validates the attributes referenced within a (possibly nested) value-path filter against the attribute path
+     * they are actually scoped to. A comparison or presence test's attribute is validated relative to {@code scope};
+     * a nested value-path (e.g. the {@code type} in {@code emails[type[value eq "x"]].value}) is itself validated
+     * against {@code scope}, and its own filter is then recursively validated against {@code scope + "." + type},
+     * not {@code scope} - so that a scalar sub-attribute used as a nested value-path (which cannot itself have
+     * sub-attributes) is correctly rejected rather than accepted because its operand happens to match some other
+     * sub-attribute of the outer attribute.
+     */
+    private void validateFilterScope(String scope, ParseTree tree, Set<String> recognized, String rawPath) {
+        new ScimFilterParserBaseVisitor<Void>() {
+            @Override
+            public Void visitComparisonExpression(ScimFilterParser.ComparisonExpressionContext ctx) {
+                checkAttribute(ctx.ATTRPATH().getText());
+                return null;
             }
+
+            @Override
+            public Void visitPresentExpression(ScimFilterParser.PresentExpressionContext ctx) {
+                checkAttribute(ctx.ATTRPATH().getText());
+                return null;
+            }
+
+            @Override
+            public Void visitValuePath(ScimFilterParser.ValuePathContext ctx) {
+                String nestedAttribute = ctx.ATTRPATH().getText();
+                checkAttribute(nestedAttribute);
+                validateFilterScope(scope + "." + nestedAttribute, ctx.expression(), recognized, rawPath);
+                return null;
+            }
+
+            private void checkAttribute(String attribute) {
+                if (!isRecognizedPath(scope + "." + attribute, recognized)) {
+                    // per RFC 7644 Table 9, a PATCH path filter problem is classified under invalidFilter, not
+                    // noTarget - the latter is reserved for a well-formed filter that matches no records
+                    throw new ScimFilterException("The filter attribute '" + attribute + "' in path '"
+                            + rawPath + "' does not target a recognized attribute");
+                }
+            }
+        }.visit(tree);
+    }
+
+    /**
+     * Validates a single attribute carried under a recognized schema URI (whether from a POST/PUT extensions map or
+     * a pathless PATCH value object), together with all of its descendants. The {@code path} is the schema-qualified
+     * attribute path (e.g. {@code urn:custom:schema:User:assurance}); when {@code value} is a complex object or an
+     * array of objects, its members are flattened into their dotted full paths (e.g. {@code ...:assurance.value}) and
+     * only those flattened leaves are checked for recognition. Intermediate nodes are not required to be standalone
+     * attributes because attribute resolution likewise resolves a nested value by its flattened dotted path
+     * (see {@code AbstractModelSchema#resolveAttributes}), e.g. a value {@code {"assurance":{"level":"x"}}} declared as
+     * {@code assurance.level} resolves directly - so an undeclared leaf such as {@code ...:assurance.bogus} is rejected
+     * while a legitimate {@code ...:assurance.level} is accepted even though bare {@code ...:assurance} is not itself a
+     * declared attribute. An empty object/array, or an array containing no object items, has no leaves to flatten;
+     * {@code path} itself is then validated instead, so a bogus attribute name cannot be smuggled in merely by
+     * giving it an empty or scalar-only value.
+     *
+     * @param patch when {@code true} an unrecognized leaf throws {@link ScimNoTargetException} (PATCH,
+     *              {@code scimType=noTarget}); otherwise {@link ScimInvalidValueException} (POST/PUT,
+     *              {@code scimType=invalidValue})
+     */
+    private void validateExtensionMember(String path, JsonNode value, Set<String> recognized, boolean patch) {
+        // descend through complex values, accumulating the dotted path, and validate only the flattened leaves.
+        // An empty object/array, or an array with no object items, has no leaves to descend into; fall through
+        // to validate the accumulated path itself so a bogus attribute name is not silently let through merely
+        // because the value it was given happens to be empty or an array of scalars.
+        if (value != null && value.isObject()) {
+            if (!value.isEmpty()) {
+                for (Map.Entry<String, JsonNode> child : value.properties()) {
+                    validateExtensionMember(path + "." + child.getKey(), child.getValue(), recognized, patch);
+                }
+                return;
+            }
+        } else if (value != null && value.isArray()) {
+            boolean hasLeaf = false;
+            for (JsonNode item : value) {
+                if (item != null && item.isObject() && !item.isEmpty()) {
+                    hasLeaf = true;
+                    for (Map.Entry<String, JsonNode> child : item.properties()) {
+                        validateExtensionMember(path + "." + child.getKey(), child.getValue(), recognized, patch);
+                    }
+                }
+            }
+            if (hasLeaf) {
+                return;
+            }
+        }
+
+        // scalar or null leaf, or an empty/scalar-only container with no leaves of its own: the accumulated
+        // (flattened) path must target a recognized attribute
+        if (!isRecognizedPath(path, recognized)) {
+            if (patch) {
+                throw new ScimNoTargetException(
+                        "The path '" + path + "' does not target a recognized attribute");
+            }
+            throw new ScimInvalidValueException("Unrecognized attribute '" + path + "'");
         }
     }
 
     /**
      * Strips filter expressions from a PATCH path so that only the structural attribute path remains.
-     * For example, {@code emails[type eq "work"].value} becomes {@code emails.value}.
+     * For example, {@code emails[type eq "work"].value} becomes {@code emails.value}. The character immediately
+     * following the closing {@code ']'} must be a {@code '.'} or the end of the path; anything else (e.g. the
+     * malformed {@code emails[type eq "work"]bogus}) is left untouched so it is rejected by the caller rather than
+     * silently truncated to a valid attribute.
      */
     private String normalizePath(String rawPath) {
         int filterStart = rawPath.indexOf('[');
@@ -317,11 +547,13 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
                 return rawPath;
             }
             String prefix = rawPath.substring(0, filterStart);
-            int dotAfterFilter = rawPath.indexOf('.', filterEnd);
-            if (dotAfterFilter != -1) {
+            if (filterEnd + 1 == rawPath.length()) {
+                return prefix;
+            }
+            if (rawPath.charAt(filterEnd + 1) == '.') {
                 return prefix + rawPath.substring(filterEnd + 1);
             }
-            return prefix;
+            return rawPath;
         }
         return rawPath;
     }

--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
@@ -159,39 +159,66 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
 
         Map<String, Object> extensions = resource.getExtensions();
         if (extensions != null) {
-            for (String key : extensions.keySet()) {
+            for (Map.Entry<String, Object> entry : extensions.entrySet()) {
+                String key = entry.getKey();
                 if (!recognized.contains(key)) {
                     throw new ScimInvalidValueException(
                             "Unrecognized attribute '" + key + "'");
+                }
+
+                // the schema URI is recognized; validate the nested attributes it carries so that e.g.
+                // {"urn:custom:schema:User": {"bogus": "x"}} is rejected rather than silently ignored
+                Object value = entry.getValue();
+                if (value instanceof Map<?, ?> nested) {
+                    for (Object nestedKey : nested.keySet()) {
+                        String qualified = key + ":" + nestedKey;
+                        if (!isRecognizedPath(qualified)) {
+                            throw new ScimInvalidValueException(
+                                    "Unrecognized attribute '" + qualified + "'");
+                        }
+                    }
                 }
             }
         }
     }
 
     /**
-     * Validates that a PATCH operation path targets a recognized attribute. The path is first normalized
-     * by stripping any filter expressions (e.g. {@code emails[type eq "work"].value} becomes {@code emails.value}),
-     * then checked against recognized schema URIs and attribute paths. Throws
-     * {@link ScimNoTargetException} (HTTP 400, {@code scimType=noTarget}) if the path is not recognized.
+     * Validates that a PATCH operation path targets a recognized attribute, throwing
+     * {@link ScimNoTargetException} (HTTP 400, {@code scimType=noTarget}) if it does not.
      *
-     * <p>A sub-attribute path such as {@code emails.type} or {@code name.givenName} is only accepted when the
-     * sub-attribute actually exists: either it is individually declared (e.g. {@code name.givenName}) or it is a
-     * canonical member of the complex attribute's backing type (e.g. {@code emails.type}). An unknown descendant
-     * such as {@code emails.bogus} or {@code name.bogus} is rejected rather than accepted by a loose prefix match.
+     * @see #isRecognizedPath(String)
      */
     private void validatePatchPath(String rawPath) {
+        if (!isRecognizedPath(rawPath)) {
+            throw new ScimNoTargetException(
+                    "The path '" + rawPath + "' does not target a recognized attribute");
+        }
+    }
+
+    /**
+     * Determines whether a path targets a recognized schema URI or attribute. The path is first normalized
+     * by stripping any filter expressions (e.g. {@code emails[type eq "work"].value} becomes {@code emails.value}),
+     * then checked against recognized schema URIs and attribute paths.
+     *
+     * <p>A sub-attribute path such as {@code emails.type} or {@code name.givenName} is only recognized when the
+     * sub-attribute actually exists: either it is individually declared (e.g. {@code name.givenName}) or it is a
+     * canonical member of the complex attribute's backing type (e.g. {@code emails.type}). An unknown descendant
+     * such as {@code emails.bogus} or {@code name.bogus} is not recognized (rather than accepted by a loose
+     * prefix match).
+     */
+    private boolean isRecognizedPath(String rawPath) {
         String normalizedPath = normalizePath(rawPath);
 
         Set<String> recognized = getRecognizedSchemaUris();
         if (recognized.contains(normalizedPath)) {
-            return;
+            return true;
         }
 
         for (ModelSchema<M, R> s : schemas) {
             // resolves simple attributes, individually declared sub-attributes (e.g. name.givenName), the
             // synthesized "<attr>.value" of a multi-valued complex attribute, and all extension path forms
             if (s.getAttributeByPath(normalizedPath) != null) {
-                return;
+                return true;
             }
             for (Attribute<M, R> attr : s.getAttributes().values()) {
                 String attrName = attr.getName();
@@ -201,25 +228,24 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
                 // whose sub-attributes are individually registered (e.g. the bare "name" of "name.givenName")
                 if (normalizedPath.equalsIgnoreCase(attrName)
                         || (parentName != null && normalizedPath.equalsIgnoreCase(parentName))) {
-                    return;
+                    return true;
                 }
 
                 // a canonical sub-attribute of a complex attribute that is not individually declared, such as
                 // "emails.type"/"emails.primary" for the multi-valued "emails" (backed by Email). Only genuine
-                // canonical members are accepted; unknown descendants fall through and are rejected below.
+                // canonical members are accepted; unknown descendants are not recognized.
                 Class<?> complexType = attr.getComplexType();
                 if (complexType != null) {
                     for (String sub : getComplexSubAttributes(complexType)) {
                         if (normalizedPath.equalsIgnoreCase(attrName + "." + sub)) {
-                            return;
+                            return true;
                         }
                     }
                 }
             }
         }
 
-        throw new ScimNoTargetException(
-                "The path '" + rawPath + "' does not target a recognized attribute");
+        return false;
     }
 
     /**
@@ -244,12 +270,38 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
      * Validates a pathless PATCH operation whose {@code value} is a JSON object. Per RFC 7644 section 3.5.2,
      * {@code add} and {@code replace} operations may omit {@code path} and instead carry the attributes to
      * modify as members of the {@code value} object. Each top-level member is treated as an attribute path
-     * (or extension schema URI) and validated the same way as an explicit operation path, throwing
+     * (or extension schema URI) and validated the same way as an explicit operation path. When a member is a
+     * recognized extension schema URI whose value is itself an object, its nested members are validated as
+     * schema-qualified attributes of that URI (e.g. {@code {"urn:...:enterprise:2.0:User": {"bogus": "x"}}} is
+     * rejected because {@code urn:...:enterprise:2.0:User:bogus} is not a recognized attribute). Throws
      * {@link ScimNoTargetException} for any member that does not target a recognized attribute.
      */
     private void validatePatchValue(JsonNode value) {
-        for (Iterator<String> names = value.fieldNames(); names.hasNext(); ) {
-            validatePatchPath(names.next());
+        Set<String> recognizedUris = getRecognizedSchemaUris();
+        for (Map.Entry<String, JsonNode> member : value.properties()) {
+            String name = member.getKey();
+            JsonNode memberValue = member.getValue();
+
+            if (recognizedUris.contains(name) && memberValue != null && memberValue.isObject()) {
+                validateExtensionMembers(name, memberValue);
+            } else {
+                validatePatchPath(name);
+            }
+        }
+    }
+
+    /**
+     * Validates the members of a value object nested under a recognized extension schema URI. Each nested member
+     * is checked as the schema-qualified attribute {@code schemaUri:memberName}, throwing
+     * {@link ScimNoTargetException} for any member that does not target a recognized attribute of that schema.
+     */
+    private void validateExtensionMembers(String schemaUri, JsonNode object) {
+        for (Iterator<String> names = object.fieldNames(); names.hasNext(); ) {
+            String qualified = schemaUri + ":" + names.next();
+            if (!isRecognizedPath(qualified)) {
+                throw new ScimNoTargetException(
+                        "The path '" + qualified + "' does not target a recognized attribute");
+            }
         }
     }
 

--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
@@ -1,7 +1,11 @@
 package org.keycloak.scim.resource.spi;
 
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
@@ -12,6 +16,7 @@ import org.keycloak.scim.protocol.ForbiddenException;
 import org.keycloak.scim.protocol.request.PatchRequest.PatchOperation;
 import org.keycloak.scim.resource.ResourceTypeRepresentation;
 import org.keycloak.scim.resource.schema.ModelSchema;
+import org.keycloak.scim.resource.schema.attribute.Attribute;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -72,6 +77,12 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
             String path = operation.getPath();
             JsonNode value = operation.getValue();
 
+            if (!isBlank(path)) {
+                validatePatchPath(path);
+            } else if (value != null && value.isObject()) {
+                validatePatchValue(value);
+            }
+
             for (ModelSchema<M, R> schema : schemas) {
                 switch (op.toLowerCase()) {
                     case "add" -> schema.add(model, path, value);
@@ -94,6 +105,7 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
     }
 
     protected void populate(M model, R resource) {
+        validateSchemas(resource);
         for (ModelSchema<M, R> schema : schemas) {
             if (schema.supports(resource.getSchemas())) {
                 schema.populate(model, resource);
@@ -115,4 +127,124 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
         }
     }
 
+    /**
+     * Validates that all schema URIs in the request's {@code schemas} array and all keys in the
+     * {@code extensions} map are recognized by at least one registered schema. Throws
+     * {@link ScimInvalidValueException} (HTTP 400, {@code scimType=invalidValue}) if any are not.
+     *
+     * <p>Called from {@link #populate(Model, ResourceTypeRepresentation)} to validate POST and PUT requests.
+     */
+    private void validateSchemas(R resource) {
+        Set<String> recognized = getRecognizedSchemaUris();
+
+        Set<String> requestSchemas = resource.getSchemas();
+        if (requestSchemas != null) {
+            for (String uri : requestSchemas) {
+                if (!recognized.contains(uri)) {
+                    throw new ScimInvalidValueException(
+                            "Schema URI '" + uri + "' is not recognized");
+                }
+            }
+        }
+
+        Map<String, Object> extensions = resource.getExtensions();
+        if (extensions != null) {
+            for (String key : extensions.keySet()) {
+                if (!recognized.contains(key)) {
+                    throw new ScimInvalidValueException(
+                            "Unrecognized attribute '" + key + "'");
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates that a PATCH operation path targets a recognized attribute. The path is first normalized
+     * by stripping any filter expressions (e.g. {@code emails[type eq "work"].value} becomes {@code emails.value}),
+     * then checked against recognized schema URIs, attribute paths, and attribute name prefixes. Throws
+     * {@link ScimNoTargetException} (HTTP 400, {@code scimType=noTarget}) if the path is not recognized.
+     */
+    private void validatePatchPath(String rawPath) {
+        String normalizedPath = normalizePath(rawPath);
+
+        Set<String> recognized = getRecognizedSchemaUris();
+        if (recognized.contains(normalizedPath)) {
+            return;
+        }
+
+        for (ModelSchema<M, R> s : schemas) {
+            if (s.getAttributeByPath(normalizedPath) != null) {
+                return;
+            }
+            for (Attribute<M, R> attr : s.getAttributes().values()) {
+                String attrName = attr.getName();
+                String parentName = attr.getParentName();
+                if (normalizedPath.equalsIgnoreCase(attrName)
+                        || normalizedPath.toLowerCase().startsWith(attrName.toLowerCase() + ".")
+                        || (parentName != null && (normalizedPath.equalsIgnoreCase(parentName)
+                            || normalizedPath.toLowerCase().startsWith(parentName.toLowerCase() + ".")))) {
+                    return;
+                }
+            }
+        }
+
+        throw new ScimNoTargetException(
+                "The path '" + rawPath + "' does not target a recognized attribute");
+    }
+
+    /**
+     * Validates a pathless PATCH operation whose {@code value} is a JSON object. Per RFC 7644 section 3.5.2,
+     * {@code add} and {@code replace} operations may omit {@code path} and instead carry the attributes to
+     * modify as members of the {@code value} object. Each top-level member is treated as an attribute path
+     * (or extension schema URI) and validated the same way as an explicit operation path, throwing
+     * {@link ScimNoTargetException} for any member that does not target a recognized attribute.
+     */
+    private void validatePatchValue(JsonNode value) {
+        for (Iterator<String> names = value.fieldNames(); names.hasNext(); ) {
+            validatePatchPath(names.next());
+        }
+    }
+
+    /**
+     * Strips filter expressions from a PATCH path so that only the structural attribute path remains.
+     * For example, {@code emails[type eq "work"].value} becomes {@code emails.value}.
+     */
+    private String normalizePath(String rawPath) {
+        int filterStart = rawPath.indexOf('[');
+        if (filterStart > 0) {
+            int filterEnd = rawPath.lastIndexOf(']');
+            if (filterEnd == -1) {
+                return rawPath;
+            }
+            String prefix = rawPath.substring(0, filterStart);
+            int dotAfterFilter = rawPath.indexOf('.', filterEnd);
+            if (dotAfterFilter != -1) {
+                return prefix + rawPath.substring(filterEnd + 1);
+            }
+            return prefix;
+        }
+        return rawPath;
+    }
+
+    /**
+     * Collects the set of all schema URIs recognized by this provider. This includes the {@code id} of
+     * each registered {@link ModelSchema} (core and extensions) as well as the schema URI extracted from
+     * each attribute via {@link Attribute#getSchema()}. The latter is important for custom extension schemas
+     * that are dynamically registered through user profile attribute annotations - their schema URIs only
+     * appear as part of the attribute name (e.g. {@code urn:custom:schema:User:myAttr} yields
+     * {@code urn:custom:schema:User}) and would otherwise not be present in the recognized set.
+     */
+    private Set<String> getRecognizedSchemaUris() {
+        Set<String> uris = new HashSet<>();
+        for (ModelSchema<M, R> s : schemas) {
+            uris.add(s.getId());
+            for (Attribute<M, R> attr : s.getAttributes().values()) {
+                String attrSchema = attr.getSchema();
+                if (attrSchema != null) {
+                    uris.add(attrSchema);
+                }
+            }
+        }
+        return uris;
+    }
 }

--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/ScimInvalidValueException.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/ScimInvalidValueException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.scim.resource.spi;
+
+/**
+ * Exception thrown when a request references an unrecognized schema or attribute.
+ */
+public class ScimInvalidValueException extends RuntimeException {
+
+    public ScimInvalidValueException(String message) {
+        super(message);
+    }
+}

--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/ScimNoTargetException.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/ScimNoTargetException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.scim.resource.spi;
+
+/**
+ * Exception thrown when a PATCH path does not target a recognized attribute.
+ */
+public class ScimNoTargetException extends RuntimeException {
+
+    public ScimNoTargetException(String message) {
+        super(message);
+    }
+}

--- a/scim/services/src/main/java/org/keycloak/scim/services/Error.java
+++ b/scim/services/src/main/java/org/keycloak/scim/services/Error.java
@@ -16,7 +16,9 @@ import org.keycloak.models.ModelValidationException;
 import org.keycloak.scim.filter.ScimFilterException;
 import org.keycloak.scim.protocol.ForbiddenException;
 import org.keycloak.scim.protocol.response.ErrorResponse;
+import org.keycloak.scim.resource.spi.ScimInvalidValueException;
 import org.keycloak.scim.resource.spi.ScimMutabilityException;
+import org.keycloak.scim.resource.spi.ScimNoTargetException;
 import org.keycloak.scim.resource.spi.ScimPatchException;
 import org.keycloak.theme.Theme;
 
@@ -43,6 +45,10 @@ class Error {
             return badRequest("invalidFilter", e.getMessage());
         } else if (e instanceof ScimMutabilityException) {
             return badRequest("mutability", e.getMessage());
+        } else if (e instanceof ScimInvalidValueException) {
+            return badRequest("invalidValue", e.getMessage());
+        } else if (e instanceof ScimNoTargetException) {
+            return badRequest("noTarget", e.getMessage());
         } else if (e instanceof ScimPatchException) {
             return badRequest("tooMany", e.getMessage());
         } else if (e instanceof ForbiddenException) {

--- a/scim/services/src/main/java/org/keycloak/scim/services/ScimResourceTypeResource.java
+++ b/scim/services/src/main/java/org/keycloak/scim/services/ScimResourceTypeResource.java
@@ -230,6 +230,12 @@ public class ScimResourceTypeResource<R extends ResourceTypeRepresentation> {
             return invalidSyntax("No PATCH op schema provided in request");
         }
 
+        for (String schema : request.getSchemas()) {
+            if (!Scim.PATCH_OP_CORE_SCHEMA.equals(schema)) {
+                return badRequest("invalidValue", "Unrecognized schema in PATCH request: " + schema);
+            }
+        }
+
         return onPersist(existing, Status.OK, (rScimResourceTypeProvider, r) -> {
             resourceTypeProvider.patch(existing, request.getOperations());
             R patched = getResource(id);

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AbstractScimTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AbstractScimTest.java
@@ -10,6 +10,7 @@
 
 package org.keycloak.tests.scim.tck;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -18,7 +19,10 @@ import java.util.function.Function;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.userprofile.config.UPAttribute;
@@ -105,6 +109,15 @@ public abstract class AbstractScimTest {
 
     protected ClientRepresentation createScimClient(String clientId) {
         return createScimClient(realm.getName(), clientId);
+    }
+
+    protected String getScimClientToken(SimpleHttp http) throws IOException {
+        return http.doPost(keycloakUrls.getToken(realm.getName()))
+                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
+                .param(OAuth2Constants.CLIENT_ID, "scim-client")
+                .param(OAuth2Constants.CLIENT_SECRET, "secret")
+                .asJson(AccessTokenResponse.class)
+                .getToken();
     }
 
     protected ClientRepresentation createScimClient(String realm, String clientId) {

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
@@ -792,4 +792,105 @@ public class GroupTest extends AbstractScimTest {
             assertTrue(error.getDetail().contains("bogusAttribute"));
         }
     }
+
+    @Test
+    public void testPatchRecognizedSubAttributes() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        User member = createScimUser();
+
+        // canonical sub-attributes of the multi-valued "members" complex attribute (backed by Member) must pass
+        // validation, whether targeted directly or through a value filter that is normalized away first
+        client.groups().patch(group.getId(), PatchRequest.create()
+                .add("members", member.getId())
+                .build());
+        client.groups().patch(group.getId(), PatchRequest.create()
+                .replace("members[value eq \"" + member.getId() + "\"].display", "Member Display")
+                .build());
+    }
+
+    @Test
+    public void testPatchUnrecognizedSubAttributeOfComplex() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // "bogus" is neither a declared nor a canonical sub-attribute of the "members" complex type
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .add("members.bogus", "someValue")
+                    .build());
+            fail("should fail because of unrecognized sub-attribute path");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertEquals("noTarget", error.getScimType());
+            assertTrue(error.getDetail().contains("members.bogus"));
+        }
+    }
+
+    @Test
+    public void testPatchUnrecognizedSubAttributeOfSimple() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // a simple attribute has no sub-attributes, so any descendant path must be rejected
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .replace("displayName.bogus", "someValue")
+                    .build());
+            fail("should fail because a simple attribute has no sub-attributes");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertEquals("noTarget", error.getScimType());
+            assertTrue(error.getDetail().contains("displayName.bogus"));
+        }
+    }
+
+    @Test
+    public void testPatchUnrecognizedFilteredSubAttribute() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // once the value filter is stripped the path is members.bogus, which does not target a real sub-attribute
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .replace("members[value eq \"x\"].bogus", "someValue")
+                    .build());
+            fail("should fail because of unrecognized filtered sub-attribute path");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertEquals("noTarget", error.getScimType());
+        }
+    }
+
+    @Test
+    public void testPatchPathlessUnrecognizedSubAttribute() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // an unrecognized sub-attribute carried as a pathless value member must be rejected
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .add("{\"members.bogus\": \"someValue\"}")
+                    .build());
+            fail("should fail because of unrecognized pathless sub-attribute");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertEquals("noTarget", error.getScimType());
+            assertTrue(error.getDetail().contains("members.bogus"));
+        }
+    }
 }

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
@@ -772,4 +772,24 @@ public class GroupTest extends AbstractScimTest {
         adminEvents.clear();
         return created;
     }
+
+    @Test
+    public void testPatchWithUnrecognizedPath() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .replace("bogusAttribute", "someValue")
+                    .build());
+            fail("should fail because of unrecognized attribute path");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertEquals("noTarget", error.getScimType());
+            assertTrue(error.getDetail().contains("bogusAttribute"));
+        }
+    }
 }

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
@@ -9,6 +9,8 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
@@ -18,13 +20,18 @@ import org.keycloak.scim.client.ScimClientException;
 import org.keycloak.scim.protocol.request.PatchRequest;
 import org.keycloak.scim.protocol.response.ErrorResponse;
 import org.keycloak.scim.protocol.response.ListResponse;
+import org.keycloak.scim.resource.Scim;
 import org.keycloak.scim.resource.group.Group;
 import org.keycloak.scim.resource.group.Member;
 import org.keycloak.scim.resource.user.User;
+import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.events.AdminEventAssertion;
 import org.keycloak.testframework.util.ApiUtil;
 
+import org.apache.http.client.HttpClient;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,11 +41,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @KeycloakIntegrationTest(config = ScimServerConfig.class)
 public class GroupTest extends AbstractScimTest {
+
+    @InjectHttpClient
+    HttpClient httpClient;
 
     @Test
     public void testCreate() {
@@ -779,18 +790,16 @@ public class GroupTest extends AbstractScimTest {
         group.setDisplayName(KeycloakModelUtils.generateId());
         group = client.groups().create(group);
 
-        try {
-            client.groups().patch(group.getId(), PatchRequest.create()
-                    .replace("bogusAttribute", "someValue")
-                    .build());
-            fail("should fail because of unrecognized attribute path");
-        } catch (ScimClientException sce) {
-            ErrorResponse error = sce.getError();
-            assertNotNull(error);
-            assertEquals(400, error.getStatusInt());
-            assertEquals("noTarget", error.getScimType());
-            assertTrue(error.getDetail().contains("bogusAttribute"));
-        }
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .replace("bogusAttribute", "someValue")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("noTarget", error.getScimType());
+        assertTrue(error.getDetail().contains("bogusAttribute"));
     }
 
     @Test
@@ -818,18 +827,16 @@ public class GroupTest extends AbstractScimTest {
         group = client.groups().create(group);
 
         // "bogus" is neither a declared nor a canonical sub-attribute of the "members" complex type
-        try {
-            client.groups().patch(group.getId(), PatchRequest.create()
-                    .add("members.bogus", "someValue")
-                    .build());
-            fail("should fail because of unrecognized sub-attribute path");
-        } catch (ScimClientException sce) {
-            ErrorResponse error = sce.getError();
-            assertNotNull(error);
-            assertEquals(400, error.getStatusInt());
-            assertEquals("noTarget", error.getScimType());
-            assertTrue(error.getDetail().contains("members.bogus"));
-        }
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .add("members.bogus", "someValue")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("noTarget", error.getScimType());
+        assertTrue(error.getDetail().contains("members.bogus"));
     }
 
     @Test
@@ -839,18 +846,16 @@ public class GroupTest extends AbstractScimTest {
         group = client.groups().create(group);
 
         // a simple attribute has no sub-attributes, so any descendant path must be rejected
-        try {
-            client.groups().patch(group.getId(), PatchRequest.create()
-                    .replace("displayName.bogus", "someValue")
-                    .build());
-            fail("should fail because a simple attribute has no sub-attributes");
-        } catch (ScimClientException sce) {
-            ErrorResponse error = sce.getError();
-            assertNotNull(error);
-            assertEquals(400, error.getStatusInt());
-            assertEquals("noTarget", error.getScimType());
-            assertTrue(error.getDetail().contains("displayName.bogus"));
-        }
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .replace("displayName.bogus", "someValue")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("noTarget", error.getScimType());
+        assertTrue(error.getDetail().contains("displayName.bogus"));
     }
 
     @Test
@@ -860,17 +865,15 @@ public class GroupTest extends AbstractScimTest {
         group = client.groups().create(group);
 
         // once the value filter is stripped the path is members.bogus, which does not target a real sub-attribute
-        try {
-            client.groups().patch(group.getId(), PatchRequest.create()
-                    .replace("members[value eq \"x\"].bogus", "someValue")
-                    .build());
-            fail("should fail because of unrecognized filtered sub-attribute path");
-        } catch (ScimClientException sce) {
-            ErrorResponse error = sce.getError();
-            assertNotNull(error);
-            assertEquals(400, error.getStatusInt());
-            assertEquals("noTarget", error.getScimType());
-        }
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .replace("members[value eq \"x\"].bogus", "someValue")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("noTarget", error.getScimType());
     }
 
     @Test
@@ -880,17 +883,124 @@ public class GroupTest extends AbstractScimTest {
         group = client.groups().create(group);
 
         // an unrecognized sub-attribute carried as a pathless value member must be rejected
-        try {
-            client.groups().patch(group.getId(), PatchRequest.create()
-                    .add("{\"members.bogus\": \"someValue\"}")
-                    .build());
-            fail("should fail because of unrecognized pathless sub-attribute");
-        } catch (ScimClientException sce) {
-            ErrorResponse error = sce.getError();
-            assertNotNull(error);
-            assertEquals(400, error.getStatusInt());
-            assertEquals("noTarget", error.getScimType());
-            assertTrue(error.getDetail().contains("members.bogus"));
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .add("{\"members.bogus\": \"someValue\"}")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("noTarget", error.getScimType());
+        assertTrue(error.getDetail().contains("members.bogus"));
+    }
+
+    @Test
+    public void testPatchInheritedNonSchemaSubAttribute() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // "primary" is inherited by the Member bean but is not a SCIM sub-attribute of the Group "members"
+        // reference attribute, so it must be rejected rather than silently accepted
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .replace("members.primary", "true")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("noTarget", error.getScimType());
+        assertTrue(error.getDetail().contains("members.primary"));
+    }
+
+    @Test
+    public void testPatchUnrecognizedFilterAttribute() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // the attribute referenced inside the value-path filter ("bogus") is not a real sub-attribute of the
+        // filtered "members" attribute, so the operation must be rejected rather than having the filter silently
+        // stripped down to "members.display"; per RFC 7644 Table 9, a path filter problem is classified as
+        // invalidFilter, not noTarget
+        Group created = group;
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.groups().patch(created.getId(), PatchRequest.create()
+                        .replace("members[bogus eq \"x\"].display", "someValue")
+                        .build()));
+        ErrorResponse error = sce.getError();
+        assertNotNull(error);
+        assertEquals(400, error.getStatusInt());
+        assertEquals("invalidFilter", error.getScimType());
+        assertTrue(error.getDetail().contains("bogus"));
+    }
+
+    @Test
+    public void testPatchCommonReadOnlyAttributesAreIgnored() {
+        Group expected = new Group();
+        expected.setDisplayName(KeycloakModelUtils.generateId());
+        expected = client.groups().create(expected);
+
+        // id, schemas and meta(.*) are common SCIM resource attributes that are not backed by any model attribute;
+        // targeting them via PATCH must be treated as a no-op rather than rejected as noTarget, whether submitted
+        // bare or with the optional core schema prefix
+        client.groups().patch(expected.getId(), PatchRequest.create()
+                .replace("id", "some-other-id")
+                .build());
+        client.groups().patch(expected.getId(), PatchRequest.create()
+                .replace("schemas", "[\"urn:ietf:params:scim:schemas:core:2.0:Group\"]")
+                .build());
+        client.groups().patch(expected.getId(), PatchRequest.create()
+                .remove("meta")
+                .build());
+        client.groups().patch(expected.getId(), PatchRequest.create()
+                .replace(Scim.GROUP_CORE_SCHEMA + ":id", "some-other-id")
+                .build());
+
+        Group actual = client.groups().get(expected.getId());
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getDisplayName(), actual.getDisplayName());
+    }
+
+    @Test
+    public void testPatchBlankPathTreatedAsPathless() {
+        Group expected = new Group();
+        expected.setDisplayName(KeycloakModelUtils.generateId());
+        expected = client.groups().create(expected);
+
+        // a blank (whitespace-only) path is not a valid attribute path and must be treated the same as an
+        // absent one, so the value object is actually applied as a pathless operation rather than silently
+        // dropped because the raw blank path was forwarded to the schema layer unchanged
+        client.groups().patch(expected.getId(), PatchRequest.create()
+                .add(" ", "{\"displayName\": \"spacePathDisplayName\"}")
+                .build());
+
+        assertEquals("spacePathDisplayName", client.groups().get(expected.getId()).getDisplayName());
+    }
+
+    @Test
+    public void testCreateWithUnrecognizedSchema() throws Exception {
+        // the Scim client cannot submit an arbitrary schemas array (Group pins it), so send the raw request; a
+        // Group create carrying an unrecognized schema URI must be rejected rather than silently accepted
+        SimpleHttp http = SimpleHttp.create(httpClient);
+        String token = getScimClientToken(http);
+
+        String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Groups";
+        try (SimpleHttpResponse response = http.doPost(url)
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/scim+json")
+                .entity(new StringEntity(
+                        "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:Group\", \"urn:bogus:Schema\"], "
+                                + "\"displayName\": \"" + KeycloakModelUtils.generateId() + "\"}",
+                        ContentType.create("application/scim+json")))
+                .asResponse()) {
+            assertEquals(400, response.getStatus());
+            ErrorResponse error = response.asJson(ErrorResponse.class);
+            assertEquals("invalidValue", error.getScimType());
+            assertTrue(error.getDetail().contains("urn:bogus:Schema"));
         }
     }
+
 }

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -1554,7 +1554,6 @@ public class UserTest extends AbstractScimTest {
         return user;
     }
 
-    @Disabled("Update attribute validation after adding custom attributes")
     @Test
     public void testCreateWithInvalidAttribute() {
         User user = new User() {
@@ -1569,6 +1568,9 @@ public class UserTest extends AbstractScimTest {
             }
         };
 
+        user.setUserName(KeycloakModelUtils.generateId());
+        user.setEmail(user.getUserName() + "@keycloak.org");
+
         try {
             client.users().create(user);
             fail("should fail because of invalid attribute");
@@ -1576,8 +1578,213 @@ public class UserTest extends AbstractScimTest {
             ErrorResponse error = sce.getError();
             assertNotNull(error);
             assertEquals(400, error.getStatusInt());
+            assertEquals("invalidValue", error.getScimType());
             assertNotNull(error.getDetail());
             assertTrue(error.getDetail().contains("invalidAttribute"));
+        }
+    }
+
+    @Test
+    public void testCreateWithUnrecognizedSchema() throws Exception {
+        SimpleHttp http = SimpleHttp.create(httpClient);
+        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
+                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
+                .param(OAuth2Constants.CLIENT_ID, "scim-client")
+                .param(OAuth2Constants.CLIENT_SECRET, "secret")
+                .asJson(AccessTokenResponse.class);
+
+        String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users";
+        try (SimpleHttpResponse response = http.doPost(url)
+                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Content-Type", "application/scim+json")
+                .entity(new StringEntity(
+                        "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:User\", \"urn:bogus:Schema\"], "
+                                + "\"userName\": \"testuser\", \"emails\": [{\"value\": \"test@test.com\"}]}",
+                        ContentType.create("application/scim+json")))
+                .asResponse()) {
+            assertEquals(400, response.getStatus());
+            ErrorResponse error = response.asJson(ErrorResponse.class);
+            assertEquals("invalidValue", error.getScimType());
+            assertTrue(error.getDetail().contains("urn:bogus:Schema"));
+        }
+    }
+
+    @Test
+    public void testPatchWithUnrecognizedPath() {
+        User expected = client.users().create(createUser());
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("bogusAttribute", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogusAttribute"));
+    }
+
+    @Test
+    public void testPatchWithUnrecognizedSchemaPath() {
+        User expected = client.users().create(createUser());
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("urn:bogus:Schema:fakeAttr", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchRemoveWithUnrecognizedPath() {
+        User expected = client.users().create(createUser());
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .remove("bogusAttribute")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogusAttribute"));
+    }
+
+    @Test
+    public void testPatchWithUnrecognizedFilteredPath() {
+        User expected = client.users().create(createUser());
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("bogus[type eq \"work\"].value", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogus[type eq \"work\"].value"));
+    }
+
+    @Test
+    public void testPatchPathlessWithUnrecognizedAttribute() {
+        User expected = client.users().create(createUser());
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"bogusAttribute\": \"someValue\"}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogusAttribute"));
+    }
+
+    @Test
+    public void testPatchPathlessWithMixedAttributes() {
+        User expected = client.users().create(createUser());
+
+        // a recognized attribute alongside an unrecognized one must still be rejected as a whole
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("{\"nickName\": \"patched\", \"bogusAttribute\": \"someValue\"}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogusAttribute"));
+    }
+
+    @Test
+    public void testPatchPathlessWithRecognizedAttribute() {
+        User expected = client.users().create(createUser());
+
+        // a pathless operation carrying only recognized attributes must pass validation and not be rejected
+        // (application of pathless values is handled by the schema layer and is out of scope for this validation)
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("{\"nickName\": \"patchednickname\"}")
+                .build());
+
+        assertRootAttributes(client.users().get(expected.getId()), expected);
+    }
+
+    @Test
+    public void testPatchPathlessWithCustomSchema() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // a recognized custom extension schema URI as a pathless value member must pass validation
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add("{\"" + customSchema + "\": {\"myattribute\": \"myvalue\"}}")
+                .build());
+
+        // an unrecognized extension schema URI must be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"urn:bogus:custom:1.0:User\": {\"myattribute\": \"x\"}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("urn:bogus:custom:1.0:User"));
+    }
+
+    @Test
+    public void testUpdateWithUnrecognizedSchema() throws Exception {
+        User expected = client.users().create(createUser());
+
+        SimpleHttp http = SimpleHttp.create(httpClient);
+        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
+                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
+                .param(OAuth2Constants.CLIENT_ID, "scim-client")
+                .param(OAuth2Constants.CLIENT_SECRET, "secret")
+                .asJson(AccessTokenResponse.class);
+
+        String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users/" + expected.getId();
+        try (SimpleHttpResponse response = http.doPut(url)
+                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Content-Type", "application/scim+json")
+                .entity(new StringEntity(
+                        "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:User\", \"urn:bogus:Schema\"], "
+                                + "\"id\": \"" + expected.getId() + "\", "
+                                + "\"userName\": \"" + expected.getUserName() + "\", "
+                                + "\"emails\": [{\"value\": \"" + expected.getEmail() + "\"}]}",
+                        ContentType.create("application/scim+json")))
+                .asResponse()) {
+            assertEquals(400, response.getStatus());
+            ErrorResponse error = response.asJson(ErrorResponse.class);
+            assertEquals("invalidValue", error.getScimType());
+            assertTrue(error.getDetail().contains("urn:bogus:Schema"));
+        }
+    }
+
+    @Test
+    public void testUpdateWithUnrecognizedExtension() throws Exception {
+        User expected = client.users().create(createUser());
+
+        SimpleHttp http = SimpleHttp.create(httpClient);
+        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
+                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
+                .param(OAuth2Constants.CLIENT_ID, "scim-client")
+                .param(OAuth2Constants.CLIENT_SECRET, "secret")
+                .asJson(AccessTokenResponse.class);
+
+        String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users/" + expected.getId();
+        try (SimpleHttpResponse response = http.doPut(url)
+                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Content-Type", "application/scim+json")
+                .entity(new StringEntity(
+                        "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:User\"], "
+                                + "\"id\": \"" + expected.getId() + "\", "
+                                + "\"userName\": \"" + expected.getUserName() + "\", "
+                                + "\"emails\": [{\"value\": \"" + expected.getEmail() + "\"}], "
+                                + "\"totallyBogus\": \"data\"}",
+                        ContentType.create("application/scim+json")))
+                .asResponse()) {
+            assertEquals(400, response.getStatus());
+            ErrorResponse error = response.asJson(ErrorResponse.class);
+            assertEquals("invalidValue", error.getScimType());
+            assertTrue(error.getDetail().contains("totallyBogus"));
         }
     }
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -1884,6 +1884,50 @@ public class UserTest extends AbstractScimTest {
     }
 
     @Test
+    public void testPatchPathlessNestedExtensionAttribute() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // a recognized attribute nested under a recognized extension schema URI passes validation
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add("{\"" + customSchema + "\": {\"myattribute\": \"myvalue\"}}")
+                .build());
+
+        // an unrecognized attribute nested under an otherwise recognized extension schema URI must be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"bogus\": \"x\"}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
+    public void testCreateWithNestedUnrecognizedExtensionAttribute() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User user = createUser();
+        user.addSchema(customSchema);
+        user.setExtensions(new HashMap<>());
+        HashMap<Object, Object> customSchemaValues = new HashMap<>();
+        customSchemaValues.put("bogus", "x");
+        user.getExtensions().put(customSchema, customSchemaValues);
+
+        // the extension schema URI is recognized, but the nested attribute is not
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().create(user));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidValue", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
     public void testUpdateWithUnrecognizedSchema() throws Exception {
         User expected = client.users().create(createUser());
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -1730,6 +1730,160 @@ public class UserTest extends AbstractScimTest {
     }
 
     @Test
+    public void testPatchRecognizedSubAttributes() {
+        User expected = client.users().create(createUser());
+
+        // canonical sub-attributes of the multi-valued "emails" complex attribute (backed by Email) as well as
+        // an individually declared sub-attribute of "name" must all pass validation whether or not the value is
+        // ultimately persisted by the schema layer.
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add("emails.value", "recognized.sub@keycloak.org")
+                .add("emails.type", "home")
+                .add("emails.primary", "true")
+                .add("emails.display", "Recognized Sub")
+                .add("name.givenName", "Recognized")
+                .build());
+
+        // the same canonical sub-attributes remain recognized when reached through a value filter, which is
+        // normalized away before validation (e.g. emails[type eq "work"].primary -> emails.primary)
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("emails[type eq \"work\"].type", "work")
+                .replace("emails[type eq \"work\"].primary", "false")
+                .build());
+    }
+
+    @Test
+    public void testPatchUnrecognizedSubAttributeOfComplex() {
+        User expected = client.users().create(createUser());
+
+        // "bogus" is neither an individually declared nor a canonical sub-attribute of the "emails" complex type
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("emails.bogus", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("emails.bogus"));
+    }
+
+    @Test
+    public void testPatchUnrecognizedSubAttributeOfDeclaredComplex() {
+        User expected = client.users().create(createUser());
+
+        // "name" only exposes the individually declared sub-attributes (givenName, familyName, ...); "bogus" is
+        // not one of them and must be rejected rather than accepted by a loose "name." prefix match
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("name.bogus", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("name.bogus"));
+    }
+
+    @Test
+    public void testPatchUnrecognizedSubAttributeOfSimple() {
+        User expected = client.users().create(createUser());
+
+        // a simple attribute has no sub-attributes at all, so any descendant path must be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("userName.bogus", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("userName.bogus"));
+    }
+
+    @Test
+    public void testPatchUnrecognizedFilteredSubAttribute() {
+        User expected = client.users().create(createUser());
+
+        // once the value filter is stripped the path is emails.bogus, which does not target a real sub-attribute
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("emails[type eq \"work\"].bogus", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchRemoveUnrecognizedSubAttribute() {
+        User expected = client.users().create(createUser());
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .remove("emails.bogus")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("emails.bogus"));
+    }
+
+    @Test
+    public void testPatchPathlessRecognizedSubAttributes() {
+        User expected = client.users().create(createUser());
+
+        // pathless value members may themselves be sub-attribute paths; canonical/declared ones must pass validation
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add("{\"emails.type\": \"home\", \"name.givenName\": \"Recognized\"}")
+                .build());
+    }
+
+    @Test
+    public void testPatchPathlessUnrecognizedSubAttribute() {
+        User expected = client.users().create(createUser());
+
+        // an unrecognized sub-attribute carried as a pathless value member must be rejected
+        ScimClientException emailsCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"emails.bogus\": \"someValue\"}")
+                        .build()));
+        assertNotNull(emailsCe.getError());
+        assertEquals(400, emailsCe.getError().getStatusInt());
+        assertEquals("noTarget", emailsCe.getError().getScimType());
+        assertTrue(emailsCe.getError().getDetail().contains("emails.bogus"));
+
+        ScimClientException nameCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("{\"name.bogus\": \"someValue\"}")
+                        .build()));
+        assertNotNull(nameCe.getError());
+        assertEquals(400, nameCe.getError().getStatusInt());
+        assertEquals("noTarget", nameCe.getError().getScimType());
+        assertTrue(nameCe.getError().getDetail().contains("name.bogus"));
+    }
+
+    @Test
+    public void testPatchCustomSchemaUnrecognizedAttribute() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // the attribute declared through user profile under the custom schema is recognized
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add(customSchema + ":myattribute", "myvalue")
+                .build());
+
+        // an attribute that is not declared under the (otherwise recognized) custom schema must be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add(customSchema + ":bogus", "someValue")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
     public void testUpdateWithUnrecognizedSchema() throws Exception {
         User expected = client.users().create(createUser());
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
-import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.GroupResource;
 import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.events.admin.OperationType;
@@ -20,7 +19,6 @@ import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.http.simple.SimpleHttpResponse;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
-import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
@@ -636,21 +634,43 @@ public class UserTest extends AbstractScimTest {
         User expected = client.users().create(createUser());
 
         SimpleHttp http = SimpleHttp.create(httpClient);
-        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
-                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
-                .param(OAuth2Constants.CLIENT_ID, "scim-client")
-                .param(OAuth2Constants.CLIENT_SECRET, "secret")
-                .asJson(AccessTokenResponse.class);
+        String token = getScimClientToken(http);
 
         String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users/" + expected.getId();
         try (SimpleHttpResponse response = http.doPatch(url)
-                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Authorization", "Bearer " + token)
                 .header("Content-Type", "application/scim+json")
                 .entity(new StringEntity(
                         "{\"schemas\": null, \"Operations\": [{\"op\": \"replace\", \"path\": \"active\", \"value\": false}]}",
                         ContentType.create("application/scim+json")))
                 .asResponse()) {
             assertEquals(400, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testPatchWithUnrecognizedSchema() throws Exception {
+        User expected = client.users().create(createUser());
+
+        SimpleHttp http = SimpleHttp.create(httpClient);
+        String token = getScimClientToken(http);
+
+        String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users/" + expected.getId();
+        // the PatchOp schema is present, but an additional unrecognized schema URI in the request's schemas array
+        // must be rejected rather than ignored; the scimType is invalidValue, consistent with how an unrecognized
+        // schema URI in a POST/PUT resource's schemas array is classified
+        try (SimpleHttpResponse response = http.doPatch(url)
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/scim+json")
+                .entity(new StringEntity(
+                        "{\"schemas\": [\"" + Scim.PATCH_OP_CORE_SCHEMA + "\", \"urn:bogus:Schema\"], "
+                                + "\"Operations\": [{\"op\": \"replace\", \"path\": \"active\", \"value\": false}]}",
+                        ContentType.create("application/scim+json")))
+                .asResponse()) {
+            assertEquals(400, response.getStatus());
+            ErrorResponse error = response.asJson(ErrorResponse.class);
+            assertEquals("invalidValue", error.getScimType());
+            assertTrue(error.getDetail().contains("urn:bogus:Schema"));
         }
     }
 
@@ -1587,15 +1607,11 @@ public class UserTest extends AbstractScimTest {
     @Test
     public void testCreateWithUnrecognizedSchema() throws Exception {
         SimpleHttp http = SimpleHttp.create(httpClient);
-        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
-                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
-                .param(OAuth2Constants.CLIENT_ID, "scim-client")
-                .param(OAuth2Constants.CLIENT_SECRET, "secret")
-                .asJson(AccessTokenResponse.class);
+        String token = getScimClientToken(http);
 
         String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users";
         try (SimpleHttpResponse response = http.doPost(url)
-                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Authorization", "Bearer " + token)
                 .header("Content-Type", "application/scim+json")
                 .entity(new StringEntity(
                         "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:User\", \"urn:bogus:Schema\"], "
@@ -1634,6 +1650,41 @@ public class UserTest extends AbstractScimTest {
         assertNotNull(ce.getError());
         assertEquals(400, ce.getError().getStatusInt());
         assertEquals("noTarget", ce.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchCommonReadOnlyAttributesAreIgnored() {
+        User expected = client.users().create(createUser());
+
+        // id, schemas and meta(.*) are common SCIM resource attributes that are not backed by any model attribute;
+        // targeting them via PATCH must be treated as a no-op rather than rejected as noTarget
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("id", "some-other-id")
+                .build());
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("schemas", "[\"urn:ietf:params:scim:schemas:core:2.0:User\"]")
+                .build());
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .remove("meta")
+                .build());
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("meta.resourceType", "Group")
+                .build());
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("meta.location", "https://bogus.example.org")
+                .build());
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("meta.version", "W/\"123\"")
+                .build());
+
+        // the same paths must also be recognized when submitted with the optional core schema prefix
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace(Scim.USER_CORE_SCHEMA + ":id", "some-other-id")
+                .build());
+
+        User actual = client.users().get(expected.getId());
+        assertEquals(expected.getId(), actual.getId());
+        assertRootAttributes(actual, expected);
     }
 
     @Test
@@ -1707,6 +1758,37 @@ public class UserTest extends AbstractScimTest {
     }
 
     @Test
+    public void testPatchPathlessWithNonObjectValueRejected() {
+        User expected = client.users().create(createUser());
+
+        // a pathless add/replace must carry the attributes to modify as members of an object value; a scalar,
+        // array or empty object value provides no target and must be rejected rather than silently no-op'd
+        ScimClientException scalarCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("someValue")
+                        .build()));
+        assertNotNull(scalarCe.getError());
+        assertEquals(400, scalarCe.getError().getStatusInt());
+        assertEquals("invalidSyntax", scalarCe.getError().getScimType());
+
+        ScimClientException arrayCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("[]")
+                        .build()));
+        assertNotNull(arrayCe.getError());
+        assertEquals(400, arrayCe.getError().getStatusInt());
+        assertEquals("invalidSyntax", arrayCe.getError().getScimType());
+
+        ScimClientException emptyObjectCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("{}")
+                        .build()));
+        assertNotNull(emptyObjectCe.getError());
+        assertEquals(400, emptyObjectCe.getError().getStatusInt());
+        assertEquals("invalidSyntax", emptyObjectCe.getError().getScimType());
+    }
+
+    @Test
     public void testPatchPathlessWithCustomSchema() {
         String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
         addOrReplaceUPAttribute(customSchema, "myattribute");
@@ -1727,6 +1809,25 @@ public class UserTest extends AbstractScimTest {
         assertEquals(400, ce.getError().getStatusInt());
         assertEquals("noTarget", ce.getError().getScimType());
         assertTrue(ce.getError().getDetail().contains("urn:bogus:custom:1.0:User"));
+    }
+
+    @Test
+    public void testPatchPathlessWithEmptyObjectUnderSchemaUriRejected() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // a recognized extension schema URI must carry a non-empty object of attributes; an empty object
+        // targets no attribute and must be rejected rather than silently accepted as a no-op
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema));
     }
 
     @Test
@@ -1765,6 +1866,22 @@ public class UserTest extends AbstractScimTest {
         assertEquals(400, ce.getError().getStatusInt());
         assertEquals("noTarget", ce.getError().getScimType());
         assertTrue(ce.getError().getDetail().contains("emails.bogus"));
+    }
+
+    @Test
+    public void testPatchEmailRefSubAttributeRejected() {
+        User expected = client.users().create(createUser());
+
+        // "$ref" is inherited from the shared MultiValuedAttribute bean but is not a defined sub-attribute of
+        // "emails" (unlike the Group "members" and User "groups" reference attributes, which do define it)
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("emails.$ref", "https://example.org/ref")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("emails.$ref"));
     }
 
     @Test
@@ -1928,19 +2045,429 @@ public class UserTest extends AbstractScimTest {
     }
 
     @Test
+    public void testPatchAddOrReplaceWithExplicitPathAndMissingValueRejected() {
+        User expected = client.users().create(createUser());
+
+        // per RFC 7644 section 3.5.2, "add" and "replace" require a value; without an early check a missing/null
+        // value reaches the schema layer's own null check as an uncaught NPE (HTTP 500) instead of a clean 400
+        ScimClientException addCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("displayName", (String) null)
+                        .build()));
+        assertNotNull(addCe.getError());
+        assertEquals(400, addCe.getError().getStatusInt());
+        assertEquals("invalidSyntax", addCe.getError().getScimType());
+
+        ScimClientException replaceCe = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("displayName", (String) null)
+                        .build()));
+        assertNotNull(replaceCe.getError());
+        assertEquals(400, replaceCe.getError().getStatusInt());
+        assertEquals("invalidSyntax", replaceCe.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchFullyQualifiedCorePath() {
+        addOrReplaceUPAttribute("nickName");
+
+        User expected = client.users().create(createUser());
+
+        // a fully-qualified core attribute path is legal per RFC 7644 (the core schema prefix is optional) and
+        // must be accepted rather than rejected as noTarget, even though core attributes are stored unqualified;
+        // the value must actually be applied too - the prefix is stripped for both recognition and application
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace(Scim.USER_CORE_SCHEMA + ":nickName", "qualifiedNick")
+                .build());
+
+        assertEquals("qualifiedNick", client.users().get(expected.getId()).getNickName());
+    }
+
+    @Test
+    public void testPatchBlankPathTreatedAsPathless() {
+        addOrReplaceUPAttribute("nickName");
+
+        User expected = client.users().create(createUser());
+
+        // a blank (whitespace-only) path is not a valid attribute path and must be treated the same as an
+        // absent one, so the value object is actually applied as a pathless operation rather than silently
+        // dropped because the raw blank path was forwarded to the schema layer unchanged
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add(" ", "{\"nickName\": \"spacePathNick\"}")
+                .build());
+
+        assertEquals("spacePathNick", client.users().get(expected.getId()).getNickName());
+    }
+
+    @Test
+    public void testPatchInheritedNonSchemaSubAttribute() {
+        User expected = client.users().create(createUser());
+
+        // "emails.primary" is a genuine SCIM sub-attribute of the emails (Email) complex type and must be accepted
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("emails.primary", "true")
+                .build());
+
+        // "groups.primary" is inherited by the GroupMembership bean but is not a SCIM sub-attribute of the User
+        // "groups" reference attribute, so it must be rejected rather than silently accepted
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("groups.primary", "true")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("groups.primary"));
+    }
+
+    @Test
+    public void testPatchPathlessNestedComplexDescendant() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "assurance.value");
+
+        User expected = client.users().create(createUser());
+
+        // a declared descendant of a complex extension attribute passes validation
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add("{\"" + customSchema + "\": {\"assurance\": {\"value\": \"high\"}}}")
+                .build());
+
+        // an undeclared descendant nested more than one level below the extension URI must still be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"assurance\": {\"bogus\": \"x\"}}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":assurance.bogus"));
+    }
+
+    @Test
+    public void testPatchExplicitPathObjectValueUnrecognizedSubAttribute() {
+        User expected = client.users().create(createUser());
+
+        // an object value carrying a declared sub-attribute of the explicit complex path is accepted
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .replace("name", "{\"givenName\": \"PatchedGivenName\"}")
+                .build());
+
+        // an object value carrying an unknown sub-attribute of the explicit complex path must be rejected rather
+        // than silently dropped when the attributes are resolved
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("name", "{\"bogus\": \"x\"}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("name.bogus"));
+    }
+
+    @Test
+    public void testPatchPathlessObjectValueUnrecognizedSubAttribute() {
+        User expected = client.users().create(createUser());
+
+        // a pathless value object whose complex member carries an unknown sub-attribute must be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"name\": {\"bogus\": \"x\"}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("name.bogus"));
+    }
+
+    @Test
+    public void testPatchUnrecognizedFilterAttribute() {
+        User expected = client.users().create(createUser());
+
+        // the attribute referenced inside a value-path filter must be a real sub-attribute of the filtered
+        // attribute; "bogus" is not, so the operation must be rejected rather than having the filter silently
+        // stripped (which for "add" would mutate the whole "emails" attribute); per RFC 7644 Table 9, a path
+        // filter problem is classified as invalidFilter, not noTarget
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("emails[bogus eq \"x\"].value", "patched@keycloak.org")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidFilter", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogus"));
+    }
+
+    @Test
+    public void testPatchUnrecognizedNestedValuePathFilterAttribute() {
+        User expected = client.users().create(createUser());
+
+        // the filtered attribute of a nested value-path (as opposed to a plain comparison/presence operand) must
+        // also be a real sub-attribute; "bogus" is not, so it must be rejected instead of being silently ignored
+        // while only the inner "value eq \"x\"" gets checked; per RFC 7644 Table 9, a path filter problem is
+        // classified as invalidFilter, not noTarget
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("emails[bogus[value eq \"x\"]].value", "patched@keycloak.org")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidFilter", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogus"));
+    }
+
+    @Test
+    public void testPatchNestedValuePathFilterAttributeWrongScope() {
+        User expected = client.users().create(createUser());
+
+        // "type" and "value" are both real sub-attributes of "emails", but "type" is scalar and cannot itself be
+        // filtered; the inner "value eq \"x\"" of the nested value-path must be validated against "emails.type",
+        // not against "emails" - so this must be rejected rather than accepted just because "emails.value" happens
+        // to also exist; per RFC 7644 Table 9, a path filter problem is classified as invalidFilter, not noTarget
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("emails[type[value eq \"x\"]].value", "patched@keycloak.org")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidFilter", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("value"));
+    }
+
+    @Test
+    public void testCreateWithNestedComplexUnrecognizedAttribute() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "assurance.value");
+
+        User user = createUser();
+        user.addSchema(customSchema);
+        user.setExtensions(new HashMap<>());
+        HashMap<Object, Object> assurance = new HashMap<>();
+        assurance.put("bogus", "x");
+        HashMap<Object, Object> customSchemaValues = new HashMap<>();
+        customSchemaValues.put("assurance", assurance);
+        user.getExtensions().put(customSchema, customSchemaValues);
+
+        // the extension URI and the "assurance" complex attribute are recognized, but its nested "bogus"
+        // descendant is not - POST/PUT must reject it rather than silently ignore it
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().create(user));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidValue", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":assurance.bogus"));
+    }
+
+    @Test
+    public void testPatchScalarUnderSchemaUri() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // a schema URI is a namespace, not an attribute; a scalar value under it targets no attribute and must be
+        // rejected rather than silently accepted
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": \"x\"}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema));
+    }
+
+    @Test
+    public void testCreateScalarUnderSchemaUri() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User user = createUser();
+        user.addSchema(customSchema);
+        user.setExtensions(new HashMap<>());
+        // the extension URI is recognized, but its value is a scalar rather than an object of attributes
+        user.getExtensions().put(customSchema, "x");
+
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().create(user));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidValue", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema));
+    }
+
+    @Test
+    public void testPatchNestedCustomComplexSubAttribute() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        // a nested sub-attribute declared without a "value" leaf, so the bare "assurance" parent is not synthesized
+        addOrReplaceUPAttribute(customSchema, "assurance.level");
+
+        User expected = client.users().create(createUser());
+
+        // the declared nested leaf resolves by its flattened dotted path (assurance.level); it must be accepted even
+        // though the intermediate "assurance" parent is not itself a declared attribute
+        client.users().patch(expected.getId(), PatchRequest.create()
+                .add("{\"" + customSchema + "\": {\"assurance\": {\"level\": \"high\"}}}")
+                .build());
+
+        // an undeclared leaf under the same nested parent must still be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"assurance\": {\"bogus\": \"x\"}}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":assurance.bogus"));
+    }
+
+    @Test
+    public void testPatchMalformedFilter() {
+        User expected = client.users().create(createUser());
+
+        // a syntactically broken value-path filter is not a "target does not exist" condition; it must surface as
+        // invalidFilter (consistent with how the apply path parses the same filter), not noTarget
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("emails[type eq].value", "patched@keycloak.org")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidFilter", ce.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchUnbalancedFilterDelimiters() {
+        User expected = client.users().create(createUser());
+
+        // a value-path filter missing its closing ']' is malformed, not a "target does not exist" condition; it
+        // must surface as invalidFilter rather than being silently left unstripped and rejected as noTarget
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("emails[type eq \"work\"", "patched@keycloak.org")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidFilter", ce.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchFilterWithMalformedSuffix() {
+        User expected = client.users().create(createUser());
+
+        // a well-formed filter followed by garbage that is not a leading '.' (e.g. not ".value") must not be
+        // silently truncated to the bare "emails" attribute; the whole path is unrecognized and must be rejected
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .replace("emails[type eq \"work\"]bogus", "patched@keycloak.org")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+    }
+
+    @Test
+    public void testPatchPathlessValueUnrecognizedFilterAttribute() {
+        User expected = client.users().create(createUser());
+
+        // the filter-attribute check applied to an explicit operation path must also apply to a member key of a
+        // pathless value object; otherwise "bogus" would be silently stripped and the key normalized to the
+        // recognized "emails.value"; per RFC 7644 Table 9, a path filter problem is classified as invalidFilter,
+        // not noTarget
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"emails[bogus eq \\\"x\\\"].value\": \"patched@keycloak.org\"}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("invalidFilter", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains("bogus"));
+    }
+
+    @Test
+    public void testPatchExtensionUnrecognizedAttributeWithEmptyObjectValue() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // an unrecognized attribute name must be rejected regardless of its value; an empty object has no leaves
+        // to flatten and validate, so the bare attribute name itself must be checked instead of silently accepted
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"bogus\": {}}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
+    public void testPatchExtensionUnrecognizedAttributeWithEmptyArrayValue() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // same as the empty-object case, but for an empty array value
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"bogus\": []}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
+    public void testPatchExtensionUnrecognizedAttributeWithScalarArrayValue() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // an array of scalars (no object items to descend into) must not let an unrecognized attribute name bypass
+        // validation either
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"bogus\": [\"a\", \"b\"]}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
+    public void testPatchExtensionUnrecognizedAttributeWithArrayOfEmptyObjectsValue() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        addOrReplaceUPAttribute(customSchema, "myattribute");
+
+        User expected = client.users().create(createUser());
+
+        // an array whose only items are empty objects has no leaves to descend into either; it must not let an
+        // unrecognized attribute name bypass validation
+        ScimClientException ce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(expected.getId(), PatchRequest.create()
+                        .add("{\"" + customSchema + "\": {\"bogus\": [{}]}}")
+                        .build()));
+        assertNotNull(ce.getError());
+        assertEquals(400, ce.getError().getStatusInt());
+        assertEquals("noTarget", ce.getError().getScimType());
+        assertTrue(ce.getError().getDetail().contains(customSchema + ":bogus"));
+    }
+
+    @Test
     public void testUpdateWithUnrecognizedSchema() throws Exception {
         User expected = client.users().create(createUser());
 
         SimpleHttp http = SimpleHttp.create(httpClient);
-        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
-                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
-                .param(OAuth2Constants.CLIENT_ID, "scim-client")
-                .param(OAuth2Constants.CLIENT_SECRET, "secret")
-                .asJson(AccessTokenResponse.class);
+        String token = getScimClientToken(http);
 
         String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users/" + expected.getId();
         try (SimpleHttpResponse response = http.doPut(url)
-                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Authorization", "Bearer " + token)
                 .header("Content-Type", "application/scim+json")
                 .entity(new StringEntity(
                         "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:User\", \"urn:bogus:Schema\"], "
@@ -1961,15 +2488,11 @@ public class UserTest extends AbstractScimTest {
         User expected = client.users().create(createUser());
 
         SimpleHttp http = SimpleHttp.create(httpClient);
-        AccessTokenResponse tokenResponse = http.doPost(keycloakUrls.getToken(realm.getName()))
-                .param(OAuth2Constants.GRANT_TYPE, OAuth2Constants.CLIENT_CREDENTIALS)
-                .param(OAuth2Constants.CLIENT_ID, "scim-client")
-                .param(OAuth2Constants.CLIENT_SECRET, "secret")
-                .asJson(AccessTokenResponse.class);
+        String token = getScimClientToken(http);
 
         String url = keycloakUrls.getBase() + "/realms/" + realm.getName() + "/scim/v2/Users/" + expected.getId();
         try (SimpleHttpResponse response = http.doPut(url)
-                .header("Authorization", "Bearer " + tokenResponse.getToken())
+                .header("Authorization", "Bearer " + token)
                 .header("Content-Type", "application/scim+json")
                 .entity(new StringEntity(
                         "{\"schemas\": [\"urn:ietf:params:scim:schemas:core:2.0:User\"], "


### PR DESCRIPTION
- reject requests that reference unrecognized schema URIs or attribute paths per RFC 7644

Closes #48602

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
