### PR TITLE
Support injecting organizations in the test-framework

### DIFF
--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/OrganizationBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/OrganizationBuilder.java
@@ -1,0 +1,95 @@
+package org.keycloak.testframework.realm;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+
+public class OrganizationBuilder extends Builder<OrganizationRepresentation> {
+
+    private OrganizationBuilder(OrganizationRepresentation rep) {
+        super(rep);
+    }
+
+    public static OrganizationBuilder create() {
+        return new OrganizationBuilder(new OrganizationRepresentation()).enabled(true);
+    }
+
+    public static OrganizationBuilder create(String name) {
+        return create().name(name);
+    }
+
+    public static OrganizationBuilder update(OrganizationRepresentation rep) {
+        return new OrganizationBuilder(rep);
+    }
+
+    public OrganizationBuilder enabled(boolean enabled) {
+        rep.setEnabled(enabled);
+        return this;
+    }
+
+    public OrganizationBuilder id(String id) {
+        rep.setId(id);
+        return this;
+    }
+
+    public OrganizationBuilder alias(String alias) {
+        rep.setAlias(alias);
+        return this;
+    }
+
+    public OrganizationBuilder name(String name) {
+        rep.setName(name);
+        return this;
+    }
+
+    public OrganizationBuilder description(String description) {
+        rep.setDescription(description);
+        return this;
+    }
+
+    public OrganizationBuilder redirectUrl(String redirectUrl) {
+        rep.setRedirectUrl(redirectUrl);
+        return this;
+    }
+
+    public OrganizationBuilder domains(String... domains) {
+        return domains(Arrays.stream(domains).map(OrganizationDomainBuilder::create).toArray(OrganizationDomainBuilder[]::new));
+    }
+
+    public OrganizationBuilder domains(OrganizationDomainBuilder... domains) {
+        return domains(Arrays.stream(domains).map(OrganizationDomainBuilder::build).toArray(OrganizationDomainRepresentation[]::new));
+    }
+
+    public OrganizationBuilder domains(OrganizationDomainRepresentation... domains) {
+        for(var domain : domains) {
+            rep.addDomain(domain);
+        }
+        return this;
+    }
+
+    public OrganizationBuilder removeDomains(String... domains) {
+        for(var domain : domains) {
+            rep.removeDomain(new OrganizationDomainRepresentation(domain));
+        }
+        return this;
+    }
+
+    public OrganizationBuilder attribute(String key, String... value) {
+        rep.setAttributes(combine(rep.getAttributes(), key, value));
+        return this;
+    }
+
+    public OrganizationBuilder attributes(Map<String, List<String>> attributes) {
+        rep.setAttributes(combine(rep.getAttributes(), attributes));
+        return this;
+    }
+
+    public OrganizationBuilder removeAttributes(String... keys) {
+        rep.setAttributes(removeKeys(rep.getAttributes(), keys));
+        return this;
+    }
+
+}

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/OrganizationDomainBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/OrganizationDomainBuilder.java
@@ -1,0 +1,37 @@
+package org.keycloak.testframework.realm;
+
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+
+public class OrganizationDomainBuilder extends Builder<OrganizationDomainRepresentation> {
+
+    private OrganizationDomainBuilder(OrganizationDomainRepresentation rep) {
+        super(rep);
+    }
+
+    public static OrganizationDomainBuilder create() {
+        return new OrganizationDomainBuilder(new OrganizationDomainRepresentation());
+    }
+
+    public static OrganizationDomainBuilder create(String name) {
+        return create().name(name);
+    }
+
+    public static OrganizationDomainBuilder update(OrganizationDomainRepresentation rep) {
+        return new OrganizationDomainBuilder(rep);
+    }
+
+    public OrganizationDomainBuilder name(String name) {
+        rep.setName(name);
+        return this;
+    }
+
+    public OrganizationDomainBuilder verified(boolean verified) {
+        rep.setVerified(verified);
+        return this;
+    }
+
+    public OrganizationDomainBuilder verified() {
+        return verified(true);
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/CoreTestFrameworkExtension.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/CoreTestFrameworkExtension.java
@@ -21,6 +21,7 @@ import org.keycloak.testframework.https.CertificatesSupplier;
 import org.keycloak.testframework.https.ManagedCertificates;
 import org.keycloak.testframework.injection.Supplier;
 import org.keycloak.testframework.realm.ClientSupplier;
+import org.keycloak.testframework.realm.OrganizationSupplier;
 import org.keycloak.testframework.realm.RealmSupplier;
 import org.keycloak.testframework.realm.UserSupplier;
 import org.keycloak.testframework.server.DistributionKeycloakServerSupplier;
@@ -39,6 +40,7 @@ public class CoreTestFrameworkExtension implements TestFrameworkExtension {
                 new ClientSupplier(),
                 new RealmSupplier(),
                 new UserSupplier(),
+                new OrganizationSupplier(),
                 new DistributionKeycloakServerSupplier(),
                 new EmbeddedKeycloakServerSupplier(),
                 new RemoteKeycloakServerSupplier(),

--- a/test-framework/core/src/main/java/org/keycloak/testframework/annotations/InjectOrganization.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/annotations/InjectOrganization.java
@@ -1,0 +1,43 @@
+package org.keycloak.testframework.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.DefaultOrganizationConfig;
+import org.keycloak.testframework.realm.ManagedOrganization;
+import org.keycloak.testframework.realm.OrganizationConfig;
+
+/**
+ * Injects a {@link ManagedOrganization} used to create an organization within the realm.
+ * <p>
+ * The realm the organization is created in must have organizations enabled, otherwise the injection fails. Configure
+ * the realm with a {@link org.keycloak.testframework.realm.RealmConfig} calling
+ * {@link org.keycloak.testframework.realm.RealmBuilder#organizationsEnabled(boolean)}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InjectOrganization {
+
+    /**
+     * Used to define a custom configuration for the organization
+     */
+    Class<? extends OrganizationConfig> config() default DefaultOrganizationConfig.class;
+
+    /**
+     * Controls the lifecycle of the resource
+     */
+    LifeCycle lifecycle() default LifeCycle.CLASS;
+
+    /**
+     * A ref must be set if a test requires multiple instances
+     */
+    String ref() default "";
+
+    /**
+     * Set to attach to the non-default realm
+     */
+    String realmRef() default "";
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/annotations/InjectOrganization.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/annotations/InjectOrganization.java
@@ -13,9 +13,16 @@ import org.keycloak.testframework.realm.OrganizationConfig;
 /**
  * Injects a {@link ManagedOrganization} used to create an organization within the realm.
  * <p>
- * The realm the organization is created in must have organizations enabled, otherwise the injection fails. Configure
- * the realm with a {@link org.keycloak.testframework.realm.RealmConfig} calling
- * {@link org.keycloak.testframework.realm.RealmBuilder#organizationsEnabled(boolean)}.
+ * Organizations are automatically enabled on the referenced realm, and only on that realm. Realms that are attached to
+ * an existing Keycloak instance through {@link InjectRealm#attachTo()} are not created by the framework and therefore
+ * not configured by it, so those have to have organizations enabled already, otherwise the injection fails.
+ * <p>
+ * Realms are only configured while they are created, so a realm with {@link LifeCycle#GLOBAL} that was already created
+ * by an earlier test class is re-used as it is. Injecting an organization for such a realm fails unless the test class
+ * that created it injected one as well.
+ * <p>
+ * Note that enabling organizations changes the behaviour of the realm once an organization exists, most notably the
+ * browser login becomes identity-first.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -27,7 +34,10 @@ public @interface InjectOrganization {
     Class<? extends OrganizationConfig> config() default DefaultOrganizationConfig.class;
 
     /**
-     * Controls the lifecycle of the resource
+     * Controls the lifecycle of the resource.
+     * <p>
+     * Since the organization configures the realm it belongs to, the realm is destroyed together with the organization.
+     * Using {@link LifeCycle#METHOD} therefore re-creates the realm for every test method as well.
      */
     LifeCycle lifecycle() default LifeCycle.CLASS;
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/AbstractInterceptorHelper.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/AbstractInterceptorHelper.java
@@ -1,8 +1,23 @@
 package org.keycloak.testframework.injection;
 
+import java.lang.annotation.Annotation;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Base class to apply interceptors to a value while an instance is being created.
+ * <p>
+ * On construction all deployed and requested instances of the registry whose supplier implements the given
+ * interceptor interface are collected. {@link #intercept(Object, InstanceContext)} then passes the value through
+ * every collected interceptor, which allows a supplier to contribute to the configuration of another instance it
+ * depends on.
+ * <p>
+ * Interceptors are collected regardless of whether they have already been deployed, as an interceptor usually
+ * depends on the instance it intercepts and is therefore deployed later.
+ *
+ * @param <I> the interceptor interface implemented by a supplier
+ * @param <V> the type of the value passed through the interceptors
+ */
 public abstract class AbstractInterceptorHelper<I, V> {
 
     private final Registry registry;
@@ -17,41 +32,130 @@ public abstract class AbstractInterceptorHelper<I, V> {
         registry.getRequestedInstances().stream().filter(r -> isInterceptor(r.getSupplier())).forEach(r -> interceptions.add(new Interception(r)));
     }
 
+    /**
+     * Passes the value through all applicable interceptors, in the order they were collected. Each interceptor that
+     * is applied registers the intercepted instance as its dependent, so the interceptor is destroyed before the
+     * instance it contributed to.
+     *
+     * @param value the value to intercept, for example the builder of the instance being created
+     * @param instanceContext the instance context of the instance being created
+     * @return the value as returned by the last applicable interceptor, or the given value if none applies
+     */
     public V intercept(V value, InstanceContext<?, ?> instanceContext) {
         for (Interception interception : interceptions) {
-            value = intercept(value, interception.supplier, interception.existingInstance);
-            registry.getLogger().logIntercepted(value, interception.supplier);
-            if (interception.existingInstance != null) {
-                interception.existingInstance.registerDependent(instanceContext);
+            if (!applies(interception, instanceContext)) {
+                continue;
+            }
+
+            value = intercept(value, interception.getSupplier(), interception.getExistingInstance());
+            registry.getLogger().logIntercepted(value, interception.getSupplier());
+            if (interception.getExistingInstance() != null) {
+                interception.getExistingInstance().registerDependent(instanceContext);
             } else {
-                interception.requestedInstance.registerDependent(instanceContext);
+                interception.getRequestedInstance().registerDependent(instanceContext);
             }
         }
         return value;
     }
 
+    /**
+     * Invokes the interceptor method of the given supplier. Implemented by subclasses as the interceptor interface,
+     * and with it the method to call, is specific to the intercepted value.
+     *
+     * @param value the value to intercept
+     * @param supplier the supplier implementing the interceptor interface
+     * @param existingInstance the instance context of the interceptor, or <code>null</code> if it is not deployed yet
+     * @return the intercepted value
+     */
     public abstract V intercept(V value, Supplier<?, ?> supplier, InstanceContext<?, ?> existingInstance);
 
+    /**
+     * Controls whether the given interception applies to the instance currently being created. Returning
+     * <code>false</code> skips the interception entirely, including registering the intercepted instance as a
+     * dependent of the interceptor.
+     *
+     * @param interception the interception to check
+     * @param target the instance context for the instance being intercepted
+     * @return <code>true</code> if the interception should be applied
+     */
+    protected boolean applies(Interception interception, InstanceContext<?, ?> target) {
+        return true;
+    }
+
+    /**
+     * Checks whether the given supplier implements the interceptor interface this helper was created for.
+     *
+     * @param supplier the supplier to check
+     * @return <code>true</code> if the supplier is an interceptor
+     */
     private boolean isInterceptor(Supplier<?, ?> supplier) {
         return interceptorClass.isAssignableFrom(supplier.getClass());
     }
 
-    private static class Interception {
+    /**
+     * A single interceptor collected by {@link AbstractInterceptorHelper}.
+     * <p>
+     * An interceptor is either already deployed or only requested so far, which is why either
+     * {@link #getExistingInstance()} or {@link #getRequestedInstance()} is set, but never both. The supplier and the
+     * annotation are available in both cases and can be used by {@link #applies(Interception, InstanceContext)} to
+     * decide whether the interceptor applies to the instance being created.
+     */
+    public static class Interception {
 
         private final Supplier<?, ?> supplier;
+        private final Annotation annotation;
         private final RequestedInstance<?, ?> requestedInstance;
         private final InstanceContext<?, ?> existingInstance;
 
         public Interception(InstanceContext<?, ?> existingInstance) {
             this.supplier = existingInstance.getSupplier();
+            this.annotation = existingInstance.getAnnotation();
             this.requestedInstance = null;
             this.existingInstance = existingInstance;
         }
 
         public Interception(RequestedInstance<?, ?> requestedInstance) {
             this.supplier = requestedInstance.getSupplier();
+            this.annotation = requestedInstance.getAnnotation();
             this.requestedInstance = requestedInstance;
             this.existingInstance = null;
+        }
+
+        /**
+         * The supplier of the interceptor, which implements the interceptor interface this helper was created for.
+         *
+         * @return the interceptor supplier
+         */
+        public Supplier<?, ?> getSupplier() {
+            return supplier;
+        }
+
+        /**
+         * The annotation of the interceptor itself. Unlike {@link #getExistingInstance()} this is always available,
+         * whether the interceptor has been deployed yet.
+         *
+         * @return the interceptor annotation
+         */
+        public Annotation getAnnotation() {
+            return annotation;
+        }
+
+        /**
+         * The instance context of the interceptor, or <code>null</code> if the interceptor has not been deployed yet.
+         *
+         * @return the interceptor instance context
+         */
+        public InstanceContext<?, ?> getExistingInstance() {
+            return existingInstance;
+        }
+
+        /**
+         * The requested instance of the interceptor, or <code>null</code> if the interceptor is already deployed.
+         *
+         * @return the requested interceptor instance
+         */
+        public RequestedInstance<?, ?> getRequestedInstance() {
+            return requestedInstance;
         }
     }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/DefaultOrganizationConfig.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/DefaultOrganizationConfig.java
@@ -1,0 +1,10 @@
+package org.keycloak.testframework.realm;
+
+public class DefaultOrganizationConfig implements OrganizationConfig {
+
+    @Override
+    public OrganizationBuilder configure(OrganizationBuilder organization) {
+        return organization;
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/ManagedOrganization.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/ManagedOrganization.java
@@ -1,0 +1,184 @@
+package org.keycloak.testframework.realm;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.testframework.injection.ManagedTestResource;
+import org.keycloak.testframework.util.ApiUtil;
+
+public class ManagedOrganization extends ManagedTestResource {
+
+    private final OrganizationRepresentation createdRepresentation;
+    private final OrganizationResource organizationResource;
+
+    private ManagedOrganizationCleanup cleanup;
+
+    public ManagedOrganization(OrganizationRepresentation createdRepresentation, OrganizationResource organizationResource) {
+        this.createdRepresentation = createdRepresentation;
+        this.organizationResource = organizationResource;
+    }
+
+    /**
+     * The UUID of the organization
+     *
+     * @return organization UUID
+     */
+    public String getId() {
+        return createdRepresentation.getId();
+    }
+
+    /**
+     * The name of the organization
+     *
+     * @return organization name
+     */
+    public String getName() {
+        return createdRepresentation.getName();
+    }
+
+    /**
+     * The alias of the organization. This is <code>null</code> if no alias was configured, in which case the server
+     * defaults the alias to the name of the organization.
+     *
+     * @return organization alias
+     */
+    public String getAlias() {
+        return createdRepresentation.getAlias();
+    }
+
+    public ManagedOrganizationCleanup cleanup() {
+        if (cleanup == null) {
+            cleanup = new ManagedOrganizationCleanup();
+        }
+        return cleanup;
+    }
+
+    /**
+     * Admin organization resource for the organization to view or update the configuration of the organization. Updates
+     * should in general not be done directly through the organization resource as it will leave the organization in an
+     * unexpected state for subsequent tests.
+     *
+     * @return organization resource
+     */
+    public OrganizationResource admin() {
+        return organizationResource;
+    }
+
+    /**
+     * Invite a user to the organization by email, which is automatically deleted once the test is completed. This
+     * creates a pending invitation for a user that does not exist in the realm yet.
+     * <p>
+     * The server sends the invitation email itself and fails if it can not, so the realm requires a working SMTP
+     * configuration. Use the mail server provided by <code>@InjectMailServer</code> to configure the realm and to read
+     * the invitation email.
+     *
+     * @param email the email address to invite
+     */
+    public void inviteUser(String email) {
+        inviteUser(email, null, null);
+    }
+
+    /**
+     * Invite a user to the organization by email, which is automatically deleted once the test is completed.
+     *
+     * @param email the email address to invite
+     * @param firstName the first name of the invited user, may be <code>null</code>
+     * @param lastName the last name of the invited user, may be <code>null</code>
+     * @see #inviteUser(String)
+     */
+    public void inviteUser(String email, String firstName, String lastName) {
+        invite(() -> organizationResource.members().inviteUser(email, firstName, lastName));
+    }
+
+    /**
+     * Invite an existing user of the realm to the organization, which is automatically deleted once the test is
+     * completed. The user is required to have an email address.
+     *
+     * @param user the user to invite
+     * @see #inviteUser(String)
+     */
+    public void inviteExistingUser(ManagedUser user) {
+        inviteExistingUser(user.getId());
+    }
+
+    /**
+     * Invite an existing user of the realm to the organization, which is automatically deleted once the test is
+     * completed. The user is required to have an email address.
+     *
+     * @param userId the UUID of the user to invite
+     * @see #inviteUser(String)
+     */
+    public void inviteExistingUser(String userId) {
+        invite(() -> organizationResource.members().inviteExistingUser(userId));
+    }
+
+    /**
+     * The pending invitation for the given email address.
+     *
+     * @param email the email address the invitation was sent to
+     * @return the invitation, or <code>null</code> if the email address was not invited
+     */
+    public OrganizationInvitationRepresentation getInvitation(String email) {
+        List<OrganizationInvitationRepresentation> invitations = organizationResource.invitations().list(null, email, null, null);
+        return invitations.isEmpty() ? null : invitations.get(0);
+    }
+
+    private void invite(Supplier<Response> invitation) {
+        Set<String> before = invitationIds();
+
+        try (Response response = invitation.get()) {
+            ApiUtil.expectStatus(response, "invite user to organization '%s'".formatted(getName()), Status.NO_CONTENT);
+        }
+
+        invitationIds().stream()
+                .filter(id -> !before.contains(id))
+                .forEach(id -> cleanup().add(o -> {
+                    try (Response response = o.invitations().delete(id)) {
+                        // the invitation may already have been deleted by the test itself
+                        ApiUtil.expectStatus(response, "delete invitation '%s' of organization '%s'".formatted(id, getName()),
+                                Status.NO_CONTENT, Status.NOT_FOUND);
+                    }
+                }));
+    }
+
+    private Set<String> invitationIds() {
+        return organizationResource.invitations().list().stream()
+                .map(OrganizationInvitationRepresentation::getId)
+                .collect(Collectors.toSet());
+    }
+
+    public void updateWithCleanup(OrganizationUpdate... updates) {
+        OrganizationRepresentation rep = admin().toRepresentation();
+        cleanup().resetToOriginalRepresentation(rep);
+
+        OrganizationBuilder configBuilder = OrganizationBuilder.update(rep);
+        for (OrganizationUpdate update : updates) {
+            configBuilder = update.update(configBuilder);
+        }
+        try (Response response = admin().update(configBuilder.build())) {
+            ApiUtil.expectStatus(response, "update organization '%s'".formatted(getName()), Status.NO_CONTENT);
+        }
+    }
+
+    @Override
+    public void runCleanup() {
+        if (cleanup != null) {
+            cleanup.runCleanupTasks(organizationResource);
+            cleanup = null;
+        }
+    }
+
+    public interface OrganizationUpdate {
+
+        OrganizationBuilder update(OrganizationBuilder organization);
+
+    }
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/ManagedOrganizationCleanup.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/ManagedOrganizationCleanup.java
@@ -1,0 +1,56 @@
+package org.keycloak.testframework.realm;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.testframework.util.ApiUtil;
+
+public class ManagedOrganizationCleanup {
+
+    private final List<OrganizationCleanup> cleanupTasks = new LinkedList<>();
+
+    /**
+     * Add a cleanup to be done for the organization after the test is completed
+     *
+     * @param organizationCleanup the required cleanup
+     * @return this cleanup
+     */
+    public ManagedOrganizationCleanup add(OrganizationCleanup organizationCleanup) {
+        cleanupTasks.add(organizationCleanup);
+        return this;
+    }
+
+    void resetToOriginalRepresentation(OrganizationRepresentation rep) {
+        if (cleanupTasks.stream().noneMatch(c -> c instanceof ResetOrganization)) {
+            OrganizationRepresentation clone = RepresentationUtils.clone(rep);
+            cleanupTasks.add(new ResetOrganization(clone));
+        }
+    }
+
+    void runCleanupTasks(OrganizationResource organization) {
+        cleanupTasks.forEach(t -> t.cleanup(organization));
+        cleanupTasks.clear();
+    }
+
+    public interface OrganizationCleanup {
+
+        void cleanup(OrganizationResource organization);
+
+    }
+
+    private record ResetOrganization(OrganizationRepresentation rep) implements OrganizationCleanup {
+
+        @Override
+        public void cleanup(OrganizationResource organization) {
+            try (Response response = organization.update(rep)) {
+                ApiUtil.expectStatus(response, "roll back organization '%s'".formatted(rep.getName()), Status.NO_CONTENT);
+            }
+        }
+
+    }
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/OrganizationConfig.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/OrganizationConfig.java
@@ -1,0 +1,7 @@
+package org.keycloak.testframework.realm;
+
+public interface OrganizationConfig {
+
+    OrganizationBuilder configure(OrganizationBuilder organization);
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/OrganizationSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/OrganizationSupplier.java
@@ -1,0 +1,77 @@
+package org.keycloak.testframework.realm;
+
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.testframework.annotations.InjectOrganization;
+import org.keycloak.testframework.injection.DependenciesBuilder;
+import org.keycloak.testframework.injection.Dependency;
+import org.keycloak.testframework.injection.InstanceContext;
+import org.keycloak.testframework.injection.RequestedInstance;
+import org.keycloak.testframework.injection.Supplier;
+import org.keycloak.testframework.injection.SupplierHelpers;
+import org.keycloak.testframework.util.ApiUtil;
+
+public class OrganizationSupplier implements Supplier<ManagedOrganization, InjectOrganization> {
+
+    @Override
+    public List<Dependency> getDependencies(RequestedInstance<ManagedOrganization, InjectOrganization> instanceContext) {
+        return DependenciesBuilder.create(ManagedRealm.class, instanceContext.getAnnotation().realmRef()).build();
+    }
+
+    @Override
+    public ManagedOrganization getValue(InstanceContext<ManagedOrganization, InjectOrganization> instanceContext) {
+        ManagedRealm realm = instanceContext.getDependency(ManagedRealm.class, instanceContext.getAnnotation().realmRef());
+
+        if (!Boolean.TRUE.equals(realm.admin().toRepresentation().isOrganizationsEnabled())) {
+            throw new IllegalStateException("Organizations are not enabled for realm '" + realm.getName()
+                    + "'. Configure the realm with a RealmConfig calling RealmBuilder.organizationsEnabled(true).");
+        }
+
+        OrganizationConfig config = SupplierHelpers.getInstanceWithInjectedFields(instanceContext.getAnnotation().config(), instanceContext);
+        OrganizationRepresentation organizationRepresentation = config.configure(OrganizationBuilder.create()).build();
+
+        if (organizationRepresentation.getName() == null) {
+            organizationRepresentation.setName(SupplierHelpers.createName(instanceContext));
+        }
+
+        try (Response response = realm.admin().organizations().create(organizationRepresentation)) {
+            expectOrganizationCreated(response, organizationRepresentation);
+            String uuid = ApiUtil.getCreatedId(response);
+
+            OrganizationResource organizationResource = realm.admin().organizations().get(uuid);
+            organizationRepresentation.setId(uuid);
+
+            return new ManagedOrganization(organizationRepresentation, organizationResource);
+        }
+    }
+
+    private void expectOrganizationCreated(Response response, OrganizationRepresentation organizationRepresentation) {
+        if (Status.CONFLICT.getStatusCode() == response.getStatus()) {
+            throw new IllegalStateException("Organization '%s' already exists".formatted(organizationRepresentation.getName()));
+        }
+        ApiUtil.expectStatus(response, "create organization '%s'".formatted(organizationRepresentation.getName()), Status.CREATED);
+    }
+
+    @Override
+    public boolean compatible(InstanceContext<ManagedOrganization, InjectOrganization> a, RequestedInstance<ManagedOrganization, InjectOrganization> b) {
+        InjectOrganization aa = a.getAnnotation();
+        InjectOrganization ba = b.getAnnotation();
+        return aa.config().equals(ba.config()) && aa.realmRef().equals(ba.realmRef());
+    }
+
+    @Override
+    public void close(InstanceContext<ManagedOrganization, InjectOrganization> instanceContext) {
+        ManagedOrganization organization = instanceContext.getValue();
+        try (Response response = organization.admin().delete()) {
+            // The organization may already have been deleted by the test itself
+            ApiUtil.expectStatus(response, "delete organization '%s'".formatted(organization.getName()),
+                    Status.NO_CONTENT, Status.NOT_FOUND);
+        }
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/OrganizationSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/OrganizationSupplier.java
@@ -1,6 +1,7 @@
 package org.keycloak.testframework.realm;
 
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -12,11 +13,12 @@ import org.keycloak.testframework.injection.DependenciesBuilder;
 import org.keycloak.testframework.injection.Dependency;
 import org.keycloak.testframework.injection.InstanceContext;
 import org.keycloak.testframework.injection.RequestedInstance;
+import org.keycloak.testframework.injection.StringUtil;
 import org.keycloak.testframework.injection.Supplier;
 import org.keycloak.testframework.injection.SupplierHelpers;
 import org.keycloak.testframework.util.ApiUtil;
 
-public class OrganizationSupplier implements Supplier<ManagedOrganization, InjectOrganization> {
+public class OrganizationSupplier implements Supplier<ManagedOrganization, InjectOrganization>, RealmConfigInterceptor<ManagedOrganization, InjectOrganization> {
 
     @Override
     public List<Dependency> getDependencies(RequestedInstance<ManagedOrganization, InjectOrganization> instanceContext) {
@@ -28,8 +30,9 @@ public class OrganizationSupplier implements Supplier<ManagedOrganization, Injec
         ManagedRealm realm = instanceContext.getDependency(ManagedRealm.class, instanceContext.getAnnotation().realmRef());
 
         if (!Boolean.TRUE.equals(realm.admin().toRepresentation().isOrganizationsEnabled())) {
-            throw new IllegalStateException("Organizations are not enabled for realm '" + realm.getName()
-                    + "'. Configure the realm with a RealmConfig calling RealmBuilder.organizationsEnabled(true).");
+            // For realms created by the framework organizations are enabled through intercept(..).
+            // For unmanaged realms organizations might not be enabled.
+            throw new IllegalStateException("Organizations are not enabled for realm '%s'".formatted(realm.getName()));
         }
 
         OrganizationConfig config = SupplierHelpers.getInstanceWithInjectedFields(instanceContext.getAnnotation().config(), instanceContext);
@@ -55,6 +58,18 @@ public class OrganizationSupplier implements Supplier<ManagedOrganization, Injec
             throw new IllegalStateException("Organization '%s' already exists".formatted(organizationRepresentation.getName()));
         }
         ApiUtil.expectStatus(response, "create organization '%s'".formatted(organizationRepresentation.getName()), Status.CREATED);
+    }
+
+    @Override
+    public RealmBuilder intercept(RealmBuilder realm, InstanceContext<ManagedOrganization, InjectOrganization> instanceContext) {
+        // instanceContext is null here as this supplier is never deployed before the realm it depends on
+        return realm.organizationsEnabled(true);
+    }
+
+    @Override
+    public boolean appliesTo(InjectOrganization annotation, InstanceContext<?, ?> realmInstanceContext) {
+        return Objects.equals(StringUtil.convertEmptyToNull(annotation.realmRef()),
+                StringUtil.convertEmptyToNull(realmInstanceContext.getRef()));
     }
 
     @Override

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmConfigInterceptor.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmConfigInterceptor.java
@@ -8,4 +8,17 @@ public interface RealmConfigInterceptor<T, S extends Annotation> {
 
     RealmBuilder intercept(RealmBuilder realm, InstanceContext<T, S> instanceContext);
 
+    /**
+     * Controls which realms this interceptor applies to. By default, an interceptor applies to every realm created
+     * within the test class. Override to only intercept a specific realm, for example the realm referenced by the
+     * <code>realmRef</code> of the interceptor's own annotation.
+     *
+     * @param annotation the annotation of the interceptor itself
+     * @param realmInstanceContext the instance context of the realm being created
+     * @return <code>true</code> if the realm should be intercepted
+     */
+    default boolean appliesTo(S annotation, InstanceContext<?, ?> realmInstanceContext) {
+        return true;
+    }
+
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmSupplier.java
@@ -120,6 +120,14 @@ public class RealmSupplier implements Supplier<ManagedRealm, InjectRealm> {
             return value;
         }
 
+        @Override
+        protected boolean applies(Interception interception, InstanceContext<?, ?> target) {
+            if (interception.getSupplier() instanceof RealmConfigInterceptor interceptor) {
+                return interceptor.appliesTo(interception.getAnnotation(), target);
+            }
+            return true;
+        }
+
     }
 
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/ApiUtil.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/ApiUtil.java
@@ -1,6 +1,10 @@
 package org.keycloak.testframework.util;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.junit.jupiter.api.Assertions;
 
@@ -23,6 +27,42 @@ public class ApiUtil {
             Assertions.assertEquals(201, response.getStatus());
             String path = response.getLocation().getPath();
             return path.substring(path.lastIndexOf('/') + 1);
+        }
+    }
+
+    /**
+     * Verify that a response has one of the expected statuses, and throw otherwise, including the actual status and
+     * the response body in the message. Several Admin API endpoints return a {@link Response} rather than throwing on
+     * a failure, which would otherwise let a failed create, update or delete pass unnoticed.
+     * <p>
+     * The response is not closed and its entity is left untouched, so this can be called inside a try-with-resources
+     * block that goes on to read the entity. If the check fails the entity is consumed to include the body in the
+     * error message, but the exception makes that unobservable to the caller.
+     *
+     * @param response the response to verify
+     * @param context what was attempted, phrased to follow "Failed to ", for example
+     *                <code>"update organization 'acme'"</code>
+     * @param expected the accepted statuses
+     * @throws IllegalStateException if the response has none of the expected statuses
+     */
+    public static void expectStatus(Response response, String context, Status... expected) {
+        for (Status status : expected) {
+            if (status.getStatusCode() == response.getStatus()) {
+                return;
+            }
+        }
+        throw new IllegalStateException("Failed to %s: expected status %s, but was %d. Response: %s".formatted(
+                context,
+                Arrays.stream(expected).map(s -> String.valueOf(s.getStatusCode())).collect(Collectors.joining(" or ")),
+                response.getStatus(),
+                readBody(response)));
+    }
+
+    private static String readBody(Response response) {
+        try {
+            return response.hasEntity() ? response.readEntity(String.class) : "<no body>";
+        } catch (RuntimeException e) {
+            return "<unreadable body: " + e.getMessage() + ">";
         }
     }
 

--- a/test-framework/docs/WRITING_TESTS.md
+++ b/test-framework/docs/WRITING_TESTS.md
@@ -488,6 +488,7 @@ Complete list of resources that can be injected into tests:
 | `@InjectSysLogServer`       | `org.keycloak.testframework.events.SysLogServer`         | Add/remove listener for logs from Keycloak server |
 | `@InjectTestDatabase`       | `org.keycloak.testframework.database.TestDatabase`       | Database                                          |
 | `@InjectUser`               | `org.keycloak.testframework.realm.ManagedUser`           | Managed user                                      |
+| `@InjectOrganization`       | `org.keycloak.testframework.realm.ManagedOrganization`   | Managed organization (realm needs orgs enabled)   |
 
 ## `keycloak-test-framework-email-server` extension
 

--- a/test-framework/docs/WRITING_TESTS.md
+++ b/test-framework/docs/WRITING_TESTS.md
@@ -488,7 +488,7 @@ Complete list of resources that can be injected into tests:
 | `@InjectSysLogServer`       | `org.keycloak.testframework.events.SysLogServer`         | Add/remove listener for logs from Keycloak server |
 | `@InjectTestDatabase`       | `org.keycloak.testframework.database.TestDatabase`       | Database                                          |
 | `@InjectUser`               | `org.keycloak.testframework.realm.ManagedUser`           | Managed user                                      |
-| `@InjectOrganization`       | `org.keycloak.testframework.realm.ManagedOrganization`   | Managed organization (realm needs orgs enabled)   |
+| `@InjectOrganization`       | `org.keycloak.testframework.realm.ManagedOrganization`   | Managed organization                              |
 
 ## `keycloak-test-framework-email-server` extension
 

--- a/test-framework/tests/src/test/java/org/keycloak/testframework/tests/OrganizationTest.java
+++ b/test-framework/tests/src/test/java/org/keycloak/testframework/tests/OrganizationTest.java
@@ -1,0 +1,243 @@
+package org.keycloak.testframework.tests;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.mail.Address;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.testframework.annotations.InjectOrganization;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.mail.MailServer;
+import org.keycloak.testframework.mail.annotations.InjectMailServer;
+import org.keycloak.testframework.realm.ManagedOrganization;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.OrganizationBuilder;
+import org.keycloak.testframework.realm.OrganizationConfig;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.realm.UserConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@KeycloakIntegrationTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class OrganizationTest {
+
+    private static final String CUSTOM_ORG_REF = "custom";
+    private static final String REALM_B_REF = "realmB";
+    private static final String ORG_B_REF = "orgB";
+    private static final String INVITEE_EMAIL = "invitee@example.org";
+
+    @InjectRealm(config = OrganizationRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectRealm(ref = REALM_B_REF, config = OrganizationRealmConfig.class)
+    ManagedRealm realmB;
+
+    @InjectOrganization
+    ManagedOrganization organization;
+
+    @InjectOrganization(ref = CUSTOM_ORG_REF, config = CustomOrganizationConfig.class)
+    ManagedOrganization customOrganization;
+
+    @InjectOrganization(ref = ORG_B_REF, realmRef = REALM_B_REF)
+    ManagedOrganization organizationB;
+
+    @InjectUser(config = UserWithEmail.class)
+    ManagedUser user;
+
+    /**
+     * The server sends the invitation email itself, so the realms require a working SMTP configuration
+     */
+    @InjectMailServer
+    MailServer mail;
+
+    @Test
+    @Order(1)
+    public void testDefaultOrganization() {
+        Assertions.assertNotNull(organization.getId());
+        Assertions.assertEquals("default", organization.getName());
+        Assertions.assertNull(organization.getAlias());
+
+        OrganizationRepresentation rep = organization.admin().toRepresentation();
+        Assertions.assertEquals(organization.getId(), rep.getId());
+        Assertions.assertEquals("default", rep.getName());
+        // the server defaults the alias to the name when none is configured
+        Assertions.assertEquals("default", rep.getAlias());
+        Assertions.assertTrue(rep.isEnabled());
+    }
+
+    @Test
+    @Order(2)
+    public void testCustomOrganizationConfig() {
+        Assertions.assertEquals(CUSTOM_ORG_REF, customOrganization.getName());
+        Assertions.assertEquals("custom-alias", customOrganization.getAlias());
+
+        OrganizationRepresentation rep = customOrganization.admin().toRepresentation();
+        Assertions.assertEquals(CUSTOM_ORG_REF, rep.getName());
+        Assertions.assertEquals("custom-alias", rep.getAlias());
+        Assertions.assertEquals("A custom organization", rep.getDescription());
+        Assertions.assertEquals("http://localhost:8080/custom", rep.getRedirectUrl());
+        Assertions.assertEquals(List.of("value1", "value2"), rep.getAttributes().get("key"));
+
+        List<String> domains = rep.getDomains().stream().map(OrganizationDomainRepresentation::getName).sorted().toList();
+        Assertions.assertEquals(List.of("custom.org", "custom.test"), domains);
+    }
+
+    @Test
+    @Order(3)
+    public void testOrganizationAttachedToReferencedRealm() {
+        Assertions.assertEquals(ORG_B_REF, organizationB.getName());
+
+        List<String> defaultRealmOrgs = organizationIds(realm);
+        Assertions.assertTrue(defaultRealmOrgs.contains(organization.getId()));
+        Assertions.assertTrue(defaultRealmOrgs.contains(customOrganization.getId()));
+        Assertions.assertFalse(defaultRealmOrgs.contains(organizationB.getId()));
+
+        List<String> realmBOrgs = organizationIds(realmB);
+        Assertions.assertEquals(List.of(organizationB.getId()), realmBOrgs);
+    }
+
+    @Test
+    @Order(4)
+    public void updateWithRollback() {
+        organization.updateWithCleanup(o -> o.description("updated description").redirectUrl("http://localhost:8080/updated"));
+
+        OrganizationRepresentation rep = organization.admin().toRepresentation();
+        Assertions.assertEquals("updated description", rep.getDescription());
+        Assertions.assertEquals("http://localhost:8080/updated", rep.getRedirectUrl());
+    }
+
+    @Test
+    @Order(5)
+    public void verifyUpdateWithRollback() {
+        OrganizationRepresentation rep = organization.admin().toRepresentation();
+        Assertions.assertNull(rep.getDescription());
+        Assertions.assertNull(rep.getRedirectUrl());
+    }
+
+    @Test
+    @Order(6)
+    public void markOrganizationDirty() {
+        organization.updateWithCleanup(o -> o.description("dirty description"));
+        organization.dirty();
+
+        Assertions.assertEquals("dirty description", organization.admin().toRepresentation().getDescription());
+    }
+
+    @Test
+    @Order(7)
+    public void verifyOrganizationRecreatedAfterDirty() {
+        OrganizationRepresentation rep = organization.admin().toRepresentation();
+        Assertions.assertEquals("default", rep.getName());
+        Assertions.assertNull(rep.getDescription());
+
+        // the organization was re-created, so the previous one must be gone and only the two
+        // organizations of the default realm remain
+        List<String> defaultRealmOrgs = organizationIds(realm);
+        Assertions.assertEquals(2, defaultRealmOrgs.size());
+        Assertions.assertTrue(defaultRealmOrgs.contains(organization.getId()));
+        Assertions.assertTrue(defaultRealmOrgs.contains(customOrganization.getId()));
+    }
+
+    @Test
+    @Order(9)
+    public void inviteUserWithCleanup() throws MessagingException {
+        organization.inviteUser(INVITEE_EMAIL, "In", "Vitee");
+
+        assertInvitationEmailSentTo(INVITEE_EMAIL);
+
+        OrganizationInvitationRepresentation invitation = organization.getInvitation(INVITEE_EMAIL);
+        Assertions.assertNotNull(invitation);
+        Assertions.assertEquals(organization.getId(), invitation.getOrganizationId());
+        Assertions.assertEquals(INVITEE_EMAIL, invitation.getEmail());
+        Assertions.assertEquals("In", invitation.getFirstName());
+        Assertions.assertEquals("Vitee", invitation.getLastName());
+        Assertions.assertEquals(OrganizationInvitationRepresentation.Status.PENDING, invitation.getStatus());
+    }
+
+    @Test
+    @Order(10)
+    public void inviteExistingUserWithCleanup() throws MessagingException {
+        organization.inviteExistingUser(user);
+
+        assertInvitationEmailSentTo(user.getEmail());
+
+        OrganizationInvitationRepresentation invitation = organization.getInvitation(user.getEmail());
+        Assertions.assertNotNull(invitation);
+        Assertions.assertEquals(organization.getId(), invitation.getOrganizationId());
+        Assertions.assertEquals(user.getEmail(), invitation.getEmail());
+        Assertions.assertEquals(OrganizationInvitationRepresentation.Status.PENDING, invitation.getStatus());
+    }
+
+    @Test
+    @Order(11)
+    public void verifyInvitationsRemovedAfterTests() {
+        Assertions.assertNull(organization.getInvitation(INVITEE_EMAIL));
+        Assertions.assertNull(organization.getInvitation(user.getEmail()));
+        Assertions.assertTrue(organization.admin().invitations().list().isEmpty());
+    }
+
+    /**
+     * The mail server is purged after each test, so a single invitation must result in exactly one received email
+     */
+    private void assertInvitationEmailSentTo(String expectedRecipient) throws MessagingException {
+        Assertions.assertTrue(mail.waitForIncomingEmail(1), "No invitation email received");
+
+        MimeMessage[] messages = mail.getReceivedMessages();
+        Assertions.assertEquals(1, messages.length);
+
+        Address[] recipients = messages[0].getAllRecipients();
+        Assertions.assertEquals(1, recipients.length);
+        Assertions.assertEquals(expectedRecipient, ((InternetAddress) recipients[0]).getAddress());
+    }
+
+    private static List<String> organizationIds(ManagedRealm managedRealm) {
+        return managedRealm.admin().organizations().list(null, null).stream()
+                .map(OrganizationRepresentation::getId)
+                .toList();
+    }
+
+    public static class OrganizationRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm.organizationsEnabled(true);
+        }
+    }
+
+    public static class CustomOrganizationConfig implements OrganizationConfig {
+
+        @Override
+        public OrganizationBuilder configure(OrganizationBuilder organization) {
+            return organization.name(CUSTOM_ORG_REF)
+                    .alias("custom-alias")
+                    .description("A custom organization")
+                    .redirectUrl("http://localhost:8080/custom")
+                    .domains("custom.org", "custom.test")
+                    .attributes(Map.of("key", List.of("value1", "value2")));
+        }
+    }
+
+    public static class UserWithEmail implements UserConfig {
+
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            return user.username("member").email("member@example.org").emailVerified(true);
+        }
+    }
+}

--- a/test-framework/tests/src/test/java/org/keycloak/testframework/tests/OrganizationTest.java
+++ b/test-framework/tests/src/test/java/org/keycloak/testframework/tests/OrganizationTest.java
@@ -7,7 +7,9 @@ import jakarta.mail.Address;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import jakarta.ws.rs.NotFoundException;
 
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
@@ -17,13 +19,12 @@ import org.keycloak.testframework.annotations.InjectUser;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.mail.MailServer;
 import org.keycloak.testframework.mail.annotations.InjectMailServer;
+import org.keycloak.testframework.realm.GroupBuilder;
 import org.keycloak.testframework.realm.ManagedOrganization;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.ManagedUser;
 import org.keycloak.testframework.realm.OrganizationBuilder;
 import org.keycloak.testframework.realm.OrganizationConfig;
-import org.keycloak.testframework.realm.RealmBuilder;
-import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.realm.UserConfig;
 
@@ -39,14 +40,22 @@ public class OrganizationTest {
 
     private static final String CUSTOM_ORG_REF = "custom";
     private static final String REALM_B_REF = "realmB";
+    private static final String REALM_C_REF = "realmC";
     private static final String ORG_B_REF = "orgB";
     private static final String INVITEE_EMAIL = "invitee@example.org";
+    private static final String SURVIVING_GROUP = "surviving-group";
 
-    @InjectRealm(config = OrganizationRealmConfig.class)
+    @InjectRealm
     ManagedRealm realm;
 
-    @InjectRealm(ref = REALM_B_REF, config = OrganizationRealmConfig.class)
+    @InjectRealm(ref = REALM_B_REF)
     ManagedRealm realmB;
+
+    /**
+     * No organization is injected for this realm, so organizations must not be enabled on it
+     */
+    @InjectRealm(ref = REALM_C_REF)
+    ManagedRealm realmC;
 
     @InjectOrganization
     ManagedOrganization organization;
@@ -114,6 +123,17 @@ public class OrganizationTest {
 
     @Test
     @Order(4)
+    public void testOrganizationsEnabledOnlyOnTargetedRealms() {
+        Assertions.assertTrue(realm.admin().toRepresentation().isOrganizationsEnabled());
+        Assertions.assertTrue(realmB.admin().toRepresentation().isOrganizationsEnabled());
+
+        // no organization is injected for realmC, so it must be left untouched
+        Assertions.assertFalse(realmC.admin().toRepresentation().isOrganizationsEnabled());
+        Assertions.assertThrows(NotFoundException.class, () -> realmC.admin().organizations().list(null, null));
+    }
+
+    @Test
+    @Order(5)
     public void updateWithRollback() {
         organization.updateWithCleanup(o -> o.description("updated description").redirectUrl("http://localhost:8080/updated"));
 
@@ -123,7 +143,7 @@ public class OrganizationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     public void verifyUpdateWithRollback() {
         OrganizationRepresentation rep = organization.admin().toRepresentation();
         Assertions.assertNull(rep.getDescription());
@@ -131,16 +151,20 @@ public class OrganizationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     public void markOrganizationDirty() {
         organization.updateWithCleanup(o -> o.description("dirty description"));
         organization.dirty();
+
+        // realmC is not intercepted, so it must not be registered as a dependent of the organization and must
+        // survive the organization being re-created
+        realmC.admin().groups().add(GroupBuilder.create().name(SURVIVING_GROUP).build()).close();
 
         Assertions.assertEquals("dirty description", organization.admin().toRepresentation().getDescription());
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     public void verifyOrganizationRecreatedAfterDirty() {
         OrganizationRepresentation rep = organization.admin().toRepresentation();
         Assertions.assertEquals("default", rep.getName());
@@ -152,6 +176,12 @@ public class OrganizationTest {
         Assertions.assertEquals(2, defaultRealmOrgs.size());
         Assertions.assertTrue(defaultRealmOrgs.contains(organization.getId()));
         Assertions.assertTrue(defaultRealmOrgs.contains(customOrganization.getId()));
+
+        // realmC was not destroyed together with the organization, so the group added before is still there
+        List<String> realmCGroups = realmC.admin().groups().groups().stream()
+                .map(GroupRepresentation::getName)
+                .toList();
+        Assertions.assertEquals(List.of(SURVIVING_GROUP), realmCGroups);
     }
 
     @Test
@@ -210,14 +240,6 @@ public class OrganizationTest {
         return managedRealm.admin().organizations().list(null, null).stream()
                 .map(OrganizationRepresentation::getId)
                 .toList();
-    }
-
-    public static class OrganizationRealmConfig implements RealmConfig {
-
-        @Override
-        public RealmBuilder configure(RealmBuilder realm) {
-            return realm.organizationsEnabled(true);
-        }
     }
 
     public static class CustomOrganizationConfig implements OrganizationConfig {


### PR DESCRIPTION
Adds `@InjectOrganization` / `ManagedOrganization` to the test framework, so tests can have an organization created for them instead of building one through the admin API by hand.

To make that work without affecting unrelated realms, `RealmConfigInterceptor` first gains the ability to target a single realm.

Closes #51751
Closes #51752

## Changes

###  Realm config interceptors can target a single realm (#51751)

A `RealmConfigInterceptor` was applied to every realm created within a test class, and could not distinguish which realm it was decorating: it was handed its own instance context, which is not yet available while the interceptor is only requested rather than deployed. So a supplier that depends on `ManagedRealm` could read neither its own `realmRef` nor the realm being created.

Interceptors can now decide per realm whether they apply. The default is unchanged, so the existing interceptors keep applying to every realm. A realm that is skipped is neither modified nor registered as a dependent of the interceptor.

### Organizations as a managed resource (#51752)

`@InjectOrganization` provides a `ManagedOrganization`, following the existing `ManagedClient` and `ManagedUser`: configuration through `OrganizationConfig` / `OrganizationBuilder` etc.

Organizations are enabled on the targeted realm automatically, and only on that realm, so tests do not have to configure this themselves. Realms attached to an existing Keycloak instance through `@InjectRealm(attachTo = ..)` are not created by the framework and therefore not configured by it; the supplier reports that clearly instead of failing with a 404 from the admin API.

Enabling organizations changes the behavior of a realm once an organization exists, most notably the browser login becomes identity-first. Keeping this scoped to the targeted realm is what keeps other realms in the same test class unaffected.

---
## Notes for Reviewers

- The first commit introduces `InjectOrganization` without enabling the organization on the realm it targets. The test author must enable it manually.
- The second commit is about the required change to target a specific realm in a `RealmConfigInterceptor`
- The third commit makes use of the new feature for `RealmConfigInterceptor`, so that a test author don't need to enable organization on the realm anymore.

Let me know, if this is too much for one PR. It should be easy to split it.

