### PR TITLE
Enforce signature verification on SAML LogoutResponse for clients with requiresClientSignature

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -270,6 +270,18 @@ public class SamlService extends AuthorizationEndpointBase {
             }
 
             session.getContext().setClient(client);
+
+            SamlClient samlClient = new SamlClient(client);
+            try {
+                if(samlClient.requiresClientSignature()) {
+                    verifySignature(holder,client);
+                }
+            } catch (VerificationException e) {
+                SamlService.logger.error("LogoutResponse signature validation failed");
+                event.error(Errors.INVALID_SIGNATURE);
+                return error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUESTER);
+            }
+
             logger.debug("logout response");
             Response response = authManager.browserLogout(session, realm, userSession, session.getContext().getUri(), clientConnection, headers);
             event.success();

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -274,10 +274,11 @@ public class SamlService extends AuthorizationEndpointBase {
             SamlClient samlClient = new SamlClient(client);
             try {
                 if(samlClient.requiresClientSignature()) {
-                    verifySignature(holder,client);
+                    verifyResponseSignature(holder,client);
                 }
             } catch (VerificationException e) {
                 SamlService.logger.error("LogoutResponse signature validation failed");
+                SamlService.logger.debug("LogoutResponse signature validation failed", e);
                 event.error(Errors.INVALID_SIGNATURE);
                 return error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUESTER);
             }
@@ -449,6 +450,8 @@ public class SamlService extends AuthorizationEndpointBase {
         protected abstract String encodeSamlDocument(Document samlDocument) throws ProcessingException;
 
         protected abstract void verifySignature(SAMLDocumentHolder documentHolder, ClientModel client) throws VerificationException;
+
+        protected abstract void verifyResponseSignature(SAMLDocumentHolder documentHolder, ClientModel client) throws VerificationException;
 
         protected abstract boolean containsUnencryptedSignature(SAMLDocumentHolder documentHolder);
 
@@ -851,6 +854,11 @@ public class SamlService extends AuthorizationEndpointBase {
         }
 
         @Override
+        protected void verifyResponseSignature(SAMLDocumentHolder documentHolder, ClientModel client) throws VerificationException {
+            SamlProtocolUtils.verifyDocumentSignature(session, client, documentHolder.getSamlDocument());
+        }
+
+        @Override
         protected boolean containsUnencryptedSignature(SAMLDocumentHolder documentHolder) {
             Document signedDoc = documentHolder.getSamlDocument();
             NodeList nl = signedDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
@@ -894,6 +902,12 @@ public class SamlService extends AuthorizationEndpointBase {
         protected void verifySignature(SAMLDocumentHolder documentHolder, ClientModel client) throws VerificationException {
             KeyLocator clientKeyLocator = SamlProtocolUtils.createKeyLocatorForClient(session, client, KeyUse.SIG);
             SamlProtocolUtils.verifyRedirectSignature(documentHolder, clientKeyLocator, session.getContext().getUri(), GeneralConstants.SAML_REQUEST_KEY);
+        }
+
+        @Override
+        protected void verifyResponseSignature(SAMLDocumentHolder documentHolder, ClientModel client) throws VerificationException {
+            KeyLocator clientKeyLocator = SamlProtocolUtils.createKeyLocatorForClient(session, client, KeyUse.SIG);
+            SamlProtocolUtils.verifyRedirectSignature(documentHolder, clientKeyLocator, session.getContext().getUri(), GeneralConstants.SAML_RESPONSE_KEY);
         }
 
         @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -47,6 +47,7 @@ import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.saml.BaseSAML2BindingBuilder;
 import org.keycloak.saml.SAML2LoginResponseBuilder;
 import org.keycloak.saml.SAML2LogoutResponseBuilder;
+import org.keycloak.saml.SignatureAlgorithm;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ProcessingException;
@@ -548,6 +549,7 @@ public class LogoutTest extends AbstractSamlTest {
                                         SAML_CLIENT_ID_SALES_POST_SIG,
                                         SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY_PK,
                                         SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY_PK)
+                                .signatureAlgorithm(SignatureAlgorithm.RSA_SHA256)
                                 .signDocument(responseDoc);
 
                         return responseDoc;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -44,6 +44,7 @@ import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.saml.BaseSAML2BindingBuilder;
 import org.keycloak.saml.SAML2LoginResponseBuilder;
 import org.keycloak.saml.SAML2LogoutResponseBuilder;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
@@ -65,6 +66,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.junit.Before;
 import org.junit.Test;
+import org.w3c.dom.Document;
 
 import static org.keycloak.protocol.saml.profile.ecp.SamlEcpProfileService.AUTHN_REQUEST_CANNOT_BE_PROCESSED;
 import static org.keycloak.testsuite.util.Matchers.isSamlLogoutRequest;
@@ -470,6 +472,95 @@ public class LogoutTest extends AbstractSamlTest {
         assertThat(samlResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
         assertThat(((StatusResponseType) samlResponse.getSamlObject()).getDestination(), is("http://url"));
         assertLogoutEvent(SAML_CLIENT_ID_SALES_POST2);
+    }
+
+    @Test
+    public void testPostBindingUnsignedLogoutResponseRejected() throws IOException {
+
+        try(Closeable salesSig = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST_SIG)
+                .setFrontchannelLogout(true)
+                .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE, "http://url")
+                .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE, "")
+                .update())
+        {
+            prepareLogIntoTwoAppsSig()
+                    // Initiate SLO from the signed client — Keycloak sends a LogoutRequest to sales-post-sig#
+                    .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, POST)
+                    .nameId(nameIdRef::get)
+                    .sessionIndex(sessionIndexRef::get)
+                    .build()
+
+                    // SP (sales-post-sig) receives the LogoutRequest and sends back an UNSIGNED LogoutResponse
+                    .processSamlResponse(POST)
+                    .transformDocument(doc -> {
+                        SAML2Object so = (SAML2Object) SAMLParser.getInstance().parse(new DOMSource(doc));
+                        assertThat(so, isSamlLogoutRequest("http://url"));
+
+                        // Build an unsigned LogoutResponse — no signDocument() call
+                        return new SAML2LogoutResponseBuilder()
+                                .destination(getAuthServerSamlEndpoint(REALM_NAME).toString())
+                                .issuer(SAML_CLIENT_ID_SALES_POST_SIG)
+                                .logoutRequestID(((LogoutRequestType) so).getID())
+                                .buildDocument();
+                    })
+                    .targetAttributeSamlResponse()
+                    .targetUri(getAuthServerSamlEndpoint(REALM_NAME))
+                    .build()
+
+                    // Must be rejected: client requires a signature but none was provided
+                    .doNotFollowRedirects()
+                    .assertResponse(LogoutTest::assertBadRequest)
+                    .execute();
+        }
+    }
+
+    @Test
+    public void testPostBindingSignedLogoutResponseAccepted() throws IOException {
+        try(Closeable salesSig = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST_SIG)
+                .setFrontchannelLogout(true)
+                .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE, "http://url")
+                .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE, "")
+                .update())
+        {
+            SAMLDocumentHolder samlResponse =  prepareLogIntoTwoAppsSig()
+                    // Initiate SLO from the signed client — Keycloak sends a LogoutRequest to sales-post-sig#
+                    .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, POST)
+                    .nameId(nameIdRef::get)
+                    .sessionIndex(sessionIndexRef::get)
+                    .build()
+
+
+                    // SP sends a properly signed LogoutResponse
+                    .processSamlResponse(POST)
+                    .transformDocument(doc -> {
+                        SAML2Object so = (SAML2Object) SAMLParser.getInstance().parse(new DOMSource(doc));
+                        assertThat(so, isSamlLogoutRequest("http://url"));
+
+                        Document responseDoc = new SAML2LogoutResponseBuilder()
+                                .destination(getAuthServerSamlEndpoint(REALM_NAME).toString())
+                                .issuer(SAML_CLIENT_ID_SALES_POST_SIG)
+                                .logoutRequestID(((LogoutRequestType) so).getID())
+                                .buildDocument();
+
+                        // Sign the response document with the SP's key
+                        new BaseSAML2BindingBuilder()
+                                .signWith(
+                                        SAML_CLIENT_ID_SALES_POST_SIG,
+                                        SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY_PK,
+                                        SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY_PK)
+                                .signDocument(responseDoc);
+
+                        return responseDoc;
+                    })
+                    .targetAttributeSamlResponse()
+                    .targetUri(getAuthServerSamlEndpoint(REALM_NAME))
+                    .build()
+
+                    .getSamlResponse(POST);
+
+            // SLO should complete successfully
+            assertThat(samlResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        }
     }
 
     @Test


### PR DESCRIPTION
Enforce signature verification on SAML LogoutResponse for clients with requiresClientSignature

-  Added signature verification in the LogoutResponse handling path. When SamlClient.requiresClientSignature() is true,   
   verifySignature() is called on the incoming LogoutResponse. If verification fails, the request is
   rejected with a 400 Bad Request and an INVALID_SIGNATURE event is logged.

- Added tests in LogoutTest.java


Closes #51211
