### PR TITLE
feat: include and identify service accounts in admin user API

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserRepresentation.java
@@ -36,6 +36,7 @@ public class UserRepresentation extends AbstractUserRepresentation{
     protected Boolean totp;
     protected String federationLink;
     protected String serviceAccountClientId; // For rep, it points to clientId (not DB ID)
+    protected Boolean serviceAccount;
 
     protected List<CredentialRepresentation> credentials;
     protected Set<String> disableableCredentialTypes;
@@ -77,6 +78,7 @@ public class UserRepresentation extends AbstractUserRepresentation{
         this.totp = rep.isTotp();
         this.federationLink = rep.getFederationLink();
         this.serviceAccountClientId = rep.getServiceAccountClientId();
+        this.serviceAccount = rep.isServiceAccount();
         this.credentials = rep.getCredentials();
         this.disableableCredentialTypes = rep.getDisableableCredentialTypes();
         this.requiredActions = rep.getRequiredActions();
@@ -218,8 +220,41 @@ public class UserRepresentation extends AbstractUserRepresentation{
         return serviceAccountClientId;
     }
 
+    /**
+     * Sets the client ID associated with this user representation.
+     * <p>
+     * Providing a non-null client id implies that this user representation is a
+     * service account, so this method also sets {@code serviceAccount} to
+     * {@code true}. Providing {@code null} also sets {@code serviceAccount} to
+     * {@code false}.
+     *
+     * @param serviceAccountClientId the client id of the backing service account client
+     */
     public void setServiceAccountClientId(String serviceAccountClientId) {
         this.serviceAccountClientId = serviceAccountClientId;
+        this.serviceAccount = serviceAccountClientId != null;
+    }
+
+    public Boolean isServiceAccount() {
+        return serviceAccount;
+    }
+
+    /**
+     * Sets whether this user representation is a service account.
+     * <p>
+     * Setting this value to {@code false} clears any previously assigned
+     * {@code serviceAccountClientId} to keep the representation consistent.
+     * Note that this may be {@code true} while {@code serviceAccountClientId} is
+     * {@code null} if the client link (database ID) of the underlying
+     * user model has not been resolved to the client ID.
+     *
+     * @param serviceAccount whether this representation is for a service account
+     */
+    public void setServiceAccount(Boolean serviceAccount) {
+        this.serviceAccount = serviceAccount;
+        if (Boolean.FALSE.equals(serviceAccount)) {
+            this.serviceAccountClientId = null;
+        }
     }
 
     public List<String> getGroups() {

--- a/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -160,6 +160,10 @@ public interface UsersResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> searchByLastName(@QueryParam("lastName") String email, @QueryParam("exact") Boolean exact);
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchIncludeServiceAccounts(@QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
+
     /**
      * Search for users based on the given filters.
      *
@@ -515,6 +519,11 @@ public interface UsersResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     Integer countEmailVerified(@QueryParam("emailVerified") Boolean emailVerified);
+
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer countIncludeServiceAccounts(@QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
 
     @Path("{id}")
     UserResource get(@PathParam("id") String id);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -332,6 +332,7 @@ public class ModelToRepresentation {
         rep.setFederationLink(user.getFederationLink());
         rep.setNotBefore(isLightweightUser(user) ? ((LightweightUserAdapter) user).getCreatedTimestamp().intValue() : session.users().getNotBeforeOfUser(realm, user));
         rep.setRequiredActions(user.getRequiredActionsStream().collect(Collectors.toList()));
+        rep.setServiceAccount(user.getServiceAccountClientLink() != null);
 
         if (setUserAttributes) {
             Map<String, List<String>> attributes = user.getAttributes();

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -262,6 +262,7 @@ public class UsersResource {
      * @param enabled Boolean representing if user is enabled or not
      * @param briefRepresentation Boolean which defines whether brief representations are returned (default: false)
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
+     * @param includeServiceAccounts Boolean which defines whether service accounts are returned (default depends on other query parameters)
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
      * @return a non-null {@code Stream} of users
      */
@@ -291,7 +292,8 @@ public class UsersResource {
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
             @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
-            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore,
+            @Parameter(description = "Boolean which defines whether service accounts are returned (default: false)") @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
 
         userPermissionEvaluator.requireQuery();
@@ -323,13 +325,15 @@ public class UsersResource {
                     attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
                 }
                 addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
+                // Only include service accounts in this branch if explicitly requested.
+                Boolean serviceAccounts = includeServiceAccounts != null ? includeServiceAccounts : false;
 
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                        maxResults, false);
+                        maxResults, serviceAccounts);
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
                 || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
-                || createdAfter != null || createdBefore != null) {
+                || createdAfter != null || createdBefore != null || includeServiceAccounts != null) {
                     Map<String, String> attributes = new HashMap<>();
                     if (last != null) {
                         attributes.put(UserModel.LAST_NAME, last);
@@ -362,8 +366,11 @@ public class UsersResource {
 
                     attributes.putAll(searchAttributes);
 
+                    // Include service accounts in this branch unless explicitly disabled.
+                    Boolean serviceAccounts = includeServiceAccounts != null ? includeServiceAccounts : true;
+
                     return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                            maxResults, true);
+                            maxResults, serviceAccounts);
                 } else {
                     return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
                             firstResult, maxResults, false);
@@ -397,6 +404,7 @@ public class UsersResource {
      * @param idpUserId The userId at an Identity Provider linked to the user
      * @param enabled Boolean representing if user is enabled or not
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
+     * @param includeServiceAccounts Boolean which defines whether service accounts are returned (default depends on other query parameters)
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
      * @return the number of users that match the given criteria
      */
@@ -428,7 +436,8 @@ public class UsersResource {
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
             @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
-            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore,
+            @Parameter(description = "Boolean which defines whether service accounts are returned (default: false)") @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
         userPermissionEvaluator.requireQuery();
 
@@ -455,8 +464,10 @@ public class UsersResource {
                 parameters.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
             }
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
-            // search /users equivalent to this doesn't include service-accounts so counting shouldn't as well
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
+            // Only include service accounts in this branch if explicitly requested.
+            // This behavior is equivalent to the /users endpoint.
+            Boolean serviceAccounts = includeServiceAccounts != null ? includeServiceAccounts : false;
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, serviceAccounts.toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {
@@ -468,7 +479,7 @@ public class UsersResource {
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
                 || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
-                || createdAfter != null || createdBefore != null) {
+                || createdAfter != null || createdBefore != null || includeServiceAccounts != null) {
             Map<String, String> parameters = new HashMap<>();
             if (last != null) {
                 parameters.put(UserModel.LAST_NAME, last);
@@ -499,8 +510,10 @@ public class UsersResource {
             }
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             parameters.putAll(searchAttributes);
-            // search /users equivalent to this does include service-accounts so we should be explicit
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "true");
+            // Include service accounts in this branch unless explicitly disabled.
+            // This behavior is equivalent to the /users endpoint.
+            Boolean serviceAccounts = includeServiceAccounts != null ? includeServiceAccounts : true;
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, serviceAccounts.toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/UserBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/UserBuilder.java
@@ -19,7 +19,7 @@ public class UserBuilder extends Builder<UserRepresentation> {
     }
 
     public static UserBuilder create() {
-        return new UserBuilder(new UserRepresentation()).enabled(true);
+        return new UserBuilder(new UserRepresentation()).enabled(true).serviceAccount(false);
     }
 
     public static UserBuilder create(String username) {
@@ -135,6 +135,11 @@ public class UserBuilder extends Builder<UserRepresentation> {
 
     public UserBuilder serviceAccountId(String serviceAccountClientId) {
         rep.setServiceAccountClientId(serviceAccountClientId);
+        return this;
+    }
+
+    public UserBuilder serviceAccount(Boolean serviceAccount) {
+        rep.setServiceAccount(serviceAccount);
         return this;
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -955,6 +955,35 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
+    public void countAndSearchIncludingServiceAccounts() {
+        createUser("user1", "user1@example.com");
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("test-client");
+        client.setPublicClient(false);
+        client.setSecret("secret");
+        client.setServiceAccountsEnabled(true);
+        client.setEnabled(true);
+        client.setRedirectUris(Arrays.asList("http://url"));
+        String clientId = ApiUtil.getCreatedId(managedRealm.admin().clients().create(client));
+
+        assertEquals(1, managedRealm.admin().users().countIncludeServiceAccounts(false).intValue());
+        assertEquals(2, managedRealm.admin().users().countIncludeServiceAccounts(true).intValue());
+
+        List<UserRepresentation> users = managedRealm.admin().users().searchIncludeServiceAccounts(false);
+        assertEquals(1, users.size());
+        Assertions.assertFalse(users.get(0).isServiceAccount(), "Should not be a service account");
+
+        List<UserRepresentation> usersWithServiceAccounts = managedRealm.admin().users().searchIncludeServiceAccounts(true);
+        List<Boolean> serviceAccountFlags = usersWithServiceAccounts.stream().map(UserRepresentation::isServiceAccount).collect(Collectors.toList());
+        assertTrue(serviceAccountFlags.contains(true), "Should contain service user");
+        assertTrue(serviceAccountFlags.contains(false), "Should contain normal user");
+
+        // client cleanup
+        managedRealm.admin().clients().get(clientId).remove();
+    }
+
+    @Test
     public void searchByCreatedAfter() {
         long beforeCreation = System.currentTimeMillis();
         createUser("timestampuser1", "timestampuser1@localhost");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
@@ -362,6 +362,7 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
         assertNull(user.getCreatedTimestamp(), "Created timestamp should not be exposed");
         assertNull(user.isEnabled(), "Enabled status should not be exposed");
         assertNull(user.isEmailVerified(), "Email verified should not be exposed");
+        assertNull(user.isServiceAccount(), "Whether user is service account should not be exposed");
         assertNull(user.getFederationLink(), "Federation link should not be exposed");
         assertNull(user.getNotBefore(), "NotBefore should not be exposed");
     }


### PR DESCRIPTION
Allow to explicitly instruct Keycloak to return service accounts in the user list via a query parameter. The returned user representations now also contain a flag to identify service accounts.

Closes #51787