### PR TITLE
[Backport 26.7] Partial evaluation misses ancestor group policies with extendChildren

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/aggregated/AggregatePolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/aggregated/AggregatePolicyProvider.java
@@ -40,6 +40,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
+import org.keycloak.representations.idm.authorization.Logic;
 import org.keycloak.representations.idm.authorization.ResourceType;
 
 import org.jboss.logging.Logger;
@@ -112,30 +113,65 @@ public class AggregatePolicyProvider implements PolicyProvider, PartialEvaluatio
 
     @Override
     public boolean evaluate(KeycloakSession session, Policy policy, UserModel subject) {
+        return Outcome.GRANT.equals(evaluateOutcome(session, policy, subject));
+    }
+
+    @Override
+    public Outcome evaluateOutcome(KeycloakSession session, Policy policy, UserModel subject) {
         DecisionStrategy decisionStrategy = policy.getDecisionStrategy();
         Set<Policy> associatedPolicies = policy.getAssociatedPolicies();
         int grants = 0;
+        int evaluated = 0;
+        int forceDeny = 0;
 
         for (Policy associatedPolicy : associatedPolicies) {
             PolicyProvider policyProvider = session.getProvider(AuthorizationProvider.class).getProvider(associatedPolicy.getType());
 
             if (policyProvider instanceof PartialEvaluationPolicyProvider partialPolicyProvider) {
-                if (partialPolicyProvider.evaluate(session, associatedPolicy, subject)) {
+                Outcome childOutcome = partialPolicyProvider.evaluateOutcome(session, associatedPolicy, subject);
+
+                if (Outcome.FORCE_DENY.equals(childOutcome)) {
+                    forceDeny++;
+                    continue;
+                }
+
+                if (Outcome.SKIP.equals(childOutcome)) {
+                    continue;
+                }
+
+                evaluated++;
+
+                boolean childGranted = Outcome.GRANT.equals(childOutcome);
+
+                if (Logic.NEGATIVE.equals(associatedPolicy.getLogic())) {
+                    childGranted = !childGranted;
+                }
+
+                if (childGranted) {
                     grants++;
                 }
             } else {
-                return false;
+                forceDeny++;
             }
         }
 
-        if (grants == 0) {
-            return false;
+        if (evaluated == 0) {
+            return forceDeny == 0 ? Outcome.SKIP: Outcome.FORCE_DENY;
         }
 
-        return switch (decisionStrategy) {
+        if (grants == 0) {
+            return Outcome.DENY;
+        }
+
+        // uses total policy count, not just evaluated, so skipped and unsupported children count against unanimity/consensus;
+        // this is intentionally conservative — partial evaluation cannot resolve unsupported policies, so it denies rather
+        // than risk granting access that runtime evaluation would deny
+        boolean granted = switch (decisionStrategy) {
             case AFFIRMATIVE -> true;
             case UNANIMOUS -> grants == associatedPolicies.size();
             case CONSENSUS -> grants > associatedPolicies.size() - grants;
         };
+
+        return granted ? Outcome.GRANT : Outcome.DENY;
     }
 }

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.authorization.policy.provider.group;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -111,7 +112,19 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
         StoreFactory storeFactory = provider.getStoreFactory();
         ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(adminPermissionsClient);
         PolicyStore policyStore = storeFactory.getPolicyStore();
-        List<String> groupIds = user.getGroupsStream().map(GroupModel::getId).toList();
+        // getParent() issues a query per ancestor; may need optimization for deep hierarchies
+        List<String> groupIds = user.getGroupsStream()
+                .flatMap(group -> {
+                    List<String> ids = new ArrayList<>();
+                    GroupModel current = group;
+                    while (current != null) {
+                        ids.add(current.getId());
+                        current = current.getParent();
+                    }
+                    return ids.stream();
+                })
+                .distinct()
+                .toList();
 
         return policyStore.findDependentPolicies(resourceServer, resourceType.getType(), groupResourceType == null ? null : groupResourceType.getType(), GroupPolicyProviderFactory.ID, "groups", groupIds);
     }

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
@@ -43,7 +43,11 @@ import org.keycloak.representations.idm.authorization.ResourceType;
 
 import org.jboss.logging.Logger;
 
+import static org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome.DENY;
+import static org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome.GRANT;
+import static org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome.SKIP;
 import static org.keycloak.models.utils.ModelToRepresentation.buildGroupPath;
+import static org.keycloak.models.utils.RoleUtils.isDirectMember;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -69,14 +73,18 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
             groupsClaim = new Entry(policy.getGroupsClaim(), userGroups);
         }
 
-        if (isGranted(realm, policy, groupsClaim)) {
+        Outcome outcome = isGranted(realm, null, policy, groupsClaim);
+
+        if (GRANT.equals(outcome)) {
             evaluation.grant();
         }
 
         logger.debugf("Groups policy %s evaluated to %s with identity groups %s", policy.getName(), evaluation.getEffect(), groupsClaim);
     }
 
-    private boolean isGranted(RealmModel realm, GroupPolicyRepresentation policy, Attributes.Entry groupsClaim) {
+    private Outcome isGranted(RealmModel realm, UserModel subject, GroupPolicyRepresentation policy, Entry groupsClaim) {
+        boolean skipped = false;
+
         for (GroupPolicyRepresentation.GroupDefinition definition : policy.getGroups()) {
             GroupModel allowedGroup = realm.getGroupById(definition.getId());
 
@@ -84,24 +92,38 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
                 continue;
             }
 
+            if (subject != null && !definition.isExtendChildren() && !isDirectMember(subject.getGroupsStream(), allowedGroup)) {
+                skipped = true;
+                continue;
+            }
+
+            String allowedGroupPath = buildGroupPath(allowedGroup);
+
             for (int i = 0; i < groupsClaim.size(); i++) {
                 String group = groupsClaim.asString(i);
 
                 if (group.indexOf('/') != -1) {
-                    String allowedGroupPath = buildGroupPath(allowedGroup);
-                    if (group.equals(allowedGroupPath) || (definition.isExtendChildren() && group.startsWith(allowedGroupPath))) {
-                        return true;
+                    if (group.equals(allowedGroupPath)) {
+                        return GRANT;
+                    }
+
+                    if (definition.isExtendChildren() && group.startsWith(allowedGroupPath)) {
+                        return GRANT;
                     }
                 }
 
                 // in case the group from the claim does not represent a path, we just check an exact name match
                 if (group.equals(allowedGroup.getName())) {
-                    return true;
+                    return GRANT;
                 }
             }
         }
 
-        return false;
+        if (skipped) {
+            return SKIP;
+        }
+
+        return DENY;
     }
 
     @Override
@@ -112,7 +134,7 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
         StoreFactory storeFactory = provider.getStoreFactory();
         ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(adminPermissionsClient);
         PolicyStore policyStore = storeFactory.getPolicyStore();
-        // getParent() issues a query per ancestor; may need optimization for deep hierarchies
+        // we probably want to cache the ids of all groups a user belongs to, considering the full hierarchy
         List<String> groupIds = user.getGroupsStream()
                 .flatMap(group -> {
                     List<String> ids = new ArrayList<>();
@@ -131,12 +153,17 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
 
     @Override
     public boolean evaluate(KeycloakSession session, Policy policy, UserModel subject) {
+        return Outcome.GRANT.equals(evaluateOutcome(session, policy, subject));
+    }
+
+    @Override
+    public Outcome evaluateOutcome(KeycloakSession session, Policy policy, UserModel subject) {
         RealmModel realm = session.getContext().getRealm();
         AuthorizationProvider authorizationProvider = session.getProvider(AuthorizationProvider.class);
         GroupPolicyRepresentation groupPolicy = representationFunction.apply(policy, authorizationProvider);
         List<String> userGroups = subject.getGroupsStream().map(ModelToRepresentation::buildGroupPath)
                 .collect(Collectors.toList());
-        return isGranted(realm, groupPolicy, new Entry(groupPolicy.getGroupsClaim(), userGroups));
+        return isGranted(realm, subject, groupPolicy, new Entry(groupPolicy.getGroupsClaim(), userGroups));
     }
 
     @Override

--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
@@ -17,7 +17,9 @@
 package org.keycloak.authorization.policy.provider.group;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -107,7 +109,7 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
                         return GRANT;
                     }
 
-                    if (definition.isExtendChildren() && group.startsWith(allowedGroupPath)) {
+                    if (definition.isExtendChildren() && group.startsWith(allowedGroupPath + "/")) {
                         return GRANT;
                     }
                 }
@@ -134,18 +136,17 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
         StoreFactory storeFactory = provider.getStoreFactory();
         ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(adminPermissionsClient);
         PolicyStore policyStore = storeFactory.getPolicyStore();
-        // we probably want to cache the ids of all groups a user belongs to, considering the full hierarchy
+        Set<String> visited = new HashSet<>();
         List<String> groupIds = user.getGroupsStream()
                 .flatMap(group -> {
                     List<String> ids = new ArrayList<>();
                     GroupModel current = group;
-                    while (current != null) {
+                    while (current != null && visited.add(current.getId())) {
                         ids.add(current.getId());
                         current = current.getParent();
                     }
                     return ids.stream();
                 })
-                .distinct()
                 .toList();
 
         return policyStore.findDependentPolicies(resourceServer, resourceType.getType(), groupResourceType == null ? null : groupResourceType.getType(), GroupPolicyProviderFactory.ID, "groups", groupIds);

--- a/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
+++ b/docs/documentation/server_admin/topics/admin-console-permissions/fine-grain-v2.adoc
@@ -256,8 +256,15 @@ make them available from queries:
 * `Role`
 * `Aggregated`
 
-In case of using an `Aggregated` policy, all the underlying policies must be of type `User`, `Group`, or `Role`. Otherwise,
-the policy will always evaluate to `DENY` when performing partial evaluation.
+When using an `Aggregated` policy, underlying policies that support partial evaluation (`User`, `Group`, `Role`, or nested `Aggregated`)
+are evaluated during partial evaluation. Underlying policies of other types (such as `Time` or `JavaScript`) are skipped
+because they cannot be pre-evaluated at the database level. If an aggregated policy contains only unsupported policy types,
+the entire aggregated policy is excluded from partial evaluation.
+
+When an aggregated policy contains a mix of supported and unsupported policy types, only the supported policies contribute to the
+decision. Unsupported policies do not count as grants but are still considered in the total policy count, which means `Unanimous`
+and `Consensus` decision strategies become more conservative. For best results, use only `User`, `Group`, `Role`, or nested
+`Aggregated` policies as the underlying policies of an aggregated policy used in view-related permissions.
 
 By using any of the policies above, {project_name} can pre-calculate the set of resources that a realm administration can view
 by looking for a direct (if using a user policy) or indirect (if using a role or group policy) reference to the realm administrator.

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluationPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluationPolicyProvider.java
@@ -33,6 +33,24 @@ import org.keycloak.representations.idm.authorization.ResourceType;
  */
 public interface PartialEvaluationPolicyProvider {
 
+    enum Outcome {
+
+        /**
+         * The evaluation resulted in a GRANT
+         */
+        GRANT,
+
+        /**
+         * The evaluation resulted in a DENY
+         */
+        DENY,
+
+        /**
+         * The evaluation should be skipped and the next policy should be evaluated.
+         */
+        SKIP
+    }
+
     /**
      * Returns a list of {@link Policy} instances representing the permissions that apply to a given {@code subject} when
      * partially evaluating the realm resources that can be accessed.
@@ -62,4 +80,8 @@ public interface PartialEvaluationPolicyProvider {
      * @return {@code true} if access is granted. Otherwise, returns {@code false}
      */
     boolean evaluate(KeycloakSession session, Policy policy, UserModel subject);
+
+    default Outcome evaluateOutcome(KeycloakSession session, Policy policy, UserModel subject) {
+        return evaluate(session, policy, subject) ? Outcome.GRANT : Outcome.DENY;
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluationPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluationPolicyProvider.java
@@ -46,9 +46,16 @@ public interface PartialEvaluationPolicyProvider {
         DENY,
 
         /**
-         * The evaluation should be skipped and the next policy should be evaluated.
+         * The evaluation should be skipped and the next policy should be evaluated. It is up
+         * to the caller to interpret a {@code SKIP} as a {@code SKIP}, a {@code GRANT}, a {@code DENY}, or
+         * just ignore the policy evaluation.
          */
-        SKIP
+        SKIP,
+
+        /**
+         * The policy could not be evaluated because and should be unconditionally denied without applying logic inversion.
+         */
+        FORCE_DENY
     }
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluator.java
@@ -31,6 +31,7 @@ import jakarta.persistence.criteria.Predicate;
 
 import org.keycloak.Config;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome;
 import org.keycloak.authorization.model.Policy;
 import org.keycloak.authorization.policy.provider.PolicyProvider;
 import org.keycloak.common.Profile;
@@ -105,13 +106,17 @@ public final class PartialEvaluator {
                         continue;
                     }
 
-                    boolean granted = provider.evaluate(session, policy, adminUser);
+                    Outcome granted = provider.evaluateOutcome(session, policy, adminUser);
 
-                    if (Logic.NEGATIVE.equals(policy.getLogic())) {
-                        granted = !granted;
+                    if (Outcome.SKIP.equals(granted)) {
+                        continue;
                     }
 
-                    if (granted) {
+                    if (Logic.NEGATIVE.equals(policy.getLogic())) {
+                        granted = granted == Outcome.GRANT ? Outcome.DENY : Outcome.GRANT;
+                    }
+
+                    if (Outcome.GRANT.equals(granted)) {
                         allowedResources.addAll(ids);
                     } else {
                         deniedResources.addAll(ids);

--- a/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluator.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/fgap/evaluation/partial/PartialEvaluator.java
@@ -112,6 +112,11 @@ public final class PartialEvaluator {
                         continue;
                     }
 
+                    if (Outcome.FORCE_DENY.equals(granted)) {
+                        deniedResources.addAll(ids);
+                        continue;
+                    }
+
                     if (Logic.NEGATIVE.equals(policy.getLogic())) {
                         granted = granted == Outcome.GRANT ? Outcome.DENY : Outcome.GRANT;
                     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.GenericType;
@@ -47,6 +48,7 @@ import org.keycloak.representations.idm.authorization.DecisionStrategy;
 import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.Logic;
 import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.representations.idm.authorization.TimePolicyRepresentation;
 import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectClient;
@@ -75,6 +77,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -197,6 +200,240 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
         search = realmAdminClient.realm(realm.getName()).users().search(null, 0, 10);
         assertFalse(search.isEmpty());
         assertEquals(1, search.size());
+    }
+
+    @Test
+    public void testNegativeAggregateWithUnsupportedChildDeniesWithCompetingAllow() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowAll = createUserPolicy(
+                realm, adminPermissionsClient, "Allow All Users Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowAll, Set.of(VIEW));
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(null, 0, 50);
+        assertThat(search, hasSize(50));
+
+        TimePolicyRepresentation timePolicy = new TimePolicyRepresentation();
+        timePolicy.setName("Always Matching Time Policy");
+        try (Response response = adminPermissionsClient.authorization().policies().time()
+                .create(timePolicy)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        AggregatePolicyRepresentation aggregatePolicy = createAggregatedPolicy(
+                adminPermissionsClient, "Negative Aggregate With Time Child Policy",
+                Logic.NEGATIVE, DecisionStrategy.AFFIRMATIVE, timePolicy.getName());
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, deniedUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), aggregatePolicy);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(deniedUser.getUsername(), 0, 10);
+        assertThat(search, is(empty()));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(null, -1, -1);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                not(hasItems(deniedUser.getId())));
+    }
+
+    @Test
+    public void testAggregatePolicyWithNegativeChildDenyOverridesTypeWideAllow() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowAll = createUserPolicy(
+                realm, adminPermissionsClient, "Allow All Users Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowAll, Set.of(VIEW));
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(null, 0, 50);
+        assertThat(search, hasSize(50));
+
+        UserPolicyRepresentation denyMyAdmin = createUserPolicy(
+                Logic.NEGATIVE, realm, adminPermissionsClient, "Not My Admin User Policy", myadmin.getId());
+        AggregatePolicyRepresentation aggregatePolicy = createAggregatedPolicy(
+                adminPermissionsClient, "Positive Aggregate With Negative Child Policy",
+                Logic.POSITIVE, DecisionStrategy.AFFIRMATIVE, denyMyAdmin.getName());
+        Set<String> deniedUsers = Set.of("user-0", "user-15", "user-30");
+
+        createPermission(adminPermissionsClient, deniedUsers, usersType, Set.of(VIEW), aggregatePolicy);
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(null, -1, -1);
+        assertThat(search.stream().map(UserRepresentation::getUsername).toList(),
+                not(hasItems("user-0", "user-15", "user-30")));
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+    }
+
+    @Test
+    public void testNestedAggregateDenyOverridesTypeWideAllow() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowAll = createUserPolicy(
+                realm, adminPermissionsClient, "Allow All Users Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowAll, Set.of(VIEW));
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(null, 0, 50);
+        assertThat(search, hasSize(50));
+
+        UserPolicyRepresentation denyMyAdmin = createUserPolicy(
+                Logic.NEGATIVE, realm, adminPermissionsClient, "Not My Admin User Policy", myadmin.getId());
+        AggregatePolicyRepresentation innerAggregate = createAggregatedPolicy(
+                adminPermissionsClient, "Inner Aggregate With Negative Child",
+                Logic.POSITIVE, DecisionStrategy.AFFIRMATIVE, denyMyAdmin.getName());
+        AggregatePolicyRepresentation outerAggregate = createAggregatedPolicy(
+                adminPermissionsClient, "Outer Aggregate Wrapping Inner",
+                Logic.POSITIVE, DecisionStrategy.AFFIRMATIVE, innerAggregate.getName());
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, deniedUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), outerAggregate);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(deniedUser.getUsername(), 0, 10);
+        assertThat(search, is(empty()));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(null, -1, -1);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                not(hasItems(deniedUser.getId())));
+    }
+
+    @Test
+    public void testGroupPolicyExtendChildrenInsideAggregateDenyOverridesTypeWideAllow() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowAll = createUserPolicy(
+                realm, adminPermissionsClient, "Allow All Users Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowAll, Set.of(VIEW));
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(null, 0, 50);
+        assertThat(search, hasSize(50));
+
+        GroupRepresentation parentGroup = createGroup("fgap-parent-" + KeycloakModelUtils.generateId());
+        GroupRepresentation childGroup = new GroupRepresentation();
+        childGroup.setName("fgap-child-" + KeycloakModelUtils.generateId());
+        try (Response response = realm.admin().groups().group(parentGroup.getId()).subGroup(childGroup)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+            childGroup.setId(ApiUtil.getCreatedId(response));
+        }
+        realm.admin().users().get(myadmin.getId()).joinGroup(childGroup.getId());
+
+        GroupPolicyRepresentation denyParentSubtree = new GroupPolicyRepresentation();
+        denyParentSubtree.setName("Deny Parent Subtree Policy");
+        denyParentSubtree.setLogic(Logic.NEGATIVE);
+        denyParentSubtree.addGroup(parentGroup.getId(), true);
+        try (Response response = adminPermissionsClient.authorization().policies().group()
+                .create(denyParentSubtree)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        AggregatePolicyRepresentation aggregatePolicy = createAggregatedPolicy(
+                adminPermissionsClient, "Aggregate Wrapping Group Deny Policy",
+                Logic.POSITIVE, DecisionStrategy.AFFIRMATIVE, denyParentSubtree.getName());
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, deniedUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), aggregatePolicy);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(deniedUser.getUsername(), 0, 10);
+        assertThat(search, is(empty()));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+
+        search = realmAdminClient.realm(realm.getName())
+                .users().search(null, -1, -1);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                not(hasItems(deniedUser.getId())));
+    }
+
+    @Test
+    public void testAggregatePolicyUnanimousWithMixedChildren() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowMyAdmin = createUserPolicy(
+                Logic.POSITIVE, realm, adminPermissionsClient, "Allow My Admin User Policy", myadmin.getId());
+        UserPolicyRepresentation denyMyAdmin = createUserPolicy(
+                Logic.NEGATIVE, realm, adminPermissionsClient, "Deny My Admin User Policy", myadmin.getId());
+        AggregatePolicyRepresentation aggregatePolicy = createAggregatedPolicy(
+                adminPermissionsClient, "Unanimous Aggregate With Mixed Children",
+                Logic.POSITIVE, DecisionStrategy.UNANIMOUS, allowMyAdmin.getName(), denyMyAdmin.getName());
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, deniedUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), aggregatePolicy);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(deniedUser.getUsername(), 0, 10);
+        assertThat(search, is(empty()));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+    }
+
+    @Test
+    public void testAggregateWithSupportedAndUnsupportedChildren() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowMyAdmin = createUserPolicy(
+                Logic.POSITIVE, realm, adminPermissionsClient, "Allow My Admin User Policy", myadmin.getId());
+
+        TimePolicyRepresentation timePolicy = new TimePolicyRepresentation();
+        timePolicy.setName("Always Matching Time Policy");
+        try (Response response = adminPermissionsClient.authorization().policies().time()
+                .create(timePolicy)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        AggregatePolicyRepresentation aggregatePolicy = createAggregatedPolicy(
+                adminPermissionsClient, "Aggregate With Supported And Unsupported Children",
+                Logic.POSITIVE, DecisionStrategy.AFFIRMATIVE, allowMyAdmin.getName(), timePolicy.getName());
+
+        createPermission(adminPermissionsClient, "user-15", usersType, Set.of(VIEW), aggregatePolicy);
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search("user-15", 0, 10);
+        assertThat(search, hasSize(1));
+        assertThat(search.get(0).getUsername(), is("user-15"));
+    }
+
+    @Test
+    public void testNestedNegativeAggregateWithUnsupportedGrandchildDenies() {
+        TimePolicyRepresentation timePolicy = new TimePolicyRepresentation();
+        timePolicy.setName("Always Matching Time Policy");
+        try (Response response = adminPermissionsClient.authorization().policies().time()
+                .create(timePolicy)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        AggregatePolicyRepresentation innerAggregate = createAggregatedPolicy(
+                adminPermissionsClient, "Inner Aggregate With Unsupported Child",
+                Logic.POSITIVE, DecisionStrategy.AFFIRMATIVE, timePolicy.getName());
+        AggregatePolicyRepresentation outerAggregate = createAggregatedPolicy(
+                adminPermissionsClient, "Outer Negative Aggregate Wrapping Inner",
+                Logic.NEGATIVE, DecisionStrategy.AFFIRMATIVE, innerAggregate.getName());
+
+        UserRepresentation targetUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, targetUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), outerAggregate);
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(targetUser.getUsername(), 0, 10);
+        assertThat(search, is(empty()));
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
@@ -547,6 +547,70 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    public void testExactGroupPolicyOnParentDoesNotDenyChildMember() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+
+        GroupRepresentation parentGroup = createGroup("fgap-exact-parent-" + KeycloakModelUtils.generateId());
+        GroupRepresentation childGroup = new GroupRepresentation();
+        childGroup.setName("fgap-exact-child-" + KeycloakModelUtils.generateId());
+        try (Response response = realm.admin().groups().group(parentGroup.getId()).subGroup(childGroup)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+            childGroup.setId(ApiUtil.getCreatedId(response));
+        }
+        realm.admin().users().get(myadmin.getId()).joinGroup(childGroup.getId());
+
+        GroupPolicyRepresentation exactParentPolicy = new GroupPolicyRepresentation();
+        exactParentPolicy.setName("Exact Parent Group Policy");
+        exactParentPolicy.setLogic(Logic.POSITIVE);
+        exactParentPolicy.addGroup(parentGroup.getId(), false);
+        try (Response response = adminPermissionsClient.authorization().policies().group()
+                .create(exactParentPolicy)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        UserPolicyRepresentation allowMyAdmin = createUserPolicy(
+                realm, adminPermissionsClient, "Only My Admin User Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowMyAdmin, Set.of(VIEW));
+
+        UserRepresentation targetUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, targetUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), exactParentPolicy);
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(targetUser.getUsername(), 0, 10);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                hasItems(targetUser.getId()));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, targetUser.getUsername()), is(1));
+    }
+
+    @Test
+    public void testMultiDefinitionGroupPolicyGrantsWhenOneDefinitionMatches() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+
+        GroupRepresentation unrelatedGroup = createGroup("fgap-unrelated-" + KeycloakModelUtils.generateId());
+        GroupRepresentation adminGroup = createGroup("fgap-admin-direct-" + KeycloakModelUtils.generateId());
+        realm.admin().users().get(myadmin.getId()).joinGroup(adminGroup.getId());
+
+        GroupPolicyRepresentation multiGroupPolicy = new GroupPolicyRepresentation();
+        multiGroupPolicy.setName("Multi Group Policy");
+        multiGroupPolicy.setLogic(Logic.POSITIVE);
+        multiGroupPolicy.addGroup(unrelatedGroup.getId(), false);
+        multiGroupPolicy.addGroup(adminGroup.getId(), false);
+        try (Response response = adminPermissionsClient.authorization().policies().group()
+                .create(multiGroupPolicy)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        UserRepresentation targetUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, targetUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), multiGroupPolicy);
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(targetUser.getUsername(), 0, 10);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                hasItems(targetUser.getId()));
+    }
+
+    @Test
     public void testSessionEndpointRespectsUserViewPermission() {
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
         String clientUuid = realm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
@@ -463,6 +463,90 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    public void testExtendChildrenGroupDenyExcludesDeniedUserFromSearch() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowMyAdmin = createUserPolicy(
+                realm, adminPermissionsClient, "Only My Admin User Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowMyAdmin, Set.of(VIEW));
+
+        GroupRepresentation parentGroup = createGroup("fgap-parent-" + KeycloakModelUtils.generateId());
+        GroupRepresentation childGroup = new GroupRepresentation();
+        childGroup.setName("fgap-child-" + KeycloakModelUtils.generateId());
+        try (Response response = realm.admin().groups().group(parentGroup.getId()).subGroup(childGroup)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+            childGroup.setId(ApiUtil.getCreatedId(response));
+        }
+        realm.admin().users().get(myadmin.getId()).joinGroup(childGroup.getId());
+
+        GroupPolicyRepresentation denyParentSubtree = new GroupPolicyRepresentation();
+        denyParentSubtree.setName("Deny Parent Subtree Policy");
+        denyParentSubtree.setLogic(Logic.NEGATIVE);
+        denyParentSubtree.addGroup(parentGroup.getId(), true);
+        try (Response response = adminPermissionsClient.authorization().policies().group()
+                .create(denyParentSubtree)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, deniedUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), denyParentSubtree);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(deniedUser.getUsername(), 0, 10);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                not(hasItems(deniedUser.getId())));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+    }
+
+    @Test
+    public void testExtendChildrenGroupDenyThreeLevelHierarchy() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowMyAdmin = createUserPolicy(
+                realm, adminPermissionsClient, "Only My Admin User Policy", myadmin.getId());
+        createAllPermission(adminPermissionsClient, usersType, allowMyAdmin, Set.of(VIEW));
+
+        GroupRepresentation grandparentGroup = createGroup("fgap-grandparent-" + KeycloakModelUtils.generateId());
+        GroupRepresentation parentGroup = new GroupRepresentation();
+        parentGroup.setName("fgap-parent-" + KeycloakModelUtils.generateId());
+        try (Response response = realm.admin().groups().group(grandparentGroup.getId()).subGroup(parentGroup)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+            parentGroup.setId(ApiUtil.getCreatedId(response));
+        }
+        GroupRepresentation childGroup = new GroupRepresentation();
+        childGroup.setName("fgap-child-" + KeycloakModelUtils.generateId());
+        try (Response response = realm.admin().groups().group(parentGroup.getId()).subGroup(childGroup)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+            childGroup.setId(ApiUtil.getCreatedId(response));
+        }
+        realm.admin().users().get(myadmin.getId()).joinGroup(childGroup.getId());
+
+        GroupPolicyRepresentation denyGrandparentSubtree = new GroupPolicyRepresentation();
+        denyGrandparentSubtree.setName("Deny Grandparent Subtree Policy");
+        denyGrandparentSubtree.setLogic(Logic.NEGATIVE);
+        denyGrandparentSubtree.addGroup(grandparentGroup.getId(), true);
+        try (Response response = adminPermissionsClient.authorization().policies().group()
+                .create(denyGrandparentSubtree)) {
+            assertThat(response.getStatus(), is(Response.Status.CREATED.getStatusCode()));
+        }
+
+        UserRepresentation deniedUser = realm.admin().users().search("user-15").get(0);
+        createPermission(adminPermissionsClient, deniedUser.getId(), USERS_RESOURCE_TYPE, Set.of(VIEW), denyGrandparentSubtree);
+
+        assertThrows(ForbiddenException.class, () -> realmAdminClient.realm(realm.getName())
+                .users().get(deniedUser.getId()).toRepresentation());
+
+        List<UserRepresentation> search = realmAdminClient.realm(realm.getName())
+                .users().search(deniedUser.getUsername(), 0, 10);
+        assertThat(search.stream().map(UserRepresentation::getId).toList(),
+                not(hasItems(deniedUser.getId())));
+        assertThat(realmAdminClient.realm(realm.getName()).users()
+                .count(null, null, null, deniedUser.getUsername()), is(0));
+    }
+
+    @Test
     public void testSessionEndpointRespectsUserViewPermission() {
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
         String clientUuid = realm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();


### PR DESCRIPTION
Closes #51144
Closes #51143
Closes #51280