### PR TITLE
Change SSSD scripts to use docker with remap instead of podman

### DIFF
--- a/.github/scripts/run-ipa.sh
+++ b/.github/scripts/run-ipa.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 
 set -o pipefail
-DOCKER=podman
+DOCKER=docker
 
-if [ -f "$HOME/ipa-data.tar" ]; then
-  echo "Using data from previous execution"
-  sudo tar xpf "$HOME/ipa-data.tar" -C "$HOME"
-else
-  mkdir "$HOME/ipa-data"
-fi
+# use userns-remap default to map users for systemd
+sudo bash -c 'cat << EOF > /etc/docker/daemon.json
+{ "userns-remap": "default" }
+EOF'
+sudo systemctl restart docker
+
+# chown file system to the mapper user 100000
+sudo chown -R 100000 "$HOME/.m2"
+sudo chown -R 100000 "$1"
 
 echo "Starting ipa-server container"
-container=$($DOCKER run --detach --rm -h ipa.example.test --sysctl net.ipv6.conf.all.disable_ipv6=0 --workdir /github/workspace -v "$HOME/ipa-data":"/data":Z -v "$1":"/github/workspace" -v "$HOME/.m2":"/root/.m2" freeipa/freeipa-server:rocky-9 ipa-server-install --unattended --realm=EXAMPLE.TEST --ds-password=password --admin-password=password --idstart=60000)
+container=$($DOCKER run --detach --rm -h ipa.example.test --sysctl net.ipv6.conf.all.disable_ipv6=0 --workdir /github/workspace -v "$1":"/github/workspace" -v "$HOME/.m2":"/root/.m2" freeipa/freeipa-server:rocky-9 ipa-server-install --unattended --realm=EXAMPLE.TEST --ds-password=password --admin-password=password --idstart=60000)
 
 echo "Container $container started, waiting ipa-server configuration"
 sleep 30
@@ -34,11 +37,6 @@ $DOCKER exec $container .github/scripts/run-ipa-tests.sh $new_install
 result=$?
 
 $DOCKER stop $container
-
-if [ $result -eq 0 ]; then
-  echo "Doing a backup of the ipa-data directory for caching"
-  sudo tar cpf "$HOME/ipa-data.tar" -C "$HOME" ipa-data
-fi
 
 echo "Tests executed with result: $result"
 exit $result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1075,18 +1075,6 @@ jobs:
         name: Integration test setup
         uses: ./.github/actions/integration-test-setup
 
-      - id: weekly-cache-key
-        name: Key for weekly rotation of cache
-        shell: bash
-        run: echo "key=ipa-data-`date -u "+%Y-%U"`" >> $GITHUB_OUTPUT
-
-      - id: cache-maven-repository
-        name: ipa-data cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/ipa-data.tar
-          key: ${{ steps.weekly-cache-key.outputs.key }}
-
       - name: Run tests
         run: .github/scripts/run-ipa.sh "${{ github.workspace }}"
 


### PR DESCRIPTION
Closes #51780

The podman command fails to start now the freeipa-server container. Probably related to https://github.com/freeipa/freeipa-container/issues/737 (but not sure). The container starts with docker and remap although we cannot cache the ipa data. As we don't execute SSSD tests much I think that is OK. At least we can test SSSD integration and the CI job passes.
