### PR TITLE
doc update for dpop and token exchange (26.6)

### DIFF
--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -326,6 +326,7 @@ s|Public clients  | Not available. Downscoping implemented by V1 can be replaced
 s|Consents        | Allowed for clients with `Consent required` as long as the user is already granted consent | Not allowed for clients with *Consent required*
 s|Authorization  | Verification that the requester client must be in the audience of the `subject_token`. Integration with client policies. No Fine-grained admin permissions | Based on fine-grained admin permissions version 1
 s|Revocation chain | Not available for access tokens. Available for refresh tokens   | Not available for access nor refresh tokens
+s|Sender-constrained tokens (DPoP, mTLS) | Supported. See <@links.securingapps id="dpop" />. | Not supported. The exchanged token is issued without any binding.
 s|Delegation per RFC 8693|Not supported yet|Not supported
 s|Resource parameter per RFC 8693|Not supported yet|Not supported
 s|Internal to external Token Exchange | Identity brokering APIs can be used instead. See link:{developerguide_link}#_identity-brokering-apis[Identity Brokering APIs] for more information. | Implemented as a preview


### PR DESCRIPTION
Closes #50963

Backport of https://github.com/keycloak/keycloak/pull/51043, only the line related to DPoP.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
