### PR TITLE
Client-protocol condition can be bypassed on admin client creation by…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/authentication/ClientAuthenticatorFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/authentication/ClientAuthenticatorFactory.java
@@ -71,7 +71,7 @@ public interface ClientAuthenticatorFactory extends ProviderFactory<ClientAuthen
      *         For example "client_secret_basic", "client_secret_post" or "private_key_jwt" might be used as returned values.
      */
     default String getProtocolAuthenticatorMethod(ClientRepresentation client) {
-        String loginProtocol = client.getProtocol() == null ? Constants.OIDC_PROTOCOL : client.getProtocol();
+        String loginProtocol = client.getProtocol() == null ? Constants.DEFAULT_PROTOCOL : client.getProtocol();
         Set<String> protocolAuthMethods = getProtocolAuthenticatorMethods(loginProtocol);
         return protocolAuthMethods == null || protocolAuthMethods.isEmpty() ? null : protocolAuthMethods.iterator().next();
     }

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -250,6 +250,9 @@ public final class Constants {
     // Provider ID of the openid-connect protocol
     public static final String OIDC_PROTOCOL = "openid-connect";
 
+    // Default login protocol
+    public static final String DEFAULT_PROTOCOL = OIDC_PROTOCOL;
+
     // Internal note for storing authorization details response in client session context
     public static final String AUTHORIZATION_DETAILS_RESPONSE = "authorization_details_response";
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -146,14 +146,13 @@ import org.jboss.logging.Logger;
 
 import static java.util.Optional.ofNullable;
 
+import static org.keycloak.models.Constants.DEFAULT_PROTOCOL;
 import static org.keycloak.models.OrganizationDomainModel.ANY_DOMAIN;
 import static org.keycloak.protocol.saml.util.ArtifactBindingUtils.computeArtifactBindingIdentifierString;
 
 public class RepresentationToModel {
 
     private static Logger logger = Logger.getLogger(RepresentationToModel.class);
-    public static final String OIDC = "openid-connect";
-
 
     public static void importRealm(KeycloakSession session, RealmRepresentation rep, RealmModel newRealm, Runnable userImport) {
         session.getProvider(DatastoreProvider.class).getExportImportManager().importRealm(rep, newRealm, userImport);
@@ -557,7 +556,7 @@ public class RepresentationToModel {
             add(updatePropertyAction(client::setFrontchannelLogout, rep::isFrontchannelLogout, client::isFrontchannelLogout));
             add(updatePropertyAction(client::setNotBefore, rep::getNotBefore, client::getNotBefore));
             // Fields with defaults if not initially provided
-            add(updatePropertyAction(client::setProtocol, rep::getProtocol, client::getProtocol, () -> OIDC));
+            add(updatePropertyAction(client::setProtocol, rep::getProtocol, client::getProtocol, () -> DEFAULT_PROTOCOL));
             add(updatePropertyAction(client::setNodeReRegistrationTimeout, rep::getNodeReRegistrationTimeout, () -> defaultNodeReRegistrationTimeout(client, isNew)));
             add(updatePropertyAction(client::setClientAuthenticatorType, rep::getClientAuthenticatorType, client::getClientAuthenticatorType, KeycloakModelUtils::getDefaultClientAuthenticatorType));
             add(updatePropertyAction(client::setFullScopeAllowed, rep::isFullScopeAllowed, () -> defaultFullScopeAllowed(client, isNew)));

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientProtocolCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientProtocolCondition.java
@@ -26,6 +26,7 @@ import org.keycloak.services.clientpolicy.ClientPolicyVote;
 import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
 import org.keycloak.services.clientpolicy.context.ClientModelContext;
 
+import static org.keycloak.models.Constants.DEFAULT_PROTOCOL;
 import static org.keycloak.services.clientpolicy.ClientPolicyEvent.REGISTER;
 
 /**
@@ -81,7 +82,12 @@ public class ClientProtocolCondition extends AbstractClientPolicyConditionProvid
             if (isCorrectClientProtocol(client)) {
                 return ClientPolicyVote.YES;
             } else {
-                return ClientPolicyVote.NO;
+                // In case that there is an attempt to update protocol to the target protocol, condition should be also evaluated to success
+                if (context instanceof ClientCRUDContext && isCorrectProtocolFromRepresentation((ClientCRUDContext)context)) {
+                    return ClientPolicyVote.YES;
+                } else {
+                    return ClientPolicyVote.NO;
+                }
             }
         } else {
             return ClientPolicyVote.ABSTAIN;
@@ -90,10 +96,8 @@ public class ClientProtocolCondition extends AbstractClientPolicyConditionProvid
 
     private boolean isCorrectClientProtocol(ClientModel client) {
         if (client != null) {
-            String protocol = client.getProtocol();
-            if (protocol != null) {
-                return protocol.equals(configuration.getProtocol());
-            }
+            String protocol = client.getProtocol() == null ? DEFAULT_PROTOCOL : client.getProtocol();
+            return protocol.equals(configuration.getProtocol());
         }
         return false;
     }
@@ -102,9 +106,10 @@ public class ClientProtocolCondition extends AbstractClientPolicyConditionProvid
         ClientRepresentation clientRep = context.getProposedClientRepresentation();
         if (clientRep != null) {
             String protocol = clientRep.getProtocol();
-            if (protocol != null) {
-                return protocol.equals(configuration.getProtocol());
+            if (protocol == null && context.getEvent() == REGISTER) {
+                protocol = DEFAULT_PROTOCOL;
             }
+            return protocol != null && protocol.equals(configuration.getProtocol());
         }
         return false;
     }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/RejectResourceOwnerPasswordCredentialsGrantExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/RejectResourceOwnerPasswordCredentialsGrantExecutor.java
@@ -75,9 +75,9 @@ public class RejectResourceOwnerPasswordCredentialsGrantExecutor implements Clie
         switch (context.getEvent()) {
             case REGISTER:
             case UPDATE:
-                ClientCRUDContext clientUpdateContext = (ClientCRUDContext)context;
-                autoConfigure(clientUpdateContext.getProposedClientRepresentation());
-                validate(clientUpdateContext.getProposedClientRepresentation());
+                ClientCRUDContext clientCRUDContext = (ClientCRUDContext)context;
+                autoConfigure(clientCRUDContext.getProposedClientRepresentation());
+                validate(clientCRUDContext);
                 break;
             case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
                 ResourceOwnerPasswordCredentialsContext ropcContext = (ResourceOwnerPasswordCredentialsContext)context;
@@ -93,8 +93,23 @@ public class RejectResourceOwnerPasswordCredentialsGrantExecutor implements Clie
             rep.setDirectAccessGrantsEnabled(Boolean.FALSE);
     }
 
-    private void validate(ClientRepresentation rep) throws ClientPolicyException {
-        boolean isResourceOwnerPasswordCredentialsGrantEnabled = rep.isDirectAccessGrantsEnabled().booleanValue();
+    private boolean getEffectiveResourceOwnerPasswordCredentialsGrantEnabled(ClientCRUDContext clientCRUDContext) {
+        Boolean resourceOwnerEnabled = clientCRUDContext.getProposedClientRepresentation().isDirectAccessGrantsEnabled();
+        if (resourceOwnerEnabled != null) {
+            return resourceOwnerEnabled;
+        } else {
+            // The "directAccessGrants" field is not filled in the representation, so it effectively has same value as before the update
+            if (clientCRUDContext.getTargetClient() != null) {
+                return clientCRUDContext.getTargetClient().isDirectAccessGrantsEnabled();
+            } else {
+                // Registration of new client. The "directAccessGrants" is disabled by default
+                return false;
+            }
+        }
+    }
+
+    private void validate(ClientCRUDContext clientCRUDContext) throws ClientPolicyException {
+        boolean isResourceOwnerPasswordCredentialsGrantEnabled = getEffectiveResourceOwnerPasswordCredentialsGrantEnabled(clientCRUDContext);
         if (!isResourceOwnerPasswordCredentialsGrantEnabled) return;
         throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT_METADATA, "Invalid client metadata: resource owner password credentials grant enabled");
     }

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientPoliciesClientCRUDTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientPoliciesClientCRUDTest.java
@@ -1,0 +1,84 @@
+package org.keycloak.tests.client.policies;
+
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.saml.SamlProtocol;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolCondition;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolConditionFactory;
+import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutor;
+import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutorFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.tests.utils.ClientPoliciesUtil.createClientProtocolConditionConfig;
+import static org.keycloak.tests.utils.ClientPoliciesUtil.createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Test for the client policies with CRUD of clients. For example test for scenarios when registration/update of client should fail because of client policies
+ */
+@KeycloakIntegrationTest
+public class ClientPoliciesClientCRUDTest extends AbstractClientPoliciesTest {
+
+    @InjectRealm
+    protected ManagedRealm realm;
+
+    @Test
+    public void testClientProtocolConditionClientCRUD() throws Exception {
+        // Register profile
+        RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration rejectResourceOwnerRegistration = createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(false);
+
+        // register policies - client protocol condition
+        ClientProtocolCondition.Configuration protocolConditionConfig = createClientProtocolConditionConfig(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        setupPolicy(realm, RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID, rejectResourceOwnerRegistration,
+                ClientProtocolConditionFactory.PROVIDER_ID, protocolConditionConfig);
+
+        // Register client including protocol. Should fail
+        try {
+            createClientByAdmin(realm, "example-client", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+                clientRep.setDirectAccessGrantsEnabled(true);
+            });
+            fail();
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Invalid client metadata: resource owner password credentials grant enabled", cpe.getErrorDetail());
+        }
+
+        // Register client without protocol. Should fail as protocol is OIDC by default
+        try {
+            createClientByAdmin(realm, "example-client", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+                clientRep.setProtocol(null);
+                clientRep.setDirectAccessGrantsEnabled(true);
+            });
+            fail();
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Invalid client metadata: resource owner password credentials grant enabled", cpe.getErrorDetail());
+        }
+
+        // Create SAML client - should be successful
+        String clientUUID = createClientByAdmin(realm, "example-client", SamlProtocol.LOGIN_PROTOCOL,clientRep -> {});
+
+        // Try to update existing SAML client. Change protocol to OIDC and try to enable directAccessGrant. It should fail
+        try {
+            updateClientByAdmin(realm, clientUUID, (clientRep) -> {
+                clientRep.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+                clientRep.setDirectAccessGrantsEnabled(true);
+            });
+            fail();
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Invalid client metadata: resource owner password credentials grant enabled", cpe.getErrorDetail());
+        }
+
+        // Lookup client and check protocol is still SAML
+        ClientRepresentation foundRep = realm.admin().clients().get(clientUUID).toRepresentation();
+        assertEquals(SamlProtocol.LOGIN_PROTOCOL, foundRep.getProtocol());
+
+        // Try to create OIDC client without directGrants - should be success
+        createClientByAdmin(realm, "example-client-oidc", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {});
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/utils/ClientPoliciesUtil.java
+++ b/tests/base/src/test/java/org/keycloak/tests/utils/ClientPoliciesUtil.java
@@ -1,0 +1,502 @@
+package org.keycloak.tests.utils;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.MultivaluedMap;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwk.ECPublicJWK;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jws.Algorithm;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.json.RawJsonValue;
+import org.keycloak.models.utils.MapperTypeSerializer;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.condition.ClientIdUriSchemeCondition;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutor;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor.SecureCibaAuthenticationRequestSigningAlgorithmExecutor;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorRepresentation;
+import org.keycloak.representations.idm.ClientPolicyRepresentation;
+import org.keycloak.representations.idm.ClientProfileRepresentation;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
+import org.keycloak.services.clientpolicy.condition.ClientAttributesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolCondition;
+import org.keycloak.services.clientpolicy.condition.ClientRolesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceGroupsCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceHostsCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceRolesCondition;
+import org.keycloak.services.clientpolicy.condition.GrantTypeCondition;
+import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutor;
+import org.keycloak.services.clientpolicy.executor.DPoPBindEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutor;
+import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.IntentClientBindCheckExecutor;
+import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.RejectImplicitGrantExecutor;
+import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtExecutor;
+import org.keycloak.util.DPoPGenerator;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.keycloak.jose.jwk.JWKUtil.toIntegerBytes;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public final class ClientPoliciesUtil {
+
+    public static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Client Profiles CRUD Operations
+
+    public static class ClientProfilesBuilder {
+        private final ClientProfilesRepresentation profilesRep;
+
+        public ClientProfilesBuilder() {
+            profilesRep = new ClientProfilesRepresentation();
+            profilesRep.setProfiles(new ArrayList<>());
+        }
+
+        // Create client profile from existing representation
+        public ClientProfilesBuilder(ClientProfilesRepresentation existingRep) {
+            this.profilesRep = existingRep;
+        }
+
+        public ClientProfilesBuilder addProfile(ClientProfileRepresentation rep) {
+            profilesRep.getProfiles().add(rep);
+            return this;
+        }
+
+        public ClientProfilesRepresentation toRepresentation() {
+            return profilesRep;
+        }
+
+        public String toString() {
+            String profilesJson = null;
+            try {
+                profilesJson = objectMapper.writeValueAsString(profilesRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return profilesJson;
+        }
+    }
+
+    public static class ClientProfileBuilder {
+
+        private final ClientProfileRepresentation profileRep;
+
+        public ClientProfileBuilder() {
+            profileRep = new ClientProfileRepresentation();
+        }
+
+        public ClientProfileBuilder createProfile(String name, String description) {
+            if (name != null) {
+                profileRep.setName(name);
+            }
+            if (description != null) {
+                profileRep.setDescription(description);
+            }
+            profileRep.setExecutors(new ArrayList<>());
+
+            return this;
+        }
+
+        public ClientProfileBuilder addExecutor(String providerId, ClientPolicyExecutorConfigurationRepresentation config) throws Exception {
+            if (config == null) {
+                config = new ClientPolicyExecutorConfigurationRepresentation();
+            }
+            ClientPolicyExecutorRepresentation executor = new ClientPolicyExecutorRepresentation();
+            executor.setExecutorProviderId(providerId);
+            executor.setConfiguration(RawJsonValue.of(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class)));
+            profileRep.getExecutors().add(executor);
+            return this;
+        }
+
+        public ClientProfileRepresentation toRepresentation() {
+            return profileRep;
+        }
+
+        public String toString() {
+            String profileJson = null;
+            try {
+                profileJson = objectMapper.writeValueAsString(profileRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return profileJson;
+        }
+    }
+
+    // Client Profiles - Executor CRUD Operations
+
+    public static HolderOfKeyEnforcerExecutor.Configuration createHolderOfKeyEnforceExecutorConfig(Boolean autoConfigure) {
+        HolderOfKeyEnforcerExecutor.Configuration config = new HolderOfKeyEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static PKCEEnforcerExecutor.Configuration createPKCEEnforceExecutorConfig(Boolean autoConfigure) {
+        PKCEEnforcerExecutor.Configuration config = new PKCEEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static FullScopeDisabledExecutor.Configuration createFullScopeDisabledExecutorConfig(Boolean autoConfigure) {
+        FullScopeDisabledExecutor.Configuration config = new FullScopeDisabledExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static ConsentRequiredExecutor.Configuration createConsentRequiredExecutorConfig(Boolean autoConfigure) {
+        ConsentRequiredExecutor.Configuration config = new ConsentRequiredExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static SecureClientAuthenticatorExecutor.Configuration createSecureClientAuthenticatorExecutorConfig(List<String> allowedClientAuthenticators, String defaultClientAuthenticator) {
+        SecureClientAuthenticatorExecutor.Configuration config = new SecureClientAuthenticatorExecutor.Configuration();
+        config.setAllowedClientAuthenticators(allowedClientAuthenticators);
+        config.setDefaultClientAuthenticator(defaultClientAuthenticator);
+        return config;
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf) {
+        return createSecureRequestObjectExecutorConfig(availablePeriod, verifyNbf, false);
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf, Boolean encryptionRequired) {
+        return createSecureRequestObjectExecutorConfig(availablePeriod, verifyNbf, encryptionRequired, null);
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf, Boolean encryptionRequired, Integer allowedClockSkew) {
+        SecureRequestObjectExecutor.Configuration config = new SecureRequestObjectExecutor.Configuration();
+        if (availablePeriod != null) config.setAvailablePeriod(availablePeriod);
+        if (verifyNbf != null) config.setVerifyNbf(verifyNbf);
+        if (encryptionRequired != null) config.setEncryptionRequired(encryptionRequired);
+        if (allowedClockSkew != null) config.setAllowedClockSkew(allowedClockSkew);
+        return config;
+    }
+
+    public static SecureResponseTypeExecutor.Configuration createSecureResponseTypeExecutor(Boolean autoConfigure, Boolean allowTokenResponseType) {
+        SecureResponseTypeExecutor.Configuration config = new SecureResponseTypeExecutor.Configuration();
+        if (autoConfigure != null) config.setAutoConfigure(autoConfigure);
+        if (allowTokenResponseType != null) config.setAllowTokenResponseType(allowTokenResponseType);
+        return config;
+    }
+
+    public static SecureSigningAlgorithmForSignedJwtExecutor.Configuration createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig(Boolean requireClientAssertion) {
+        SecureSigningAlgorithmForSignedJwtExecutor.Configuration config = new SecureSigningAlgorithmForSignedJwtExecutor.Configuration();
+        config.setRequireClientAssertion(requireClientAssertion);
+        return config;
+    }
+
+    public static SecureSigningAlgorithmExecutor.Configuration createSecureSigningAlgorithmEnforceExecutorConfig(String defaultAlgorithm) {
+        SecureSigningAlgorithmExecutor.Configuration config = new SecureSigningAlgorithmExecutor.Configuration();
+        config.setDefaultAlgorithm(defaultAlgorithm);
+        return config;
+    }
+
+    public static SecureCibaAuthenticationRequestSigningAlgorithmExecutor.Configuration createSecureCibaAuthenticationRequestSigningAlgorithmExecutorConfig(String defaultAlgorithm) {
+        SecureCibaAuthenticationRequestSigningAlgorithmExecutor.Configuration config = new SecureCibaAuthenticationRequestSigningAlgorithmExecutor.Configuration();
+        config.setDefaultAlgorithm(defaultAlgorithm);
+        return config;
+    }
+
+    public static RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean autoConfigure) {
+        RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration config = new RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static RejectImplicitGrantExecutor.Configuration createRejectImplicitGrantExecutorConfig(Boolean autoConfigure) {
+        RejectImplicitGrantExecutor.Configuration config = new RejectImplicitGrantExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static IntentClientBindCheckExecutor.Configuration createIntentClientBindCheckExecutorConfig(String intentName, String endpoint) {
+        IntentClientBindCheckExecutor.Configuration config = new IntentClientBindCheckExecutor.Configuration();
+        config.setIntentName(intentName);
+        config.setIntentClientBindCheckEndpoint(endpoint);
+        return config;
+    }
+
+    public static DPoPBindEnforcerExecutor.Configuration createDPoPBindEnforcerExecutorConfig(Boolean autoConfigure, Boolean enforceAuthorizationCodeBindingToDpop, Boolean bindRefreshToken) {
+        DPoPBindEnforcerExecutor.Configuration config = new DPoPBindEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        config.setEnforceAuthorizationCodeBindingToDpop(enforceAuthorizationCodeBindingToDpop);
+        config.setAllowOnlyRefreshTokenBinding(bindRefreshToken);
+        return config;
+    }
+
+    public static SecureRedirectUrisEnforcerExecutor.Configuration createSecureRedirectUrisEnforcerExecutorConfig(
+            Consumer<SecureRedirectUrisEnforcerExecutor.Configuration> apply) {
+        SecureRedirectUrisEnforcerExecutor.Configuration config = new SecureRedirectUrisEnforcerExecutor.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static ClientIdMetadataDocumentExecutor.Configuration createClientIdMetadataDocumentExecutorConfig(
+            Consumer<ClientIdMetadataDocumentExecutor.Configuration> apply) {
+        ClientIdMetadataDocumentExecutor.Configuration config = new ClientIdMetadataDocumentExecutor.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static ClientIdUriSchemeCondition.Configuration createClientIdUriSchemeConditionConfig(
+            Consumer<ClientIdUriSchemeCondition.Configuration> apply) {
+        ClientIdUriSchemeCondition.Configuration config = new ClientIdUriSchemeCondition.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static <CONFIG extends ClientPolicyExecutorConfigurationRepresentation> CONFIG createExecutorConfig(
+            CONFIG config, Consumer<CONFIG> apply) {
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static <CONFIG extends ClientPolicyConditionConfigurationRepresentation> CONFIG createConditionConfig(
+            CONFIG config, Consumer<CONFIG> apply) {
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static class ClientPoliciesBuilder {
+        private final ClientPoliciesRepresentation policiesRep;
+
+        public ClientPoliciesBuilder() {
+            policiesRep = new ClientPoliciesRepresentation();
+            policiesRep.setPolicies(new ArrayList<>());
+        }
+
+        public ClientPoliciesBuilder addPolicy(ClientPolicyRepresentation rep) {
+            policiesRep.getPolicies().add(rep);
+            return this;
+        }
+
+        public ClientPoliciesRepresentation toRepresentation() {
+            return policiesRep;
+        }
+
+        public String toString() {
+            String policiesJson = null;
+            try {
+                policiesJson = objectMapper.writeValueAsString(policiesRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                fail();
+            }
+            return policiesJson;
+        }
+    }
+
+    public static class ClientPolicyBuilder {
+
+        private final ClientPolicyRepresentation policyRep;
+
+        public ClientPolicyBuilder() {
+            policyRep = new ClientPolicyRepresentation();
+        }
+
+        public ClientPolicyBuilder createPolicy(String name, String description, Boolean isEnabled) {
+            policyRep.setName(name);
+            if (description != null) {
+                policyRep.setDescription(description);
+            }
+            if (isEnabled != null) {
+                policyRep.setEnabled(isEnabled);
+            } else {
+                policyRep.setEnabled(Boolean.FALSE);
+            }
+
+            policyRep.setConditions(new ArrayList<>());
+            policyRep.setProfiles(new ArrayList<>());
+
+            return this;
+        }
+
+        public ClientPolicyBuilder addCondition(String providerId, ClientPolicyConditionConfigurationRepresentation config) throws Exception {
+            if (config == null) {
+                config = new ClientPolicyConditionConfigurationRepresentation();
+            }
+            ClientPolicyConditionRepresentation condition = new ClientPolicyConditionRepresentation();
+            condition.setConditionProviderId(providerId);
+            condition.setConfiguration(RawJsonValue.of(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class)));
+            policyRep.getConditions().add(condition);
+            return this;
+        }
+
+        public ClientPolicyBuilder addProfile(String profileName) {
+            policyRep.getProfiles().add(profileName);
+            return this;
+        }
+
+        public ClientPolicyRepresentation toRepresentation() {
+            return policyRep;
+        }
+
+        public String toString() {
+            String policyJson = null;
+            try {
+                policyJson = objectMapper.writeValueAsString(policyRep);
+            } catch (JsonProcessingException e) {
+                fail();
+            }
+            return policyJson;
+        }
+    }
+
+    // Client Policies - Condition CRUD Operations
+
+    public static ClientPolicyConditionConfigurationRepresentation createAnyClientConditionConfig() {
+        return new ClientPolicyConditionConfigurationRepresentation();
+    }
+
+    public static ClientPolicyConditionConfigurationRepresentation createAnyClientConditionConfig(Boolean isNegativeLogic) {
+        ClientPolicyConditionConfigurationRepresentation config = new ClientPolicyConditionConfigurationRepresentation();
+        config.setNegativeLogic(isNegativeLogic);
+        return config;
+    }
+
+    public static ClientAccessTypeCondition.Configuration createClientAccessTypeConditionConfig(List<String> types) {
+        ClientAccessTypeCondition.Configuration config = new ClientAccessTypeCondition.Configuration();
+        config.setType(types);
+        return config;
+    }
+
+    public static ClientProtocolCondition.Configuration createClientProtocolConditionConfig(String protocol) {
+        ClientProtocolCondition.Configuration config = new ClientProtocolCondition.Configuration();
+        config.setProtocol(protocol);
+        return config;
+    }
+
+    public static ClientRolesCondition.Configuration createClientRolesConditionConfig(List<String> roles) {
+        ClientRolesCondition.Configuration config = new ClientRolesCondition.Configuration();
+        config.setRoles(roles);
+        return config;
+    }
+
+    public static ClientScopesCondition.Configuration createClientScopesConditionConfig(String type, List<String> scopes) {
+        ClientScopesCondition.Configuration config = new ClientScopesCondition.Configuration();
+        config.setType(type);
+        config.setScopes(scopes);
+        return config;
+    }
+
+    public static ClientAttributesCondition.Configuration createClientAttributesConditionConfig(MultivaluedMap<String, String> attributes) {
+        ClientAttributesCondition.Configuration config = new ClientAttributesCondition.Configuration();
+        String attrsAsString = MapperTypeSerializer.serialize(attributes);
+        config.setAttributes(attrsAsString);
+        return config;
+    }
+
+    public static ClientUpdaterContextCondition.Configuration createClientUpdateContextConditionConfig(List<String> updateClientSource) {
+        ClientUpdaterContextCondition.Configuration config = new ClientUpdaterContextCondition.Configuration();
+        config.setUpdateClientSource(updateClientSource);
+        return config;
+    }
+
+    public static ClientUpdaterSourceGroupsCondition.Configuration createClientUpdateSourceGroupsConditionConfig(List<String> groups) {
+        ClientUpdaterSourceGroupsCondition.Configuration config = new ClientUpdaterSourceGroupsCondition.Configuration();
+        config.setGroups(groups);
+        return config;
+    }
+
+    public static ClientUpdaterSourceHostsCondition.Configuration createClientUpdateSourceHostsConditionConfig(List<String> trustedHosts) {
+        ClientUpdaterSourceHostsCondition.Configuration config = new ClientUpdaterSourceHostsCondition.Configuration();
+        config.setTrustedHosts(trustedHosts);
+        return config;
+    }
+
+    public static ClientUpdaterSourceRolesCondition.Configuration createClientUpdateSourceRolesConditionConfig(List<String> roles) {
+        ClientUpdaterSourceRolesCondition.Configuration config = new ClientUpdaterSourceRolesCondition.Configuration();
+        config.setRoles(roles);
+        return config;
+    }
+
+    public static GrantTypeCondition.Configuration createGrantTypeConditionConfig(List<String> grantTypes) {
+        GrantTypeCondition.Configuration config = new GrantTypeCondition.Configuration();
+        config.setGrantTypes(grantTypes);
+        return config;
+    }
+
+    // DPoP
+    public static  JWK createRsaJwk(Key publicKey) {
+        return JWKBuilder.create()
+                .rsa(publicKey, KeyUse.SIG);
+    }
+
+    public static JWK createEcJwk(Key publicKey) {
+        ECPublicKey ecKey = (ECPublicKey) publicKey;
+
+        int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+        ECPublicJWK k = new ECPublicJWK();
+        k.setKeyType(KeyType.EC);
+        k.setCrv("P-" + fieldSize);
+        k.setX(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+
+        return k;
+    }
+
+    public static KeyPair generateEcdsaKey(String ecDomainParamName) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        return org.keycloak.common.util.KeyUtils.generateEcKeyPair(ecDomainParamName);
+    }
+
+    public static String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, String algorithm, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken) throws IOException {
+        return generateSignedDPoPProof(jti, htm, htu, iat, algorithm, jwsHeader, privateKey, accessToken, new DPoPGenerator());
+    }
+
+    public static String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, String algorithm, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken, DPoPGenerator dpopGenerator) throws IOException {
+        if (algorithm.equals(jwsHeader.getAlgorithm().toString())) {
+            return dpopGenerator.generateSignedDPoPProof(jti, htm, htu, iat, jwsHeader, privateKey, accessToken);
+        } else {
+            // Ability to test failure scenarios when different algorithms are used for the JWSHeader and for the actual key
+            JWSHeader updatedHeader = new JWSHeader(Algorithm.valueOf(algorithm), jwsHeader.getType(), jwsHeader.getKeyId(), jwsHeader.getKey());
+            String dpop = dpopGenerator.generateSignedDPoPProof(jti, htm, htu, iat, updatedHeader, privateKey, accessToken);
+            String dpopOrigHeader = Base64Url.encode(JsonSerialization.writeValueAsBytes(jwsHeader));
+            // Replace header with the original algorithm
+            String updatedAlgorithmHeader = dpop.substring(0, dpop.indexOf('.'));
+            return dpop.replace(updatedAlgorithmHeader, dpopOrigHeader);
+        }
+    }
+}


### PR DESCRIPTION
… omitting protocol

closes #51202

Additional notes about PR:

- During client creation, the `ClientProtocolCondition` assumes that protocol is default protocol (`openid-connect`) in case that "protocol" field is omitted

- During client update, the condition considers existing client protocol, but also in case that client protocol is going to be updated to target protocol (for example existing client of `saml` protocol is going to be updated to `openid-connect`), the new protocol is considered as well. This is needed as there was similar bug to the reported, that it was possible to bypass the condition by creating `saml` client and then updating protocol to `openid-connect` (together with enabling `direct-access-grants`). Added also the automated test for this scenario.

- Introduced constant `Constants.DEFAULT_PROTOCOL` to be used in various places where "default protocol" is supposed to be used.

- Added `ClientPoliciesUtil` from the old testsuite to the new testsuite. This is helper class mostly for creating configurations of client policies conditions/executions .

- Fixed also `RejectResourceOwnerPasswordCredentialsGrantExecutor` when NPE was possible in some scenario when omitted from the `ClientRepresentation` 
