### PR TITLE
Fix SAML ECP endpoint returning application/json on SOAP parse errors

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
@@ -66,7 +66,12 @@ public class SamlEcpProfileService extends SamlService {
     }
 
     public Response authenticate(InputStream inputStream) {
-        return authenticate(Soap.extractSoapMessage(inputStream));
+        try {
+            return authenticate(Soap.extractSoapMessage(inputStream));
+        } catch (Exception e) {
+            logger.debugf(e, "Error while processing SOAP request.");
+            return Soap.createFault().reason("Some error occurred while processing the SOAP request.").build();
+        }
     }
 
     public Response authenticate(Document soapMessage) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SOAPBindingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SOAPBindingTest.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.testsuite.saml;
 
+import java.nio.charset.StandardCharsets;
+
 import jakarta.ws.rs.core.Response;
 import jakarta.xml.soap.MessageFactory;
 import jakarta.xml.soap.SOAPMessage;
@@ -32,6 +34,12 @@ import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.util.SamlClientBuilder;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Test;
 
 import static org.keycloak.testsuite.util.Matchers.isSamlResponse;
@@ -40,12 +48,15 @@ import static org.keycloak.testsuite.util.SamlClient.Binding.POST;
 import static org.keycloak.testsuite.util.SamlClient.Binding.SOAP;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNotNull;
 
 public class SOAPBindingTest extends AbstractSamlTest {
 
@@ -293,5 +304,72 @@ public class SOAPBindingTest extends AbstractSamlTest {
         });
 
 
+    }
+
+    @Test
+    public void soapBindingErrorHandlingEmptyBody() throws Exception {
+        String soapEndpoint = String.valueOf(getAuthServerSamlEndpoint(REALM_NAME));
+        HttpPost post = new HttpPost(soapEndpoint);
+        post.setEntity(new ByteArrayEntity("".getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_SOAP_XML));
+        try (CloseableHttpClient client = HttpClientBuilder.create().build();
+             CloseableHttpResponse response = client.execute(post)) {
+
+            // Before the fix, this returned Content-Type: application/json via KeycloakErrorHandler
+            // instead of a SOAP fault, because the exception from Soap.extractSoapMessage() was not caught.
+            assertThat(response.getStatusLine().getStatusCode(), is(equalTo(500)));
+            assertThat(response.getFirstHeader("Content-Type").getValue(), containsString("text/xml"));
+
+            // Verify response contains SOAP fault
+            MessageFactory messageFactory = MessageFactory.newInstance();
+            SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
+            assertThat(soapMessage.getSOAPBody().getFault(), notNullValue());
+        }
+    }
+
+    @Test
+    public void soapBindingErrorHandlingMalformedXml() throws Exception {
+        String soapEndpoint = String.valueOf(getAuthServerSamlEndpoint(REALM_NAME));
+        String malformedXml = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                              "<soap:Body>" +
+                              "<malformed>This is not valid SOAP</malformed>";
+        HttpPost post = new HttpPost(soapEndpoint);
+        post.setEntity(new ByteArrayEntity(malformedXml.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_SOAP_XML));
+
+        try (CloseableHttpClient client = HttpClientBuilder.create().build();
+             CloseableHttpResponse response = client.execute(post)) {
+
+            assertThat(response.getStatusLine().getStatusCode(), is(equalTo(500)));
+            assertNotNull(response.getFirstHeader("Content-Type"));
+            assertThat(response.getFirstHeader("Content-Type").getValue(), containsString("text/xml"));
+
+            // Verify response contains SOAP fault
+            MessageFactory messageFactory = MessageFactory.newInstance();
+            SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
+            assertThat(soapMessage.getSOAPBody().getFault(), notNullValue());
+        }
+    }
+
+    @Test
+    public void soapBindingErrorHandlingInvalidSamlContent() throws Exception {
+        String soapEndpoint = String.valueOf(getAuthServerSamlEndpoint(REALM_NAME));
+        String validSoapWithInvalidSaml = "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+                                          "<soap:Body>" +
+                                          "<NotASamlRequest>Invalid SAML content</NotASamlRequest>" +
+                                          "</soap:Body>" +
+                                          "</soap:Envelope>";
+        HttpPost post = new HttpPost(soapEndpoint);
+        post.setEntity(new ByteArrayEntity(validSoapWithInvalidSaml.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_SOAP_XML));
+        post.setHeader("Authorization", "Basic YmJ1cmtlOmJidXJrZQ==");
+        try (CloseableHttpClient client = HttpClientBuilder.create().build();
+             CloseableHttpResponse response = client.execute(post)) {
+
+            assertThat(response.getStatusLine().getStatusCode(), is(equalTo(500)));
+            assertThat(response.getFirstHeader("Content-Type").getValue(), containsString("text/xml"));
+
+            // Verify response contains SOAP fault
+            MessageFactory messageFactory = MessageFactory.newInstance();
+            SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
+            assertThat(soapMessage.getSOAPBody().getFault(), notNullValue());
+        }
     }
 }


### PR DESCRIPTION
Add a try/catch to authenticate(InputStream) in SamlEcpProfileService so that exceptions from Soap.extractSoapMessage() are caught and returned as SOAP faults instead of propagating to KeycloakErrorHandler.

Closes #49022

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
