### PR TITLE
Mask client secret from view-clients role holders on GET endpoints

### DIFF
--- a/docs/documentation/server_admin/topics/clients/oidc/con-confidential-client-credentials.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-confidential-client-credentials.adoc
@@ -14,11 +14,15 @@ The *Client Authenticator* drop-down list specifies the type of credential to us
 
 This choice is the default setting. A random secret is generated automatically, but you can override it with a specific value if needed. The client secret can also reference a value stored in an <<_vault-administration,external vault>>. Click *Regenerate* to recreate random secret if necessary.
 
-
 As specified in the OAuth2 and OpenID Connect specifications, it is possible to authenticate client either with the client secret in the `Authorization: Basic`
 header (together with `client_id`) or by sending `client_id` and `client_secret` as parameters in the HTTP POST method body. You can configure the *Allowed authentication
 method* to restrict only to one specified method of those if you want to authenticate client for example just with the `Authorization: Basic` method, but never with the request
 parameters sent in the HTTP POST method body.
+
+WARNING: Viewing the client secret through the Admin REST API requires `manage-clients` permission.
+Users with only `view-clients` permission will see a masked placeholder (`**********`) instead of the actual secret.
+This applies to the client list endpoint (`GET /admin/realms/{realm}/clients`), the individual client endpoint (`GET /admin/realms/{realm}/clients/{id}`), and the dedicated client secret endpoint (`GET /admin/realms/{realm}/clients/{id}/client-secret`).
+Ensure that any delegated administrator or automation that needs to read client secrets is granted the `manage-clients` realm role.
 
 *Signed JWT issued by the client*
 image:images/client-credentials-jwt.png[Signed JWT]

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -11,6 +11,14 @@ The listing endpoints for default and optional client scopes now return an empty
 
 If you have delegated administrators that assign client scopes using Fine-Grained Admin Permissions, ensure they also have the `manage-clients` realm admin role or a type-level `manage` permission on the Clients resource type.
 
+=== Client secret no longer returned for view-only client permissions
+
+The Admin REST API endpoints for retrieving client representations (`GET /admin/realms/\{realm}/clients` and `GET /admin/realms/\{realm}/clients/\{id}`) no longer include the client secret in the response when the caller only has `view-clients` permission. To view the client secret, the caller must have `manage-clients` permission.
+
+Previously, any caller with the `view-clients` role could read client secrets from the API response, which posed a security risk as it allowed read-only administrators to access sensitive credentials. After upgrading, callers with only `view-clients` permission will see a masked placeholder (`**********`) instead of the actual secret value.
+
+If you have delegated administrators or automation that reads client secrets using the `view-clients` role, ensure they are granted the `manage-clients` realm admin role or equivalent `manage` permission on the Clients resource type.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
@@ -234,6 +234,10 @@ public class StripSecretsUtils {
         return rep;
     }
 
+    public static ClientRepresentation strip(ClientRepresentation rep) {
+        return stripClient(rep);
+    }
+
     private static ComponentExportRepresentation stripComponentExport(KeycloakSession session, String providerType, ComponentExportRepresentation rep) {
         return stripComponentExport(session, providerType, rep, ComponentUtil::getComponentConfigProperties);
     }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
@@ -225,17 +225,13 @@ public class StripSecretsUtils {
         return user;
     }
 
-    protected static ClientRepresentation stripClient(ClientRepresentation rep) {
+    public static ClientRepresentation stripClient(ClientRepresentation rep) {
         if (rep.getSecret() != null) {
             rep.setSecret(maskNonVaultValue(rep.getSecret()));
         }
 
         stripFromMap(rep.getAttributes(), ClientSecretConstants.CLIENT_ROTATED_SECRET);
         return rep;
-    }
-
-    public static ClientRepresentation strip(ClientRepresentation rep) {
-        return stripClient(rep);
     }
 
     private static ComponentExportRepresentation stripComponentExport(KeycloakSession session, String providerType, ComponentExportRepresentation rep) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -61,6 +61,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
+import org.keycloak.models.utils.StripSecretsUtils;
 import org.keycloak.protocol.ClientInstallationProvider;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocolFactory;
@@ -205,6 +206,10 @@ public class ClientResource {
         viewClientModel();
 
         ClientRepresentation representation = ModelToRepresentation.toRepresentation(client, session);
+
+        if (!auth.clients().canManage(client)) {
+            StripSecretsUtils.strip(representation);
+        }
 
         if (!auth.clients().canViewClientScopes()) {
             representation.setDefaultClientScopes(Collections.emptyList());
@@ -367,7 +372,7 @@ public class ClientResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
     @Operation( summary = "Get the client secret")
     public CredentialRepresentation getClientSecret() {
-        auth.clients().requireView(client);
+        auth.clients().requireManage(client);
 
         logger.debug("getClientSecret");
         UserCredentialModel model = UserCredentialModel.secret(client.getSecret());
@@ -831,7 +836,7 @@ public class ClientResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
     @Operation( summary = "Get the rotated client secret")
     public CredentialRepresentation getClientRotatedSecret() {
-        auth.clients().requireView(client);
+        auth.clients().requireManage(client);
 
         logger.debug("getClientRotatedSecret");
         OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientModel(client);

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -208,7 +208,7 @@ public class ClientResource {
         ClientRepresentation representation = ModelToRepresentation.toRepresentation(client, session);
 
         if (!auth.clients().canManage(client)) {
-            StripSecretsUtils.strip(representation);
+            StripSecretsUtils.stripClient(representation);
         }
 
         if (!auth.clients().canViewClientScopes()) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -127,7 +127,7 @@ public class ClientsResource {
                 getClientModels(clientId, viewableOnly, search, searchQuery, firstResult, maxResults), c -> {
                     ClientRepresentation representation = ModelToRepresentation.toRepresentation(c, session);
                     if (!auth.clients().canManage(c)) {
-                        StripSecretsUtils.strip(representation);
+                        StripSecretsUtils.stripClient(representation);
                     }
                     representation.setAccess(auth.clients().getAccess(c));
                     return representation;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -46,6 +46,7 @@ import org.keycloak.models.ModelException;
 import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.StripSecretsUtils;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import org.keycloak.services.ErrorResponse;
@@ -125,6 +126,9 @@ public class ClientsResource {
         return ModelToRepresentation.filterValidRepresentations(
                 getClientModels(clientId, viewableOnly, search, searchQuery, firstResult, maxResults), c -> {
                     ClientRepresentation representation = ModelToRepresentation.toRepresentation(c, session);
+                    if (!auth.clients().canManage(c)) {
+                        StripSecretsUtils.strip(representation);
+                    }
                     representation.setAccess(auth.clients().getAccess(c));
                     return representation;
                 });

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientSecretVisibilityTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientSecretVisibilityTest.java
@@ -11,7 +11,6 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.testframework.admin.AdminClientFactory;
-import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectAdminClientFactory;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -47,9 +46,6 @@ public class ClientSecretVisibilityTest {
     @InjectAdminClientFactory
     AdminClientFactory adminClientFactory;
 
-    @InjectAdminClient
-    Keycloak adminClient;
-
     private String confidentialClientUuid;
 
     @BeforeEach
@@ -62,15 +58,11 @@ public class ClientSecretVisibilityTest {
     @Test
     public void viewOnly_getClient_secretIsMasked() {
         try (Keycloak viewClient = createViewOnlyClient()) {
-            try {
-                ClientRepresentation rep = viewClient.realm(realm.getName())
-                        .clients().get(confidentialClientUuid)
-                        .toRepresentation();
-                assertThat(rep.getSecret(), is(not(CONFIDENTIAL_CLIENT_SECRET)));
-                assertThat(rep.getSecret(), anyOf(nullValue(), is(ComponentRepresentation.SECRET_VALUE)));
-            } catch (ForbiddenException expected) {
-                    // Expected -- view-only users must not access the dedicated secret endpoint
-            }
+            ClientRepresentation rep = viewClient.realm(realm.getName())
+                    .clients().get(confidentialClientUuid)
+                    .toRepresentation();
+            assertThat(rep.getSecret(), is(not(CONFIDENTIAL_CLIENT_SECRET)));
+            assertThat(rep.getSecret(), anyOf(nullValue(), is(ComponentRepresentation.SECRET_VALUE)));
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientSecretVisibilityTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientSecretVisibilityTest.java
@@ -1,0 +1,231 @@
+package org.keycloak.tests.admin;
+
+import java.util.List;
+
+import jakarta.ws.rs.ForbiddenException;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.Constants;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.testframework.admin.AdminClientFactory;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectAdminClientFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@KeycloakIntegrationTest
+public class ClientSecretVisibilityTest {
+
+    private static final String VIEW_ONLY_USER = "view-only-user";
+    private static final String MANAGE_USER = "manage-user";
+    private static final String PASSWORD = "password";
+    private static final String CONFIDENTIAL_CLIENT_ID = "test-confidential";
+    private static final String CONFIDENTIAL_CLIENT_SECRET = "test-secret-value";
+
+    @InjectRealm(config = SecretVisibilityRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectAdminClientFactory
+    AdminClientFactory adminClientFactory;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    private String confidentialClientUuid;
+
+    @BeforeEach
+    public void setUp() {
+        confidentialClientUuid = realm.admin()
+                .clients().findByClientId(CONFIDENTIAL_CLIENT_ID)
+                .get(0).getId();
+    }
+
+    @Test
+    public void viewOnly_getClient_secretIsMasked() {
+        try (Keycloak viewClient = createViewOnlyClient()) {
+            try {
+                ClientRepresentation rep = viewClient.realm(realm.getName())
+                        .clients().get(confidentialClientUuid)
+                        .toRepresentation();
+                assertThat(rep.getSecret(), is(not(CONFIDENTIAL_CLIENT_SECRET)));
+                assertThat(rep.getSecret(), anyOf(nullValue(), is(ComponentRepresentation.SECRET_VALUE)));
+            } catch (ForbiddenException expected) {
+                    // Expected -- view-only users must not access the dedicated secret endpoint
+            }
+        }
+    }
+
+    @Test
+    public void viewOnly_getClients_secretsAreMasked() {
+        try (Keycloak viewClient = createViewOnlyClient()) {
+            List<ClientRepresentation> clients = viewClient.realm(realm.getName())
+                    .clients().findAll();
+
+            ClientRepresentation target = clients.stream()
+                    .filter(c -> CONFIDENTIAL_CLIENT_ID.equals(c.getClientId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "Confidential client not found in list"));
+
+            assertThat(target.getSecret(), is(not(CONFIDENTIAL_CLIENT_SECRET)));
+            assertThat(target.getSecret(),
+                    anyOf(nullValue(), is(ComponentRepresentation.SECRET_VALUE)));
+        }
+    }
+
+    @Test
+    public void viewOnly_getClientRotatedSecret_returns403() {
+        try (Keycloak viewClient = createViewOnlyClient()) {
+            try {
+                viewClient.realm(realm.getName())
+                        .clients().get(confidentialClientUuid)
+                        .getClientRotatedSecret();
+                fail("Expected ForbiddenException for view-only user"
+                        + " on getClientRotatedSecret()");
+            } catch (ForbiddenException expected) {
+                // Expected -- 403 before the not-found check
+            } catch (jakarta.ws.rs.NotFoundException e) {
+                fail("Got 404 instead of 403 — auth check is too permissive");
+            }
+        }
+    }
+
+    @Test
+    public void viewOnly_getClientSecret_returns403() {
+        try (Keycloak viewClient = createViewOnlyClient()) {
+            try {
+                viewClient.realm(realm.getName())
+                        .clients().get(confidentialClientUuid)
+                        .getSecret();
+                fail("Expected ForbiddenException for view-only user on getClientSecret()");
+            } catch (ForbiddenException expected) {
+                // Expected -- view-only users must not access the dedicated secret endpoint
+            }
+        }
+    }
+
+    @Test
+    public void manageRole_getClient_secretIsVisible() {
+        try (Keycloak manageClient = createManageClient()) {
+            ClientRepresentation rep = manageClient.realm(realm.getName())
+                    .clients().get(confidentialClientUuid).toRepresentation();
+
+            assertThat(rep.getSecret(), is(notNullValue()));
+            assertThat(rep.getSecret(), is(not(ComponentRepresentation.SECRET_VALUE)));
+        }
+    }
+
+    @Test
+    public void manageRole_getClients_secretsAreVisible() {
+        try (Keycloak manageClient = createManageClient()) {
+            List<ClientRepresentation> clients = manageClient.realm(realm.getName())
+                    .clients().findAll();
+
+            ClientRepresentation target = clients.stream()
+                    .filter(c -> CONFIDENTIAL_CLIENT_ID.equals(c.getClientId()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            "Confidential client not found in list"));
+
+            assertThat(target.getSecret(), is(notNullValue()));
+            assertThat(target.getSecret(), is(not(ComponentRepresentation.SECRET_VALUE)));
+        }
+    }
+
+    @Test
+    public void manageRole_getClientSecret_returnsSecret() {
+        try (Keycloak manageClient = createManageClient()) {
+            CredentialRepresentation secret = manageClient.realm(realm.getName())
+                    .clients().get(confidentialClientUuid)
+                    .getSecret();
+
+            assertThat(secret, is(notNullValue()));
+            assertThat(secret.getValue(), is(notNullValue()));
+            assertThat(secret.getValue(), is(not(ComponentRepresentation.SECRET_VALUE)));
+        }
+    }
+
+    @Test
+    public void publicClient_getClient_secretIsNull() {
+        List<ClientRepresentation> clients = realm.admin().clients().findAll();
+
+        ClientRepresentation publicClient = clients.stream()
+                .filter(c -> "test-public".equals(c.getClientId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Public client not found"));
+
+        assertThat(publicClient.getSecret(), is(nullValue()));
+    }
+
+    // --- Realm Configuration ---
+
+    public static class SecretVisibilityRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.clients(ClientBuilder.create(CONFIDENTIAL_CLIENT_ID)
+                    .secret(CONFIDENTIAL_CLIENT_SECRET)
+                    .directAccessGrantsEnabled(true));
+
+            // Public client for regression test
+            realm.clients(ClientBuilder.create("test-public")
+                          .publicClient());
+
+            // User with only view-clients role
+            realm.users(UserBuilder.create(VIEW_ONLY_USER)
+                    .password(PASSWORD)
+                    .email("viewonly@localhost")
+                    .firstName("View")
+                    .lastName("Only")
+                    .clientRoles(Constants.REALM_MANAGEMENT_CLIENT_ID,
+                            AdminRoles.VIEW_CLIENTS));
+
+            // User with manage-clients role
+            realm.users(UserBuilder.create(MANAGE_USER)
+                    .password(PASSWORD)
+                    .email("manage@localhost")
+                    .firstName("Manage")
+                    .lastName("Clients")
+                    .clientRoles(Constants.REALM_MANAGEMENT_CLIENT_ID,
+                            AdminRoles.MANAGE_CLIENTS));
+
+            return realm;
+        }
+    }
+
+    private Keycloak createViewOnlyClient() {
+        return adminClientFactory.create()
+                .realm(realm.getName())
+                .username(VIEW_ONLY_USER)
+                .password(PASSWORD)
+                .clientId(Constants.ADMIN_CLI_CLIENT_ID)
+                .build();
+    }
+
+    private Keycloak createManageClient() {
+        return adminClientFactory.create()
+                .realm(realm.getName())
+                .username(MANAGE_USER)
+                .password(PASSWORD)
+                .clientId(Constants.ADMIN_CLI_CLIENT_ID)
+                .build();
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
@@ -157,6 +157,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
         invoke(realm -> realm.clients().get(foo.getId()).generateNewSecret(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).regenerateRegistrationAccessToken(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).getSecret(), Resource.CLIENT, true);
+        invoke(realm -> realm.clients().get(foo.getId()).getClientRotatedSecret(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).getServiceAccountUser(), Resource.CLIENT, false);
         invoke(realm -> realm.clients().get(foo.getId()).pushRevocation(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).getApplicationSessionCount(), Resource.CLIENT, false);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
@@ -156,7 +156,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
         }, Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).generateNewSecret(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).regenerateRegistrationAccessToken(), Resource.CLIENT, true);
-        invoke(realm -> realm.clients().get(foo.getId()).getSecret(), Resource.CLIENT, false);
+        invoke(realm -> realm.clients().get(foo.getId()).getSecret(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).getServiceAccountUser(), Resource.CLIENT, false);
         invoke(realm -> realm.clients().get(foo.getId()).pushRevocation(), Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).getApplicationSessionCount(), Resource.CLIENT, false);


### PR DESCRIPTION

Changes:
  - StripSecretsUtils.strip() to mask the secret field when the caller lacks manage-clients permission
  - ClientResource.getClientSecret() and getClientRotatedSecret() now require manage-clients instead of view-clients,returning 403 to view-only callers
  - Added public StripSecretsUtils.stri (ClientRepresentation) overload to expose the existing protected stripClient() logic
  - Added and updated tests

Closes #49220
