### PR TITLE
[Backport 26.7] GET /roles/{role}/users returns user PII without the per-user view filter with FGAP V1

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -41,6 +41,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.Encode;
 import org.keycloak.events.admin.OperationType;
@@ -52,6 +53,7 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ManagementPermissionReference;
@@ -62,6 +64,7 @@ import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
+import org.keycloak.services.resources.admin.fgap.UserPermissionEvaluator;
 import org.keycloak.utils.ProfileHelper;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -599,9 +602,19 @@ public class RoleContainerResource extends RoleResource {
         }
 
         boolean briefRep = Boolean.TRUE.equals(briefRepresentation);
+        UserPermissionEvaluator usersEvaluator = auth.users();
 
-        return session.users().getRoleMembersStream(realm, role, firstResult, maxResults)
-                .map((u) -> ModelToRepresentation.toRepresentation(session, u, briefRep));
+        Stream<UserModel> members = session.users().getRoleMembersStream(realm, role, firstResult, maxResults);
+
+        if (!AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
+            members = members.filter(usersEvaluator::canView);
+        }
+
+        return members.map(user -> {
+            UserRepresentation userRep = ModelToRepresentation.toRepresentation(session, user, briefRep);
+            userRep.setAccess(usersEvaluator.getAccessForListing(user));
+            return userRep;
+        });
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
@@ -565,6 +565,49 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     }
 
     @Test
+    public void testRealmRoleMemberFilteringByViewPermission() {
+        RoleRepresentation role = new RoleRepresentation();
+        role.setName("test_realm_role");
+        realm.admin().roles().create(role);
+        role = realm.admin().roles().get(role.getName()).toRepresentation();
+        realm.cleanup().add(r -> r.roles().deleteRole("test_realm_role"));
+
+        for (String username : List.of("user_x", "user_y", "user_z")) {
+            String userId = ApiUtil.getCreatedId(realm.admin().users().create(UserBuilder.create()
+                    .username(username)
+                    .password("password")
+                    .firstName("user")
+                    .lastName(username)
+                    .email(username + "@test")
+                    .build()));
+            realm.admin().users().get(userId).roles().realmLevel().add(List.of(role));
+            realm.cleanup().add(r -> r.users().delete(userId).close());
+        }
+
+        UserPolicyRepresentation policy = createUserPolicy(realm, adminPermissionsClient, "Myadmin user policy",
+                realm.admin().users().search("myadmin").get(0).getId());
+        Set<String> allowedUsers = Set.of("user_x", "user_y");
+        createPermission(adminPermissionsClient, allowedUsers, AdminPermissionsSchema.USERS.getType(),
+                Set.of(AdminPermissionsSchema.VIEW), policy);
+
+        String realmMgmtClientId = realm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+        RoleRepresentation viewRealmRole = realm.admin().clients().get(realmMgmtClientId)
+                .roles().get(AdminRoles.VIEW_REALM).toRepresentation();
+        String myadminId = realm.admin().users().search("myadmin").get(0).getId();
+        realm.admin().users().get(myadminId).roles().clientLevel(realmMgmtClientId).add(List.of(viewRealmRole));
+        realm.cleanup().add(r -> r.users().get(r.users().search("myadmin").get(0).getId())
+                .roles().clientLevel(realmMgmtClientId).remove(List.of(viewRealmRole)));
+
+        List<String> roleMembers = realmAdminClient.realm(realm.getName())
+                .roles().get(role.getName()).getUserMembers().stream()
+                .map(UserRepresentation::getUsername).toList();
+
+        assertThat(roleMembers, hasSize(allowedUsers.size()));
+        assertThat(roleMembers, hasItems(allowedUsers.toArray(new String[0])));
+    }
+
+    @Test
     public void testViewGroupMembersPolicyUsingAggregatedPolicy() {
         List<UserRepresentation> search = realmAdminClient.realm(realm.getName()).users().search(null, 0, 10);
         assertTrue(search.isEmpty());


### PR DESCRIPTION
Closes #51142

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
