### PR TITLE
Omit privateKey client attributes from admin events

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -262,4 +262,7 @@ public final class Constants {
     // This attribute can be used in a realm import definition to signal that default client scopes should be created in addition to the client scopes defined by the realm import definition.
     // When this attribute is omitted or set to false, the default client scopes are not created if at least one other client scope is defined by the realm import definition.
     public static final String CREATE_DEFAULT_CLIENT_SCOPES = "CreateDefaultClientScopes";
+
+    // Suffix for "private key" client attribute. The attribute of this name should not be persisted to the DB and should not be displayed in admin events
+    public static final String PRIVATE_KEY_ATTR_SUFFIX = "private.key";
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StripSecretsUtils.java
@@ -49,6 +49,8 @@ import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
+import static org.keycloak.models.Constants.PRIVATE_KEY_ATTR_SUFFIX;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -231,6 +233,16 @@ public class StripSecretsUtils {
         }
 
         stripFromMap(rep.getAttributes(), ClientSecretConstants.CLIENT_ROTATED_SECRET);
+
+        if (rep.getAttributes() != null) {
+            Map<String, String> clientAttrsCopy = new HashMap<>(rep.getAttributes());
+            for (Map.Entry<String, String> entry : clientAttrsCopy.entrySet()) {
+                if (entry.getKey().endsWith(PRIVATE_KEY_ATTR_SUFFIX)) {
+                    rep.getAttributes().put(entry.getKey(), maskNonVaultValue(entry.getValue()));
+                }
+            }
+        }
+
         return rep;
     }
 

--- a/services/src/main/java/org/keycloak/services/util/CertificateInfoHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/CertificateInfoHelper.java
@@ -55,6 +55,8 @@ import org.keycloak.util.Strings;
 
 import org.jboss.logging.Logger;
 
+import static org.keycloak.models.Constants.PRIVATE_KEY_ATTR_SUFFIX;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -66,7 +68,7 @@ public class CertificateInfoHelper {
 
     private static final Logger logger = Logger.getLogger(CertificateInfoHelper.class);
 
-    public static final String PRIVATE_KEY = "private.key";
+    public static final String PRIVATE_KEY = PRIVATE_KEY_ATTR_SUFFIX;
     public static final String X509CERTIFICATE = "certificate";
     public static final String PUBLIC_KEY = "public.key";
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -103,6 +103,7 @@ import static java.util.Arrays.asList;
 import static org.keycloak.models.Constants.OIDC_PROTOCOL;
 import static org.keycloak.models.Constants.REALM_MANAGEMENT_CLIENT_ID;
 import static org.keycloak.models.Constants.defaultClients;
+import static org.keycloak.representations.idm.ComponentRepresentation.SECRET_VALUE;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -818,6 +819,21 @@ public class ClientTest {
         MatcherAssert.assertThat("service-account-serviceclient", Matchers.equalTo(userRep.getUsername()));
         // KEYCLOAK-11197 service accounts are no longer created with a placeholder e-mail.
         assertNull(userRep.getEmail());
+    }
+
+    // GH issue 51241
+    @Test
+    public void updateClientMaskedPrivateKeys() {
+        ClientRepresentation client = createClient();
+
+        ClientResource clientRes = managedRealm.admin().clients().get(client.getId());
+        client = clientRes.toRepresentation();
+        client.getAttributes().put("jwt.credential.private.key", "example-private-key");
+        clientRes.update(client);
+
+        // The "jwt.credential.private.key" is present in the event, but masked
+        client.getAttributes().put("jwt.credential.private.key", SECRET_VALUE);
+        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientResourcePath(client.getId()), client, ResourceType.CLIENT);
     }
 
     @Test


### PR DESCRIPTION
closes #51241

NOTE: The fix https://github.com/keycloak/keycloak/issues/49239 makes sure that "private.key" attributes are never persisted to the DB as attributes of the client. However clients, which existed before this fix, may still contain "private.key" attributes. During client create/update/import, it was still possible that those attributes would be shown in the admin events. This PR makes those attributes masked, so that they never appear in the admin events.

There is follow-up issue https://github.com/keycloak/keycloak/issues/49238 to remove private-keys entirely from client attributes, which is for Keycloak 27.
