### PR TITLE
Restrict Twitter request token deserialization

### DIFF
--- a/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
@@ -45,6 +45,7 @@ import org.keycloak.broker.provider.UserAuthenticationIdentityProvider;
 import org.keycloak.broker.provider.util.IdentityBrokerState;
 import org.keycloak.broker.social.SocialIdentityProvider;
 import org.keycloak.common.ClientConnection;
+import org.keycloak.common.util.DelegatingSerializationFilter;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
@@ -108,6 +109,11 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
 
     protected static RequestToken base64DecodeRequestToken(String serialized) throws IOException, ClassNotFoundException {
         try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(Base64.getMimeDecoder().decode(serialized)))) {
+            DelegatingSerializationFilter.builder()
+                    .addAllowedClass(RequestToken.class)
+                    .addAllowedClass(String.class)
+                    .addAllowedPattern("twitter4j.OAuthToken")
+                    .setFilter(in);
             return (RequestToken) in.readObject();
         }
     }

--- a/services/src/test/java/org/keycloak/social/twitter/TwitterIdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/social/twitter/TwitterIdentityProviderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.social.twitter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.Test;
+import twitter4j.RequestToken;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class TwitterIdentityProviderTest {
+
+    @Test
+    public void shouldDecodeRequestToken() throws Exception {
+        RequestToken requestToken = createRequestToken();
+
+        RequestToken decoded = TwitterIdentityProvider.base64DecodeRequestToken(serialize(requestToken));
+
+        assertEquals(requestToken, decoded);
+    }
+
+    @Test
+    public void shouldRejectUnexpectedSerializedClass() throws Exception {
+        String serialized = serialize(new UnexpectedObject());
+
+        assertThrows(InvalidClassException.class,
+                () -> TwitterIdentityProvider.base64DecodeRequestToken(serialized));
+    }
+
+    private static RequestToken createRequestToken() throws Exception {
+        // RequestToken has no public constructor; populate responseStr to match tokens created from an HTTP response.
+        Constructor<RequestToken> constructor = RequestToken.class.getDeclaredConstructor(
+                String.class, String.class, String.class, String.class);
+        constructor.setAccessible(true);
+        RequestToken requestToken = constructor.newInstance(
+                "request-token", "request-secret", "https://example.com/authorize", "https://example.com/authenticate");
+
+        Field response = RequestToken.class.getSuperclass().getDeclaredField("responseStr");
+        response.setAccessible(true);
+        response.set(requestToken, new String[] { "oauth_token=request-token", "oauth_token_secret=request-secret" });
+        return requestToken;
+    }
+
+    private static String serialize(Serializable value) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutput = new ObjectOutputStream(Base64.getEncoder().wrap(output))) {
+            objectOutput.writeObject(value);
+        }
+        return output.toString(StandardCharsets.US_ASCII);
+    }
+
+    private static final class UnexpectedObject implements Serializable {
+        private static final long serialVersionUID = 1L;
+    }
+}


### PR DESCRIPTION
Closes #51377

## What changed
- apply the Keycloak deserialization filter before reading the Twitter request token
- allow only the request token, its serialized superclass, and its string response data
- test valid Twitter request tokens and rejection of unexpected classes

## Why
The Twitter callback read a serialized authentication-session note without checking its classes first. The filter now rejects classes outside the request token before deserialization completes.

## Testing
- ./mvnw -pl services -am -Dtest=TwitterIdentityProviderTest -Dsurefire.failIfNoSpecifiedTests=false test
- ./mvnw spotless:check