### PR TITLE
Validate configured CIMD provider

### DIFF
--- a/docs/guides/securing-apps/mcp-authz-server.adoc
+++ b/docs/guides/securing-apps/mcp-authz-server.adoc
@@ -233,8 +233,9 @@ NOTE: The specification states that the `client_id` URL SHOULD NOT include a que
 
 ===== System-wide settings for the Client ID Metadata Document executor
 
-The `client-id-metadata-document` executor has the following system-wide settings that control caching and metadata size limits. These settings cannot be configured through the Admin Console. Instead, they are configured as SPI options when starting {project_name}.
+The `client-id-metadata-document` executor has the following system-wide settings that control the provider, caching, and metadata size limits. These settings cannot be configured through the Admin Console. Instead, they are configured as SPI options when starting {project_name}.
 
+* *cimd-provider-name*: The provider used to process Client ID Metadata Documents. Default: `persistent-cimd`.
 * *min-cache-time*: The minimum time (in seconds) that a fetched Client ID Metadata Document is cached. Default: `300` (5 minutes).
 * *max-cache-time*: The maximum time (in seconds) that a fetched Client ID Metadata Document is cached. Default: `259200` (3 days).
 * *upper-limit-metadata-bytes*: The maximum size (in bytes) of a Client ID Metadata Document that {project_name} accepts. Default: `5000` (5 KB).
@@ -242,7 +243,7 @@ The `client-id-metadata-document` executor has the following system-wide setting
 To configure these settings, use the `--spi-client-policy-executor--client-id-metadata-document--<property>=<value>` command-line option when starting {project_name}. For example:
 
 ```bash
-bin/kc.[sh|bat] start --spi-client-policy-executor--client-id-metadata-document--min-cache-time=600 --spi-client-policy-executor--client-id-metadata-document--max-cache-time=86400 --spi-client-policy-executor--client-id-metadata-document--upper-limit-metadata-bytes=10000
+bin/kc.[sh|bat] start --spi-client-policy-executor--client-id-metadata-document--cimd-provider-name=persistent-cimd --spi-client-policy-executor--client-id-metadata-document--min-cache-time=600 --spi-client-policy-executor--client-id-metadata-document--max-cache-time=86400 --spi-client-policy-executor--client-id-metadata-document--upper-limit-metadata-bytes=10000
 ```
 
 === Visual Studio Code desktop integration

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.protocol.oauth2.cimd.provider.ClientIdMetadataDocumentProvider;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
@@ -60,6 +61,11 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
+        String providerName = providerConfig.getCimdProviderName();
+        if (factory.getProviderFactory(ClientIdMetadataDocumentProvider.class, providerName) == null) {
+            throw new IllegalStateException("Client ID Metadata Document provider '" + providerName
+                    + "' configured with '" + CONFIG_CIMD_PROVIDER_NAME + "' was not found");
+        }
     }
 
     @Override

--- a/services/src/test/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactoryTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
+
+import java.lang.reflect.Proxy;
+import java.util.Set;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractClientIdMetadataDocumentExecutorFactoryTest {
+
+    @Test
+    public void shouldRejectUnknownCimdProvider() {
+        ClientIdMetadataDocumentExecutorFactory factory = new ClientIdMetadataDocumentExecutorFactory();
+        factory.init(new TestConfig("unknown-cimd"));
+
+        KeycloakSessionFactory sessionFactory = (KeycloakSessionFactory) Proxy.newProxyInstance(
+                KeycloakSessionFactory.class.getClassLoader(),
+                new Class<?>[] { KeycloakSessionFactory.class },
+                (proxy, method, args) -> null);
+
+        IllegalStateException exception = Assert.assertThrows(IllegalStateException.class,
+                () -> factory.postInit(sessionFactory));
+        Assert.assertEquals("Client ID Metadata Document provider 'unknown-cimd' configured with 'cimd-provider-name' was not found",
+                exception.getMessage());
+    }
+
+    private static class TestConfig extends Config.AbstractScope {
+
+        private final String providerName;
+
+        private TestConfig(String providerName) {
+            this.providerName = providerName;
+        }
+
+        @Override
+        public String get(String key) {
+            return AbstractClientIdMetadataDocumentExecutorFactory.CONFIG_CIMD_PROVIDER_NAME.equals(key) ? providerName : null;
+        }
+
+        @Override
+        public Config.Scope scope(String... scope) {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Set<String> getPropertyNames() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        @Override
+        public Config.Scope root() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+    }
+}


### PR DESCRIPTION
Closes #51738

When `cimd-provider-name` references a provider that is not installed, provider resolution returns `null` and later causes a `NullPointerException` on the authorization endpoint.

This change:

- validates the configured CIMD provider during server startup
- reports an error containing the invalid provider name and the `cimd-provider-name` option
- documents `cimd-provider-name`, its default value, and its command-line usage
- adds a unit test covering an unknown provider

Verification:

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Command used:

```powershell
.\mvnw.cmd -pl services -am -Dtest=AbstractClientIdMetadataDocumentExecutorFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
```