### PR TITLE
#51761 PAR request URI lifespan is used as a hard cap on interactive login duration

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -595,8 +595,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
 
     @Override
     public void authenticationComplete(AuthenticationSessionModel authSession) {
-        // Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
-        // not at the point of visiting the authorization endpoint
+        // If the Request has been a PAR-Request it must not have been consumed already by an authenticationComplete
         String requestUri = authSession.getAuthNote(Constants.AUTHORIZATION_REQUEST_URI);
         RequestUriType requestUriType = Optional.ofNullable(requestUri)
                 .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -40,6 +40,7 @@ import org.keycloak.headers.SecurityHeadersProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.SingleUseObjectProvider;
+import org.keycloak.models.utils.SessionExpiration;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
@@ -186,7 +187,10 @@ public class ParEndpoint extends AbstractParEndpoint {
         }
 
         SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        singleUseStore.put(buildCacheKey(realm.getId(), key), expiresIn, params);
+        //  PAR object needs to be valid for the time of PAR lifespan together with the authenticationSession time
+        //  (See https://github.com/keycloak/keycloak/issues/48072 for the details)
+        int storeLifespan = expiresIn + SessionExpiration.getAuthSessionLifespan(realm);
+        singleUseStore.put(buildCacheKey(realm.getId(), key), storeLifespan, params);
 
         ParResponse parResponse = new ParResponse(requestUri, expiresIn);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -68,6 +68,7 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         RealmModel realm = session.getContext().getRealm();
         int expiresIn = realm.getParPolicy().getRequestUriLifespan();
         long created = Long.parseLong(retrievedRequest.get(PAR_CREATED_TIME));
+
         if (System.currentTimeMillis() - created < (expiresIn * 1000L)) {
             requestParams = retrievedRequest;
         } else {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
@@ -227,6 +227,61 @@ public class ParTest extends AbstractClientPoliciesTest {
         }
     }
 
+    // PAR object needs to be valid for the time of PAR lifespan together with the authenticationSession time as
+    // (See https://github.com/keycloak/keycloak/issues/48072 for the details)
+    @Test
+    public void requestUriLifetimeDoesNotLimitAuthenticationSessionLength() throws Exception {
+        try {
+            // setup PAR realm settings
+            int requestUriLifespan = 45;
+            setParRealmSettings(requestUriLifespan);
+
+            // create client dynamically
+            String clientId = createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+                clientRep.setRequirePushedAuthorizationRequests(Boolean.TRUE);
+                clientRep.setRedirectUris(new ArrayList<String>(Arrays.asList(CLIENT_REDIRECT_URI)));
+            });
+            OIDCClientRepresentation oidcCRep = getClientDynamically(clientId);
+            String clientSecret = oidcCRep.getClientSecret();
+            assertEquals(Boolean.TRUE, oidcCRep.getRequirePushedAuthorizationRequests());
+            assertTrue(oidcCRep.getRedirectUris().contains(CLIENT_REDIRECT_URI));
+            assertEquals(OIDCLoginProtocol.CLIENT_SECRET_BASIC, oidcCRep.getTokenEndpointAuthMethod());
+
+            // Pushed Authorization Request
+            oauth.client(clientId, clientSecret);
+            oauth.redirectUri(CLIENT_REDIRECT_URI);
+            ParResponse pResp = oauth.doPushedAuthorizationRequest();
+            assertEquals(201, pResp.getStatusCode());
+            String requestUri = pResp.getRequestUri();
+            assertEquals(requestUriLifespan, pResp.getExpiresIn());
+
+            // Authorization Request with request_uri of PAR
+            // remove parameters as query strings of uri
+            oauth.redirectUri(null);
+            oauth.scope(null);
+            oauth.responseType(null);
+            String state = "testSuccessfulSinglePar";
+            oauth.loginForm().requestUri(requestUri).state(state).open();
+            assertThat(driver.getCurrentUrl(), startsWith(OAuthClient.AUTH_SERVER_ROOT + "/realms/" + oauth.getRealm() + "/login-actions/authenticate"));
+            // make sure interactive login waits longer than requestUriLifespan
+            driver.wait(requestUriLifespan * 1000L * 2);
+            oauth.fillLoginForm(TEST_USER_NAME, TEST_USER_PASSWORD);
+            AuthorizationEndpointResponse loginResponse = oauth.parseLoginResponse();
+            assertEquals(state, loginResponse.getState());
+            String code = loginResponse.getCode();
+            String sessionId =loginResponse.getSessionState();
+
+            // For this test it's enough to check that Code2Token succesds
+            oauth.redirectUri(CLIENT_REDIRECT_URI); // get tokens, it needed. https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
+            AccessTokenResponse res = oauth.doAccessTokenRequest(code);
+            assertEquals(200, res.getStatusCode());
+
+        } finally {
+            restoreParRealmSettings();
+        }
+    }
+
+
     // success with one public client conducting one authz request
     @Test
     public void testSuccessfulSingleParPublicClient() throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
@@ -264,7 +264,7 @@ public class ParTest extends AbstractClientPoliciesTest {
             oauth.loginForm().requestUri(requestUri).state(state).open();
             assertThat(driver.getCurrentUrl(), startsWith(OAuthClient.AUTH_SERVER_ROOT + "/realms/" + oauth.getRealm() + "/login-actions/authenticate"));
             // make sure interactive login waits longer than requestUriLifespan
-            driver.wait(requestUriLifespan * 1000L * 2);
+            timeOffSet.set(requestUriLifespan * 2);
             oauth.fillLoginForm(TEST_USER_NAME, TEST_USER_PASSWORD);
             AuthorizationEndpointResponse loginResponse = oauth.parseLoginResponse();
             assertEquals(state, loginResponse.getState());


### PR DESCRIPTION
Extend the SingleUseObjectStore Lifetime for PAR Requests in order to fix https://github.com/keycloak/keycloak/issues/51761

