### PR TITLE
Distribution SBOM generation

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "prepare": "cd .. && husky js/.husky",
     "build": "wireit"

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <node.version>v24.9.0</node.version>
-        <pnpm.version>11.1.1</pnpm.version>
+        <pnpm.version>11.21.0</pnpm.version>
         <!-- The JavaScript projects use non-standard folders for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>
         <maven.build.cache.input.2>public</maven.build.cache.input.2>
@@ -122,6 +122,19 @@
                         </goals>
                         <configuration>
                             <arguments>build</arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-js-sbom</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>pnpm</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Generate an SBOM for the NPM packages.
+                                 -prod argument excludes non-production dependencies. W/o it non-production dependencies
+                                 will appear with scope 'excluded', meaning excluded from runtime -->
+                            <arguments>sbom --sbom-format cyclonedx --prod --filter !create-keycloak-theme --filter !keycloak-server --out ${project.build.directory}/js-sbom.cdx.json</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/quarkus/dist/assembly.xml
+++ b/quarkus/dist/assembly.xml
@@ -72,6 +72,9 @@
             <includes>
                 <include>**/**</include>
             </includes>
+            <excludes>
+                <exclude>*-cyclonedx.json</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>src/main/content/conf</directory>
@@ -114,5 +117,24 @@
             <outputDirectory>conf</outputDirectory>
         </file>
     </files>
+
+    <!-- Generate an SBOM for the assembly archive -->
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>sbom</handlerName>
+            <configuration>
+                <!-- External SBOMs to merge -->
+                <externalSboms>../../js/target/js-sbom.cdx.json,../server/target/lib/quarkus-run-cyclonedx.json</externalSboms>
+                <!-- Where to store the SBOM: embedded - as an archive entry, external - as an external file, all - both -->
+                <outputMode>all</outputMode>
+                <!-- Whether to manifest libraries only, skipping miscellaneous files
+                <librariesOnly>true</librariesOnly-->
+                <!-- Whether to pretty-print the JSON
+                <prettyPrint>true</prettyPrint-->
+                <!-- Whether to attach external SBOM file as a Maven artifact
+                <attach>true</attach-->
+            </configuration>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
 
 </assembly>

--- a/quarkus/dist/pom.xml
+++ b/quarkus/dist/pom.xml
@@ -107,6 +107,13 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>dev.cyberstamp.maven.assembly.sbom</groupId>
+                        <artifactId>assembly-sbom-handler</artifactId>
+                        <version>0.1.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -50,12 +50,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-cyclonedx</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>
         <!-- define this as a property, so it can still be overwritten on the CLI -->
         <!-- direct the auto-created files to the target folder, so they are cleaned by "mvn clean" -->
         <kc.home.dir>${project.build.directory}/kc</kc.home.dir>
+        <!-- Enable Quarkus SBOM generation for this build -->
+        <quarkus.cyclonedx.enabled>true</quarkus.cyclonedx.enabled>
     </properties>
 
     <build>
@@ -81,6 +87,7 @@
                         <kc.home.dir>${kc.home.dir}</kc.home.dir>
                         <kc.db>dev-file</kc.db>
                         <java.util.concurrent.ForkJoinPool.common.threadFactory>io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory</java.util.concurrent.ForkJoinPool.common.threadFactory>
+                        <quarkus.cyclonedx.enabled>${quarkus.cyclonedx.enabled}</quarkus.cyclonedx.enabled>
                     </systemProperties>
                 </configuration>
                 <executions>

--- a/quarkus/server/src/main/resources/application.properties
+++ b/quarkus/server/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.package.jar.type=mutable-jar
 quarkus.package.output-directory=lib
 quarkus.package.jar.user-providers-directory=../providers
 quarkus.package.main-class=keycloak
+
+# disable Quarkus SBOM generation by default, for re-augmentation specifically
+quarkus.cyclonedx.enabled=false


### PR DESCRIPTION
This PR adds SBOM generation to the Keycloak distribution.
Fixes https://github.com/keycloak/keycloak/issues/9448

Given the distribution is assembled from builds of different modules, SBOM generation also consists of a few steps.

**PNPM**

The `js` module produces an SBOM using `pnpm sbom`. AFAICT, that's one of the best SBOM generators in the Node.js ecosystem.
I added `--prod` argument to exclude non-prod dependencies. Although it could be omitted, in which case non-prod dependencies will be added with scope `excluded`, which should indicate to the scanners that a package is not a part of runtime.

**Quarkus**

Given it's a Quarkus application, to get it accurately manifested, `quarkus-cyclonedx` extension was added as a dependency. It is however disabled in `application.properties` to not generate  SBOMs on re-augmentation. But it is enabled for the Keycloak build itself.

The purpose of the Quarkus SBOM generator is to properly identify all the Maven artifacts that make up the Quarkus app.
Refer to https://quarkus.io/guides/cyclonedx for options but it should be good as-is.

**Maven assembly**

This is where the distribution is finalized. The SBOM here is generated with `assembly-sbom-handler` configured as a plugin into the assembly Maven plugin.
This SBOM generator tracks everything that gets packaged and takes the `js` and the `quarkus` SBOMs as extra sources of component information.

I added some comments on a few most relevant configuration options. Refer to https://github.com/cyberstamp/maven-assembly-sbom#assembly-handler for more.

I am not sure generating both embedded and external SBOMs at the same time is necessary but it was easy to check the results.