### PR TITLE
Migrate basic broker infrastructure to new testsuite

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/broker/AbstractBrokerLoginTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/AbstractBrokerLoginTest.java
@@ -1,0 +1,89 @@
+package org.keycloak.tests.broker;
+
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testsuite.util.AccountHelper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Protocol-agnostic broker login scenarios. Concrete OIDC/SAML tests get these {@code @Test} methods by
+ * extending a protocol-specific subclass that supplies the realms and broker configuration.
+ */
+public abstract class AbstractBrokerLoginTest extends AbstractBrokerTest {
+
+    @Test
+    public void testLogInAsUserInIDP() {
+        loginThroughIdpAndLogout();
+    }
+
+    // Shared brokered login + single-logout round-trip, used both as its own test and as the setup step for
+    // testLoginWithExistingUser(), so neither test invokes the other's @Test method as a subroutine.
+    protected void loginThroughIdpAndLogout() {
+        loginUser();
+        singleLogout();
+    }
+
+    protected void loginUser() {
+        logInAsUserInIDP();
+
+        updateAccountInformation();
+
+        ManagedRealm consumerRealm = getConsumerRealm();
+        UserRepresentation userRep = AccountHelper.getUserRepresentation(
+                consumerRealm.admin(), getUserLogin());
+        Assertions.assertNotNull(userRep, "There must be user " + getUserLogin() + " in consumer realm");
+        // The review-profile page filled in these names via the UI; assert they were actually persisted
+        // rather than overwriting them here, so a broken UI flow is caught instead of masked.
+        Assertions.assertEquals("Firstname", userRep.getFirstName(),
+                "First name should have been persisted by the review-profile page");
+        Assertions.assertEquals("Lastname", userRep.getLastName(),
+                "Last name should have been persisted by the review-profile page");
+
+        int userCount = consumerRealm.admin().users().count();
+        Assertions.assertTrue(userCount > 0, "There must be at least one user");
+
+        // userRep was fetched above via an exact username search, so assert its email directly instead of
+        // scanning the (paginated) users().list(), which could miss the user beyond the first page.
+        Assertions.assertEquals(getUserEmail(), userRep.getEmail(),
+                "There must be user " + getUserLogin() + " with the expected email in consumer realm");
+    }
+
+    protected void singleLogout() {
+        ManagedRealm consumerRealm = getConsumerRealm();
+        ManagedRealm providerRealm = getProviderRealm();
+
+        oauth.openLoginForm();
+        Assertions.assertTrue(oauth.parseLoginResponse().isSuccess(), "Should be logged in");
+
+        AccountHelper.logout(consumerRealm.admin(), getUserLogin());
+        AccountHelper.logout(providerRealm.admin(), getUserLogin());
+
+        oauth.openLoginForm();
+        loginPage.assertCurrent();
+    }
+
+    @Test
+    public void testLoginWithExistingUser() {
+        ManagedRealm consumerRealm = getConsumerRealm();
+
+        int userCountBefore = consumerRealm.admin().users().count();
+
+        loginThroughIdpAndLogout();
+
+        int userCount = consumerRealm.admin().users().count();
+        Assertions.assertEquals(userCountBefore + 1, userCount,
+                "First broker login should have created exactly one user in the consumer realm");
+
+        oauth.openLoginForm();
+
+        logInWithBroker();
+
+        loginPage.fillLogin(getUserLogin(), getUserPassword());
+        loginPage.submit();
+
+        Assertions.assertTrue(oauth.parseLoginResponse().isSuccess());
+        Assertions.assertEquals(userCount, consumerRealm.admin().users().count());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/AbstractBrokerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/AbstractBrokerTest.java
@@ -1,0 +1,162 @@
+package org.keycloak.tests.broker;
+
+import java.util.List;
+import java.util.Set;
+
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.FederatedIdentityRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.IdpReviewUserProfilePage;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.testsuite.util.AccountHelper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.openqa.selenium.TimeoutException;
+
+/**
+ * Protocol-agnostic base for the broker tests. Holds the injected clients/pages that are identical across
+ * every broker test and the shared login/first-broker-login helpers. The realms differ per test (each
+ * concrete test injects its own provider/consumer realm with a protocol-specific config), so they are left
+ * as abstract accessors; everything else is inherited directly as protected fields.
+ */
+public abstract class AbstractBrokerTest {
+
+    protected static final String PROVIDER_REALM = "provider";
+    protected static final String CONSUMER_REALM = "consumer";
+    protected static final String USER_LOGIN = "testuser";
+    protected static final String USER_EMAIL = "user@localhost.com";
+    protected static final String USER_PASSWORD = "password";
+    protected static final String CONSUMER_BROKER_APP_CLIENT_ID = "broker-app";
+    protected static final String CONSUMER_BROKER_APP_SECRET = "broker-app-secret";
+
+    // Drive the login flows against the migrated broker-app client (as the legacy suite did) rather than the
+    // framework default test-app; the supplier creates it in the consumer realm from BrokerAppClientConfig.
+    @InjectOAuthClient(realmRef = "consumer", config = BrokerAppClientConfig.class)
+    protected OAuthClient oauth;
+
+    @InjectWebDriver
+    protected ManagedWebDriver webDriver;
+
+    @InjectPage
+    protected LoginPage loginPage;
+
+    @InjectPage
+    protected IdpReviewUserProfilePage updateProfilePage;
+
+    protected abstract ManagedRealm getProviderRealm();
+
+    protected abstract ManagedRealm getConsumerRealm();
+
+    protected abstract String getIdpAlias();
+
+    // The provider user is created without a first/last name so the consumer's first-broker-login
+    // review-profile page appears. The new-testsuite provider realm enables the VERIFY_PROFILE required
+    // action by default, which would otherwise stop the incomplete user at the provider; disable it so
+    // the incomplete profile reaches the consumer (the legacy suite did not enable VERIFY_PROFILE).
+    @BeforeEach
+    void relaxProviderProfileVerification() {
+        for (RequiredActionProviderRepresentation action : getProviderRealm().admin().flows().getRequiredActions()) {
+            if (UserModel.RequiredAction.VERIFY_PROFILE.name().equals(action.getAlias())) {
+                action.setEnabled(false);
+                getProviderRealm().admin().flows().updateRequiredAction(action.getAlias(), action);
+            }
+        }
+    }
+
+    protected String getUserLogin() {
+        return USER_LOGIN;
+    }
+
+    protected String getUserPassword() {
+        return USER_PASSWORD;
+    }
+
+    protected String getUserEmail() {
+        return USER_EMAIL;
+    }
+
+    protected void logInWithBroker() {
+        loginPage.clickSocial(getIdpAlias());
+    }
+
+    protected void logInWithIdp() {
+        logInWithBroker();
+    }
+
+    protected void logInAsUserInIDP() {
+        oauth.openLoginForm();
+        logInWithBroker();
+        logInAsUserInIDPForFirstTime();
+    }
+
+    protected void logInAsUserInIDPForFirstTime() {
+        loginPage.fillLogin(getUserLogin(), getUserPassword());
+        loginPage.submit();
+    }
+
+    // Drives the consumer's first-broker-login review-profile page, which must appear the first time a
+    // user logs in through a broker because the imported user is missing its first and last name. Fails
+    // the test if the page does not show, mirroring the legacy assertCurrent() on the update-profile page.
+    protected void updateAccountInformation() {
+        Assertions.assertTrue(profilePageAppeared(),
+                "The first-broker-login review-profile page was expected but did not appear");
+        updateProfilePage.update("Firstname", "Lastname");
+    }
+
+    // Tolerant variant for flows that intentionally skip the review-profile page (e.g. when
+    // update-profile-on-first-login is turned off). Fills the page only if it actually appears.
+    protected void updateAccountInformationIfPresent() {
+        if (profilePageAppeared()) {
+            updateProfilePage.update("Firstname", "Lastname");
+        }
+    }
+
+    private boolean profilePageAppeared() {
+        Set<String> profilePageIds = Set.of("login-login-update-profile", "login-idp-review-user-profile");
+        try {
+            webDriver.waiting().until(d -> {
+                String currentPageId = webDriver.page().getCurrentPageId();
+                if (currentPageId != null && profilePageIds.contains(currentPageId)) {
+                    return true;
+                }
+                return null;
+            });
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    protected UserRepresentation createUser(String username, String email) {
+        ManagedRealm consumerRealm = getConsumerRealm();
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setEmailVerified(true);
+        user.setEnabled(true);
+        consumerRealm.admin().users().create(user).close();
+        return user;
+    }
+
+    // Mid-test helper used by singleLogout() to verify login state after logout.
+    protected void logoutFromConsumerRealm() {
+        AccountHelper.logout(getConsumerRealm().admin(), getUserLogin());
+    }
+
+    protected void assertNumFederatedIdentities(String username, int expected) {
+        ManagedRealm consumerRealm = getConsumerRealm();
+        List<UserRepresentation> users = consumerRealm.admin().users().search(username, true);
+        Assertions.assertEquals(1, users.size(), "Expected exactly one user with username " + username);
+        List<FederatedIdentityRepresentation> fedIdentities =
+                consumerRealm.admin().users().get(users.get(0).getId()).getFederatedIdentity();
+        Assertions.assertEquals(expected, fedIdentities.size());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/AbstractKcOidcBrokerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/AbstractKcOidcBrokerTest.java
@@ -1,0 +1,242 @@
+package org.keycloak.tests.broker;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.broker.oidc.KeycloakOIDCIdentityProviderFactory;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.AudienceProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.HardcodedClaim;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.protocol.oidc.mappers.UserAttributeMapper;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.IdentityProviderBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ProtocolMapperBuilder;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.keycloak.broker.oidc.OAuth2IdentityProviderConfig.TOKEN_ENDPOINT_URL;
+
+/**
+ * Shared broker configuration that mirrors the legacy {@code KcOidcBrokerConfiguration}: the consumer
+ * realm brokers to the provider through the Keycloak-specific {@code keycloak-oidc} identity provider.
+ * This is the default for the OIDC broker tests. Tests that need the generic {@code oidc} provider
+ * (as the legacy suite did in a couple of cases) can extend this with a generic-provider variant.
+ */
+public abstract class AbstractKcOidcBrokerTest extends AbstractBrokerLoginTest {
+
+    protected static final String IDP_OIDC_ALIAS = "kc-oidc-idp";
+    protected static final String IDP_OIDC_PROVIDER_ID = KeycloakOIDCIdentityProviderFactory.PROVIDER_ID;
+    protected static final String CLIENT_ID = "brokerapp";
+    protected static final String CLIENT_SECRET = "secret";
+    protected static final String ATTRIBUTE_TO_MAP_NAME = "user-attribute";
+    protected static final String ATTRIBUTE_TO_MAP_NAME_2 = "user-attribute-2";
+    protected static final String USER_INFO_CLAIM = "user-claim";
+    protected static final String HARDCODED_CLAIM = "test";
+    protected static final String HARDCODED_VALUE = "value";
+
+    // Default provider/consumer realms for the common case. Tests that need a different config shadow just
+    // the field they vary (same name/type, different @InjectRealm#config) - the framework resolves both the
+    // shadowed and inherited field to the same deployed realm, so no getter override is needed either way.
+    @InjectRealm(ref = "provider", lifecycle = LifeCycle.METHOD, config = OidcProviderRealmConfig.class)
+    protected ManagedRealm providerRealm;
+
+    @InjectRealm(ref = "consumer", lifecycle = LifeCycle.METHOD, config = OidcConsumerRealmConfig.class)
+    protected ManagedRealm consumerRealm;
+
+    @Override
+    protected ManagedRealm getProviderRealm() {
+        return providerRealm;
+    }
+
+    @Override
+    protected ManagedRealm getConsumerRealm() {
+        return consumerRealm;
+    }
+
+    @Override
+    protected String getIdpAlias() {
+        return IDP_OIDC_ALIAS;
+    }
+
+    @BeforeEach
+    void configureBrokerEndpoints() {
+        String providerBaseUrl = getProviderRealm().getBaseUrl();
+        IdentityProviderRepresentation idp = getConsumerRealm().admin()
+                .identityProviders().get(getIdpAlias()).toRepresentation();
+        Map<String, String> config = idp.getConfig();
+        config.put(OIDCIdentityProviderConfig.ISSUER, providerBaseUrl);
+        config.put("authorizationUrl", providerBaseUrl + "/protocol/openid-connect/auth");
+        config.put(TOKEN_ENDPOINT_URL, providerBaseUrl + "/protocol/openid-connect/token");
+        config.put("logoutUrl", providerBaseUrl + "/protocol/openid-connect/logout");
+        config.put("userInfoUrl", providerBaseUrl + "/protocol/openid-connect/userinfo");
+        config.put(OIDCIdentityProviderConfig.JWKS_URL, providerBaseUrl + "/protocol/openid-connect/certs");
+        config.put(OIDCIdentityProviderConfig.USE_JWKS_URL, "true");
+        config.put(OIDCIdentityProviderConfig.VALIDATE_SIGNATURE, "true");
+        getConsumerRealm().admin().identityProviders().get(getIdpAlias()).update(idp);
+
+        // Provider-side client (brokerapp) represents the consumer: its broker callback endpoints
+        // (redirect/admin/backchannel-logout) must point at the consumer's actual base URL, mirroring the
+        // legacy KcOidcBrokerConfiguration and the SAML base's configureSamlBrokerEndpoints().
+        String consumerBaseUrl = getConsumerRealm().getBaseUrl();
+        String consumerBrokerEndpoint = consumerBaseUrl + "/broker/" + IDP_OIDC_ALIAS + "/endpoint";
+        ClientsResource providerClients = getProviderRealm().admin().clients();
+        List<ClientRepresentation> found = providerClients.findByClientId(CLIENT_ID);
+        if (!found.isEmpty()) {
+            ClientRepresentation client = found.get(0);
+            client.setRedirectUris(List.of(consumerBrokerEndpoint + "/*"));
+            client.setAdminUrl(consumerBrokerEndpoint);
+            Map<String, String> attributes = client.getAttributes();
+            if (attributes == null) {
+                attributes = new HashMap<>();
+                client.setAttributes(attributes);
+            }
+            attributes.put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL,
+                    consumerBaseUrl + "/protocol/openid-connect/logout/backchannel-logout");
+            providerClients.get(client.getId()).update(client);
+        }
+    }
+
+    static IdentityProviderBuilder createOidcIdentityProvider() {
+        return IdentityProviderBuilder.create()
+                .providerId(IDP_OIDC_PROVIDER_ID)
+                .alias(IDP_OIDC_ALIAS)
+                .displayName("kc-oidc-idp")
+                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+                .attribute("clientId", CLIENT_ID)
+                .attribute("clientSecret", CLIENT_SECRET)
+                .attribute("prompt", "login")
+                .attribute("loginHint", "true")
+                .attribute("backchannelSupported", "true")
+                .attribute("defaultScope", "email profile");
+    }
+
+    static RealmBuilder configureConsumerRealm(RealmBuilder realm, IdentityProviderBuilder idpBuilder) {
+        // The broker-app client is created by the injected OAuthClient (see BrokerAppClientConfig), so it is
+        // not declared here.
+        return realm.name(CONSUMER_REALM)
+                .eventsListeners("jboss-logging")
+                .resetPasswordAllowed(true)
+                .identityProviders(idpBuilder.build());
+    }
+
+    static class OidcProviderRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm.name(PROVIDER_REALM)
+                    .eventsListeners("jboss-logging")
+                    // The provider user has no first/last name on purpose: the imported consumer user is
+                    // then incomplete, so the consumer's first-broker-login review-profile page appears
+                    // (mirroring the legacy suite, which also created the provider user without those names).
+                    .users(UserBuilder.create(USER_LOGIN)
+                            .email(USER_EMAIL)
+                            .emailVerified(true)
+                            .password(USER_PASSWORD)
+                            .enabled(true))
+                    // The broker callback endpoints (redirect/admin/backchannel-logout) are seeded here with
+                    // a placeholder host/port; configureBrokerEndpoints() rewrites them to the consumer
+                    // realm's actual base URL once it is known. post.logout.redirect.uris="+" needs no rewrite.
+                    .clients(ClientBuilder.create(CLIENT_ID)
+                            .secret(CLIENT_SECRET)
+                            .redirectUris("http://localhost:8080/broker/" + IDP_OIDC_ALIAS + "/endpoint/*")
+                            .adminUrl("http://localhost:8080/broker/" + IDP_OIDC_ALIAS + "/endpoint")
+                            .attribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL,
+                                    "http://localhost:8080/protocol/openid-connect/logout/backchannel-logout")
+                            .attribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, "+")
+                            .protocolMappers(
+                                    ProtocolMapperBuilder.create().name("email")
+                                            .protocolMapper(UserAttributeMapper.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "email")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, "true")
+                                            .config(OIDCAttributeMapperHelper.JSON_TYPE, "String")
+                                            .config("user.attribute", "email")
+                                            .build(),
+                                    ProtocolMapperBuilder.create().name("nested.email")
+                                            .protocolMapper(UserAttributeMapper.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "nested.email")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, "true")
+                                            .config(OIDCAttributeMapperHelper.JSON_TYPE, "String")
+                                            .config("user.attribute", "nested.email")
+                                            .build(),
+                                    ProtocolMapperBuilder.create().name("dotted.email")
+                                            .protocolMapper(UserAttributeMapper.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "dotted\\.email")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, "true")
+                                            .config(OIDCAttributeMapperHelper.JSON_TYPE, "String")
+                                            .config("user.attribute", "dotted.email")
+                                            .build(),
+                                    ProtocolMapperBuilder.create().name(ATTRIBUTE_TO_MAP_NAME)
+                                            .protocolMapper(UserAttributeMapper.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, ATTRIBUTE_TO_MAP_NAME)
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, "true")
+                                            .config(OIDCAttributeMapperHelper.JSON_TYPE, "String")
+                                            .config("user.attribute", ATTRIBUTE_TO_MAP_NAME)
+                                            .config(ProtocolMapperUtils.MULTIVALUED, "true")
+                                            .build(),
+                                    ProtocolMapperBuilder.create().name(ATTRIBUTE_TO_MAP_NAME_2)
+                                            .protocolMapper(UserAttributeMapper.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, ATTRIBUTE_TO_MAP_NAME_2)
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_USERINFO, "true")
+                                            .config(OIDCAttributeMapperHelper.JSON_TYPE, "String")
+                                            .config("user.attribute", ATTRIBUTE_TO_MAP_NAME_2)
+                                            .config(ProtocolMapperUtils.MULTIVALUED, "true")
+                                            .build(),
+                                    // Legacy KcOidcBrokerConfiguration's "json-mapper": a hardcoded claim whose
+                                    // value is a JSON object ({"test":"value"}) exposed under the "user-claim"
+                                    // claim, included only in the ID token. Broker mapper tests rely on this
+                                    // exact shape, so mirror it rather than a scalar hardcoded string.
+                                    ProtocolMapperBuilder.create().name("json-mapper")
+                                            .protocolMapper(HardcodedClaim.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, USER_INFO_CLAIM)
+                                            .config(OIDCAttributeMapperHelper.JSON_TYPE, "JSON")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(HardcodedClaim.CLAIM_VALUE,
+                                                    "{\"" + HARDCODED_CLAIM + "\": \"" + HARDCODED_VALUE + "\"}")
+                                            .build(),
+                                    ProtocolMapperBuilder.create().name("audience")
+                                            .protocolMapper(AudienceProtocolMapper.PROVIDER_ID)
+                                            .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                                            .config("included.custom.audience", CLIENT_ID)
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true")
+                                            .config(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true")
+                                            .build()));
+        }
+    }
+
+    static class OidcConsumerRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return configureConsumerRealm(realm, createOidcIdentityProvider());
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/AbstractKcSamlBrokerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/AbstractKcSamlBrokerTest.java
@@ -1,0 +1,270 @@
+package org.keycloak.tests.broker;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.admin.client.resource.IdentityProviderResource;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.SamlProtocol;
+import org.keycloak.protocol.saml.mappers.AttributeStatementHelper;
+import org.keycloak.protocol.saml.mappers.UserAttributeStatementMapper;
+import org.keycloak.protocol.saml.mappers.UserPropertyAttributeStatementMapper;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.IdentityProviderBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.ARTIFACT_BINDING_RESPONSE;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.ARTIFACT_RESOLUTION_SERVICE_URL;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.BACKCHANNEL_SUPPORTED;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.FORCE_AUTHN;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.NAME_ID_POLICY_FORMAT;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.POST_BINDING_AUTHN_REQUEST;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.POST_BINDING_RESPONSE;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.SINGLE_LOGOUT_SERVICE_URL;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.SINGLE_SIGN_ON_SERVICE_URL;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.VALIDATE_SIGNATURE;
+import static org.keycloak.broker.saml.SAMLIdentityProviderConfig.WANT_AUTHN_REQUESTS_SIGNED;
+import static org.keycloak.protocol.saml.SamlProtocol.SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE;
+import static org.keycloak.protocol.saml.SamlProtocol.SAML_IDP_INITIATED_SSO_URL_NAME;
+
+public abstract class AbstractKcSamlBrokerTest extends AbstractBrokerLoginTest {
+
+    protected static final String IDP_SAML_ALIAS = "kc-saml-idp";
+    protected static final String IDP_SAML_PROVIDER_ID = "saml";
+    protected static final String SAML_CLIENT_ID_SALES_POST = "http://localhost:8080/sales-post/";
+    protected static final String ATTRIBUTE_TO_MAP_NAME = "user-attribute";
+    protected static final String ATTRIBUTE_TO_MAP_NAME_2 = "user-attribute-2";
+    protected static final String ATTRIBUTE_TO_MAP_FRIENDLY_NAME = "user-attribute-friendly";
+
+    // Placeholder SAML entity id for the provider-side client that represents the consumer realm. The
+    // realm is built before its runtime base URL is known, so this is created with a default host/port
+    // and then rewritten to the actual consumer base URL in configureSamlBrokerEndpoints().
+    protected static final String CONSUMER_SAML_ENTITY_ID = "http://localhost:8080/realms/" + CONSUMER_REALM;
+
+    // Default provider/consumer realms for the common case. Tests that need a different config shadow just
+    // the field they vary (same name/type, different @InjectRealm#config) - the framework resolves both the
+    // shadowed and inherited field to the same deployed realm, so no getter override is needed either way.
+    @InjectRealm(ref = "provider", lifecycle = LifeCycle.METHOD, config = SamlProviderRealmConfig.class)
+    protected ManagedRealm providerRealm;
+
+    @InjectRealm(ref = "consumer", lifecycle = LifeCycle.METHOD, config = SamlConsumerRealmConfig.class)
+    protected ManagedRealm consumerRealm;
+
+    @Override
+    protected ManagedRealm getProviderRealm() {
+        return providerRealm;
+    }
+
+    @Override
+    protected ManagedRealm getConsumerRealm() {
+        return consumerRealm;
+    }
+
+    @Override
+    protected String getIdpAlias() {
+        return IDP_SAML_ALIAS;
+    }
+
+    // Mirrors the OIDC config's configureBrokerEndpoints(): the SAML broker endpoints and the consumer's
+    // SAML entity id depend on the runtime realm base URLs, which are only available once the realms exist.
+    // Rewrite them here from ManagedRealm#getBaseUrl() instead of hard-coding localhost:8080, so the tests
+    // hold under non-default host/port/scheme (as the legacy suite did via getConsumerRoot()/getProviderRoot()).
+    @BeforeEach
+    void configureSamlBrokerEndpoints() {
+        String providerSamlEndpoint = getProviderRealm().getBaseUrl() + "/protocol/saml";
+        String consumerBaseUrl = getConsumerRealm().getBaseUrl();
+        String consumerBrokerEndpoint = consumerBaseUrl + "/broker/" + IDP_SAML_ALIAS + "/endpoint";
+        // ManagedRealm#getBaseUrl() is "<serverRoot>/realms/<realm>"; strip the realm suffix to get the
+        // server root that the consumer-side SP client URLs (sales-post) must point at.
+        String consumerServerRoot = consumerBaseUrl.substring(0, consumerBaseUrl.indexOf("/realms/"));
+
+        // Consumer IdP -> provider realm SAML endpoint.
+        IdentityProviderResource idpResource = getConsumerRealm().admin().identityProviders().get(getIdpAlias());
+        IdentityProviderRepresentation idp = idpResource.toRepresentation();
+        Map<String, String> idpConfig = idp.getConfig();
+        idpConfig.put(SINGLE_SIGN_ON_SERVICE_URL, providerSamlEndpoint);
+        idpConfig.put(ARTIFACT_RESOLUTION_SERVICE_URL, providerSamlEndpoint);
+        idpConfig.put(SINGLE_LOGOUT_SERVICE_URL, providerSamlEndpoint);
+        idpResource.update(idp);
+
+        // Provider-side client representing the consumer: its SAML entity id and broker endpoints must
+        // match the consumer's actual base URL.
+        ClientsResource providerClients = getProviderRealm().admin().clients();
+        List<ClientRepresentation> found = providerClients.findByClientId(CONSUMER_SAML_ENTITY_ID);
+        if (!found.isEmpty()) {
+            ClientRepresentation client = found.get(0);
+            client.setClientId(consumerBaseUrl);
+            client.setRedirectUris(List.of(consumerBrokerEndpoint));
+            Map<String, String> attributes = client.getAttributes();
+            if (attributes == null) {
+                attributes = new HashMap<>();
+                client.setAttributes(attributes);
+            }
+            attributes.put(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE, consumerBrokerEndpoint);
+            attributes.put(SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE, consumerBrokerEndpoint);
+            providerClients.get(client.getId()).update(client);
+        }
+
+        // Consumer-side SAML SP clients (sales-post): their baseUrl/redirectUris/ACS must point at the
+        // consumer server root, mirroring the legacy getConsumerRoot() wiring. The SP entity id (clientId)
+        // stays a fixed identifier, as in the legacy suite.
+        String salesPostBaseUrl = consumerServerRoot + "/sales-post";
+        ClientsResource consumerClients = getConsumerRealm().admin().clients();
+        for (String salesPostClientId : List.of(SAML_CLIENT_ID_SALES_POST, SAML_CLIENT_ID_SALES_POST + ".dot/ted")) {
+            List<ClientRepresentation> spFound = consumerClients.findByClientId(salesPostClientId);
+            if (spFound.isEmpty()) {
+                continue;
+            }
+            ClientRepresentation sp = spFound.get(0);
+            sp.setBaseUrl(salesPostBaseUrl);
+            sp.setRedirectUris(List.of(salesPostBaseUrl + "/*"));
+            Map<String, String> spAttributes = sp.getAttributes();
+            if (spAttributes != null && spAttributes.containsKey(SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE)) {
+                spAttributes.put(SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE, salesPostBaseUrl + "/saml");
+            }
+            consumerClients.get(sp.getId()).update(sp);
+        }
+    }
+
+    static ProtocolMapperRepresentation createSamlProtocolMapper(String name, String protocolMapper,
+            String userAttribute, String samlAttributeName, String nameFormat, String friendlyName) {
+        ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+        mapper.setName(name);
+        mapper.setProtocol(SamlProtocol.LOGIN_PROTOCOL);
+        mapper.setProtocolMapper(protocolMapper);
+        Map<String, String> config = mapper.getConfig();
+        config.put(ProtocolMapperUtils.USER_ATTRIBUTE, userAttribute);
+        config.put(AttributeStatementHelper.SAML_ATTRIBUTE_NAME, samlAttributeName);
+        config.put(AttributeStatementHelper.SAML_ATTRIBUTE_NAMEFORMAT, nameFormat);
+        if (friendlyName != null) {
+            config.put(AttributeStatementHelper.FRIENDLY_NAME, friendlyName);
+        }
+        return mapper;
+    }
+
+    static class SamlProviderRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            // Created with the placeholder entity id/endpoints; configureSamlBrokerEndpoints() rewrites
+            // them to the consumer realm's actual base URL once it is known.
+            String samlClientId = CONSUMER_SAML_ENTITY_ID;
+            String consumerBrokerEndpoint = CONSUMER_SAML_ENTITY_ID + "/broker/" + IDP_SAML_ALIAS + "/endpoint";
+
+            Map<String, String> clientAttributes = new HashMap<>();
+            clientAttributes.put(SamlConfigAttributes.SAML_AUTHNSTATEMENT, "true");
+            clientAttributes.put(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE, consumerBrokerEndpoint);
+            clientAttributes.put(SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE, consumerBrokerEndpoint);
+            clientAttributes.put(SamlConfigAttributes.SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "true");
+            clientAttributes.put(SamlConfigAttributes.SAML_NAME_ID_FORMAT_ATTRIBUTE, "username");
+            clientAttributes.put(SamlConfigAttributes.SAML_ASSERTION_SIGNATURE, "false");
+            clientAttributes.put(SamlConfigAttributes.SAML_SERVER_SIGNATURE, "false");
+            clientAttributes.put(SamlConfigAttributes.SAML_CLIENT_SIGNATURE_ATTRIBUTE, "false");
+            clientAttributes.put(SamlConfigAttributes.SAML_ENCRYPT, "false");
+
+            ClientBuilder samlClient = ClientBuilder.create(samlClientId)
+                    .enabled(true)
+                    .protocol(IDP_SAML_PROVIDER_ID)
+                    .redirectUris(consumerBrokerEndpoint)
+                    .protocolMappers(
+                            createSamlProtocolMapper("email", UserPropertyAttributeStatementMapper.PROVIDER_ID,
+                                    "email", "urn:oid:1.2.840.113549.1.9.1",
+                                    "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", "email"),
+                            createSamlProtocolMapper("email - dotted", UserAttributeStatementMapper.PROVIDER_ID,
+                                    "dotted.email", "dotted.email",
+                                    "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", null),
+                            createSamlProtocolMapper("email - nested", UserAttributeStatementMapper.PROVIDER_ID,
+                                    "nested.email", "nested.email",
+                                    "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", null),
+                            createSamlProtocolMapper("attribute - name", UserAttributeStatementMapper.PROVIDER_ID,
+                                    ATTRIBUTE_TO_MAP_NAME, ATTRIBUTE_TO_MAP_NAME,
+                                    AttributeStatementHelper.BASIC, ""),
+                            createSamlProtocolMapper("attribute - name 2", UserAttributeStatementMapper.PROVIDER_ID,
+                                    ATTRIBUTE_TO_MAP_NAME_2, ATTRIBUTE_TO_MAP_NAME_2,
+                                    AttributeStatementHelper.BASIC, ""),
+                            createSamlProtocolMapper("attribute - friendly name", UserAttributeStatementMapper.PROVIDER_ID,
+                                    ATTRIBUTE_TO_MAP_FRIENDLY_NAME, "urn:oid:1.2.3.4.5.6.7",
+                                    AttributeStatementHelper.BASIC, ATTRIBUTE_TO_MAP_FRIENDLY_NAME));
+
+            for (Map.Entry<String, String> attr : clientAttributes.entrySet()) {
+                samlClient.attribute(attr.getKey(), attr.getValue());
+            }
+
+            return realm.name(PROVIDER_REALM)
+                    .eventsListeners("jboss-logging")
+                    // No first/last name on the provider user: the imported consumer user stays incomplete
+                    // so the consumer's first-broker-login review-profile page appears, as in the legacy suite.
+                    .users(UserBuilder.create(USER_LOGIN)
+                            .email(USER_EMAIL)
+                            .emailVerified(true)
+                            .password(USER_PASSWORD)
+                            .enabled(true))
+                    .clients(samlClient);
+        }
+    }
+
+    static class SamlConsumerRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            IdentityProviderBuilder idpBuilder = IdentityProviderBuilder.create()
+                    .providerId(IDP_SAML_PROVIDER_ID)
+                    .alias(IDP_SAML_ALIAS)
+                    .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+                    .attribute(SINGLE_SIGN_ON_SERVICE_URL, "http://localhost:8080/realms/" + PROVIDER_REALM + "/protocol/saml")
+                    .attribute(ARTIFACT_RESOLUTION_SERVICE_URL, "http://localhost:8080/realms/" + PROVIDER_REALM + "/protocol/saml")
+                    .attribute(SINGLE_LOGOUT_SERVICE_URL, "http://localhost:8080/realms/" + PROVIDER_REALM + "/protocol/saml")
+                    .attribute(NAME_ID_POLICY_FORMAT, "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress")
+                    .attribute(FORCE_AUTHN, "false")
+                    .attribute(POST_BINDING_RESPONSE, "true")
+                    .attribute(POST_BINDING_AUTHN_REQUEST, "true")
+                    .attribute(VALIDATE_SIGNATURE, "false")
+                    .attribute(WANT_AUTHN_REQUESTS_SIGNED, "false")
+                    .attribute(BACKCHANNEL_SUPPORTED, "false")
+                    .attribute(ARTIFACT_BINDING_RESPONSE, "false")
+                    .trustEmail(true)
+                    .storeToken(true)
+                    .addReadTokenRoleOnCreate(true);
+
+            return realm.name(CONSUMER_REALM)
+                    .eventsListeners("jboss-logging")
+                    .resetPasswordAllowed(true)
+                    .identityProviders(idpBuilder.build())
+                    // The broker-app client used to drive the login flow is created by the injected
+                    // OAuthClient (see BrokerAppClientConfig), so only the SAML SP clients are declared here.
+                    // sales-post SP clients use placeholder host/port URLs; configureSamlBrokerEndpoints()
+                    // rewrites baseUrl/redirectUris/ACS to the consumer server root once it is known.
+                    .clients(
+                            ClientBuilder.create(SAML_CLIENT_ID_SALES_POST)
+                                    .enabled(true)
+                                    .fullScopeEnabled(true)
+                                    .protocol(SamlProtocol.LOGIN_PROTOCOL)
+                                    .baseUrl("http://localhost:8080/sales-post")
+                                    .redirectUris("http://localhost:8080/sales-post/*")
+                                    .attribute(SamlConfigAttributes.SAML_AUTHNSTATEMENT, SamlProtocol.ATTRIBUTE_TRUE_VALUE)
+                                    .attribute(SamlConfigAttributes.SAML_CLIENT_SIGNATURE_ATTRIBUTE, SamlProtocol.ATTRIBUTE_FALSE_VALUE),
+                            ClientBuilder.create(SAML_CLIENT_ID_SALES_POST + ".dot/ted")
+                                    .enabled(true)
+                                    .fullScopeEnabled(true)
+                                    .protocol(SamlProtocol.LOGIN_PROTOCOL)
+                                    .baseUrl("http://localhost:8080/sales-post")
+                                    .redirectUris("http://localhost:8080/sales-post/*")
+                                    .attribute(SamlConfigAttributes.SAML_AUTHNSTATEMENT, SamlProtocol.ATTRIBUTE_TRUE_VALUE)
+                                    .attribute(SamlConfigAttributes.SAML_CLIENT_SIGNATURE_ATTRIBUTE, SamlProtocol.ATTRIBUTE_FALSE_VALUE)
+                                    .attribute(SAML_IDP_INITIATED_SSO_URL_NAME, "sales-post")
+                                    .attribute(SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE, "http://localhost:8080/sales-post/saml"));
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/BrokerAppClientConfig.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/BrokerAppClientConfig.java
@@ -1,0 +1,21 @@
+package org.keycloak.tests.broker;
+
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+
+/**
+ * Configures the injected consumer {@code OAuthClient} as the migrated {@code broker-app} client
+ * (confidential, direct-access-grants enabled) that the legacy broker suite used to drive the login flows,
+ * instead of the framework default {@code test-app}. The redirect URI is supplied by the OAuthClient
+ * supplier, so it is not set here.
+ */
+public class BrokerAppClientConfig implements ClientConfig {
+
+    @Override
+    public ClientBuilder configure(ClientBuilder client) {
+        return client
+                .clientId(AbstractBrokerTest.CONSUMER_BROKER_APP_CLIENT_ID)
+                .secret(AbstractBrokerTest.CONSUMER_BROKER_APP_SECRET)
+                .directAccessGrantsEnabled();
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/KcOidcBrokerClientSecretBasicAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/KcOidcBrokerClientSecretBasicAuthTest.java
@@ -1,0 +1,26 @@
+package org.keycloak.tests.broker;
+
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+
+@KeycloakIntegrationTest
+public class KcOidcBrokerClientSecretBasicAuthTest extends AbstractKcOidcBrokerTest {
+
+    @InjectRealm(ref = "consumer", lifecycle = LifeCycle.METHOD,
+            config = ConsumerRealmWithBasicAuth.class)
+    ManagedRealm consumerRealm;
+
+    static class ConsumerRealmWithBasicAuth implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return configureConsumerRealm(realm,
+                    createOidcIdentityProvider()
+                            .attribute("clientAuthMethod", OIDCLoginProtocol.CLIENT_SECRET_BASIC));
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/KcOidcBrokerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/KcOidcBrokerTest.java
@@ -1,0 +1,7 @@
+package org.keycloak.tests.broker;
+
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+
+@KeycloakIntegrationTest
+public class KcOidcBrokerTest extends AbstractKcOidcBrokerTest {
+}

--- a/tests/base/src/test/java/org/keycloak/tests/broker/KcSamlBrokerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/KcSamlBrokerTest.java
@@ -1,0 +1,7 @@
+package org.keycloak.tests.broker;
+
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+
+@KeycloakIntegrationTest
+public class KcSamlBrokerTest extends AbstractKcSamlBrokerTest {
+}


### PR DESCRIPTION
This is the foundational PR of the broker test migration - moving the broker suite from the legacy Arquillian testsuite (`testsuite/integration-arquillian/.../broker`) to the new JUnit 5 framework under `tests/base/.../broker`.

### Scope
Kept deliberately small so the shared infrastructure can be reviewed on its own:

- The reusable support layer every later batch builds on: `AbstractBrokerTest`, `AbstractBrokerLoginTest`, and the protocol bases `AbstractKcOidcBrokerTest` / `AbstractKcSamlBrokerTest` (abstract-class hierarchy; concrete tests inherit the injected clients/pages and the `@Test` login logic). The protocol bases also inject the default provider/consumer realms, so a concrete test using the default config needs no fields or getters at all; a test that needs a different config for one or both realms shadows just the field(s) it varies (same name/type, different `@InjectRealm#config`) - the framework resolves the shadowed and inherited field to the same deployed realm, so no getter override is needed either way.
- Three basic login tests exercising that layer: `KcOidcBrokerTest`, `KcOidcBrokerClientSecretBasicAuthTest`, `KcSamlBrokerTest`.

The design uses abstract classes by default (the new framework injects into class fields, not interfaces, so this removes the getter boilerplate and matches the rest of `tests/base`); interfaces are kept only for cases that must mix two independent `@Test` axes (JWE variants, the token-store matrix). This is the pattern the rest of the migration follows, so that is the main thing to scrutinize.

Closes #51954
