### PR TITLE
Prevent LDAP bind credentials from being sent to a changed server

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/services/managers/LDAPServerCapabilitiesManager.java
@@ -78,6 +78,10 @@ public class LDAPServerCapabilitiesManager {
                     bindCredential = ldapConfig.getBindCredential();
                 }
             }
+            if (ComponentRepresentation.SECRET_VALUE.equals(bindCredential)) {
+                throw new CredentialReentryRequiredException(
+                        "Bind credentials must be re-entered when the Connection URL or Bind DN is changed");
+            }
         }
         MultivaluedHashMap<String, String> configMap = new MultivaluedHashMap<>();
         configMap.putSingle(LDAPConstants.AUTH_TYPE, config.getAuthType());
@@ -134,6 +138,12 @@ public class LDAPServerCapabilitiesManager {
         }
     }
 
+    public static class CredentialReentryRequiredException extends RuntimeException {
+        public CredentialReentryRequiredException(String s) {
+            super(s);
+        }
+    }
+
     public static String getErrorCode(Throwable throwable) {
         String errorMsg = "UnknownError";
         if (throwable instanceof javax.naming.NamingException)
@@ -150,6 +160,8 @@ public class LDAPServerCapabilitiesManager {
              errorMsg = "ServiceUnavailable";
         if (throwable instanceof InvalidBindDNException)
              errorMsg = "InvalidBindDN";
+        if (throwable instanceof CredentialReentryRequiredException)
+             errorMsg = "CredentialReentryRequired";
         if (throwable instanceof javax.naming.NameNotFoundException)
              errorMsg = "NameNotFound";
         if (throwable instanceof GroupTreeResolver.GroupTreeResolveException) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -20,8 +20,11 @@ package org.keycloak.storage.ldap;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.naming.NamingException;
@@ -50,6 +53,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.services.resources.admin.ComponentResource;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
@@ -331,7 +335,69 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
         if (config.getId() == null) {
             // the ldap component is being created, use short id for ldap components
             config.setId(KeycloakModelUtils.generateShortId());
+        } else {
+            // Updating an existing LDAP provider - check if the connection URL changed while
+            // the bind credential was not re-entered (auto-preserved via SECRET_VALUE placeholder).
+            // This prevents credentials from being silently sent to a different server.
+            validateBindCredentialOnUrlChange(session, realm, config, cfg);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateBindCredentialOnUrlChange(KeycloakSession session, RealmModel realm,
+                                                   ComponentModel config, LDAPConfig cfg) {
+        if (LDAPConstants.AUTH_TYPE_NONE.equals(cfg.getAuthType())) {
+            return;
+        }
+
+        Set<String> secretPlaceholderFields = session.getAttribute(
+                ComponentResource.SECRET_PLACEHOLDER_FIELDS_ATTR, Set.class);
+        if (secretPlaceholderFields == null || !secretPlaceholderFields.contains(LDAPConstants.BIND_CREDENTIAL)) {
+            // Bind credential was explicitly provided (not a SECRET_VALUE placeholder), no risk.
+            return;
+        }
+
+        ComponentModel oldComponent = realm.getComponent(config.getId());
+        if (oldComponent == null) {
+            return;
+        }
+
+        String oldUrl = oldComponent.getConfig().getFirst(LDAPConstants.CONNECTION_URL);
+        String newUrl = config.getConfig().getFirst(LDAPConstants.CONNECTION_URL);
+        if (!connectionUrlsMatch(oldUrl, newUrl)) {
+            throw new ComponentValidationException("ldapErrorCredentialReentryRequiredOnUrlChange");
+        }
+
+        String oldBindDn = oldComponent.getConfig().getFirst(LDAPConstants.BIND_DN);
+        String newBindDn = config.getConfig().getFirst(LDAPConstants.BIND_DN);
+        if (!Objects.equals(oldBindDn == null ? null : oldBindDn.toLowerCase(Locale.ROOT),
+                            newBindDn == null ? null : newBindDn.toLowerCase(Locale.ROOT))) {
+            throw new ComponentValidationException("ldapErrorCredentialReentryRequiredOnUrlChange");
+        }
+    }
+
+    /**
+     * Compares two LDAP connection URL strings, which may contain multiple space-separated URIs.
+     * Uses URI-based comparison to handle equivalent but textually different representations.
+     */
+    private static boolean connectionUrlsMatch(String url1, String url2) {
+        if (Objects.equals(url1, url2)) {
+            return true;
+        }
+        if (url1 == null || url2 == null) {
+            return false;
+        }
+        String[] urls1 = url1.trim().split(" ");
+        String[] urls2 = url2.trim().split(" ");
+        if (urls1.length != urls2.length) {
+            return false;
+        }
+        for (int i = 0; i < urls1.length; i++) {
+            if (!Objects.equals(URI.create(urls1[i]), URI.create(urls2[i]))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsConnection.tsx
@@ -15,7 +15,7 @@ import {
   Switch,
 } from "@patternfly/react-core";
 import { get, isEqual } from "lodash-es";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Controller,
   FormProvider,
@@ -86,6 +86,41 @@ export const LdapSettingsConnection = ({
   };
 
   const [isBindTypeDropdownOpen, setIsBindTypeDropdownOpen] = useState(false);
+
+  const connectionUrl = useWatch({
+    control: form.control,
+    name: "config.connectionUrl.0",
+  });
+
+  const bindDn = useWatch({
+    control: form.control,
+    name: "config.bindDn.0",
+  });
+
+  // Track the initial connection URL and bind DN so we can detect changes in edit mode.
+  // When either changes, the bind credential field is cleared to prevent previously
+  // stored credentials from being silently sent to a different server.
+  const initialUrlRef = useRef<string | null>(null);
+  const initialBindDnRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!edit) return;
+
+    if (initialUrlRef.current === null) {
+      if (connectionUrl) {
+        initialUrlRef.current = connectionUrl;
+      }
+    } else if (connectionUrl !== initialUrlRef.current) {
+      form.setValue("config.bindCredential.0", "");
+    }
+
+    if (initialBindDnRef.current === null) {
+      if (bindDn) {
+        initialBindDnRef.current = bindDn;
+      }
+    } else if (bindDn !== initialBindDnRef.current) {
+      form.setValue("config.bindCredential.0", "");
+    }
+  }, [connectionUrl, bindDn, edit, form]);
 
   const ldapBindType = useWatch({
     control: form.control,

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -18,10 +18,12 @@ package org.keycloak.services.resources.admin;
 
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.BadRequestException;
@@ -75,6 +77,14 @@ import org.jboss.resteasy.reactive.NoCache;
 @Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
 public class ComponentResource {
     protected static final Logger logger = Logger.getLogger(ComponentResource.class);
+
+    /**
+     * Session attribute key used to record which config fields in an update request contained the
+     * {@link ComponentRepresentation#SECRET_VALUE} placeholder instead of an actual value. This allows
+     * downstream validation (e.g. in provider factories) to distinguish auto-preserved secrets from
+     * explicitly re-entered ones.
+     */
+    public static final String SECRET_PLACEHOLDER_FIELDS_ATTR = "component.update.secretPlaceholderFields";
 
     protected final RealmModel realm;
 
@@ -184,6 +194,19 @@ public class ComponentResource {
                 throw new NotFoundException("Could not find component");
             }
             rejectInternalComponent(model.getProviderType(), model.getProviderId());
+            // Record which config fields have the SECRET_VALUE placeholder before merging,
+            // so downstream validation can detect auto-preserved (not re-entered) secrets.
+            if (rep.getConfig() != null) {
+                Set<String> secretPlaceholderFields = new HashSet<>();
+                for (Map.Entry<String, List<String>> entry : rep.getConfig().entrySet()) {
+                    if (entry.getValue() != null && entry.getValue().contains(ComponentRepresentation.SECRET_VALUE)) {
+                        secretPlaceholderFields.add(entry.getKey());
+                    }
+                }
+                if (!secretPlaceholderFields.isEmpty()) {
+                    session.setAttribute(SECRET_PLACEHOLDER_FIELDS_ATTR, secretPlaceholderFields);
+                }
+            }
             RepresentationToModel.updateComponent(session, rep, model, false);
             adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
             realm.updateComponent(model);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/userstorage/UserStorageRestTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/userstorage/UserStorageRestTest.java
@@ -145,6 +145,7 @@ public class UserStorageRestTest extends AbstractUserStorageRestTest {
         ldapRep = managedRealm.admin().components().component(id).toRepresentation();
         ldapRep.getConfig().putSingle(LDAPConstants.CUSTOM_USER_SEARCH_FILTER, "(dc=something2");
         ldapRep.getConfig().putSingle(LDAPConstants.BIND_DN, "cn=manager-updated");
+        ldapRep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, "password");
         try {
             managedRealm.admin().components().component(id).update(ldapRep);
             Assertions.fail("Not expected to successfull update");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
@@ -248,10 +248,12 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
 
         getCleanup().addCleanup(() -> {
             ldapProvider.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
+            ldapProvider.getConfig().put(LDAPConstants.BIND_CREDENTIAL, List.of("secret"));
             managedRealm.admin().components().component(ldapProvider.getId()).update(ldapProvider);
         });
 
         ldapProvider.getConfig().put(LDAPConstants.CONNECTION_URL, List.of("ldap://invalid"));
+        ldapProvider.getConfig().put(LDAPConstants.BIND_CREDENTIAL, List.of("secret"));
         managedRealm.admin().components().component(ldapProvider.getId()).update(ldapProvider);
 
         List<UserRepresentation> search = managedRealm.admin().users().search("*", -1, -1, true);
@@ -278,6 +280,7 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
         storageProviders = managedRealm.admin().components().query(realmId, UserStorageProvider.class.getName());
         ComponentRepresentation ldapProviderValid = storageProviders.get(0);
         ldapProviderValid.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
+        ldapProviderValid.getConfig().put(LDAPConstants.BIND_CREDENTIAL, List.of("secret"));
         managedRealm.admin().components().component(ldapProviderValid.getId()).update(ldapProviderValid);
         user1 = userResource.toRepresentation();
         user1.setLastName("changed");
@@ -291,6 +294,7 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
         user1 = userResource.toRepresentation();
         assertFalse(user1.isEnabled());
         ldapProviderValid.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
+        ldapProviderValid.getConfig().put(LDAPConstants.BIND_CREDENTIAL, List.of("secret"));
         managedRealm.admin().components().component(ldapProviderValid.getId()).update(ldapProviderValid);
         user1 = userResource.toRepresentation();
         assertTrue(user1.isEnabled());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/UserFederationLdapConnectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/UserFederationLdapConnectionTest.java
@@ -231,6 +231,58 @@ public class UserFederationLdapConnectionTest extends AbstractAdminTest {
     }
 
     @Test
+    public void testUpdateComponentRejectsUrlChangeWithPlaceholderCredential() {
+        Map<String, String> cfg = ldapRule.getConfig();
+        cfg.put(LDAPConstants.CONNECTION_URL, "ldap://localhost:10389");
+        String ldapModelId = runOnServerAdminClientTest.fetchString(LdapHelper.createLDAPProvider(cfg, false)).replace("\"", "");
+        try {
+            ComponentRepresentation rep = realm.components().component(ldapModelId).toRepresentation();
+
+            // changing URL while credential is the sentinel should be rejected
+            rep.getConfig().putSingle(LDAPConstants.CONNECTION_URL, "ldap://anotherhost:10389");
+            rep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, ComponentRepresentation.SECRET_VALUE);
+            Assertions.assertThrows(BadRequestException.class, () ->
+                    realm.components().component(ldapModelId).update(rep));
+
+            // re-entering the credential explicitly should allow the URL change
+            rep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, "secret");
+            realm.components().component(ldapModelId).update(rep);
+
+            // verify the URL was actually updated
+            ComponentRepresentation updated = realm.components().component(ldapModelId).toRepresentation();
+            Assertions.assertEquals("ldap://anotherhost:10389", updated.getConfig().getFirst(LDAPConstants.CONNECTION_URL));
+        } finally {
+            adminClient.realm(REALM_NAME).components().removeComponent(ldapModelId);
+        }
+    }
+
+    @Test
+    public void testUpdateComponentRejectsBindDnChangeWithPlaceholderCredential() {
+        Map<String, String> cfg = ldapRule.getConfig();
+        cfg.put(LDAPConstants.CONNECTION_URL, "ldap://localhost:10389");
+        String ldapModelId = runOnServerAdminClientTest.fetchString(LdapHelper.createLDAPProvider(cfg, false)).replace("\"", "");
+        try {
+            ComponentRepresentation rep = realm.components().component(ldapModelId).toRepresentation();
+
+            // changing bind DN while credential is the sentinel should be rejected
+            rep.getConfig().putSingle(LDAPConstants.BIND_DN, "uid=anotheradmin,ou=system");
+            rep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, ComponentRepresentation.SECRET_VALUE);
+            Assertions.assertThrows(BadRequestException.class, () ->
+                    realm.components().component(ldapModelId).update(rep));
+
+            // re-entering the credential explicitly should allow the bind DN change
+            rep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, "secret");
+            realm.components().component(ldapModelId).update(rep);
+
+            // verify the bind DN was actually updated
+            ComponentRepresentation updated = realm.components().component(ldapModelId).toRepresentation();
+            Assertions.assertEquals("uid=anotheradmin,ou=system", updated.getConfig().getFirst(LDAPConstants.BIND_DN));
+        } finally {
+            adminClient.realm(REALM_NAME).components().removeComponent(ldapModelId);
+        }
+    }
+
+    @Test
     public void testLdapCapabilities() {
 
         // Query the rootDSE success

--- a/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
@@ -27,6 +27,7 @@ ldapErrorValidatePasswordPolicyAvailableForWritableOnly=Validate Password Policy
 ldapErrorConnectionUrlContainsComma=Connection URL must not contain commas. Use spaces to separate multiple LDAP URLs (e.g. "ldap://host1:389 ldap://host2:389").
 ldapErrorInvalidConnectionUrl=Connection URL contains an invalid LDAP URL.
 ldapErrorInvalidConnectionUrlScheme=Connection URL contains a URL with an unsupported scheme. Each URL must use the ldap:// or ldaps:// scheme.
+ldapErrorCredentialReentryRequiredOnUrlChange=Bind credentials must be re-entered when the Connection URL or Bind DN is changed.
 
 clientRedirectURIsFragmentError=A redirect URI must not contain an URL fragment
 clientPostLogoutRedirectURIsFragmentError=A post-logout redirect URI must not contain an URL fragment


### PR DESCRIPTION
- this change adds validation on both the save and test paths to reject requests where the URL or Bind DN changed while the credential is still the placeholder
- the admin UI now also clears the credential field when either value changes, prompting re-entry

Closes #47295
Closes #51146

_Fix developed with the aid of Claude Opus 4.6_

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
