### PR TITLE
Fix order in the clientsV2 tests sorting now is done by DB

### DIFF
--- a/js/libs/keycloak-admin-client/test/clientsV2.spec.ts
+++ b/js/libs/keycloak-admin-client/test/clientsV2.spec.ts
@@ -128,11 +128,7 @@ describe("Clients V2 API", () => {
     expect(sortedClients).to.be.ok;
     expect(sortedClients).to.be.an("array");
     const clientIds = sortedClients!.map((c) => c.clientId!);
-    expect(
-      [...clientIds].sort((a, b) =>
-        b.localeCompare(a, undefined, { sensitivity: "base" }),
-      ),
-    ).to.deep.equal(clientIds);
+    expect([...clientIds].sort().reverse()).to.deep.equal(clientIds);
 
     const sortedClient1 = sortedClients!.find((c) => c.clientId === clientId1);
     expect(sortedClient1).to.be.ok;


### PR DESCRIPTION
Closes #51853

Fixing the order in the test now that cloud team confirmed this is the expected order.
