### PR TITLE
Fix response for requests with malformed content type sent to GET UserInfo and TokenIntrospection endpoints

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -39,6 +39,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.AccessTokenIntrospectionProviderFactory;
 import org.keycloak.protocol.oidc.TokenIntrospectionProvider;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
+import org.keycloak.protocol.oidc.utils.ContentTypeValidationUtil;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -77,6 +78,10 @@ public class TokenIntrospectionEndpoint {
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, org.keycloak.utils.MediaType.APPLICATION_JWT})
     public Response introspect() {
+        // https://datatracker.ietf.org/doc/html/rfc7662#section-2.1 says 'application/x-www-form-urlencoded'
+        // not requiring concrete content type to keep this backwards compatible for the moment being
+        ContentTypeValidationUtil.requireValidOrNoContentType(request.getHttpHeaders());
+
         event.event(EventType.INTROSPECT_TOKEN);
 
         checkSsl();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -70,6 +70,7 @@ import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.TokenManager.NotBeforeCheck;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
 import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
+import org.keycloak.protocol.oidc.utils.ContentTypeValidationUtil;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -133,6 +134,7 @@ public class UserInfoEndpoint {
     public Response issueUserInfoGet() {
         setNoCacheHeaders();
         setupCors();
+        ContentTypeValidationUtil.requireValidOrNoContentType(request.getHttpHeaders());
         AppAuthManager.AuthHeader accessToken = AppAuthManager.extractAuthorizationHeaderTokenOrReturnNull(session.getContext().getRequestHeaders());
         authorization(accessToken);
         return issueUserInfo();

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/ContentTypeValidationUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/ContentTypeValidationUtil.java
@@ -9,11 +9,24 @@ import org.keycloak.services.ErrorResponseException;
 
 public final class ContentTypeValidationUtil {
 
+    // request content types are not validated for HTTP requests without payload
+    // but we should validate it where a specification, e.g. RFC 6750, requires it
+    public static void requireValidOrNoContentType(HttpHeaders headers) {
+        getAndValidateContentType(headers);
+    }
+
     // FIXME: remove this validation when we use Quarkus with https://github.com/quarkusio/quarkus/pull/55676
     public static void requireValidContentType(HttpHeaders headers, MediaType requiredMediaType) {
+        MediaType requestMediaType = getAndValidateContentType(headers);
+        if (requestMediaType != null && !requestMediaType.isCompatible(requiredMediaType)) {
+            throw new ErrorResponseException(Errors.INVALID_REQUEST, "The content-type header value does not match consumed media type " + requiredMediaType, Response.Status.BAD_REQUEST);
+        }
+    }
+
+    private static MediaType getAndValidateContentType(HttpHeaders headers) {
         String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
         if (contentType == null) {
-            return;
+            return null;
         }
         MediaType requestMediaType;
         try {
@@ -21,9 +34,7 @@ public final class ContentTypeValidationUtil {
         } catch (IllegalArgumentException e) {
             throw new ErrorResponseException(Errors.INVALID_REQUEST, "The content-type header value did not correspond to a valid media type", Response.Status.BAD_REQUEST);
         }
-        if (!requestMediaType.isCompatible(requiredMediaType)) {
-            throw new ErrorResponseException(Errors.INVALID_REQUEST, "The content-type header value does not match consumed media type " + requiredMediaType, Response.Status.BAD_REQUEST);
-        }
+        return requestMediaType;
     }
 
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/MalformedContentTypeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/MalformedContentTypeTest.java
@@ -19,9 +19,11 @@ import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testsuite.util.oauth.AbstractHttpResponse;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.BackchannelLogoutResponse;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
 import org.keycloak.testsuite.util.oauth.LogoutResponse;
 import org.keycloak.testsuite.util.oauth.ParResponse;
 import org.keycloak.testsuite.util.oauth.TokenRevocationResponse;
+import org.keycloak.testsuite.util.oauth.UserInfoResponse;
 import org.keycloak.testsuite.util.oauth.ciba.AuthenticationRequestAcknowledgement;
 import org.keycloak.testsuite.util.oauth.device.DeviceAuthorizationResponse;
 
@@ -48,6 +50,27 @@ class MalformedContentTypeTest {
                 "text/[html]",
                 ""
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource("malformedContentTypes")
+    void userInfoEndpoint(String contentType) {
+        AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest("test-user@localhost", "password");
+        UserInfoResponse response = oauth.userInfoRequest(tokenResponse.getAccessToken())
+                .header("Content-Type", contentType)
+                .send();
+        assertOAuthInvalidRequest(response);
+    }
+
+    @ParameterizedTest
+    @MethodSource("malformedContentTypes")
+    void tokenIntrospection(String contentType) {
+        AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest("test-user@localhost", "password");
+        IntrospectionResponse response = oauth.introspectionRequest(tokenResponse.getAccessToken())
+                .tokenTypeHint("access_token")
+                .header("Content-Type", contentType)
+                .send();
+        assertOAuthInvalidRequest(response);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* closes: https://github.com/keycloak/keycloak/issues/49785
* supersedes: https://github.com/keycloak/keycloak/pull/50109
* `UserInfo` endpoint does not accept any payload, so normally we shouldn't validate content type, but per linked issue we should return 400 and `invalid_request`
* I am not completely sure why token introspection doesn't have `@Consumes` with `application/x-www-form-urlencoded` so I kept original behavior when valid content type is sent