### PR TITLE
[Backport 26.7] Skip resolving roles when processing transient tokens on FGAP requests

### DIFF
--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -96,10 +96,18 @@ for guidance on tuning cache sizes.
 
 ===== Role policies and fine-grained admin permissions
 
-When using link:{adminguide_finegrained_link}[fine-grained admin permissions], role policies always resolve roles
-directly from the user rather than from the token. The *Fetch Roles* setting on role policies has no effect in
-this context and is disabled in the administration console.
+When using link:{adminguide_finegrained_link}[fine-grained admin permissions], the effective admin roles considered
+by role policies are the intersection of the roles present in the token and the roles the user actually has. Because
+the token reflects the authenticating client's scope and protocol mapper configuration, the same user can have
+different effective roles depending on which client they authenticate with.
 
-For regular authorization services outside the admin permissions scope, the *Fetch Roles* setting controls whether
-role policies check roles from the token or fetch them from the user's role mappings.
+The *Fetch Roles* setting on role policies controls whether this intersection is applied. When *Fetch Roles* is
+disabled (the default), only roles that are both assigned to the user and present in the token are considered.
+When *Fetch Roles* is enabled, roles are resolved directly from the user's role assignments, bypassing the token
+and any client scope filtering.
+
+For deployments where multiple clients authenticate administrators with different levels of access, keep
+*Fetch Roles* disabled on role policies so that client scope constrains which admin roles are considered
+for authorization decisions. This ensures that a client with a restricted scope cannot be used to exercise
+permissions beyond what its scope allows, even if the authenticating user holds broader role assignments.
 

--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -72,21 +72,34 @@ mappings or group memberships, and not to users with admin roles mapped only thr
 
 ==== Multi-realm administration considerations
 
-When a user in the `master` realm is granted the `admin` role or realm-specific roles across many realms,
-the access token issued during authentication includes admin roles for every realm the user can administer.
-In deployments with a large number of realms, keep the following in mind.
+The `admin` role in the `master` realm is a composite role. For every realm in the deployment, it includes
+the full set of admin roles from that realm's `<realm name>-realm` client. For example, with 100 realms,
+the `admin` composite contains over 2,000 role mappings (approximately 21 roles per realm). This has
+implications for token size and performance.
 
 ===== Token size
 
-Each realm adds its `realm-management` client roles to the token. With hundreds of realms, the token
-can exceed HTTP header size limits enforced by load balancers or reverse proxies.
+When using full (non-lightweight) access tokens, all admin roles from the `admin` composite are included
+in the token. With hundreds of realms, the token can exceed HTTP header size limits enforced by load
+balancers or reverse proxies.
 
-To mitigate this, use lightweight access tokens. The `security-admin-console` and `admin-cli` clients
-use lightweight access tokens by default since {project_name} 26. Lightweight tokens do not carry roles
-over the wire — the server resolves them from the user session when needed.
+To mitigate this, use lightweight access tokens. The `security-admin-console` and `admin-cli` clients use
+lightweight access tokens by default since {project_name} 26. Lightweight tokens do not carry roles over
+the wire — the server resolves them from the user session when needed.
 
 ===== Cache sizing
 
-Deployments with many realms should size the `realms`, `users`, and `authorization` caches.
-See the server caching guide for guidance on tuning cache sizes.
+Deployments with many realms should ensure that the `realms`, `users`, and `authorization` local caches are
+properly sized. Undersized caches lead to frequent evictions and cache misses, resulting in additional
+database round-trips that degrade performance. See the link:{server_guide_base_link}/caching[server caching guide]
+for guidance on tuning cache sizes.
+
+===== Role policies and fine-grained admin permissions
+
+When using link:{adminguide_finegrained_link}[fine-grained admin permissions], role policies always resolve roles
+directly from the user rather than from the token. The *Fetch Roles* setting on role policies has no effect in
+this context and is disabled in the administration console.
+
+For regular authorization services outside the admin permissions scope, the *Fetch Roles* setting controls whether
+role policies check roles from the token or fetch them from the user's role mappings.
 

--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -74,40 +74,19 @@ mappings or group memberships, and not to users with admin roles mapped only thr
 
 When a user in the `master` realm is granted the `admin` role or realm-specific roles across many realms,
 the access token issued during authentication includes admin roles for every realm the user can administer.
-In deployments with a large number of realms, this has several implications.
+In deployments with a large number of realms, keep the following in mind.
 
 ===== Token size
 
-Access tokens grow with the number of realms the user can administer. Each realm adds its
-`realm-management` client roles to the token. With hundreds of realms, the resulting token can exceed
-HTTP `Authorization` header size limits enforced by load balancers, reverse proxies, or application servers,
-causing authentication failures.
+Each realm adds its `realm-management` client roles to the token. With hundreds of realms, the token
+can exceed HTTP header size limits enforced by load balancers or reverse proxies.
 
-Use lightweight access tokens to mitigate this. Since Keycloak 26, the `security-admin-console` and
-`admin-cli` clients use lightweight access tokens by default. Lightweight tokens do not carry roles over the
-wire — the server resolves them from the user session when processing admin API requests.
-
-===== Access control model
-
-When using the default role-based access control (RBAC), admin roles embedded in the token are not used
-for Admin API authorization decisions. The server checks the user's actual role assignments directly. In this
-model, the roles in the token are informational and their presence adds overhead without contributing to
-access control.
-
-When using fine-grained admin permissions (FGAP), role-based policies can be configured to resolve roles
-from the user's actual role assignments rather than from the token. Enable the *Fetch Roles* setting on
-role policies associated with permissions to avoid relying on roles embedded in the token.
+To mitigate this, use lightweight access tokens. The `security-admin-console` and `admin-cli` clients
+use lightweight access tokens by default since {project_name} 26. Lightweight tokens do not carry roles
+over the wire — the server resolves them from the user session when needed.
 
 ===== Cache sizing
 
-Deployments with many realms increase the working set of the `realms`, `users`, and `authorization` caches.
-Undersized caches lead to frequent evictions and cache misses, resulting in additional database round-trips
-that degrade admin API performance. Refer to the
-ifeval::[{project_community}==true]
-link:{adminguide_link}#_cache_configuration[cache configuration]
-endif::[]
-ifeval::[{project_product}==true]
-link:{adminguide_link}#_cache_configuration[cache configuration]
-endif::[]
-documentation for guidance on monitoring cache metrics and tuning cache sizes for your deployment.
+Deployments with many realms should size the `realms`, `users`, and `authorization` caches.
+See the server caching guide for guidance on tuning cache sizes.
 

--- a/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/master-realm.adoc
@@ -70,3 +70,44 @@ application access control.
 Effectively, access to the Admin API is only granted to users with admin roles explicitly assigned through direct role
 mappings or group memberships, and not to users with admin roles mapped only through client protocol mappers.
 
+==== Multi-realm administration considerations
+
+When a user in the `master` realm is granted the `admin` role or realm-specific roles across many realms,
+the access token issued during authentication includes admin roles for every realm the user can administer.
+In deployments with a large number of realms, this has several implications.
+
+===== Token size
+
+Access tokens grow with the number of realms the user can administer. Each realm adds its
+`realm-management` client roles to the token. With hundreds of realms, the resulting token can exceed
+HTTP `Authorization` header size limits enforced by load balancers, reverse proxies, or application servers,
+causing authentication failures.
+
+Use lightweight access tokens to mitigate this. Since Keycloak 26, the `security-admin-console` and
+`admin-cli` clients use lightweight access tokens by default. Lightweight tokens do not carry roles over the
+wire — the server resolves them from the user session when processing admin API requests.
+
+===== Access control model
+
+When using the default role-based access control (RBAC), admin roles embedded in the token are not used
+for Admin API authorization decisions. The server checks the user's actual role assignments directly. In this
+model, the roles in the token are informational and their presence adds overhead without contributing to
+access control.
+
+When using fine-grained admin permissions (FGAP), role-based policies can be configured to resolve roles
+from the user's actual role assignments rather than from the token. Enable the *Fetch Roles* setting on
+role policies associated with permissions to avoid relying on roles embedded in the token.
+
+===== Cache sizing
+
+Deployments with many realms increase the working set of the `realms`, `users`, and `authorization` caches.
+Undersized caches lead to frequent evictions and cache misses, resulting in additional database round-trips
+that degrade admin API performance. Refer to the
+ifeval::[{project_community}==true]
+link:{adminguide_link}#_cache_configuration[cache configuration]
+endif::[]
+ifeval::[{project_product}==true]
+link:{adminguide_link}#_cache_configuration[cache configuration]
+endif::[]
+documentation for guidance on monitoring cache metrics and tuning cache sizes for your deployment.
+

--- a/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
@@ -2,7 +2,7 @@ import { HelpItem, useFetch } from "@keycloak/keycloak-ui-shared";
 import { Button, Checkbox, FormGroup } from "@patternfly/react-core";
 import { MinusCircleIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../../admin-client";
@@ -13,32 +13,16 @@ import {
   FilterType,
 } from "../../../components/role-mapping/AddRoleMappingModal";
 import { Row, ServiceRole } from "../../../components/role-mapping/RoleMapping";
-import { NewPermissionPolicyDetailsParams } from "../../../permissions-configuration/routes/NewPermissionPolicy";
-import { useIsAdminPermissionsClient } from "../../../utils/useIsAdminPermissionsClient";
-import { useParams } from "../../../utils/useParams";
-import type { PolicyDetailsParams } from "../../routes/PolicyDetails";
 import type { RequiredIdValue } from "./ClientScope";
 
 export const Role = () => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
-  const { id } = useParams<PolicyDetailsParams>();
-  const { permissionClientId } = useParams<NewPermissionPolicyDetailsParams>();
-  const isAdminPermissionsClient = useIsAdminPermissionsClient(
-    permissionClientId || id,
-  );
   const { control, getValues, setValue } = useFormContext<{
     roles?: RequiredIdValue[];
     fetchRoles?: boolean;
   }>();
-
-  useEffect(() => {
-    if (isAdminPermissionsClient) {
-      setValue("fetchRoles", true);
-    }
-  }, [isAdminPermissionsClient, setValue]);
-
   const values = getValues("roles");
 
   const [open, setOpen] = useState(false);
@@ -172,7 +156,6 @@ export const Role = () => {
         name="fetchRoles"
         label={t("fetchRoles")}
         labelIcon={t("fetchRolesHelp")}
-        isDisabled={isAdminPermissionsClient}
       />
     </>
   );

--- a/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/Role.tsx
@@ -2,7 +2,7 @@ import { HelpItem, useFetch } from "@keycloak/keycloak-ui-shared";
 import { Button, Checkbox, FormGroup } from "@patternfly/react-core";
 import { MinusCircleIcon } from "@patternfly/react-icons";
 import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../../admin-client";
@@ -13,16 +13,32 @@ import {
   FilterType,
 } from "../../../components/role-mapping/AddRoleMappingModal";
 import { Row, ServiceRole } from "../../../components/role-mapping/RoleMapping";
+import { NewPermissionPolicyDetailsParams } from "../../../permissions-configuration/routes/NewPermissionPolicy";
+import { useIsAdminPermissionsClient } from "../../../utils/useIsAdminPermissionsClient";
+import { useParams } from "../../../utils/useParams";
+import type { PolicyDetailsParams } from "../../routes/PolicyDetails";
 import type { RequiredIdValue } from "./ClientScope";
 
 export const Role = () => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
+  const { id } = useParams<PolicyDetailsParams>();
+  const { permissionClientId } = useParams<NewPermissionPolicyDetailsParams>();
+  const isAdminPermissionsClient = useIsAdminPermissionsClient(
+    permissionClientId || id,
+  );
   const { control, getValues, setValue } = useFormContext<{
     roles?: RequiredIdValue[];
     fetchRoles?: boolean;
   }>();
+
+  useEffect(() => {
+    if (isAdminPermissionsClient) {
+      setValue("fetchRoles", true);
+    }
+  }, [isAdminPermissionsClient, setValue]);
+
   const values = getValues("roles");
 
   const [open, setOpen] = useState(false);
@@ -156,6 +172,7 @@ export const Role = () => {
         name="fetchRoles"
         label={t("fetchRoles")}
         labelIcon={t("fetchRolesHelp")}
+        isDisabled={isAdminPermissionsClient}
       />
     </>
   );

--- a/server-spi-private/src/main/java/org/keycloak/models/AdminRoles.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/AdminRoles.java
@@ -18,6 +18,7 @@
 package org.keycloak.models;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -62,16 +63,23 @@ public class AdminRoles {
 
     public static final String IMPERSONATION = "impersonation";
 
-    public static String[] ALL_REALM_ROLES = {CREATE_CLIENT, VIEW_REALM, VIEW_USERS, VIEW_CLIENTS, VIEW_EVENTS, VIEW_IDENTITY_PROVIDERS, VIEW_AUTHORIZATION, VIEW_ORGANIZATIONS, MANAGE_REALM, MANAGE_USERS, MANAGE_CLIENTS, MANAGE_EVENTS, MANAGE_IDENTITY_PROVIDERS, MANAGE_AUTHORIZATION, MANAGE_ORGANIZATIONS, QUERY_USERS, QUERY_CLIENTS, QUERY_REALMS, QUERY_GROUPS, QUERY_ORGANIZATIONS};
-    public static String[] ALL_QUERY_ROLES = {QUERY_USERS, QUERY_CLIENTS, QUERY_REALMS, QUERY_GROUPS, QUERY_ORGANIZATIONS};
+    public static final String[] ALL_REALM_ROLES = {CREATE_CLIENT, VIEW_REALM, VIEW_USERS, VIEW_CLIENTS, VIEW_EVENTS, VIEW_IDENTITY_PROVIDERS, VIEW_AUTHORIZATION, VIEW_ORGANIZATIONS, MANAGE_REALM, MANAGE_USERS, MANAGE_CLIENTS, MANAGE_EVENTS, MANAGE_IDENTITY_PROVIDERS, MANAGE_AUTHORIZATION, MANAGE_ORGANIZATIONS, QUERY_USERS, QUERY_CLIENTS, QUERY_REALMS, QUERY_GROUPS, QUERY_ORGANIZATIONS};
+    public static final String[] ALL_QUERY_ROLES = {QUERY_USERS, QUERY_CLIENTS, QUERY_REALMS, QUERY_GROUPS, QUERY_ORGANIZATIONS};
 
-    public static Set<String> ALL_ROLES = new HashSet<>();
+    public static final Set<String> REALM_LEVEL_ROLES = Set.of(ADMIN, CREATE_REALM);
+    public static final Set<String> ALL_ROLES;
+    public static final Set<String> REALM_MANAGEMENT_ROLES;
+
     static {
-        ALL_ROLES.addAll(Arrays.asList(ALL_REALM_ROLES));
-        ALL_ROLES.add(IMPERSONATION);
-        ALL_ROLES.add(ADMIN);
-        ALL_ROLES.add(CREATE_REALM);
-        ALL_ROLES.add(REALM_ADMIN);
+        Set<String> allRoles = new HashSet<>(Arrays.asList(ALL_REALM_ROLES));
+        allRoles.addAll(REALM_LEVEL_ROLES);
+        allRoles.add(IMPERSONATION);
+        allRoles.add(REALM_ADMIN);
+        ALL_ROLES = Collections.unmodifiableSet(allRoles);
+
+        Set<String> realmManagementRoles = new HashSet<>(Set.of(ALL_REALM_ROLES));
+        realmManagementRoles.addAll(Set.of(IMPERSONATION, REALM_ADMIN));
+        REALM_MANAGEMENT_ROLES = Collections.unmodifiableSet(realmManagementRoles);
     }
 
     public static boolean isAdminRole(RoleModel role) {
@@ -86,18 +94,25 @@ public class AdminRoles {
         RoleContainerModel container = role.getContainer();
 
         if (container instanceof RealmModel r) {
-            return r.getName().equals(Config.getAdminRealm());
+            return isAdminRealm(r.getName());
         }
 
         if (container instanceof ClientModel c) {
-            if (c.getClientId().equals(Constants.REALM_MANAGEMENT_CLIENT_ID)) {
-                return true;
-            }
-            return c.getRealm().getName().equals(Config.getAdminRealm())
-                    && c.getClientId().endsWith(APP_SUFFIX);
+            return isAdminClient(c.getRealm(), c.getClientId());
         }
 
         return false;
+    }
+
+    public static boolean isAdminRealm(String realmName) {
+        return Config.getAdminRealm().equals(realmName);
+    }
+
+    public static boolean isAdminClient(RealmModel realm, String clientId) {
+        if (Constants.REALM_MANAGEMENT_CLIENT_ID.equals(clientId)) {
+            return true;
+        }
+        return isAdminRealm(realm.getName()) && clientId.endsWith(APP_SUFFIX);
     }
 
     public static boolean isAdminRoleOrComposite(RoleModel role) {

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -32,6 +32,7 @@ import org.keycloak.authorization.identity.Identity;
 import org.keycloak.authorization.store.ResourceServerStore;
 import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.authorization.util.Tokens;
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
@@ -69,6 +70,8 @@ public class KeycloakIdentity implements Identity {
     private final boolean resourceServer;
     private final String id;
     private UserModel user;
+    private ClientModel requestingClient;
+    private boolean transientRolesResolved;
 
     public KeycloakIdentity(KeycloakSession keycloakSession) {
         this(Tokens.getAccessToken(keycloakSession), keycloakSession);
@@ -300,7 +303,40 @@ public class KeycloakIdentity implements Identity {
             return false;
         }
 
-        return user.hasRole(role);
+        boolean hasRole = user.hasRole(role);
+
+        if (AdminRoles.isAdminRole(role) && !hasRole) {
+            return false;
+        }
+
+        ClientModel requestingClient = getRequestingClient();
+
+        if (requestingClient != null && !requestingClient.hasScope(role)) {
+            resolveTransientClientScopeRoles();
+
+            Map<String, Access> resourceAccess = accessToken.getResourceAccess();
+
+            if (resourceAccess == null) {
+                return false;
+            }
+
+            Access access = resourceAccess.get(clientId);
+
+            if (access == null) {
+                return false;
+            }
+
+            hasRole = access.isUserInRole(roleName);
+        }
+
+        return hasRole;
+    }
+
+    private void resolveTransientClientScopeRoles() {
+        if (!transientRolesResolved) {
+            AuthenticationManager.resolveLightweightAccessTokenRoles(keycloakSession, accessToken, realm);
+            transientRolesResolved = true;
+        }
     }
 
     @Override
@@ -315,7 +351,27 @@ public class KeycloakIdentity implements Identity {
             return false;
         }
 
-        return user.hasRole(role);
+        boolean hasRole = user.hasRole(role);
+
+        if (AdminRoles.isAdminRole(role) && !hasRole) {
+            return false;
+        }
+
+        ClientModel requestingClient = getRequestingClient();
+
+        if (requestingClient != null && !requestingClient.hasScope(role)) {
+            resolveTransientClientScopeRoles();
+
+            Access realmAccess = accessToken.getRealmAccess();
+
+            if (realmAccess == null) {
+                return false;
+            }
+
+            hasRole = realmAccess.isUserInRole(roleName);
+        }
+
+        return hasRole;
     }
 
     public AccessToken getAccessToken() {
@@ -337,6 +393,15 @@ public class KeycloakIdentity implements Identity {
         }
 
         return null;
+    }
+
+    private ClientModel getRequestingClient() {
+        if (requestingClient == null) {
+            if (this.accessToken.getIssuedFor() != null) {
+                requestingClient = realm.getClientByClientId(accessToken.getIssuedFor());
+            }
+        }
+        return requestingClient;
     }
 
     private UserModel getUserFromToken() {

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -37,9 +37,11 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessToken.Access;
@@ -66,6 +68,7 @@ public class KeycloakIdentity implements Identity {
     protected final Attributes attributes;
     private final boolean resourceServer;
     private final String id;
+    private UserModel user;
 
     public KeycloakIdentity(KeycloakSession keycloakSession) {
         this(Tokens.getAccessToken(keycloakSession), keycloakSession);
@@ -185,10 +188,10 @@ public class KeycloakIdentity implements Identity {
     }
 
     public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession) {
-        this(accessToken, keycloakSession, keycloakSession.getContext().getRealm());
+        this(accessToken, keycloakSession, keycloakSession.getContext().getRealm(), false);
     }
 
-    public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession, RealmModel realm) {
+    public KeycloakIdentity(AccessToken accessToken, KeycloakSession keycloakSession, RealmModel realm, boolean ignoreTokenRoles) {
         if (accessToken == null) {
             throw new ErrorResponseException("invalid_bearer_token", "Could not obtain bearer access_token from request.", Status.FORBIDDEN);
         }
@@ -248,7 +251,11 @@ public class KeycloakIdentity implements Identity {
                 throw new IllegalArgumentException("User from token not found");
             }
 
-            addRolesAsAttributes(accessToken, realm, user, attributes);
+            if (!ignoreTokenRoles) {
+                addRolesAsAttributes(accessToken, realm, user, attributes);
+            } else {
+                this.user = user;
+            }
 
             if (clientUser != null && user.getId().equals(clientUser.getId())) {
                 AuthorizationProvider provider = keycloakSession.getProvider(AuthorizationProvider.class);
@@ -281,6 +288,36 @@ public class KeycloakIdentity implements Identity {
         return this.attributes;
     }
 
+    @Override
+    public boolean hasClientRole(String clientId, String roleName) {
+        if (user == null) {
+            return Identity.super.hasClientRole(clientId, roleName);
+        }
+
+        RoleModel role = KeycloakModelUtils.getRoleByName(realm, clientId, roleName);
+
+        if (role == null) {
+            return false;
+        }
+
+        return user.hasRole(role);
+    }
+
+    @Override
+    public boolean hasRealmRole(String roleName) {
+        if (user == null) {
+            return Identity.super.hasRealmRole(roleName);
+        }
+
+        RoleModel role = KeycloakModelUtils.getRoleByName(realm, null, roleName);
+
+        if (role == null) {
+            return false;
+        }
+
+        return user.hasRole(role);
+    }
+
     public AccessToken getAccessToken() {
         return this.accessToken;
     }
@@ -303,6 +340,9 @@ public class KeycloakIdentity implements Identity {
     }
 
     private UserModel getUserFromToken() {
+        if (user != null) {
+            return user;
+        }
         if (accessToken.getSessionState() == null) {
             return TokenManager.lookupUserFromStatelessToken(keycloakSession, realm, accessToken);
         }

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -53,6 +53,7 @@ import org.keycloak.util.JsonSerialization;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import static org.keycloak.models.utils.KeycloakModelUtils.removeTransientAdminRoles;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -153,6 +154,12 @@ public class KeycloakIdentity implements Identity {
 
             ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionScopeParameter(clientSessionModel, keycloakSession);
             this.accessToken = new TokenManager().createClientAccessToken(keycloakSession, realm, client, userSession.getUser(), userSession, clientSessionCtx, clientSessionCtx.isOfflineTokenRequested());
+            UserModel tokenUser = userSession.getUser();
+            removeTransientAdminRoles(realm, null, tokenUser, this.accessToken.getRealmAccess());
+            Map<String, Access> resourceAccess = this.accessToken.getResourceAccess();
+            if (resourceAccess != null) {
+                resourceAccess.forEach((cId, access) -> removeTransientAdminRoles(realm, cId, tokenUser, access));
+            }
         }
 
         ClientModel clientModel = getTargetClient();

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -53,7 +53,6 @@ import org.keycloak.util.JsonSerialization;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import static org.keycloak.models.utils.KeycloakModelUtils.removeTransientAdminRoles;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -323,7 +322,6 @@ public class KeycloakIdentity implements Identity {
         Access realmAccess = accessToken.getRealmAccess();
 
         if (realmAccess != null) {
-            removeTransientAdminRoles(realm, null, user, realmAccess);
             attributes.put("kc.realm.roles", realmAccess.getRoles());
         }
 
@@ -331,7 +329,6 @@ public class KeycloakIdentity implements Identity {
 
         if (resourceAccess != null) {
             resourceAccess.forEach((clientId, access) -> {
-                removeTransientAdminRoles(realm, clientId, user, access);
                 attributes.put("kc.client." + clientId + ".roles", access.getRoles());
             });
         }

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoleTokenPostProcessor.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoleTokenPostProcessor.java
@@ -2,20 +2,25 @@ package org.keycloak.services.resources.admin;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.protocol.oidc.token.TokenPostProcessor;
 import org.keycloak.protocol.oidc.token.TokenPostProcessorContext;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessToken.Access;
 import org.keycloak.util.TokenUtil;
 
-import static org.keycloak.models.utils.KeycloakModelUtils.removeTransientAdminRoles;
+import static org.keycloak.models.AdminRoles.isAdminClient;
 
 /**
  * A {@link TokenPostProcessor} that removes from access tokens any admin role not explicitly granted to the
@@ -35,17 +40,75 @@ public class AdminRoleTokenPostProcessor implements TokenPostProcessor {
         AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
         UserSessionModel userSession = clientSession.getUserSession();
         UserModel user = userSession.getUser();
-        RealmModel realm = session.getContext().getRealm();
         AccessToken accessToken = context.accessToken();
 
         TokenUtil.convertTokenRolesFromOtherClaims(accessToken);
+        removeTransientAdminRoles(user, accessToken);
+    }
 
-        removeTransientAdminRoles(realm, null, user, accessToken.getRealmAccess());
-
-        Map<String, Access> resourceAccess = accessToken.getResourceAccess();
-
-        for (Entry<String, Access> access : resourceAccess.entrySet()) {
-            removeTransientAdminRoles(realm, access.getKey(), user, access.getValue());
+    private void removeTransientAdminRoles(UserModel user, AccessToken accessToken) {
+        if (!containsAdminRoles(accessToken)) {
+            return;
         }
+
+        Set<String> expandedRoles = RoleUtils.getDeepUserRoleMappings(user).stream()
+                .filter(AdminRoles::isAdminRole)
+                .map(RoleModel::getName)
+                .collect(Collectors.toSet());
+
+        Access realmAccess = accessToken.getRealmAccess();
+        Map<String, Access> resourceAccess = accessToken.getResourceAccess();
+        RealmModel realm = session.getContext().getRealm();
+
+        if (AdminRoles.isAdminRealm(realm.getName())) {
+            removeMappedRoles(realmAccess, AdminRoles.REALM_LEVEL_ROLES, expandedRoles);
+        }
+
+        if (resourceAccess != null) {
+            for (Entry<String, Access> clientRole : resourceAccess.entrySet()) {
+                if (isAdminClient(realm, clientRole.getKey())) {
+                    removeMappedRoles(clientRole.getValue(), AdminRoles.REALM_MANAGEMENT_ROLES, expandedRoles);
+                }
+            }
+        }
+    }
+
+    private boolean containsAdminRoles(AccessToken accessToken) {
+        Access realmAccess = accessToken.getRealmAccess();
+        Map<String, Access> resourceAccess = accessToken.getResourceAccess();
+        RealmModel realm = session.getContext().getRealm();
+
+        if (realmAccess == null && (resourceAccess == null || resourceAccess.isEmpty())) {
+            return false;
+        }
+
+        if (AdminRoles.isAdminRealm(realm.getName()) && containsAdminRoles(realmAccess, AdminRoles.REALM_LEVEL_ROLES)) {
+            return true;
+        }
+
+        if (resourceAccess != null) {
+            for (Entry<String, Access> entry : resourceAccess.entrySet()) {
+                if (isAdminClient(realm, entry.getKey()) && containsAdminRoles(entry.getValue(), AdminRoles.REALM_MANAGEMENT_ROLES)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean containsAdminRoles(Access access, Set<String> adminRoles) {
+        if (access == null || access.getRoles() == null) {
+            return false;
+        }
+        return access.getRoles().stream().anyMatch(adminRoles::contains);
+    }
+
+    private void removeMappedRoles(Access access, Set<String> rolesToRemove, Set<String> expandedUserRoles) {
+        if (access == null || access.getRoles() == null) {
+            return;
+        }
+
+        access.getRoles().removeIf(role -> rolesToRemove.contains(role) && !expandedUserRoles.contains(role));
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
@@ -49,7 +49,6 @@ import org.keycloak.models.cache.CacheRealmProvider;
 import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.Permission;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 
@@ -106,8 +105,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
 
     private void initIdentity(KeycloakSession session, AdminAuth auth) {
         AccessToken accessToken = auth.getToken();
-        AuthenticationManager.resolveLightweightAccessTokenRoles(session, accessToken, adminsRealm);
-        this.identity = new KeycloakIdentity(accessToken, session, adminsRealm);
+        this.identity = new KeycloakIdentity(accessToken, session, adminsRealm, true);
     }
 
     MgmtPermissions(KeycloakSession session, RealmModel adminsRealm, UserModel admin) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/UMAGrantTypeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/UMAGrantTypeTest.java
@@ -1,0 +1,120 @@
+package org.keycloak.tests.admin.authz;
+
+import java.util.Set;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.Constants;
+import org.keycloak.protocol.oidc.mappers.HardcodedRole;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.tests.common.BasicUserConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.models.utils.ModelToRepresentation.toRepresentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest
+public class UMAGrantTypeTest {
+
+    @InjectRealm(lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @InjectUser(config = BasicUserConfig.class)
+    ManagedUser user;
+
+    @InjectClient(config = AuthzResourceServerConfig.class)
+    ManagedClient resourceServer;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @Test
+    public void testAdminRolesIgnoredWhenUsingIdTokenAsClaimToken() {
+        ClientResource clientResource = resourceServer.admin();
+        String clientId = resourceServer.getClientId();
+        String clientSecret = resourceServer.getSecret();
+
+        ProtocolMapperRepresentation mapper = toRepresentation(
+                HardcodedRole.create("inject-view-clients",
+                        Constants.REALM_MANAGEMENT_CLIENT_ID + "." + AdminRoles.VIEW_CLIENTS)
+        );
+        clientResource.getProtocolMappers().createMapper(mapper).close();
+
+        ClientRepresentation realmMgmt = realm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation viewClientsRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.VIEW_CLIENTS).toRepresentation();
+
+        RolePolicyRepresentation rolePolicy = new RolePolicyRepresentation();
+        rolePolicy.setName("require-view-clients");
+        rolePolicy.addRole(viewClientsRole.getId(), true);
+        try (Response response = clientResource.authorization().policies().role().create(rolePolicy)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        rolePolicy = clientResource.authorization().policies().role().findByName("require-view-clients");
+
+        ResourceRepresentation resource = new ResourceRepresentation();
+        resource.setName("protected-resource");
+        try (Response response = clientResource.authorization().resources().create(resource)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        resource = clientResource.authorization().resources().findByName("protected-resource").get(0);
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        permission.setName("protect-resource");
+        permission.setResources(Set.of(resource.getId()));
+        permission.setPolicies(Set.of(rolePolicy.getId()));
+        try (Response response = clientResource.authorization().permissions().resource().create(permission)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+
+        AccessTokenResponse tokenResponse = oauth.client(clientId, clientSecret)
+                .doPasswordGrantRequest(user.getUsername(), user.getPassword());
+        String idToken = tokenResponse.getIdToken();
+        assertNotNull(idToken);
+
+        tokenResponse = oauth.client(clientId, clientSecret)
+                .permissionGrantRequest()
+                .claimToken(idToken)
+                .send();
+        assertNull(tokenResponse.getAccessToken(),
+                "Authorization should be denied when admin role is only mapper-injected via IDToken claim_token");
+        assertNotNull(tokenResponse.getError(),
+                "Response should contain an error when admin role is only mapper-injected");
+    }
+
+    public static class AuthzResourceServerConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .directAccessGrantsEnabled(true);
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/RealmAdminAccessTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/RealmAdminAccessTest.java
@@ -18,11 +18,13 @@
 package org.keycloak.tests.admin.authz.fgap;
 
 import java.util.List;
+import java.util.Set;
 
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.Constants;
@@ -30,10 +32,13 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.Logic;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
 import org.keycloak.testframework.admin.AdminClientFactory;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectAdminClientFactory;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
@@ -121,6 +126,243 @@ public class RealmAdminAccessTest extends AbstractPermissionTest {
                 assertWorkflowAccess(client);
             } finally {
                 client.realm(myrealm.getRealm()).remove();
+            }
+        }
+    }
+
+    @Test
+    public void testRolePolicyRespectsClientScope() {
+        String realmName = realm.getName();
+
+        // Create a custom role and a user who has it
+        RoleRepresentation customRole = new RoleRepresentation();
+        customRole.setName("custom-manager");
+        realm.admin().roles().create(customRole);
+        customRole = realm.admin().roles().get("custom-manager").toRepresentation();
+
+        UserRepresentation scopedAdmin = createUser("scoped-admin", "password");
+        realm.admin().users().get(scopedAdmin.getId()).roles()
+                .realmLevel().add(List.of(customRole));
+
+        // Grant query-users and view-users so the admin can reach and list users
+        ClientRepresentation realmMgmt = realm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation queryUsersRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.QUERY_USERS).toRepresentation();
+        RoleRepresentation viewUsersRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.VIEW_USERS).toRepresentation();
+        realm.admin().users().get(scopedAdmin.getId()).roles()
+                .clientLevel(realmMgmt.getId()).add(List.of(queryUsersRole, viewUsersRole));
+
+        // Create a role policy requiring custom-manager with fetchRoles=false so that
+        // RolePolicyProvider delegates to identity.hasRealmRole() rather than user.hasRole()
+        RolePolicyRepresentation rolePolicy = createRolePolicy(realm, adminPermissionsClient,
+                "Custom Manager Role Policy", customRole.getId(), Logic.POSITIVE);
+        rolePolicy = adminPermissionsClient.authorization().policies().role()
+                .findByName(rolePolicy.getName());
+        rolePolicy.setFetchRoles(false);
+        adminPermissionsClient.authorization().policies().role()
+                .findById(rolePolicy.getId()).update(rolePolicy);
+        createAllPermission(adminPermissionsClient, AdminPermissionsSchema.USERS.getType(),
+                rolePolicy, Set.of(AdminPermissionsSchema.MANAGE));
+
+        // Create a restricted client that includes custom-manager in scope
+        ClientRepresentation fullScopeClient = ClientBuilder.create("full-scope-client")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .build();
+        try (Response response = realm.admin().clients().create(fullScopeClient)) {
+            fullScopeClient.setId(ApiUtil.getCreatedId(response));
+        }
+
+        // Verify the permission works with a full-scope client
+        try (Keycloak client = adminClientFactory.create()
+                .realm(realmName)
+                .clientId("full-scope-client")
+                .username("scoped-admin")
+                .password("password")
+                .build()) {
+            UserRepresentation target = client.realm(realmName).users().search("myadmin").get(0);
+            target.setLastName("updated");
+            client.realm(realmName).users().get(target.getId()).update(target);
+        }
+
+        // Now create a restricted client that does NOT include custom-manager in scope
+        ClientRepresentation restrictedClient = ClientBuilder.create("restricted-client")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .fullScopeEnabled(false)
+                .build();
+        try (Response response = realm.admin().clients().create(restrictedClient)) {
+            restrictedClient.setId(ApiUtil.getCreatedId(response));
+        }
+
+        // Add query-users and view-users to scope — custom-manager is NOT in scope
+        realm.admin().clients().get(restrictedClient.getId()).getScopeMappings()
+                .clientLevel(realmMgmt.getId()).add(List.of(queryUsersRole, viewUsersRole));
+
+        // The role policy should deny because custom-manager is not in the client's scope
+        try (Keycloak client = adminClientFactory.create()
+                .realm(realmName)
+                .clientId("restricted-client")
+                .username("scoped-admin")
+                .password("password")
+                .build()) {
+            UserRepresentation target = client.realm(realmName).users().search("myadmin").get(0);
+            target.setLastName("should-not-update");
+            try {
+                client.realm(realmName).users().get(target.getId()).update(target);
+                fail("Updating a user should be denied when the role required by the policy is not in the client scope");
+            } catch (ForbiddenException e) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void testFetchRolesEnabledBypassesScopeFiltering() {
+        String realmName = realm.getName();
+
+        RoleRepresentation customRole = new RoleRepresentation();
+        customRole.setName("custom-manager");
+        realm.admin().roles().create(customRole);
+        customRole = realm.admin().roles().get("custom-manager").toRepresentation();
+
+        UserRepresentation scopedAdmin = createUser("scoped-admin", "password");
+        realm.admin().users().get(scopedAdmin.getId()).roles()
+                .realmLevel().add(List.of(customRole));
+
+        ClientRepresentation realmMgmt = realm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation queryUsersRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.QUERY_USERS).toRepresentation();
+        RoleRepresentation viewUsersRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.VIEW_USERS).toRepresentation();
+        realm.admin().users().get(scopedAdmin.getId()).roles()
+                .clientLevel(realmMgmt.getId()).add(List.of(queryUsersRole, viewUsersRole));
+
+        RolePolicyRepresentation rolePolicy = createRolePolicy(realm, adminPermissionsClient,
+                "Fetch Roles Policy", customRole.getId(), Logic.POSITIVE);
+        rolePolicy = adminPermissionsClient.authorization().policies().role()
+                .findByName(rolePolicy.getName());
+        rolePolicy.setFetchRoles(true);
+        adminPermissionsClient.authorization().policies().role()
+                .findById(rolePolicy.getId()).update(rolePolicy);
+        createAllPermission(adminPermissionsClient, AdminPermissionsSchema.USERS.getType(),
+                rolePolicy, Set.of(AdminPermissionsSchema.MANAGE));
+
+        ClientRepresentation restrictedClient = ClientBuilder.create("restricted-client")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .fullScopeEnabled(false)
+                .build();
+        try (Response response = realm.admin().clients().create(restrictedClient)) {
+            restrictedClient.setId(ApiUtil.getCreatedId(response));
+        }
+
+        realm.admin().clients().get(restrictedClient.getId()).getScopeMappings()
+                .clientLevel(realmMgmt.getId()).add(List.of(queryUsersRole, viewUsersRole));
+
+        // fetchRoles=true resolves roles directly from the user model, bypassing scope filtering
+        try (Keycloak client = adminClientFactory.create()
+                .realm(realmName)
+                .clientId("restricted-client")
+                .username("scoped-admin")
+                .password("password")
+                .build()) {
+            UserRepresentation target = client.realm(realmName).users().search("myadmin").get(0);
+            target.setLastName("updated-via-fetch-roles");
+            client.realm(realmName).users().get(target.getId()).update(target);
+        }
+    }
+
+    @Test
+    public void testClientRolePolicyRespectsClientScope() {
+        String realmName = realm.getName();
+
+        // Create a custom client with a client role
+        ClientRepresentation customApp = ClientBuilder.create("custom-app")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .build();
+        try (Response response = realm.admin().clients().create(customApp)) {
+            customApp.setId(ApiUtil.getCreatedId(response));
+        }
+        RoleRepresentation appManagerRole = new RoleRepresentation();
+        appManagerRole.setName("app-manager");
+        realm.admin().clients().get(customApp.getId()).roles().create(appManagerRole);
+        appManagerRole = realm.admin().clients().get(customApp.getId())
+                .roles().get("app-manager").toRepresentation();
+
+        UserRepresentation scopedAdmin = createUser("scoped-admin", "password");
+        realm.admin().users().get(scopedAdmin.getId()).roles()
+                .clientLevel(customApp.getId()).add(List.of(appManagerRole));
+
+        ClientRepresentation realmMgmt = realm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation queryUsersRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.QUERY_USERS).toRepresentation();
+        RoleRepresentation viewUsersRole = realm.admin().clients().get(realmMgmt.getId())
+                .roles().get(AdminRoles.VIEW_USERS).toRepresentation();
+        realm.admin().users().get(scopedAdmin.getId()).roles()
+                .clientLevel(realmMgmt.getId()).add(List.of(queryUsersRole, viewUsersRole));
+
+        RolePolicyRepresentation rolePolicy = createRolePolicy(realm, adminPermissionsClient,
+                "App Manager Policy", appManagerRole.getId(), Logic.POSITIVE);
+        rolePolicy = adminPermissionsClient.authorization().policies().role()
+                .findByName(rolePolicy.getName());
+        rolePolicy.setFetchRoles(false);
+        adminPermissionsClient.authorization().policies().role()
+                .findById(rolePolicy.getId()).update(rolePolicy);
+        createAllPermission(adminPermissionsClient, AdminPermissionsSchema.USERS.getType(),
+                rolePolicy, Set.of(AdminPermissionsSchema.MANAGE));
+
+        // Full-scope client — client role is in scope, operation should succeed
+        ClientRepresentation fullScopeClient = ClientBuilder.create("full-scope-client")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .build();
+        try (Response response = realm.admin().clients().create(fullScopeClient)) {
+            fullScopeClient.setId(ApiUtil.getCreatedId(response));
+        }
+
+        try (Keycloak client = adminClientFactory.create()
+                .realm(realmName)
+                .clientId("full-scope-client")
+                .username("scoped-admin")
+                .password("password")
+                .build()) {
+            UserRepresentation target = client.realm(realmName).users().search("myadmin").get(0);
+            target.setLastName("updated");
+            client.realm(realmName).users().get(target.getId()).update(target);
+        }
+
+        // Restricted-scope client without the client role — operation should be denied
+        ClientRepresentation restrictedClient = ClientBuilder.create("restricted-client")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .fullScopeEnabled(false)
+                .build();
+        try (Response response = realm.admin().clients().create(restrictedClient)) {
+            restrictedClient.setId(ApiUtil.getCreatedId(response));
+        }
+
+        realm.admin().clients().get(restrictedClient.getId()).getScopeMappings()
+                .clientLevel(realmMgmt.getId()).add(List.of(queryUsersRole, viewUsersRole));
+
+        try (Keycloak client = adminClientFactory.create()
+                .realm(realmName)
+                .clientId("restricted-client")
+                .username("scoped-admin")
+                .password("password")
+                .build()) {
+            UserRepresentation target = client.realm(realmName).users().search("myadmin").get(0);
+            target.setLastName("should-not-update");
+            try {
+                client.realm(realmName).users().get(target.getId()).update(target);
+                fail("Updating a user should be denied when the client role required by the policy is not in the client scope");
+            } catch (ForbiddenException e) {
+                // expected
             }
         }
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/rbac/RealmAdminAccessTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/rbac/RealmAdminAccessTest.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.common.VerificationException;
@@ -19,12 +20,18 @@ import org.keycloak.protocol.oidc.mappers.RoleNameMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.admin.AdminClientFactory;
+import org.keycloak.testframework.annotations.InjectAdminClientFactory;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
 import org.keycloak.testframework.realm.RoleBuilder;
+import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.util.ApiUtil;
 
 import org.junit.jupiter.api.Test;
@@ -38,6 +45,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest
 public class RealmAdminAccessTest extends AbstractAdminRBACTest {
+
+    @InjectAdminClientFactory
+    AdminClientFactory scopedClientFactory;
 
     @Test
     public void testIgnoreAdminRolesGrantedViaProtocolMapper() {
@@ -432,7 +442,7 @@ public class RealmAdminAccessTest extends AbstractAdminRBACTest {
     }
 
     @Test
-    public void testIgnoreCompositeRealmRoleWithRealmManagementAdminRoles() {
+    public void testCompositeRealmRoleWithAdminSubRolesNotStrippedFromToken() {
         String realmName = "test-realm";
         RealmResource testRealm = createRealm(adminClient, realmName);
 
@@ -456,18 +466,30 @@ public class RealmAdminAccessTest extends AbstractAdminRBACTest {
                 AccessToken token = TokenVerifier.create(tokenResponse.getToken(), AccessToken.class).getToken();
                 AccessToken.Access realmAccess = token.getRealmAccess();
 
-                if (realmAccess != null && realmAccess.getRoles() != null) {
-                    assertFalse(realmAccess.getRoles().contains("custom-admin"),
-                            "Composite realm role containing realm-management admin roles should be stripped");
+                assertTrue(realmAccess != null
+                                && realmAccess.getRoles() != null
+                                && realmAccess.getRoles().contains("custom-admin"),
+                        "Composite realm role with a non-admin name should remain in the token");
+
+                AccessToken.Access realmMgmtAccess = token.getResourceAccess(Constants.REALM_MANAGEMENT_CLIENT_ID);
+                if (realmMgmtAccess != null && realmMgmtAccess.getRoles() != null) {
+                    assertFalse(realmMgmtAccess.getRoles().contains(AdminRoles.VIEW_CLIENTS),
+                            "Admin sub-role should not be granted via composite injection");
                 }
             } catch (VerificationException e) {
                 throw new RuntimeException(e);
             }
         });
+
+        assertThrows(ForbiddenException.class, () -> {
+            runAs(realmName, client.getClientId(), username, userClient -> {
+                userClient.realm(realmName).clients().findAll();
+            });
+        });
     }
 
     @Test
-    public void testIgnoreCompositeRealmRoleWithMasterRealmClientAdminRoles() {
+    public void testCompositeRealmRoleWithMasterRealmClientAdminSubRolesNotStrippedFromToken() {
         String targetRealmName = "target-realm";
         createRealm(adminClient, targetRealmName);
 
@@ -489,9 +511,15 @@ public class RealmAdminAccessTest extends AbstractAdminRBACTest {
                     AccessToken token = TokenVerifier.create(tokenResponse.getToken(), AccessToken.class).getToken();
                     AccessToken.Access realmAccess = token.getRealmAccess();
 
-                    if (realmAccess != null && realmAccess.getRoles() != null) {
-                        assertFalse(realmAccess.getRoles().contains("cross-realm-admin"),
-                                "Composite realm role containing <realm>-realm admin roles should be stripped");
+                    assertTrue(realmAccess != null
+                                    && realmAccess.getRoles() != null
+                                    && realmAccess.getRoles().contains("cross-realm-admin"),
+                            "Composite realm role with a non-admin name should remain in the token");
+
+                    AccessToken.Access realmClientAccess = token.getResourceAccess(targetRealmName + "-realm");
+                    if (realmClientAccess != null && realmClientAccess.getRoles() != null) {
+                        assertFalse(realmClientAccess.getRoles().contains(AdminRoles.MANAGE_USERS),
+                                "Admin sub-role should not be granted via composite injection");
                     }
                 } catch (VerificationException e) {
                     throw new RuntimeException(e);
@@ -529,6 +557,126 @@ public class RealmAdminAccessTest extends AbstractAdminRBACTest {
     }
 
     @Test
+    public void testCustomClientRoleWithAdminRoleNameNotStripped() {
+        String realmName = "test-realm";
+        RealmResource testRealm = createRealm(adminClient, realmName);
+        String username = "test-user";
+        UserRepresentation user = createUser(testRealm, username);
+
+        ClientRepresentation customApp = new ClientRepresentation();
+        customApp.setClientId("custom-app");
+        customApp.setEnabled(true);
+        customApp.setPublicClient(true);
+        customApp.setDirectAccessGrantsEnabled(true);
+        customApp.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        try (Response response = testRealm.clients().create(customApp)) {
+            customApp.setId(ApiUtil.getCreatedId(response));
+        }
+
+        RoleRepresentation customManageUsers = new RoleRepresentation();
+        customManageUsers.setName(AdminRoles.MANAGE_USERS);
+        testRealm.clients().get(customApp.getId()).roles().create(customManageUsers);
+        customManageUsers = testRealm.clients().get(customApp.getId())
+                .roles().get(AdminRoles.MANAGE_USERS).toRepresentation();
+
+        testRealm.users().get(user.getId()).roles()
+                .clientLevel(customApp.getId()).add(List.of(customManageUsers));
+
+        ClientRepresentation tokenClient = createClient(testRealm, "token-client",
+                toRepresentation(HardcodedRole.create("inject-custom-manage-users",
+                        "custom-app." + AdminRoles.MANAGE_USERS))
+        );
+
+        runAs(realmName, tokenClient.getClientId(), username, userClient -> {
+            AccessTokenResponse tokenResponse = userClient.tokenManager().getAccessToken();
+            try {
+                AccessToken token = TokenVerifier.create(tokenResponse.getToken(), AccessToken.class).getToken();
+                AccessToken.Access customAppAccess = token.getResourceAccess("custom-app");
+
+                assertTrue(customAppAccess != null
+                                && customAppAccess.getRoles() != null
+                                && customAppAccess.getRoles().contains(AdminRoles.MANAGE_USERS),
+                        "Custom client role named '" + AdminRoles.MANAGE_USERS
+                                + "' on non-admin client should not be stripped from the token");
+
+                AccessToken.Access realmMgmtAccess = token.getResourceAccess(Constants.REALM_MANAGEMENT_CLIENT_ID);
+                if (realmMgmtAccess != null && realmMgmtAccess.getRoles() != null) {
+                    assertTrue(realmMgmtAccess.getRoles().stream().noneMatch(AdminRoles.ALL_ROLES::contains),
+                            "No admin roles should appear on realm-management for this user");
+                }
+            } catch (VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void testInjectedAdminRoleStrippedDespiteNameCollisionWithCustomClientRole() {
+        String realmName = "test-realm";
+        RealmResource testRealm = createRealm(adminClient, realmName);
+        String username = "test-user";
+        UserRepresentation user = createUser(testRealm, username);
+
+        // Create a custom client with a role named identically to an admin role
+        ClientRepresentation customApp = new ClientRepresentation();
+        customApp.setClientId("custom-app");
+        customApp.setEnabled(true);
+        customApp.setPublicClient(true);
+        customApp.setDirectAccessGrantsEnabled(true);
+        customApp.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        try (Response response = testRealm.clients().create(customApp)) {
+            customApp.setId(ApiUtil.getCreatedId(response));
+        }
+
+        RoleRepresentation customManageUsers = new RoleRepresentation();
+        customManageUsers.setName(AdminRoles.MANAGE_USERS);
+        testRealm.clients().get(customApp.getId()).roles().create(customManageUsers);
+        customManageUsers = testRealm.clients().get(customApp.getId())
+                .roles().get(AdminRoles.MANAGE_USERS).toRepresentation();
+
+        // User has custom-app.manage-users but NOT realm-management.manage-users
+        testRealm.users().get(user.getId()).roles()
+                .clientLevel(customApp.getId()).add(List.of(customManageUsers));
+
+        // Hardcoded mapper injects the ADMIN version of manage-users on realm-management
+        ClientRepresentation tokenClient = createClient(testRealm, "token-client",
+                toRepresentation(HardcodedRole.create("inject-admin-manage-users",
+                        Constants.REALM_MANAGEMENT_CLIENT_ID + "." + AdminRoles.MANAGE_USERS))
+        );
+
+        runAs(realmName, tokenClient.getClientId(), username, userClient -> {
+            AccessTokenResponse tokenResponse = userClient.tokenManager().getAccessToken();
+            try {
+                AccessToken token = TokenVerifier.create(tokenResponse.getToken(), AccessToken.class).getToken();
+
+                // custom-app.manage-users should remain (non-admin client, legitimately granted)
+                AccessToken.Access customAppAccess = token.getResourceAccess("custom-app");
+                assertTrue(customAppAccess != null
+                                && customAppAccess.getRoles() != null
+                                && customAppAccess.getRoles().contains(AdminRoles.MANAGE_USERS),
+                        "custom-app." + AdminRoles.MANAGE_USERS + " should not be stripped");
+
+                // realm-management.manage-users was injected, not granted — must be stripped
+                AccessToken.Access realmMgmtAccess = token.getResourceAccess(Constants.REALM_MANAGEMENT_CLIENT_ID);
+                assertTrue(realmMgmtAccess == null
+                                || realmMgmtAccess.getRoles() == null
+                                || !realmMgmtAccess.getRoles().contains(AdminRoles.MANAGE_USERS),
+                        "Injected " + AdminRoles.MANAGE_USERS + " on realm-management should be stripped "
+                                + "even when the user has a same-named role on a non-admin client");
+            } catch (VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // The injected admin role should not grant actual admin access
+        assertThrows(ForbiddenException.class, () -> {
+            runAs(realmName, tokenClient.getClientId(), username, userClient -> {
+                userClient.realm(realmName).users().list();
+            });
+        });
+    }
+
+    @Test
     public void testManageUsersAdminCannotGrantRealmAdmin() {
         String realmName = "test-realm";
         RealmResource testRealm = createRealm(adminClient, realmName);
@@ -545,6 +693,257 @@ public class RealmAdminAccessTest extends AbstractAdminRBACTest {
                 grantRealmManagementRole(attackerClient.realm(realmName), victimName, AdminRoles.REALM_ADMIN);
             });
         });
+    }
+
+    @Test
+    public void testClientScopeLimitsRbacAccess() {
+        String realmName = "test-realm";
+        RealmResource testRealm = createRealm(adminClient, realmName);
+        createUser(testRealm, "scoped-admin");
+        grantRealmManagementRole(testRealm, "scoped-admin", AdminRoles.REALM_ADMIN);
+
+        String realmMgmtUuid = testRealm.clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+        ClientRepresentation restrictedClient = createRestrictedScopeClient(testRealm, "restricted-client");
+        RoleRepresentation viewUsersRole = testRealm.clients().get(realmMgmtUuid)
+                .roles().get(AdminRoles.VIEW_USERS).toRepresentation();
+        testRealm.clients().get(restrictedClient.getId()).getScopeMappings()
+                .clientLevel(realmMgmtUuid).add(List.of(viewUsersRole));
+
+        runAs(realmName, "restricted-client", "scoped-admin", client -> {
+            assertFalse(client.realm(realmName).users().search("").isEmpty());
+        });
+
+        runAs(realmName, "restricted-client", "scoped-admin", client -> {
+            assertEquals(Status.FORBIDDEN.getStatusCode(), client.realm(realmName).users().create(
+                    UserBuilder.create("should-not-be-created").build()).getStatus());
+        });
+    }
+
+    @Test
+    public void testMasterRealmRealmRoleScopeBoundary() {
+        grantRealmRole(masterRealm.admin(), masterUser.admin().toRepresentation(), AdminRoles.CREATE_REALM);
+
+        ClientRepresentation restrictedClient = createRestrictedScopeClient(
+                masterRealm.admin(), "restricted-client");
+        try {
+            assertThrows(ForbiddenException.class, () -> {
+                runAs("master", "restricted-client", masterUser.getUsername(), client -> {
+                    RealmRepresentation r = new RealmRepresentation();
+                    r.setRealm("scope-bypass-realm");
+                    r.setEnabled(true);
+                    client.realms().create(r);
+                });
+            });
+        } finally {
+            masterRealm.admin().clients().get(restrictedClient.getId()).remove();
+        }
+    }
+
+    @Test
+    public void testMasterRealmClientScopeBoundary() {
+        String targetRealmName = "target-realm";
+        createRealm(adminClient, targetRealmName);
+        grantMasterRealmManagementRole(targetRealmName, masterUser.getUsername(), AdminRoles.VIEW_USERS);
+        grantMasterRealmManagementRole(targetRealmName, masterUser.getUsername(), AdminRoles.MANAGE_USERS);
+        grantMasterRealmManagementRole(targetRealmName, masterUser.getUsername(), AdminRoles.QUERY_USERS);
+
+        String masterAdminClientUuid = masterRealm.admin().clients()
+                .findByClientId(targetRealmName + "-realm").get(0).getId();
+        ClientRepresentation restrictedClient = createRestrictedScopeClient(
+                masterRealm.admin(), "restricted-client");
+        RoleRepresentation viewUsersRole = masterRealm.admin().clients().get(masterAdminClientUuid)
+                .roles().get(AdminRoles.VIEW_USERS).toRepresentation();
+        RoleRepresentation queryUsersRole = masterRealm.admin().clients().get(masterAdminClientUuid)
+                .roles().get(AdminRoles.QUERY_USERS).toRepresentation();
+        masterRealm.admin().clients().get(restrictedClient.getId()).getScopeMappings()
+                .clientLevel(masterAdminClientUuid).add(List.of(viewUsersRole, queryUsersRole));
+
+        try {
+            // view-users + query-users are in scope — listing users should not throw
+            runAs("master", "restricted-client", masterUser.getUsername(), client -> {
+                client.realm(targetRealmName).users().search("");
+            });
+
+            // manage-users is NOT in scope — creating a user should be denied
+            runAs("master", "restricted-client", masterUser.getUsername(), client -> {
+                assertEquals(Status.FORBIDDEN.getStatusCode(), client.realm(targetRealmName).users().create(
+                        UserBuilder.create("should-not-be-created-from-master").build()).getStatus());
+            });
+        } finally {
+            masterRealm.admin().clients().get(restrictedClient.getId()).remove();
+        }
+    }
+
+    @Test
+    public void testDifferentlyScopedTokensFromSameClientHaveDifferentEffectiveAdminRoles() {
+        String realmName = "test-realm";
+        RealmResource testRealm = createRealm(adminClient, realmName);
+        UserRepresentation user = createUser(testRealm, "scoped-admin");
+
+        String realmMgmtUuid = testRealm.clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+
+        for (String roleName : List.of(AdminRoles.VIEW_CLIENTS, AdminRoles.QUERY_CLIENTS,
+                AdminRoles.VIEW_USERS, AdminRoles.QUERY_USERS)) {
+            RoleRepresentation role = testRealm.clients().get(realmMgmtUuid)
+                    .roles().get(roleName).toRepresentation();
+            testRealm.users().get(user.getId()).roles()
+                    .clientLevel(realmMgmtUuid).add(List.of(role));
+        }
+
+        // Optional scope that brings view-clients + query-clients into the token
+        ClientScopeRepresentation viewClientsScope = new ClientScopeRepresentation();
+        viewClientsScope.setName("scope-view-clients");
+        viewClientsScope.setProtocol("openid-connect");
+        try (Response response = testRealm.clientScopes().create(viewClientsScope)) {
+            viewClientsScope.setId(ApiUtil.getCreatedId(response));
+        }
+        testRealm.clientScopes().get(viewClientsScope.getId()).getScopeMappings()
+                .clientLevel(realmMgmtUuid).add(List.of(
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.VIEW_CLIENTS).toRepresentation(),
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.QUERY_CLIENTS).toRepresentation()));
+
+        // Optional scope that brings view-users + query-users into the token
+        ClientScopeRepresentation viewUsersScope = new ClientScopeRepresentation();
+        viewUsersScope.setName("scope-view-users");
+        viewUsersScope.setProtocol("openid-connect");
+        try (Response response = testRealm.clientScopes().create(viewUsersScope)) {
+            viewUsersScope.setId(ApiUtil.getCreatedId(response));
+        }
+        testRealm.clientScopes().get(viewUsersScope.getId()).getScopeMappings()
+                .clientLevel(realmMgmtUuid).add(List.of(
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.VIEW_USERS).toRepresentation(),
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.QUERY_USERS).toRepresentation()));
+
+        // Non-full-scope client with both optional scopes
+        ClientRepresentation tokenClient = createRestrictedScopeClient(testRealm, "test-client");
+        testRealm.clients().get(tokenClient.getId()).addOptionalClientScope(viewClientsScope.getId());
+        testRealm.clients().get(tokenClient.getId()).addOptionalClientScope(viewUsersScope.getId());
+
+        // Token requested with scope=scope-view-clients: only view-clients roles in the token
+        try (Keycloak viewClientsOnly = scopedClientFactory.create()
+                .realm(realmName)
+                .clientId("test-client")
+                .username("scoped-admin")
+                .password("password")
+                .scope("scope-view-clients")
+                .build()) {
+            assertFalse(viewClientsOnly.realm(realmName).clients().findAll().isEmpty(),
+                    "Token with view-clients scope should be able to list clients");
+            assertThrows(ForbiddenException.class, () ->
+                            viewClientsOnly.realm(realmName).users().search(""),
+                    "Token with only view-clients scope should NOT be able to list users");
+        }
+
+        // Token requested with scope=scope-view-users: only view-users roles in the token
+        try (Keycloak viewUsersOnly = scopedClientFactory.create()
+                .realm(realmName)
+                .clientId("test-client")
+                .username("scoped-admin")
+                .password("password")
+                .scope("scope-view-users")
+                .build()) {
+            assertFalse(viewUsersOnly.realm(realmName).users().search("").isEmpty(),
+                    "Token with view-users scope should be able to list users");
+            assertThrows(ForbiddenException.class, () ->
+                            viewUsersOnly.realm(realmName).clients().findAll(),
+                    "Token with only view-users scope should NOT be able to list clients");
+        }
+    }
+
+    @Test
+    public void testDifferentlyScopedLightweightTokensFromSameClientHaveDifferentEffectiveAdminRoles() {
+        String realmName = "test-realm";
+        RealmResource testRealm = createRealm(adminClient, realmName);
+        UserRepresentation user = createUser(testRealm, "scoped-admin");
+
+        String realmMgmtUuid = testRealm.clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+
+        for (String roleName : List.of(AdminRoles.VIEW_CLIENTS, AdminRoles.QUERY_CLIENTS,
+                AdminRoles.VIEW_USERS, AdminRoles.QUERY_USERS)) {
+            RoleRepresentation role = testRealm.clients().get(realmMgmtUuid)
+                    .roles().get(roleName).toRepresentation();
+            testRealm.users().get(user.getId()).roles()
+                    .clientLevel(realmMgmtUuid).add(List.of(role));
+        }
+
+        ClientScopeRepresentation viewClientsScope = new ClientScopeRepresentation();
+        viewClientsScope.setName("scope-view-clients");
+        viewClientsScope.setProtocol("openid-connect");
+        try (Response response = testRealm.clientScopes().create(viewClientsScope)) {
+            viewClientsScope.setId(ApiUtil.getCreatedId(response));
+        }
+        testRealm.clientScopes().get(viewClientsScope.getId()).getScopeMappings()
+                .clientLevel(realmMgmtUuid).add(List.of(
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.VIEW_CLIENTS).toRepresentation(),
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.QUERY_CLIENTS).toRepresentation()));
+
+        ClientScopeRepresentation viewUsersScope = new ClientScopeRepresentation();
+        viewUsersScope.setName("scope-view-users");
+        viewUsersScope.setProtocol("openid-connect");
+        try (Response response = testRealm.clientScopes().create(viewUsersScope)) {
+            viewUsersScope.setId(ApiUtil.getCreatedId(response));
+        }
+        testRealm.clientScopes().get(viewUsersScope.getId()).getScopeMappings()
+                .clientLevel(realmMgmtUuid).add(List.of(
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.VIEW_USERS).toRepresentation(),
+                        testRealm.clients().get(realmMgmtUuid).roles().get(AdminRoles.QUERY_USERS).toRepresentation()));
+
+        ClientRepresentation tokenClient = ClientBuilder.create("test-client-lightweight")
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .fullScopeEnabled(false)
+                .attribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, Boolean.TRUE.toString())
+                .build();
+        try (Response response = testRealm.clients().create(tokenClient)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+            tokenClient.setId(ApiUtil.getCreatedId(response));
+        }
+        testRealm.clients().get(tokenClient.getId()).addOptionalClientScope(viewClientsScope.getId());
+        testRealm.clients().get(tokenClient.getId()).addOptionalClientScope(viewUsersScope.getId());
+
+        try (Keycloak viewClientsOnly = scopedClientFactory.create()
+                .realm(realmName)
+                .clientId("test-client-lightweight")
+                .username("scoped-admin")
+                .password("password")
+                .scope("scope-view-clients")
+                .build()) {
+            assertFalse(viewClientsOnly.realm(realmName).clients().findAll().isEmpty(),
+                    "Lightweight token with view-clients scope should be able to list clients");
+            assertThrows(ForbiddenException.class, () ->
+                            viewClientsOnly.realm(realmName).users().search(""),
+                    "Lightweight token with only view-clients scope should NOT be able to list users");
+        }
+
+        try (Keycloak viewUsersOnly = scopedClientFactory.create()
+                .realm(realmName)
+                .clientId("test-client-lightweight")
+                .username("scoped-admin")
+                .password("password")
+                .scope("scope-view-users")
+                .build()) {
+            assertFalse(viewUsersOnly.realm(realmName).users().search("").isEmpty(),
+                    "Lightweight token with view-users scope should be able to list users");
+            assertThrows(ForbiddenException.class, () ->
+                            viewUsersOnly.realm(realmName).clients().findAll(),
+                    "Lightweight token with only view-users scope should NOT be able to list clients");
+        }
+    }
+
+    private ClientRepresentation createRestrictedScopeClient(RealmResource realm, String clientId) {
+        ClientRepresentation client = ClientBuilder.create(clientId)
+                .publicClient()
+                .directAccessGrantsEnabled()
+                .fullScopeEnabled(false)
+                .build();
+        try (Response response = realm.clients().create(client)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+            client.setId(ApiUtil.getCreatedId(response));
+        }
+        return client;
     }
 
     private ClientRepresentation createClient(RealmResource realm, String clientId, ProtocolMapperRepresentation... mapper) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminMasterRealmTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminMasterRealmTest.java
@@ -115,19 +115,12 @@ public class FineGrainedAdminMasterRealmTest extends AbstractFineGrainedAdminTes
             newClient.setProtocol("openid-connect");
             newClient.setPublicClient(false);
             newClient.setEnabled(true);
+            // FGAP resolves roles server-side, so the admin has immediate permissions on a newly created realm without needing a token refresh
             Response response = realmClient.realm("anotherRealm").clients().create(newClient);
-            Assertions.assertEquals(403, response.getStatus());
-            response.close();
-
-            realmClient.close();
-            //creating new client to refresh token
-            realmClient = adminClientFactory.create().realm("master")
-                    .username("admin").password("admin").clientId("fullScopedClient").clientSecret("618268aa-51e6-4e64-93c4-3c0bc65b8171").build();
-            assertThat(realmClient.realms().findAll().stream().map(RealmRepresentation::getRealm).collect(Collectors.toSet()),
-                    hasItem("anotherRealm"));
-            response = realmClient.realm("anotherRealm").clients().create(newClient);
             Assertions.assertEquals(201, response.getStatus());
             response.close();
+            assertThat(realmClient.realms().findAll().stream().map(RealmRepresentation::getRealm).collect(Collectors.toSet()),
+                    hasItem("anotherRealm"));
         } finally {
             adminClient.realm("anotherRealm").remove();
             realmClient.close();


### PR DESCRIPTION
Closes #51554
Closes #51523
Closes #51707
