### PR TITLE
Add frontChannelLogoutUrl to secure client uris validation

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisExecutor.java
@@ -122,6 +122,10 @@ public class SecureClientUrisExecutor implements ClientPolicyExecutorProvider<Se
         String logoutUrl = Optional.ofNullable(clientRep.getAttributes()).orElse(Collections.emptyMap()).get(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL);
         if (logoutUrl != null) confirmSecureUris(List.of(logoutUrl), "logoutUrl");
 
+        // front-channel logout URL
+        String frontChannelLogoutUrl = Optional.ofNullable(clientRep.getAttributes()).orElse(Collections.emptyMap()).get(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI);
+        if (frontChannelLogoutUrl != null) confirmSecureUris(List.of(frontChannelLogoutUrl), "frontChannelLogoutUrl");
+
         // OAuth2 : redirectUris
         List<String> redirectUris = clientRep.getRedirectUris();
         if (redirectUris != null) confirmSecureUris(redirectUris, "redirectUris");

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisPatternExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisPatternExecutor.java
@@ -206,6 +206,8 @@ public class SecureClientUrisPatternExecutor implements ClientPolicyExecutorProv
                 return getAttributeMultivalued(attributes, OIDCConfigAttributes.REQUEST_URIS);
             case "backchannelLogoutUrl":
                 return singletonOrEmpty(attributes.get(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL));
+            case "frontChannelLogoutUrl":
+                return singletonOrEmpty(attributes.get(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI));
             case "postLogoutRedirectUris":
                 return getAttributeMultivalued(attributes, OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS);
             case "cibaClientNotificationEndpoint":

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisPatternExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisPatternExecutorFactory.java
@@ -46,6 +46,7 @@ public class SecureClientUrisPatternExecutorFactory implements ClientPolicyExecu
             "jwksUri",
             "requestUris",
             "backchannelLogoutUrl",
+            "frontChannelLogoutUrl",
             "postLogoutRedirectUris",
             "cibaClientNotificationEndpoint",
             OIDCConfigAttributes.LOGO_URI,

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientUrisPatternExecutorTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientUrisPatternExecutorTest.java
@@ -84,6 +84,7 @@ public class ClientUrisPatternExecutorTest extends AbstractClientPoliciesTest {
         testFieldByAdmin("jwksUri", OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(OIDCConfigAttributes.JWKS_URL, val));
         testFieldByAdmin("requestUris", OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(OIDCConfigAttributes.REQUEST_URIS, val));
         testFieldByAdmin("backchannelLogoutUrl", OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, val));
+        testFieldByAdmin("frontChannelLogoutUrl", OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, val));
         testFieldByAdmin("postLogoutRedirectUris", OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, val));
         testFieldByAdmin("cibaClientNotificationEndpoint", OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(CibaConfig.CIBA_BACKCHANNEL_CLIENT_NOTIFICATION_ENDPOINT, val));
         testFieldByAdmin(OIDCConfigAttributes.LOGO_URI, OIDCLoginProtocol.LOGIN_PROTOCOL, (c, val) -> c.getAttributes().put(OIDCConfigAttributes.LOGO_URI, val));
@@ -131,6 +132,7 @@ public class ClientUrisPatternExecutorTest extends AbstractClientPoliciesTest {
         testFieldDynamically(reg, "logoUri", OIDCClientRepresentation::setLogoUri);
         testFieldDynamically(reg, "policyUri", OIDCClientRepresentation::setPolicyUri);
         testFieldDynamically(reg, "backchannelLogoutUrl", OIDCClientRepresentation::setBackchannelLogoutUri);
+        testFieldDynamically(reg, "frontChannelLogoutUrl", OIDCClientRepresentation::setFrontChannelLogoutUri);
 
         //test sectorIdentifierUri
         String sectorIdentifierUriPattern = "^http://localhost.*/sector-identifier-redirect-uris$";


### PR DESCRIPTION
Closes #50965

Just adding the frontChannelLogoutUrl to `SecureClientUrisExecutor` and `SecureClientUrisPatternExecutor`

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
