### PR TITLE
[Keycloak 26.7] Generic identity-provider creation can bind brokers to organizations without manage-organizations

### DIFF
--- a/services/src/main/java/org/keycloak/organization/utils/Organizations.java
+++ b/services/src/main/java/org/keycloak/organization/utils/Organizations.java
@@ -51,6 +51,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.protocol.mappers.oidc.OrganizationScope;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.Urls;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
@@ -126,6 +127,13 @@ public class Organizations {
         }
 
         return brokers;
+    }
+
+    public static void stripOrganizationId(IdentityProviderRepresentation representation) {
+        representation.setOrganizationId(null);
+        if (representation.getConfig() != null) {
+            representation.getConfig().remove(OrganizationModel.ORGANIZATION_ATTRIBUTE);
+        }
     }
 
     public static Consumer<GroupModel> removeGroup(KeycloakSession session, RealmModel realm) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -51,6 +51,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.models.utils.StripSecretsUtils;
+import org.keycloak.organization.utils.Organizations;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 import org.keycloak.representations.idm.IdentityProviderMapperTypeRepresentation;
@@ -198,6 +199,9 @@ public class IdentityProviderResource {
         if (providerRep.getAlias() != null && !oldProviderAlias.equals(providerRep.getAlias())) {
             throw new IllegalArgumentException("Identity Provider alias cannot be changed");
         }
+
+        // organization-related information should not be processed by non-organization API
+        Organizations.stripOrganizationId(providerRep);
 
         IdentityProviderModel updated = RepresentationToModel.toModel(realm, providerRep, session);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProvidersResource.java
@@ -57,6 +57,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.models.utils.StripSecretsUtils;
+import org.keycloak.organization.utils.Organizations;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.idm.CertificateRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
@@ -271,6 +272,9 @@ public class IdentityProvidersResource {
         this.auth.realm().requireManageIdentityProviders();
 
         ReservedCharValidator.validateNoSpace(representation.getAlias());
+
+        // organization-related information should not be processed by non-organization API
+        Organizations.stripOrganizationId(representation);
 
         try {
             IdentityProviderModel identityProvider = RepresentationToModel.toModel(realm, representation, session);

--- a/tests/base/src/test/java/org/keycloak/tests/organization/authz/OrganizationAdminRolesPermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/authz/OrganizationAdminRolesPermissionsTest.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.tests.organization.authz;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -25,6 +28,7 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.Constants;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
@@ -46,6 +50,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @KeycloakIntegrationTest
@@ -932,6 +937,71 @@ public class OrganizationAdminRolesPermissionsTest extends AbstractOrganizationT
             try (Response response = manageOrgsResource.organizations().get(orgId).members().member(userId).delete()) {
                 assertThat(response.getStatus(), equalTo(Status.NO_CONTENT.getStatusCode()));
             }
+        }
+    }
+
+    @Test
+    public void testGenericIdpEndpointCannotBindOrganization() {
+        String orgId;
+        try (
+                Keycloak manageOrgsClient = adminClientFactory.create()
+                        .realm(realm.getName()).username("manage-orgs-admin").password("password").clientId(Constants.ADMIN_CLI_CLIENT_ID).build()
+        ) {
+            RealmResource manageOrgsResource = manageOrgsClient.realm(realm.getName());
+
+            OrganizationRepresentation orgRep = createRepresentation("genericIdpBindOrg", "genericidpbind.org");
+            try (Response response = manageOrgsResource.organizations().create(orgRep)) {
+                assertThat(response.getStatus(), equalTo(Status.CREATED.getStatusCode()));
+                orgId = ApiUtil.getCreatedId(response);
+                realm.cleanup().add(r -> r.organizations().get(orgId).delete().close());
+            }
+        }
+
+        // view-orgs-manage-idps-admin has view-organizations + manage-identity-providers but NOT manage-organizations
+        try (
+                Keycloak viewOrgsManageIdpsClient = adminClientFactory.create()
+                        .realm(realm.getName()).username("view-orgs-manage-idps-admin").password("password").clientId(Constants.ADMIN_CLI_CLIENT_ID).build()
+        ) {
+            RealmResource viewOrgsManageIdpsResource = viewOrgsManageIdpsClient.realm(realm.getName());
+
+            // create IdP via generic endpoint with organizationId set — binding should be stripped
+            IdentityProviderRepresentation idpRep = new IdentityProviderRepresentation();
+            idpRep.setAlias("genericOrgBoundIdp");
+            idpRep.setProviderId("oidc");
+            idpRep.setOrganizationId(orgId);
+            Map<String, String> config = new HashMap<>();
+            config.put(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, "genericidpbind.org");
+            idpRep.setConfig(config);
+
+            try (Response response = viewOrgsManageIdpsResource.identityProviders().create(idpRep)) {
+                assertThat(response.getStatus(), equalTo(Status.CREATED.getStatusCode()));
+                realm.cleanup().add(r -> r.identityProviders().get("genericOrgBoundIdp").remove());
+            }
+
+            IdentityProviderRepresentation created = viewOrgsManageIdpsResource
+                    .identityProviders().get("genericOrgBoundIdp").toRepresentation();
+            assertNull(created.getOrganizationId(),
+                    "Generic IdP create should not bind the IdP to an organization");
+
+            // update the IdP via generic endpoint with organizationId set — binding should still be stripped
+            created.setOrganizationId(orgId);
+            created.getConfig().put(OrganizationModel.ORGANIZATION_ATTRIBUTE, orgId);
+            viewOrgsManageIdpsResource.identityProviders().get("genericOrgBoundIdp").update(created);
+
+            IdentityProviderRepresentation updated = viewOrgsManageIdpsResource
+                    .identityProviders().get("genericOrgBoundIdp").toRepresentation();
+            assertNull(updated.getOrganizationId(),
+                    "Generic IdP update should not bind the IdP to an organization");
+        }
+
+        // verify the org has no linked IdPs
+        try (
+                Keycloak manageOrgsClient = adminClientFactory.create()
+                        .realm(realm.getName()).username("manage-orgs-admin").password("password").clientId(Constants.ADMIN_CLI_CLIENT_ID).build()
+        ) {
+            RealmResource manageOrgsResource = manageOrgsClient.realm(realm.getName());
+            assertThat(manageOrgsResource.organizations().get(orgId).identityProviders().getIdentityProviders(),
+                    Matchers.empty());
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -798,6 +798,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         idp.getConfig().put(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, ANY_DOMAIN);
         managedRealm.admin().identityProviders().get(bc.getIDPAlias()).update(idp);
 
+        idp = bc.setUpIdentityProvider();
         idp.setAlias("second-idp");
         idp.setInternalId(null);
         managedRealm.admin().identityProviders().create(idp).close();
@@ -823,6 +824,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         idp.getConfig().put(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, ANY_DOMAIN);
         managedRealm.admin().identityProviders().get(bc.getIDPAlias()).update(idp);
 
+        idp = bc.setUpIdentityProvider();
         idp.setAlias("second-idp");
         idp.setInternalId(null);
         managedRealm.admin().identityProviders().create(idp).close();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/OrganizationIdentityProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/OrganizationIdentityProviderTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -62,12 +63,11 @@ public class OrganizationIdentityProviderTest extends AbstractOrganizationTest {
         IdentityProviderResource idpResource = managedRealm.admin().identityProviders().get(expected.getAlias());
         IdentityProviderRepresentation actual = idpResource.toRepresentation();
         Assertions.assertEquals(actual.getOrganizationId(), organization.getId());
+        // ignore organization id from repo when updating
         actual.setOrganizationId("somethingelse");
-        try {
-            idpResource.update(actual);
-            Assertions.fail("Should fail because it maps to an invalid org");
-        } catch (BadRequestException ignore) {
-        }
+        idpResource.update(actual);
+        actual = idpResource.toRepresentation();
+        assertEquals(actual.getOrganizationId(), organization.getId());
 
         OrganizationRepresentation secondOrg = createOrganization("secondorg");
         actual.setOrganizationId(secondOrg.getId());
@@ -233,8 +233,11 @@ public class OrganizationIdentityProviderTest extends AbstractOrganizationTest {
         idpRep.setAlias("newbroker");
         idpRep.setInternalId(null);
         try (Response response = managedRealm.admin().identityProviders().create(idpRep)) {
-            Assertions.assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            Assertions.assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+            getCleanup().addCleanup(() -> managedRealm.admin().identityProviders().get("newbroker").remove());
         }
+        IdentityProviderRepresentation created = managedRealm.admin().identityProviders().get("newbroker").toRepresentation();
+        Assertions.assertNull(created.getOrganizationId());
     }
 
     @Test


### PR DESCRIPTION
Closes #51283

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
