### PR TITLE
Support lightweight access tokens for JWT Authorization Grant

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/UseLightweightAccessTokenExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/UseLightweightAccessTokenExecutor.java
@@ -44,6 +44,7 @@ public class UseLightweightAccessTokenExecutor implements ClientPolicyExecutorPr
             case SERVICE_ACCOUNT_TOKEN_REQUEST:
             case BACKCHANNEL_TOKEN_REQUEST:
             case DEVICE_TOKEN_REQUEST:
+            case JWT_AUTHORIZATION_GRANT:
                 session.setAttribute(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, true);
                 break;
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantLightweightAccessTokenClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantLightweightAccessTokenClientPoliciesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.oauth;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.services.clientpolicy.condition.GrantTypeConditionFactory;
+import org.keycloak.services.clientpolicy.executor.UseLightweightAccessTokenExecutorFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientPolicyBuilder;
+import org.keycloak.testframework.realm.ClientProfileBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest
+public class JWTAuthorizationGrantLightweightAccessTokenClientPoliciesTest extends BaseAbstractJWTAuthorizationGrantTest {
+
+    private static final String HEAVY_CLAIM = "heavy_claim";
+
+    @InjectRealm(config = JWTAuthorizationGrantRealmConfig.class)
+    protected ManagedRealm realm;
+
+    @Test
+    public void testUseLightweightAccessTokenExecutor() {
+        realm.updateClientWithCleanup("test-app", client -> client
+                .protocolMappers(ModelToRepresentation.toRepresentation(HardcodedClaim.create(
+                        HEAVY_CLAIM,
+                        HEAVY_CLAIM,
+                        "heavy-value",
+                        "String",
+                        true,
+                        false,
+                        false))));
+
+        String assertion = identityProvider.encodeToken(createDefaultAuthorizationGrantToken());
+        AccessTokenResponse response = oAuthClient.openid(false).jwtAuthorizationGrantRequest(assertion).send();
+        Assertions.assertTrue(response.isSuccess(), response.getErrorDescription());
+
+        AccessToken lightweightToken = oAuthClient.parseToken(response.getAccessToken(), AccessToken.class);
+        Assertions.assertEquals("test-app", lightweightToken.getIssuedFor());
+        Assertions.assertNull(lightweightToken.getPreferredUsername());
+        Assertions.assertFalse(lightweightToken.getOtherClaims().containsKey(HEAVY_CLAIM));
+    }
+
+    public static class JWTAuthorizationGrantRealmConfig extends OIDCIdentityProviderJWTAuthorizationGrantTest.JWTAuthorizationGrantRealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            super.configure(realm);
+
+            realm.clientProfile(ClientProfileBuilder.create()
+                    .name("lightweight-token-profile")
+                    .description("Use lightweight access tokens")
+                    .executor(UseLightweightAccessTokenExecutorFactory.PROVIDER_ID, null)
+                    .build());
+
+            realm.clientPolicy(ClientPolicyBuilder.create()
+                    .name("lightweight-token-policy")
+                    .description("Use lightweight access tokens for JWT Authorization Grant requests")
+                    .condition(GrantTypeConditionFactory.PROVIDER_ID, ClientPolicyBuilder.grantTypeConditionConfiguration(
+                            false, OAuth2Constants.JWT_AUTHORIZATION_GRANT))
+                    .profile("lightweight-token-profile")
+                    .build());
+
+            return realm;
+        }
+    }
+}


### PR DESCRIPTION
The lightweight access token client-policy executor does not currently handle `JWT_AUTHORIZATION_GRANT`. Consequently, a matching client policy invokes the executor, but the resulting access token is still minted as a regular token and retains protocol-mapped claims.

This change handles the JWT Authorization Grant event in the executor and adds an integration test verifying that a deliberately configured protocol-mapped claim is omitted from the resulting lightweight access token.

## Benefits

- Makes lightweight-token policies consistent across supported token-producing grant types.
- Allows clients to receive lightweight tokens through JWT Authorization Grant without enabling lightweight tokens globally for every client flow.
- Reduces token size and unnecessary claim propagation in identity-chaining and cross-domain authorization scenarios.

Related to #43971.

AI assistance was used to help implement and test this change. I have reviewed and understand the complete change and take responsibility for maintaining it.