### PR TITLE
Registration access token regeneration stores live bearer tokens in a…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
@@ -229,6 +229,9 @@ public class StripSecretsUtils {
         if (rep.getSecret() != null) {
             rep.setSecret(maskNonVaultValue(rep.getSecret()));
         }
+        if (rep.getRegistrationAccessToken() != null) {
+            rep.setRegistrationAccessToken(maskNonVaultValue(rep.getRegistrationAccessToken()));
+        }
 
         stripFromMap(rep.getAttributes(), ClientSecretConstants.CLIENT_ROTATED_SECRET);
         return rep;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -357,6 +357,7 @@ public class ClientResource {
         rep.setRegistrationAccessToken(token);
 
         adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).representation(rep).success();
+        rep.setRegistrationAccessToken(token); // Reset again to the "real" value. In the admin event, it is masked
         return rep;
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/CredentialsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/CredentialsTest.java
@@ -62,6 +62,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.keycloak.representations.idm.ComponentRepresentation.SECRET_VALUE;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -125,12 +127,13 @@ public class CredentialsTest {
         String newToken = accountClient.regenerateRegistrationAccessToken().getRegistrationAccessToken();
         assertNull(oldToken); // registration access token not saved in ClientRep
         assertNotNull(newToken); // it's only available via regenerateRegistrationAccessToken()
+        assertNotEquals(SECRET_VALUE, newToken); // New token is not masked in the update-response
         assertNull(accountClient.toRepresentation().getRegistrationAccessToken());
 
-        // Test event
+        // Test event - registration access token should be masked in the event
         ClientRepresentation testedRep = new ClientRepresentation();
         testedRep.setClientId(rep.getClientId());
-        testedRep.setRegistrationAccessToken(newToken);
+        testedRep.setRegistrationAccessToken(SECRET_VALUE);
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.ACTION, AdminEventPaths.clientRegenerateRegistrationAccessTokenPath(accountClient.toRepresentation().getId()), testedRep, ResourceType.CLIENT);
     }
 


### PR DESCRIPTION
…dmin events

closes #51242

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
