### PR TITLE
Restore refresh token reuse count on rollback

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java
@@ -34,6 +34,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.SessionLookup;
 import org.keycloak.organization.protocol.mappers.oidc.OrganizationScope;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -66,10 +67,11 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
         ClientModel authorizedClient = ctx.grantContext().getClient();
         String scopeParameter = ctx.scopeParameter();
 
+        TokenReuseRollback tokenReuseRollback = null;
         if (realm.isRevokeRefreshToken()) {
             // If refresh tokens are revoked, we need to serialize all requests to avoid wrong conclusions.
             // This needs to be called before we load the user session from the database or the cache
-            createTemporaryExclusiveLockForTokenRefreshOperation(session, oldRefreshToken, tokenManager);
+            tokenReuseRollback = createTemporaryExclusiveLockAndEnlistTokenReuseRollback(session, oldRefreshToken, tokenManager);
         }
 
         event.session(oldRefreshToken.getSessionState())
@@ -134,7 +136,7 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
             throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Invalid refresh token. Token client and authorized client don't match");
         }
 
-        validateTokenReuseForRefresh(session, realm, oldRefreshToken, validation, tokenManager);
+        validateTokenReuseForRefresh(session, realm, oldRefreshToken, validation, tokenManager, tokenReuseRollback);
 
         event.user(validation.userSession.getUser());
 
@@ -228,8 +230,9 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
         };
     }
 
-    private void createTemporaryExclusiveLockForTokenRefreshOperation(KeycloakSession session, RefreshToken refreshToken, TokenManager tokenManager) {
+    private TokenReuseRollback createTemporaryExclusiveLockAndEnlistTokenReuseRollback(KeycloakSession session, RefreshToken refreshToken, TokenManager tokenManager) {
         String lockId = "refreshLock:" + refreshToken.getSessionId() + ":" + tokenManager.getReuseIdKey(refreshToken);
+        TokenReuseRollback tokenReuseRollback = new TokenReuseRollback();
         Retry.executeWithBackoff((int iteration) -> {
             // This assumes that 60 seconds is the maximum time this operation will take
             if (!session.singleUseObjects().putIfAbsent(lockId, 60)) {
@@ -238,6 +241,8 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
 
             // Trigger the session provider, to ensure that it enlists first for enlistAfterCompletion
             session.sessions();
+
+            enlistTokenReuseRollback(session, tokenReuseRollback);
 
             KeycloakSessionFactory factory = session.getKeycloakSessionFactory();
             session.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
@@ -252,6 +257,7 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
                 }
             });
         }, Duration.of(10, ChronoUnit.SECONDS), 10);
+        return tokenReuseRollback;
     }
 
     /**
@@ -265,14 +271,14 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
     }
 
     private void validateTokenReuseForRefresh(KeycloakSession session, RealmModel realm, RefreshToken refreshToken,
-                                              TokenManager.TokenValidation validation, TokenManager tokenManager) throws OAuthErrorException {
+                                              TokenManager.TokenValidation validation, TokenManager tokenManager,
+                                              TokenReuseRollback tokenReuseRollback) throws OAuthErrorException {
         if (realm.isRevokeRefreshToken()) {
             AuthenticatedClientSessionModel clientSession = validation.clientSessionCtx.getClientSession();
             try {
                 tokenManager.validateTokenReuse(session, realm, refreshToken, clientSession, true);
                 String key = tokenManager.getReuseIdKey(refreshToken);
-                int currentCount = clientSession.getRefreshTokenUseCount(key);
-                clientSession.setRefreshTokenUseCount(key, currentCount + 1);
+                incrementTokenReuseCount(tokenReuseRollback, clientSession, key);
             } catch (OAuthErrorException oee) {
                 if (logger.isDebugEnabled()) {
                     logger.debugf("Failed validation of refresh token %s due it was used before. Realm: %s, client: %s, user: %s, user session: %s. Will detach client session from user session",
@@ -284,6 +290,52 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
                     if (cs != null) cs.detachFromUserSession();
                 });
                 throw oee;
+            }
+        }
+    }
+
+    private static void enlistTokenReuseRollback(KeycloakSession session, TokenReuseRollback tokenReuseRollback) {
+        KeycloakModelUtils.enlistAfterRollback(session, tokenReuseRollback::restore);
+    }
+
+    private static void incrementTokenReuseCount(TokenReuseRollback tokenReuseRollback,
+                                                 AuthenticatedClientSessionModel clientSession, String key) {
+        String countNote = AuthenticatedClientSessionModel.REFRESH_TOKEN_USE_PREFIX + key;
+        String previousCount = clientSession.getNote(countNote);
+        int currentCount = clientSession.getRefreshTokenUseCount(key);
+        tokenReuseRollback.capture(clientSession, countNote, previousCount);
+        clientSession.setRefreshTokenUseCount(key, currentCount + 1);
+    }
+
+    private static class TokenReuseRollback {
+
+        private AuthenticatedClientSessionModel clientSession;
+        private String countNote;
+        private String previousCount;
+
+        private void capture(AuthenticatedClientSessionModel clientSession, String countNote,
+                             String previousCount) {
+            if (this.clientSession == null) {
+                this.clientSession = clientSession;
+                this.countNote = countNote;
+                this.previousCount = previousCount;
+            }
+        }
+
+        private void restore(SessionLookup ctx) {
+            if (clientSession == null) {
+                return;
+            }
+
+            AuthenticatedClientSessionModel rollbackClientSession = ctx.findClientSession(clientSession);
+            if (rollbackClientSession == null) {
+                return;
+            }
+
+            if (previousCount == null) {
+                rollbackClientSession.removeNote(countNote);
+            } else {
+                rollbackClientSession.setNote(countNote, previousCount);
             }
         }
     }

--- a/tests/base/src/test/java/org/keycloak/protocol/oidc/refresh/RefreshTokenReuseRollbackTest.java
+++ b/tests/base/src/test/java/org/keycloak/protocol/oidc/refresh/RefreshTokenReuseRollbackTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oidc.refresh;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.representations.RefreshToken;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.tests.common.TestRealmUserConfig;
+import org.keycloak.tests.oauth.RefreshTokenTest;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest
+public class RefreshTokenReuseRollbackTest {
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectRealm(config = RefreshTokenTest.RefreshTokenTestRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectUser(config = TestRealmUserConfig.class)
+    ManagedUser user;
+
+    @InjectRunOnServer(permittedPackages = "org.keycloak.protocol.oidc.refresh")
+    RunOnServerClient runOnServer;
+
+    @Test
+    public void rollbackRestoresRefreshTokenReuseCount() {
+        realm.updateWithCleanup(r -> r.revokeRefreshToken(true).refreshTokenMaxReuse(1));
+
+        oauth.doLogin(user.getUsername(), "password");
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse response = oauth.doAccessTokenRequest(code);
+        assertEquals(200, response.getStatusCode());
+
+        RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        String realmName = realm.getName();
+        String userSessionId = refreshToken.getSessionId();
+        String reuseKey = new TokenManager().getReuseIdKey(refreshToken);
+
+        runOnServer.run(session -> {
+            var testRealm = session.realms().getRealmByName(realmName);
+            var userSession = session.sessions().getUserSession(testRealm, userSessionId);
+            assertNotNull(userSession);
+            var client = testRealm.getClientByClientId("test-app");
+            assertNotNull(client);
+            var clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+            assertNotNull(clientSession);
+            assertEquals(0, clientSession.getRefreshTokenUseCount(reuseKey));
+
+            Object tokenReuseRollback = enlistTokenReuseRollback(session);
+            incrementTokenReuseCount(tokenReuseRollback, clientSession, reuseKey);
+            incrementTokenReuseCount(tokenReuseRollback, clientSession, reuseKey);
+            assertEquals(2, clientSession.getRefreshTokenUseCount(reuseKey));
+            session.getTransactionManager().setRollbackOnly();
+        });
+
+        Integer countAfterRollback = runOnServer.fetch(session -> {
+            var testRealm = session.realms().getRealmByName(realmName);
+            var userSession = session.sessions().getUserSession(testRealm, userSessionId);
+            assertNotNull(userSession);
+            var client = testRealm.getClientByClientId("test-app");
+            assertNotNull(client);
+            var clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
+            assertNotNull(clientSession);
+            return clientSession.getRefreshTokenUseCount(reuseKey);
+        }, Integer.class);
+
+        assertEquals(0, countAfterRollback,
+                "A rolled-back refresh must not consume token reuse allowance");
+    }
+
+    private static Object enlistTokenReuseRollback(Object session) {
+        try {
+            Class<?> rollbackType = Arrays.stream(AbstractRefreshTokenProvider.class.getDeclaredClasses())
+                    .filter(type -> type.getSimpleName().equals("TokenReuseRollback"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Unable to find refresh-token reuse rollback type"));
+            var method = AbstractRefreshTokenProvider.class.getDeclaredMethod("enlistTokenReuseRollback",
+                    org.keycloak.models.KeycloakSession.class,
+                    rollbackType);
+            method.setAccessible(true);
+            var constructor = method.getParameterTypes()[1].getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Object tokenReuseRollback = constructor.newInstance();
+            method.invoke(null, session, tokenReuseRollback);
+            return tokenReuseRollback;
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to enlist refresh-token reuse rollback", e);
+        }
+    }
+
+    private static void incrementTokenReuseCount(Object tokenReuseRollback, Object clientSession, String reuseKey) {
+        try {
+            var method = AbstractRefreshTokenProvider.class.getDeclaredMethod("incrementTokenReuseCount",
+                    tokenReuseRollback.getClass(),
+                    org.keycloak.models.AuthenticatedClientSessionModel.class,
+                    String.class);
+            method.setAccessible(true);
+            method.invoke(null, tokenReuseRollback, clientSession, reuseKey);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new AssertionError("Unable to invoke refresh-token reuse increment", e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #49213

## Summary

- keep refresh-token reuse accounting visible within the current transaction
- restore the exact previous reuse-count note when that transaction rolls back
- add an integration regression test proving rollback does not consume reuse allowance

## Why

Persistent session cache entities are mutable, so clearing the transaction changelog does not restore an already-mutated client-session note. Deferring the increment until after commit could weaken the current ordering and persistence semantics. Rollback compensation preserves the immediate check-and-increment behavior while repairing the failed-transaction path.

## Verification

- reproduced before the fix: `expected <0> but was <1>` after rollback
- `./mvnw -B -ntp -pl tests/base -am -Dtest=RefreshTokenReuseRollbackTest -Dsurefire.failIfNoSpecifiedTests=false package` — 82/82 reactor modules; 1 test passed
- `./mvnw -B -ntp -pl tests/base -am '-Dtest=RefreshTokenReuseRollbackTest,RefreshTokenRevokeTest#refreshTokenReuseTokenWithRefreshTokensRevokedAfterSingleReuse' -Dsurefire.failIfNoSpecifiedTests=false package` — 82/82 reactor modules; 2 tests passed
- `./mvnw -B -ntp spotless:check`
- `git diff --check`

No documentation change is needed because this restores internal transactional consistency without changing public API or configuration.

## AI assistance disclosure

OpenAI Codex assisted with investigation, implementation, and test generation. I reviewed and understand every change and can maintain it.