### PR TITLE
Emit RISC account-purged SSF events on user deletion

### DIFF
--- a/docs/guides/securing-apps/ssf-support.adoc
+++ b/docs/guides/securing-apps/ssf-support.adoc
@@ -390,6 +390,10 @@ The {project_name} SSF Transmitter targets conformance with:
   deleted, either by an administrator or by the user themselves from the account console.
   Deletions that do not remove the account -- a partial import under the `OVERWRITE` policy,
   or the service-account user removed alongside its client -- do not emit it.
++
+NOTE: `account-purged` is currently emitted only for deletions performed through the admin
+API or the account console. Deletions performed by a workflow's delete-user step, or by
+removing an organization that owns managed members, do not yet emit it.
 * Legacy SSE CAEP profile for Apple Business Manager interop (gated behind the `sse-caep-enabled` SPI flag).
 
 </@tmpl.guide>

--- a/docs/guides/securing-apps/ssf-support.adoc
+++ b/docs/guides/securing-apps/ssf-support.adoc
@@ -383,9 +383,13 @@ The {project_name} SSF Transmitter targets conformance with:
 * https://openid.net/specs/openid-caep-interoperability-profile-1_0.html[CAEP Interoperability Profile 1.0 (draft)]
   -- `session-revoked` and `credential-change` event types.
 * https://openid.net/specs/openid-risc-1_0-final.html[RISC 1.0 (Final)]
-  -- `account-disabled` and `account-enabled` event types. Emitted when an admin toggles a
-  user's enabled state, and when brute-force protection permanently locks an account out
-  (`reason=disabled-by-bruteforce`).
+  -- `account-disabled`, `account-enabled` and `account-purged` event types.
+  `account-disabled` / `account-enabled` are emitted when an admin toggles a user's enabled
+  state, and when brute-force protection permanently locks an account out
+  (`reason=disabled-by-bruteforce`). `account-purged` is emitted when a user account is
+  deleted, either by an administrator or by the user themselves from the account console.
+  Deletions that do not remove the account -- a partial import under the `OVERWRITE` policy,
+  or the service-account user removed alongside its client -- do not emit it.
 * Legacy SSE CAEP profile for Apple Business Manager interop (gated behind the `sse-caep-enabled` SPI flag).
 
 </@tmpl.guide>

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -511,11 +511,15 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
 
     @Override
     public boolean removeUser(RealmModel realm, UserModel user) {
+        // Published before any removal work, including the federated pre-removal
+        // below. That call deletes the user's federated attributes, so a listener
+        // running after it would observe a user that has already lost part of its
+        // state -- which the "pre removed" contract does not lead anyone to expect.
+        publishUserPreRemovedEvent(realm, user);
+
         if (getFederatedStorage() != null && user.getServiceAccountClientLink() == null) {
             getFederatedStorage().preRemove(realm, user);
         }
-
-        publishUserPreRemovedEvent(realm, user);
 
         StorageId storageId = new StorageId(user.getId());
 

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/DefaultSsfEventProviderFactory.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/DefaultSsfEventProviderFactory.java
@@ -14,6 +14,7 @@ import org.keycloak.ssf.event.caep.CaepCredentialChange;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
 import org.keycloak.ssf.event.risc.RiscAccountDisabled;
 import org.keycloak.ssf.event.risc.RiscAccountEnabled;
+import org.keycloak.ssf.event.risc.RiscAccountPurged;
 import org.keycloak.ssf.event.stream.SsfStreamUpdatedEvent;
 import org.keycloak.ssf.event.stream.SsfStreamVerificationEvent;
 
@@ -55,6 +56,7 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
         // RISC events
         events.put(RiscAccountDisabled.TYPE, RiscAccountDisabled::new);
         events.put(RiscAccountEnabled.TYPE, RiscAccountEnabled::new);
+        events.put(RiscAccountPurged.TYPE, RiscAccountPurged::new);
 
         STANDARD_EVENT_FACTORIES = Map.copyOf(events);
     }
@@ -70,9 +72,9 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
      * use-cases enumerated by the OpenID CAEP Interoperability Profile 1.0.
      * The profile is opt-in per use-case ("Implementations MAY choose to
      * support one or more …"), so supporting any one of them is enough to
-     * count as interoperable. {@code account-disabled} and
-     * {@code account-enabled} are RISC 1.0 events, not part of that CAEP
-     * profile, added alongside it.
+     * count as interoperable. {@code account-disabled},
+     * {@code account-enabled} and {@code account-purged} are RISC 1.0
+     * events, not part of that CAEP profile, added alongside it.
      *
      * @see <a href="https://openid.github.io/sharedsignals/openid-caep-interoperability-profile-1_0.html">OpenID CAEP Interoperability Profile 1.0</a>
      * @see <a href="https://openid.net/specs/openid-risc-1_0-final.html">OpenID RISC 1.0 (Final)</a>
@@ -81,7 +83,8 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
             CaepCredentialChange.TYPE,
             CaepSessionRevoked.TYPE,
             RiscAccountDisabled.TYPE,
-            RiscAccountEnabled.TYPE);
+            RiscAccountEnabled.TYPE,
+            RiscAccountPurged.TYPE);
 
     /**
      * Subset of {@link #EMITTABLE_EVENT_TYPES} that {@code SecurityEventTokenMapper}
@@ -92,7 +95,8 @@ public class DefaultSsfEventProviderFactory implements SsfEventProviderFactory, 
             CaepCredentialChange.TYPE,
             CaepSessionRevoked.TYPE,
             RiscAccountDisabled.TYPE,
-            RiscAccountEnabled.TYPE);
+            RiscAccountEnabled.TYPE,
+            RiscAccountPurged.TYPE);
 
     private volatile SsfEventRegistry registry;
 

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountPurged.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountPurged.java
@@ -1,0 +1,74 @@
+package org.keycloak.ssf.event.risc;
+
+import java.util.Map;
+
+import org.keycloak.ssf.event.InitiatingEntity;
+import org.keycloak.ssf.event.InitiatingEntityAware;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The Account Purged event indicates that an account has been permanently deleted.
+ *
+ * <p>Unlike {@link RiscAccountDisabled}, RISC defines no {@code reason} claim for this
+ * event — a purge is terminal and carries no rationale enumeration.
+ *
+ * <p>Receivers use this to drive their own data-retention cleanup, so it is emitted only
+ * for a genuine purge. Keycloak has several code paths that delete a user row without the
+ * account ceasing to exist — most notably a partial import under the OVERWRITE policy,
+ * which deletes and immediately recreates the user — and those deliberately do not emit.
+ *
+ * See: https://openid.net/specs/openid-risc-1_0-final.html
+ */
+public class RiscAccountPurged extends RiscEvent implements InitiatingEntityAware {
+
+    public static final String TYPE = "https://schemas.openid.net/secevent/risc/event-type/account-purged";
+
+    /**
+     * The time of the event (UNIX timestamp). RISC 1.0 lists no attributes for
+     * account-purged, so this is a CAEP-defined claim carried as an extension —
+     * declared here rather than on {@link RiscEvent} because RISC does not define
+     * it profile-wide. Nullable so an absent timestamp is omitted from the wire
+     * JSON rather than serialized as {@code "event_timestamp": 0}.
+     */
+    @JsonProperty("event_timestamp")
+    protected Long eventTimestamp;
+
+    /**
+     * The entity that initiated the deletion — {@link InitiatingEntity#ADMIN} for a
+     * deletion through the admin API, {@link InitiatingEntity#USER} for self-service
+     * deletion from the account console. Unlike account-disabled, there is no policy
+     * -driven trigger to account for: Keycloak never purges an account on its own.
+     */
+    @JsonProperty("initiating_entity")
+    protected InitiatingEntity initiatingEntity;
+
+    public RiscAccountPurged() {
+        super(TYPE);
+    }
+
+    public Long getEventTimestamp() {
+        return eventTimestamp;
+    }
+
+    public void setEventTimestamp(long eventTimestamp) {
+        this.eventTimestamp = eventTimestamp;
+    }
+
+    @Override
+    public InitiatingEntity getInitiatingEntity() {
+        return initiatingEntity;
+    }
+
+    @Override
+    public void setInitiatingEntity(InitiatingEntity initiatingEntity) {
+        this.initiatingEntity = initiatingEntity;
+    }
+
+    @Override
+    protected void appendFields(Map<String, Object> fields) {
+        super.appendFields(fields);
+        fields.put("eventTimestamp", eventTimestamp);
+        fields.put("initiatingEntity", initiatingEntity);
+    }
+}

--- a/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountPurged.java
+++ b/ssf/core/src/main/java/org/keycloak/ssf/event/risc/RiscAccountPurged.java
@@ -18,6 +18,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * account ceasing to exist — most notably a partial import under the OVERWRITE policy,
  * which deletes and immediately recreates the user — and those deliberately do not emit.
  *
+ * <p><b>Known gap.</b> Emission is driven by the admin / user event that follows a
+ * deletion, so deletion paths that fire neither produce no event. The significant one is
+ * the workflow delete step ({@code DeleteUserStepProvider}): the workflow engine raises no
+ * Keycloak events at all, so scheduled data-retention deletions are currently silent —
+ * exactly the case receivers would most expect to hear about. Deleting an organization's
+ * managed members is silent for the same reason. Both are tracked separately from the
+ * initial account-purged support.
+ *
  * See: https://openid.net/specs/openid-risc-1_0-final.html
  */
 public class RiscAccountPurged extends RiscEvent implements InitiatingEntityAware {

--- a/ssf/core/src/test/java/org/keycloak/ssf/event/risc/RiscAccountEventsTest.java
+++ b/ssf/core/src/test/java/org/keycloak/ssf/event/risc/RiscAccountEventsTest.java
@@ -50,8 +50,30 @@ class RiscAccountEventsTest {
     }
 
     @Test
+    void accountPurged_serializesTimestampAndInitiatingEntity() throws Exception {
+        RiscAccountPurged event = new RiscAccountPurged();
+        event.setEventTimestamp(1712345678L);
+        event.setInitiatingEntity(InitiatingEntity.USER);
+
+        JsonNode json = JsonSerialization.mapper.valueToTree(event);
+
+        assertEquals(1712345678L, json.path("event_timestamp").asLong());
+        assertEquals("user", json.path("initiating_entity").asText());
+        // RISC defines no reason for a purge; the claim must not leak in from
+        // the sibling account-disabled shape this class was modelled on.
+        assertTrue(json.path("reason").isMissingNode(),
+                "account-purged must not carry a reason claim: " + json);
+    }
+
+    @Test
     void unsetClaims_areOmittedFromWireJson() throws Exception {
         JsonNode disabled = JsonSerialization.mapper.valueToTree(new RiscAccountDisabled());
+        JsonNode purged = JsonSerialization.mapper.valueToTree(new RiscAccountPurged());
+
+        assertTrue(purged.path("event_timestamp").isMissingNode(),
+                "unset event_timestamp must be omitted, not serialized as 0: " + purged);
+        assertTrue(purged.path("initiating_entity").isMissingNode(),
+                "unset initiating_entity must be omitted: " + purged);
 
         // @JsonInclude(NON_NULL) on SsfEvent must still apply to the claims now
         // declared on the concrete class — a primitive long would have emitted 0.

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
@@ -288,6 +288,26 @@ public class SsfTransmitterAccountPurgedEventTests {
                 "delivered purge should be for the org-notified user");
     }
 
+    @Test
+    public void orgExcludedUser_purgeSuppressed() throws Exception {
+        // The exclusion leg of the org branch, under default_subjects=ALL where the
+        // user would otherwise be delivered. Proves the snapshot's captured aliases
+        // resolve back to live organizations and are evaluated by the same
+        // SsfSubjectInclusionResolver the live path uses -- an extension overriding
+        // that resolver must get the same verdict for purges as for every other event.
+        String orgAlias = createOrgExcluded();
+        setReceiverAttributes(Map.of(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "ALL"));
+
+        String userId = createUser("purge-org-excluded", "purge-org-excluded@" + orgAlias + ".local.test");
+        addUserToOrg(orgAlias, userId);
+
+        deleteUser(userId);
+
+        Assertions.assertNull(pushes.poll(NO_PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "a user excluded via their organization must not have their purge delivered, "
+                        + "even under default_subjects=ALL");
+    }
+
     // --- deletions that are not purges --------------------------------------
 
     @Test
@@ -377,13 +397,22 @@ public class SsfTransmitterAccountPurgedEventTests {
      * {@code ssf.notify.<RECEIVER>=true}, and returns its alias.
      */
     protected String createOrg(boolean notify) {
+        return createOrg(notify ? "true" : null);
+    }
+
+    /** Creates an organization carrying {@code ssf.notify.<RECEIVER>=false}. */
+    protected String createOrgExcluded() {
+        return createOrg("false");
+    }
+
+    protected String createOrg(String notifyValue) {
         String orgAlias = "purge-org-" + System.nanoTime();
         OrganizationRepresentation rep = new OrganizationRepresentation();
         rep.setName(orgAlias);
         rep.setAlias(orgAlias);
         rep.addDomain(new OrganizationDomainRepresentation(orgAlias + ".local.test"));
-        if (notify) {
-            rep.singleAttribute("ssf.notify." + RECEIVER, "true");
+        if (notifyValue != null) {
+            rep.singleAttribute("ssf.notify." + RECEIVER, notifyValue);
         }
         try (Response response = realm.admin().organizations().create(rep)) {
             Assertions.assertEquals(201, response.getStatus(),

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
@@ -1,0 +1,597 @@
+package org.keycloak.tests.ssf.transmitter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.common.Profile;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.partialimport.PartialImportResults;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.ssf.Ssf;
+import org.keycloak.ssf.event.risc.RiscAccountPurged;
+import org.keycloak.ssf.subject.EmailSubjectId;
+import org.keycloak.ssf.subject.IssuerSubjectId;
+import org.keycloak.ssf.subject.SubjectResolver;
+import org.keycloak.ssf.transmitter.DefaultSsfTransmitterProviderFactory;
+import org.keycloak.ssf.transmitter.SsfScopes;
+import org.keycloak.ssf.transmitter.SsfTransmitterConfig;
+import org.keycloak.ssf.transmitter.event.SsfUserSubjectFormats;
+import org.keycloak.ssf.transmitter.stream.StreamConfig;
+import org.keycloak.ssf.transmitter.stream.StreamDeliveryConfig;
+import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
+import org.keycloak.ssf.transmitter.support.SsfTransmitterUrls;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectHttpServer;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.server.DefaultKeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.testframework.util.HttpServerUtil;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the RISC {@code account-purged} event.
+ *
+ * <p>These cover ground the mapper unit tests structurally cannot. Every purge
+ * happens <em>after</em> Keycloak has already deleted the user row, so the SET's
+ * subject can only come from the {@code PurgedUserSnapshot} captured on
+ * {@code UserModel.UserPreRemovedEvent}. The unit tests construct the mapper with a
+ * {@code null} session and so never exercise the capture hook, the listener's
+ * snapshot fallback, or the dispatch-time subject gate — the three places where a
+ * regression would silently stop purge events reaching receivers.
+ *
+ * <p>The negative cases matter as much as the positive ones: Keycloak has several
+ * paths that delete a user row without an account ceasing to exist, and they are kept
+ * out of the purge branch by the admin event's operation type and resource type rather
+ * than by anything deliberate. Those are pinned here so a future widening of the path
+ * matching cannot start emitting spurious GDPR-relevant signals unnoticed.
+ */
+@KeycloakIntegrationTest(config = SsfTransmitterAccountPurgedEventTests.AccountPurgedServerConfig.class)
+public class SsfTransmitterAccountPurgedEventTests {
+
+    static final String RECEIVER = "ssf-receiver-account-purged";
+    static final String RECEIVER_SECRET = "receiver-account-purged-secret";
+
+    static final String PUSH_CONTEXT_PATH = "/ssf/push-account-purged";
+    static final String MOCK_PUSH_ENDPOINT = "http://127.0.0.1:8500" + PUSH_CONTEXT_PATH;
+    static final String PUSH_AUTH_HEADER = "Bearer dummy-account-purged-receiver";
+
+    static final long PUSH_WAIT_SECONDS = 5;
+    static final long NO_PUSH_WAIT_SECONDS = 3;
+
+    @InjectRealm(config = AccountPurgedRealm.class)
+    ManagedRealm realm;
+
+    @InjectSimpleHttp
+    SimpleHttp http;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectHttpServer
+    HttpServer mockReceiverServer;
+
+    private final BlockingQueue<String> pushes = new LinkedBlockingQueue<>();
+
+    @BeforeEach
+    public void setup() throws IOException {
+        pushes.clear();
+
+        mockReceiverServer.createContext(PUSH_CONTEXT_PATH, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                try (InputStream is = exchange.getRequestBody()) {
+                    pushes.add(new String(is.readAllBytes(), StandardCharsets.UTF_8));
+                }
+                HttpServerUtil.sendResponse(exchange, 202, Map.of());
+            }
+        });
+
+        assignOptionalClientScopes(RECEIVER, SsfScopes.SCOPE_SSF_READ, SsfScopes.SCOPE_SSF_MANAGE);
+
+        // Tests in this class deliberately vary the receiver's subject format and
+        // default_subjects policy, so reset both to the class defaults rather than
+        // inheriting whatever the previous test left behind.
+        setReceiverAttributes(Map.of(
+                ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "ALL",
+                ClientStreamStore.SSF_STREAM_USER_SUBJECT_FORMAT_KEY, IssuerSubjectId.TYPE));
+
+        createPushStream(Set.of(RiscAccountPurged.TYPE));
+    }
+
+    @AfterEach
+    public void cleanup() {
+        bestEffortDeleteStream();
+        // Organizations created by the +tenant / org-notify tests would otherwise
+        // leak into later tests and change their subject-gate verdicts.
+        bestEffortDeleteAllOrganizations();
+        try {
+            mockReceiverServer.removeContext(PUSH_CONTEXT_PATH);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    // --- the purge itself ---------------------------------------------------
+
+    @Test
+    public void adminDeletesUser_deliversAccountPurgedEvent() throws Exception {
+        String userId = createUser("purge-basic", "purge-basic@local.test");
+
+        deleteUser(userId);
+
+        JsonNode set = decodeSet(awaitPush("an admin user deletion must auto-emit RiscAccountPurged"));
+
+        Assertions.assertTrue(set.path("events").has(RiscAccountPurged.TYPE),
+                "delivered SET should carry the account-purged event type");
+        Assertions.assertEquals("admin",
+                set.path("events").path(RiscAccountPurged.TYPE).path("initiating_entity").asText(),
+                "a deletion through the admin REST API must report initiating_entity=admin");
+
+        // The decisive assertion: the user row was gone before the admin event fired,
+        // so a correct subject here can only have come from the pre-removal snapshot.
+        Assertions.assertEquals(IssuerSubjectId.TYPE, set.path("sub_id").path("format").asText(),
+                "default user subject format is iss_sub");
+        Assertions.assertEquals(userId, set.path("sub_id").path("sub").asText(),
+                "sub_id.sub must identify the user that was purged");
+    }
+
+    @Test
+    public void emailSubjectFormat_purgedSubjectCarriesEmail() throws Exception {
+        // Exercises the snapshot fallback in SecurityEventTokenMapper.lookupUserEmail:
+        // for a purged user the live lookup always misses, so an email-format stream
+        // can only be served from the attributes copied before deletion.
+        setReceiverAttributes(Map.of(
+                ClientStreamStore.SSF_STREAM_USER_SUBJECT_FORMAT_KEY, EmailSubjectId.TYPE));
+
+        String email = "purge-email@local.test";
+        String userId = createUser("purge-email", email);
+
+        deleteUser(userId);
+
+        JsonNode set = decodeSet(awaitPush(
+                "an email-format stream must still receive a purge event for a deleted user"));
+
+        Assertions.assertEquals(EmailSubjectId.TYPE, set.path("sub_id").path("format").asText(),
+                "stream is configured for the email subject format");
+        Assertions.assertEquals(email, set.path("sub_id").path("email").asText(),
+                "the purged user's email must survive in the snapshot");
+    }
+
+    // --- subject gate -------------------------------------------------------
+
+    @Test
+    public void defaultSubjectsNone_notifiedUser_purgeDelivered() throws Exception {
+        // The highest-value case in this class. default_subjects=NONE is the
+        // transmitter default, and under it the dispatcher delivers only to subjects
+        // explicitly carrying ssf.notify.<clientId>=true. That attribute lives on the
+        // user, which no longer exists by the time the gate runs — so this passes only
+        // if the snapshot faithfully carried the user's attributes across the deletion.
+        setReceiverAttributes(Map.of(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "NONE"));
+
+        String userId = createUser("purge-notified", "purge-notified@local.test");
+        // Subscribe through the SSF admin endpoint rather than by setting the
+        // attribute on the user representation: ssf.notify.<clientId> is an
+        // unmanaged attribute, which User Profile silently drops on the admin
+        // user API by default. This is also the path an operator actually uses.
+        addSubject(userId);
+
+        deleteUser(userId);
+
+        JsonNode set = decodeSet(awaitPush(
+                "a subscribed user's purge must be delivered even under default_subjects=NONE"));
+        Assertions.assertEquals(userId, set.path("sub_id").path("sub").asText(),
+                "delivered purge should be for the subscribed user");
+    }
+
+    @Test
+    public void defaultSubjectsNone_unnotifiedUser_purgeSuppressed() throws Exception {
+        // Negative control for the test above: without it, that test would still pass
+        // if the subject gate were bypassed altogether for purge events.
+        setReceiverAttributes(Map.of(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "NONE"));
+
+        String userId = createUser("purge-unnotified", "purge-unnotified@local.test");
+
+        deleteUser(userId);
+
+        Assertions.assertNull(pushes.poll(NO_PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "under default_subjects=NONE an unsubscribed user's purge must be suppressed");
+    }
+
+    // --- organizations ------------------------------------------------------
+
+    @Test
+    public void tenantSubjectFormat_purgedSubjectCarriesOrgAlias() throws Exception {
+        // Organization membership is the one thing the snapshot genuinely cannot
+        // answer on demand: OrganizationProvider.getByMember is an id-keyed query,
+        // not an attribute read, so a detached user resolves to no organizations.
+        // The alias therefore has to be resolved eagerly at capture time and served
+        // back through buildTenantSubjectFromSnapshot.
+        String orgAlias = createOrg(false);
+        setReceiverAttributes(Map.of(
+                ClientStreamStore.SSF_STREAM_USER_SUBJECT_FORMAT_KEY,
+                SsfUserSubjectFormats.COMPLEX_ISS_SUB_PLUS_TENANT));
+
+        String userId = createUser("purge-tenant", "purge-tenant@" + orgAlias + ".local.test");
+        addUserToOrg(orgAlias, userId);
+
+        deleteUser(userId);
+
+        JsonNode set = decodeSet(awaitPush(
+                "a +tenant stream must still receive a purge event for a deleted org member"));
+
+        JsonNode subId = set.path("sub_id");
+        Assertions.assertEquals("complex", subId.path("format").asText(),
+                "the +tenant composition must produce a complex subject");
+        Assertions.assertEquals(userId, subId.path("user").path("sub").asText(),
+                "complex subject's user member identifies the purged user");
+        Assertions.assertEquals(SubjectResolver.ORG_URN_ALIAS_PREFIX + orgAlias,
+                subId.path("tenant").path("uri").asText(),
+                "the organization alias must survive the deletion via the snapshot, as an alias URN");
+    }
+
+    @Test
+    public void orgNotifiedUser_purgeDelivered() throws Exception {
+        // The org leg of the subject gate. The user carries no ssf.notify attribute
+        // of its own -- it qualifies only through its organization, a verdict the
+        // detached snapshot has to answer from attributes captured before deletion.
+        String orgAlias = createOrg(true);
+        setReceiverAttributes(Map.of(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "NONE"));
+
+        String userId = createUser("purge-org-notified", "purge-org-notified@" + orgAlias + ".local.test");
+        addUserToOrg(orgAlias, userId);
+
+        deleteUser(userId);
+
+        JsonNode set = decodeSet(awaitPush(
+                "a user notified via their organization must have their purge delivered "
+                        + "even under default_subjects=NONE"));
+        Assertions.assertEquals(userId, set.path("sub_id").path("sub").asText(),
+                "delivered purge should be for the org-notified user");
+    }
+
+    // --- deletions that are not purges --------------------------------------
+
+    @Test
+    public void partialImportOverwrite_noPurgeEvent() throws Exception {
+        // A partial import under the OVERWRITE policy really does delete the user row
+        // -- then recreates it in the same request. The account never ceased to exist,
+        // so emitting a purge would tell receivers to run data-retention cleanup for a
+        // live account. It is kept out only by the admin event's operation type being
+        // UPDATE rather than DELETE, which is one enum value away from the purge gate.
+        String username = "purge-overwrite";
+        createUser(username, "purge-overwrite@local.test");
+
+        UserRepresentation replacement = new UserRepresentation();
+        replacement.setUsername(username);
+        replacement.setEmail("purge-overwrite@local.test");
+        replacement.setEnabled(true);
+
+        PartialImportRepresentation partialImport = new PartialImportRepresentation();
+        // setIfResourceExists is the setter for the policy -- there is no setPolicy.
+        partialImport.setIfResourceExists(PartialImportRepresentation.Policy.OVERWRITE.name());
+        partialImport.setUsers(List.of(replacement));
+
+        try (Response response = realm.admin().partialImport(partialImport)) {
+            Assertions.assertEquals(200, response.getStatus(),
+                    "partial import should succeed in test setup");
+            PartialImportResults results = response.readEntity(PartialImportResults.class);
+            Assertions.assertEquals(1, results.getOverwritten(),
+                    "the existing user should have been overwritten, not added");
+        }
+
+        Assertions.assertNull(pushes.poll(NO_PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "an OVERWRITE partial import deletes and recreates the user -- "
+                        + "the account was never purged, so no SET may be emitted");
+    }
+
+    @Test
+    public void clientDeleteWithServiceAccount_noPurgeEvent() throws Exception {
+        // Deleting a client removes its service-account user, but reports the deletion
+        // as ResourceType.CLIENT at clients/{id}. Service accounts are not human
+        // subjects and must never produce a purge SET.
+        ClientRepresentation throwaway = ClientBuilder.create("purge-service-account-client")
+                .secret("throwaway-secret")
+                .serviceAccountsEnabled(true)
+                .publicClient(false)
+                .build();
+
+        String clientUuid;
+        try (Response response = realm.admin().clients().create(throwaway)) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    "throwaway client creation should succeed in test setup");
+            clientUuid = ApiUtil.getCreatedId(response);
+        }
+
+        realm.admin().clients().get(clientUuid).remove();
+
+        Assertions.assertNull(pushes.poll(NO_PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "removing a client deletes its service-account user, but that is not an "
+                        + "account purge and must not be emitted");
+    }
+
+    // --- triggers -----------------------------------------------------------
+
+    protected String createUser(String username, String email) {
+        return createUser(username, email, Map.of());
+    }
+
+    protected String createUser(String username, String email, Map<String, List<String>> attributes) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setFirstName("Purge");
+        user.setLastName("Tester");
+        user.setEnabled(true);
+        if (!attributes.isEmpty()) {
+            user.setAttributes(attributes);
+        }
+
+        try (Response response = realm.admin().users().create(user)) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    () -> "user creation should succeed in test setup for " + username);
+            return ApiUtil.getCreatedId(response);
+        }
+    }
+
+    /**
+     * Creates an organization, optionally carrying
+     * {@code ssf.notify.<RECEIVER>=true}, and returns its alias.
+     */
+    protected String createOrg(boolean notify) {
+        String orgAlias = "purge-org-" + System.nanoTime();
+        OrganizationRepresentation rep = new OrganizationRepresentation();
+        rep.setName(orgAlias);
+        rep.setAlias(orgAlias);
+        rep.addDomain(new OrganizationDomainRepresentation(orgAlias + ".local.test"));
+        if (notify) {
+            rep.singleAttribute("ssf.notify." + RECEIVER, "true");
+        }
+        try (Response response = realm.admin().organizations().create(rep)) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    "test organization creation should succeed");
+        }
+        return orgAlias;
+    }
+
+    protected void addUserToOrg(String orgAlias, String userId) {
+        String orgId = realm.admin().organizations().getAll().stream()
+                .filter(o -> orgAlias.equals(o.getAlias()))
+                .map(OrganizationRepresentation::getId)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected org with alias '" + orgAlias + "' to exist"));
+        realm.admin().organizations().get(orgId).members().addMember(userId).close();
+    }
+
+    protected void bestEffortDeleteAllOrganizations() {
+        try {
+            realm.admin().organizations().getAll().forEach(o ->
+                    realm.admin().organizations().get(o.getId()).delete().close());
+        } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Subscribes a user to the receiver's stream via
+     * {@code POST /admin/realms/{realm}/ssf/clients/{clientId}/subjects/add},
+     * which writes {@code ssf.notify.<clientId>=true} server-side.
+     */
+    protected void addSubject(String userId) throws IOException {
+        String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/subjects/add";
+        try (SimpleHttpResponse response = http.doPost(url)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of("type", "user-id", "value", userId))
+                .asResponse()) {
+            Assertions.assertEquals(200, response.getStatus(),
+                    () -> "subjects/add should succeed in test setup; body=" + safeBody(response));
+        }
+    }
+
+    protected void deleteUser(String userId) {
+        try (Response response = realm.admin().users().delete(userId)) {
+            Assertions.assertEquals(204, response.getStatus(),
+                    "user deletion should succeed");
+        }
+    }
+
+    // --- setup --------------------------------------------------------------
+
+    protected void setReceiverAttributes(Map<String, String> attributes) {
+        ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
+        ClientRepresentation rep = clientResource.toRepresentation();
+        rep.getAttributes().putAll(attributes);
+        clientResource.update(rep);
+    }
+
+    protected void createPushStream(Set<String> eventsRequested) throws IOException {
+        StreamDeliveryConfig delivery = new StreamDeliveryConfig();
+        delivery.setMethod(Ssf.DELIVERY_METHOD_PUSH_URI);
+        delivery.setEndpointUrl(MOCK_PUSH_ENDPOINT);
+        delivery.setAuthorizationHeader(PUSH_AUTH_HEADER);
+
+        StreamConfig streamConfig = new StreamConfig();
+        streamConfig.setDelivery(delivery);
+        streamConfig.setEventsRequested(eventsRequested);
+        streamConfig.setDescription("Account purged event integration test");
+
+        String token = obtainReceiverManageToken();
+        try (SimpleHttpResponse response = http.doPost(SsfTransmitterUrls.getStreamsEndpointUrl(realm.getBaseUrl()))
+                .json(streamConfig)
+                .auth(token)
+                .acceptJson()
+                .asResponse()) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    () -> "stream creation should succeed in test setup; body=" + safeBody(response));
+        }
+    }
+
+    protected String obtainReceiverManageToken() throws IOException {
+        String tokenUrl = realm.getBaseUrl() + "/protocol/openid-connect/token";
+        try (SimpleHttpResponse response = http.doPost(tokenUrl)
+                .authBasic(RECEIVER, RECEIVER_SECRET)
+                .param("grant_type", "client_credentials")
+                .param("scope", SsfScopes.SCOPE_SSF_MANAGE + " " + SsfScopes.SCOPE_SSF_READ)
+                .asResponse()) {
+            Assertions.assertEquals(200, response.getStatus(),
+                    "client_credentials grant should succeed for the receiver");
+            return response.asJson().get("access_token").asText();
+        }
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    protected String awaitPush(String message) throws InterruptedException {
+        String push = pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS);
+        Assertions.assertNotNull(push, message);
+        return push;
+    }
+
+    protected JsonNode decodeSet(String encoded) throws Exception {
+        JWSInput jws = new JWSInput(encoded);
+        return JsonSerialization.readValue(jws.getContent(), JsonNode.class);
+    }
+
+    protected void assignOptionalClientScopes(String clientId, String... scopeNames) {
+        ClientRepresentation client = findClientByClientId(clientId);
+        Assertions.assertNotNull(client, () -> "expected client '" + clientId + "' to exist");
+        ClientResource clientResource = realm.admin().clients().get(client.getId());
+
+        Set<String> alreadyAssigned = clientResource.getOptionalClientScopes().stream()
+                .map(ClientScopeRepresentation::getName)
+                .collect(Collectors.toSet());
+
+        List<ClientScopeRepresentation> allScopes = realm.admin().clientScopes().findAll();
+        for (String scopeName : scopeNames) {
+            if (alreadyAssigned.contains(scopeName)) {
+                continue;
+            }
+            ClientScopeRepresentation scope = allScopes.stream()
+                    .filter(s -> scopeName.equals(s.getName()))
+                    .findFirst()
+                    .orElse(null);
+            Assertions.assertNotNull(scope,
+                    () -> "expected realm scope '" + scopeName + "' to exist");
+            clientResource.addOptionalClientScope(scope.getId());
+        }
+    }
+
+    protected ClientRepresentation findClientByClientId(String clientId) {
+        List<ClientRepresentation> clients = realm.admin().clients().findByClientId(clientId);
+        if (clients.isEmpty()) {
+            return null;
+        }
+        return clients.get(0);
+    }
+
+    protected void bestEffortDeleteStream() {
+        ClientRepresentation client = findClientByClientId(RECEIVER);
+        if (client == null) {
+            return;
+        }
+        String adminStreamUrl = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + client.getClientId() + "/stream";
+        try (SimpleHttpResponse ignored = http.doDelete(adminStreamUrl)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .asResponse()) {
+            // 204 / 404 both fine
+        } catch (IOException e) {
+            // best-effort
+        }
+    }
+
+    private String safeBody(SimpleHttpResponse response) {
+        try {
+            return response.asString();
+        } catch (Exception e) {
+            return "<no body: " + e.getMessage() + ">";
+        }
+    }
+
+    // --- config -------------------------------------------------------------
+
+    public static class AccountPurgedServerConfig extends DefaultKeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            KeycloakServerConfigBuilder configured = super.configure(config);
+            // ORGANIZATION is Type.DEFAULT and cannot be passed as an explicit
+            // --features toggle, so the +tenant and org-notify tests rely on it
+            // being enabled by default; only the realm-level switch is needed.
+            config.features(Profile.Feature.SSF);
+            config.log().categoryLevel("org.keycloak.ssf", "DEBUG");
+            config.spiOption("ssf-transmitter", "default",
+                    DefaultSsfTransmitterProviderFactory.CONFIG_OUTBOX_DRAINER_INTERVAL, "500ms");
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_MIN_VERIFICATION_INTERVAL_SECONDS, "0");
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_ALLOW_INSECURE_PUSH_TARGETS, "true");
+            return configured;
+        }
+    }
+
+    public static class AccountPurgedRealm implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.name("ssf-transmitter-account-purged");
+            realm.attribute(Ssf.SSF_TRANSMITTER_ENABLED_KEY, "true");
+            realm.organizationsEnabled(true);
+
+            realm.eventsEnabled(true);
+            realm.adminEventsEnabled(true);
+            realm.eventsListeners("jboss-logging", "ssf-events");
+
+            realm.clients(
+                    ClientBuilder.create(RECEIVER)
+                            .secret(RECEIVER_SECRET)
+                            .serviceAccountsEnabled(true)
+                            .directAccessGrantsEnabled(false)
+                            .publicClient(false)
+                            .attribute(ClientStreamStore.SSF_ENABLED_KEY, "true")
+                            .attribute(ClientStreamStore.SSF_VALID_PUSH_URLS_KEY, "http://127.0.0.1:8500/*")
+                            .attribute(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "ALL")
+                            .build()
+            );
+
+            return realm;
+        }
+    }
+}

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
@@ -25,6 +25,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.ssf.Ssf;
 import org.keycloak.ssf.event.risc.RiscAccountPurged;
@@ -127,6 +128,10 @@ public class SsfTransmitterAccountPurgedEventTests {
         });
 
         assignOptionalClientScopes(RECEIVER, SsfScopes.SCOPE_SSF_READ, SsfScopes.SCOPE_SSF_MANAGE);
+
+        // Tests vary the realm's duplicate-email policy; reset it so ordering
+        // cannot leak one test's setting into the next.
+        setDuplicateEmailsAllowed(false);
 
         // Tests in this class deliberately vary the receiver's subject format and
         // default_subjects policy, so reset both to the class defaults rather than
@@ -308,6 +313,34 @@ public class SsfTransmitterAccountPurgedEventTests {
                         + "even under default_subjects=ALL");
     }
 
+
+    @Test
+    public void emailSubject_duplicateEmails_purgeResolvesTheDeletedUser() throws Exception {
+        // Regression: the dispatcher's subject gate used to resolve the token's
+        // subject live-first. In a realm that allows duplicate emails,
+        // getUserByEmail returns the first surviving match -- so after purging the
+        // subscribed user, the gate evaluated a *different* account that happens to
+        // share the address, and dropped the purge under default_subjects=NONE.
+        setDuplicateEmailsAllowed(true);
+        setReceiverAttributes(Map.of(
+                ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "NONE",
+                ClientStreamStore.SSF_STREAM_USER_SUBJECT_FORMAT_KEY, EmailSubjectId.TYPE));
+
+        String sharedEmail = "purge-shared@local.test";
+        String purgedId = createUser("purge-dup-a", sharedEmail);
+        addSubject(purgedId);
+        // The survivor is deliberately NOT subscribed: if the gate resolves it
+        // instead of the snapshot, the purge is suppressed and this test fails.
+        createUser("purge-dup-b", sharedEmail);
+
+        deleteUser(purgedId);
+
+        JsonNode set = decodeSet(awaitPush(
+                "the purge must be gated on the deleted user, not on another account sharing its email"));
+        Assertions.assertEquals(sharedEmail, set.path("sub_id").path("email").asText(),
+                "the SET subject is the purged user's email");
+    }
+
     // --- deletions that are not purges --------------------------------------
 
     @Test
@@ -463,6 +496,17 @@ public class SsfTransmitterAccountPurgedEventTests {
     }
 
     // --- setup --------------------------------------------------------------
+
+    /**
+     * Toggles the realm's duplicate-email policy. Keycloak only permits duplicate
+     * emails when login-by-email is off, so the two move together.
+     */
+    protected void setDuplicateEmailsAllowed(boolean allowed) {
+        RealmRepresentation rep = realm.admin().toRepresentation();
+        rep.setLoginWithEmailAllowed(!allowed);
+        rep.setDuplicateEmailsAllowed(allowed);
+        realm.admin().update(rep);
+    }
 
     protected void setReceiverAttributes(Map<String, String> attributes) {
         ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterAccountPurgedEventTests.java
@@ -25,7 +25,6 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.PartialImportRepresentation;
-import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.ssf.Ssf;
 import org.keycloak.ssf.event.risc.RiscAccountPurged;
@@ -128,10 +127,6 @@ public class SsfTransmitterAccountPurgedEventTests {
         });
 
         assignOptionalClientScopes(RECEIVER, SsfScopes.SCOPE_SSF_READ, SsfScopes.SCOPE_SSF_MANAGE);
-
-        // Tests vary the realm's duplicate-email policy; reset it so ordering
-        // cannot leak one test's setting into the next.
-        setDuplicateEmailsAllowed(false);
 
         // Tests in this class deliberately vary the receiver's subject format and
         // default_subjects policy, so reset both to the class defaults rather than
@@ -321,7 +316,6 @@ public class SsfTransmitterAccountPurgedEventTests {
         // getUserByEmail returns the first surviving match -- so after purging the
         // subscribed user, the gate evaluated a *different* account that happens to
         // share the address, and dropped the purge under default_subjects=NONE.
-        setDuplicateEmailsAllowed(true);
         setReceiverAttributes(Map.of(
                 ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "NONE",
                 ClientStreamStore.SSF_STREAM_USER_SUBJECT_FORMAT_KEY, EmailSubjectId.TYPE));
@@ -497,17 +491,6 @@ public class SsfTransmitterAccountPurgedEventTests {
 
     // --- setup --------------------------------------------------------------
 
-    /**
-     * Toggles the realm's duplicate-email policy. Keycloak only permits duplicate
-     * emails when login-by-email is off, so the two move together.
-     */
-    protected void setDuplicateEmailsAllowed(boolean allowed) {
-        RealmRepresentation rep = realm.admin().toRepresentation();
-        rep.setLoginWithEmailAllowed(!allowed);
-        rep.setDuplicateEmailsAllowed(allowed);
-        realm.admin().update(rep);
-    }
-
     protected void setReceiverAttributes(Map<String, String> attributes) {
         ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
         ClientRepresentation rep = clientResource.toRepresentation();
@@ -647,6 +630,12 @@ public class SsfTransmitterAccountPurgedEventTests {
             realm.name("ssf-transmitter-account-purged");
             realm.attribute(Ssf.SSF_TRANSMITTER_ENABLED_KEY, "true");
             realm.organizationsEnabled(true);
+            // Duplicate emails are enabled realm-wide for the duplicate-email regression
+            // test below; Keycloak only permits them when login-by-email is off. Set at
+            // realm creation rather than mutated per test -- a runtime realm update
+            // round-trips the whole representation and is not worth the blast radius.
+            realm.loginWithEmailAllowed(false);
+            realm.duplicateEmailsAllowed(true);
 
             realm.eventsEnabled(true);
             realm.adminEventsEnabled(true);

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -442,7 +442,21 @@ public class SecurityEventTokenMapper {
             // null-safe: an NPE would be swallowed by the catch below and turn every
             // purge into a silent "error generating" null.
             PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, purgeRealm(adminEvent), userId);
-            if (snapshot != null && snapshot.isLocalRemovalOnly()) {
+            if (snapshot == null) {
+                // The snapshot is the only evidence that this deletion was a real purge.
+                // Without it the check below cannot run, and a federated READ_ONLY /
+                // UNSYNCED account would be reported as purged while it still exists --
+                // under default_subjects=ALL an unresolvable subject is delivered on the
+                // benefit of the doubt, so nothing downstream would catch it either.
+                // Capture is best-effort and swallows its own failures, and for a
+                // federated user it does remote I/O against the very directory in
+                // question, so a miss here is not hypothetical. Emitting nothing costs a
+                // receiver one signal; emitting wrongly costs it data it cannot recover.
+                log.warnf("Not emitting account-purged for user %s: no pre-removal snapshot was "
+                        + "captured, so the deletion cannot be confirmed as a real purge", userId);
+                return null;
+            }
+            if (snapshot.isLocalRemovalOnly()) {
                 log.debugf("Skipping account-purged for user %s: the removal only dropped Keycloak's "
                         + "local copy and the account still exists in its federated store", userId);
                 return null;

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialModel;
@@ -700,10 +701,14 @@ public class SecurityEventTokenMapper {
             throw new SsfException("Cannot build tenant subject: user " + userId + " not found (stream "
                     + (stream != null ? stream.getStreamId() : null) + ")");
         }
-        OrganizationModel org = orgProvider.getByMember(user)
-                .filter(candidate -> orgProvider.isManagedMember(candidate, user))
-                .findFirst()
-                .orElseGet(() -> orgProvider.getByMember(user).findFirst().orElse(null));
+        // Resolved as the system, not as the acting admin — see
+        // PurgedUserSnapshot.organizationsOf for why org reads on the emission path
+        // must not be FGAP-filtered.
+        OrganizationModel org = AdminPermissionsSchema.runWithoutAuthorization(session, () ->
+                orgProvider.getByMember(user)
+                        .filter(candidate -> orgProvider.isManagedMember(candidate, user))
+                        .findFirst()
+                        .orElseGet(() -> orgProvider.getByMember(user).findFirst().orElse(null)));
         if (org == null) {
             throw new SsfException("Configured user subject format includes '+tenant' but user " + userId
                     + " belongs to no organization (stream " + (stream != null ? stream.getStreamId() : null) + ")");
@@ -736,7 +741,9 @@ public class SecurityEventTokenMapper {
                     + snapshot.getId() + " belonged to no organization (stream "
                     + (stream != null ? stream.getStreamId() : null) + ")");
         }
-        OrganizationModel org = orgProvider.getByAlias(alias);
+        // getByAlias defaults to getAllStream and is FGAP-filtered like getByMember.
+        OrganizationModel org = AdminPermissionsSchema.runWithoutAuthorization(
+                session, () -> orgProvider.getByAlias(alias));
         if (org == null) {
             throw new SsfException("Cannot build tenant subject for purged user " + snapshot.getId()
                     + ": organization '" + alias + "' no longer exists (stream "

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -460,7 +460,11 @@ public class SecurityEventTokenMapper {
 
             return eventToken;
         } catch (Exception e) {
-            log.error("Error generating account purged event", e);
+            // Carries the subject and stream: this is the line read when a purge
+            // vanishes, and a bare stack trace does not say which one.
+            log.errorf(e, "Error generating account-purged event. userId=%s streamId=%s",
+                    userEvent != null ? userEvent.getUserId() : null,
+                    stream != null ? stream.getStreamId() : null);
             return null;
         }
     }
@@ -721,11 +725,17 @@ public class SecurityEventTokenMapper {
         // Resolved as the system, not as the acting admin — see
         // PurgedUserSnapshot.organizationsOf for why org reads on the emission path
         // must not be FGAP-filtered.
-        OrganizationModel org = AdminPermissionsSchema.runWithoutAuthorization(session, () ->
-                orgProvider.getByMember(user)
-                        .filter(candidate -> orgProvider.isManagedMember(candidate, user))
-                        .findFirst()
-                        .orElseGet(() -> orgProvider.getByMember(user).findFirst().orElse(null)));
+        // Memberships are read once and the managed-preferred pick made from that
+        // list: the fallback used to re-run getByMember, so a user with no managed
+        // membership cost two queries per event. Mirrors PurgedUserSnapshot's
+        // captureOrganizations, which resolves the same policy the same way.
+        OrganizationModel org = AdminPermissionsSchema.runWithoutAuthorization(session, () -> {
+            List<OrganizationModel> organizations = orgProvider.getByMember(user).toList();
+            return organizations.stream()
+                    .filter(candidate -> orgProvider.isManagedMember(candidate, user))
+                    .findFirst()
+                    .orElseGet(() -> organizations.stream().findFirst().orElse(null));
+        });
         if (org == null) {
             throw new SsfException("Configured user subject format includes '+tenant' but user " + userId
                     + " belongs to no organization (stream " + (stream != null ? stream.getStreamId() : null) + ")");

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -480,7 +480,13 @@ public class SecurityEventTokenMapper {
             return null;
         }
         if (adminEvent != null && adminEvent.getRealmId() != null) {
-            return session.realms().getRealm(adminEvent.getRealmId());
+            RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
+            if (realm != null) {
+                return realm;
+            }
+            // An id that no longer resolves falls through to the context rather than
+            // returning null: null guarantees the snapshot lookup misses, and a missed
+            // lookup silently skips the local-removal suppression.
         }
         return session.getContext() != null ? session.getContext().getRealm() : null;
     }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -433,13 +433,15 @@ public class SecurityEventTokenMapper {
             // successful deletion while the authoritative store keeps the account, so
             // the account was never purged and receivers must not be told it was.
             // See PurgedUserSnapshot.isLocalRemovalOnly.
-            // Resolved defensively: the context realm is set on every path that emits,
-            // but an NPE here would be swallowed by the catch below and turn every
+            // Resolved the way SsfTransmitterEventListener resolves it, from the admin
+            // event's own realm id, falling back to the context. The two agree today --
+            // the admin API sets the context realm to the realm being administered, and
+            // AdminEventBuilder stamps that same realm onto the event -- but a snapshot
+            // looked up under a different realm than it was captured under would miss
+            // silently, and a missed lookup here means the suppression never fires. Also
+            // null-safe: an NPE would be swallowed by the catch below and turn every
             // purge into a silent "error generating" null.
-            RealmModel contextRealm = session != null && session.getContext() != null
-                    ? session.getContext().getRealm()
-                    : null;
-            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, contextRealm, userId);
+            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, purgeRealm(adminEvent), userId);
             if (snapshot != null && snapshot.isLocalRemovalOnly()) {
                 log.debugf("Skipping account-purged for user %s: the removal only dropped Keycloak's "
                         + "local copy and the account still exists in its federated store", userId);
@@ -467,6 +469,20 @@ public class SecurityEventTokenMapper {
                     stream != null ? stream.getStreamId() : null);
             return null;
         }
+    }
+
+    /**
+     * The realm a purge snapshot was captured under: the admin event's realm when there
+     * is one, otherwise the context realm that the self-service path runs in.
+     */
+    protected RealmModel purgeRealm(AdminEvent adminEvent) {
+        if (session == null) {
+            return null;
+        }
+        if (adminEvent != null && adminEvent.getRealmId() != null) {
+            return session.realms().getRealm(adminEvent.getRealmId());
+        }
+        return session.getContext() != null ? session.getContext().getRealm() : null;
     }
 
     protected void applyCustomAttributes(Event userEvent, AdminEvent adminEvent, CaepCredentialChange credentialChangeEvent) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -33,6 +33,7 @@ import org.keycloak.ssf.event.caep.CaepCredentialChange;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
 import org.keycloak.ssf.event.risc.RiscAccountDisabled;
 import org.keycloak.ssf.event.risc.RiscAccountEnabled;
+import org.keycloak.ssf.event.risc.RiscAccountPurged;
 import org.keycloak.ssf.event.stream.SsfStreamUpdatedEvent;
 import org.keycloak.ssf.event.stream.SsfStreamVerificationEvent;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
@@ -46,6 +47,7 @@ import org.keycloak.ssf.subject.SubjectResolver;
 import org.keycloak.ssf.subject.UriSubjectId;
 import org.keycloak.ssf.transmitter.SsfTransmitterConfig;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
+import org.keycloak.ssf.transmitter.subject.PurgedUserSnapshot;
 import org.keycloak.ssf.transmitter.support.SsfUtil;
 
 import org.jboss.logging.Logger;
@@ -74,6 +76,13 @@ public class SecurityEventTokenMapper {
     // requires the previous/updated "enabled" details UserResource attaches
     // when that specific field changed.
     protected static final Pattern USER_UPDATED_BY_ADMIN_PATH_PATTERN = Pattern.compile("^users/([^/]+)$");
+
+    // Same "users/{id}" shape as above — the admin user resource is one endpoint —
+    // but reached with OperationType.DELETE rather than UPDATE. Kept as its own
+    // constant so neither the enable/disable gate nor the purge gate has to be
+    // read as "the other one, but with a different verb". The operation type is
+    // what separates them; see isUserPurgeAdminEvent.
+    protected static final Pattern USER_DELETED_BY_ADMIN_PATH_PATTERN = Pattern.compile("^users/([^/]+)$");
 
     public static final String KC_CREDENTIAL_ID = "kc_credential_id";
 
@@ -391,6 +400,53 @@ public class SecurityEventTokenMapper {
         }
     }
 
+    /**
+     * Generates a RISC account-purged event.
+     *
+     * <p>RISC defines no {@code reason} claim for a purge, so unlike
+     * {@link #generateAccountDisabledEvent} this takes no reason argument — the
+     * subject, the timestamp and the initiating entity are the whole payload.
+     *
+     * <p>This is the one generator whose subject can never be resolved from live
+     * storage: the user row is deleted before either triggering event fires. The
+     * lookups inside {@link #composeUserSubject} therefore fall back to the
+     * {@link PurgedUserSnapshot} captured on {@code UserPreRemovedEvent}. When no
+     * snapshot exists — a deletion path that does not publish that provider event —
+     * subject construction throws and the event is dropped with a log line rather
+     * than shipping a SET with an unidentifiable subject.
+     *
+     * @param userEvent the {@code DELETE_ACCOUNT} event, or the synthetic equivalent
+     *                  built by {@link #generateAccountPurgedEventForAdminAction}
+     * @param adminEvent the admin event that triggered the deletion, or {@code null}
+     *                   for self-service deletion from the account console. Unlike the
+     *                   disable path, "not admin-initiated" genuinely does mean
+     *                   "user-initiated" here, so the standard two-argument
+     *                   {@link #applyInitiatingEntity} is correct.
+     * @param stream the receiving stream
+     */
+    public SsfSecurityEventToken generateAccountPurgedEvent(Event userEvent, AdminEvent adminEvent, StreamConfig stream) {
+        try {
+            String userId = userEvent.getUserId();
+
+            SsfSecurityEventToken eventToken = newSecurityEventToken(stream);
+            eventToken.setTxn(UUID.randomUUID().toString());
+            eventToken.setSubjectId(composeUserSubject(eventToken, userId, stream));
+
+            RiscAccountPurged accountPurgedEvent = new RiscAccountPurged();
+            accountPurgedEvent.setEventTimestamp(Time.currentTime());
+            applyInitiatingEntity(userEvent, adminEvent, accountPurgedEvent);
+
+            Map<String, Object> events = new HashMap<>();
+            events.put(RiscAccountPurged.TYPE, accountPurgedEvent);
+            eventToken.setEvents(events);
+
+            return eventToken;
+        } catch (Exception e) {
+            log.error("Error generating account purged event", e);
+            return null;
+        }
+    }
+
     protected void applyCustomAttributes(Event userEvent, AdminEvent adminEvent, CaepCredentialChange credentialChangeEvent) {
         // Keycloak user events aren't required to carry a details map —
         // RESET_PASSWORD in particular doesn't populate it. Skip the
@@ -633,6 +689,14 @@ public class SecurityEventTokenMapper {
         OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
         UserModel user = session.users().getUserById(realm, userId);
         if (user == null) {
+            // The user may have been purged on this very request. Organization
+            // membership is an id-keyed query rather than an attribute read, so the
+            // snapshot cannot answer getByMember — it carries the alias that was
+            // resolved while the membership still existed instead.
+            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, userId);
+            if (snapshot != null) {
+                return buildTenantSubjectFromSnapshot(snapshot, orgProvider, stream);
+            }
             throw new SsfException("Cannot build tenant subject: user " + userId + " not found (stream "
                     + (stream != null ? stream.getStreamId() : null) + ")");
         }
@@ -651,6 +715,34 @@ public class SecurityEventTokenMapper {
         // SubjectResolver and the wire value stays human-readable
         // without exposing the transmitter's internal UUIDs.
         return createTenantSubjectId(org, user);
+    }
+
+    /**
+     * Tenant-subject variant for a user that no longer exists, used by the
+     * account-purged path. The organization itself outlives the user, so the alias
+     * captured at snapshot time is resolved back to a live {@link OrganizationModel}
+     * — which keeps the {@link #createTenantSubjectId} extension point working
+     * exactly as it does for live users.
+     *
+     * <p>Fails loud for the same reason the live path does: a SET shaped differently
+     * from what the receiver negotiated is worse than no SET at all.
+     */
+    protected SubjectId buildTenantSubjectFromSnapshot(PurgedUserSnapshot snapshot,
+                                                       OrganizationProvider orgProvider,
+                                                       StreamConfig stream) {
+        String alias = snapshot.getTenantAlias();
+        if (alias == null) {
+            throw new SsfException("Configured user subject format includes '+tenant' but purged user "
+                    + snapshot.getId() + " belonged to no organization (stream "
+                    + (stream != null ? stream.getStreamId() : null) + ")");
+        }
+        OrganizationModel org = orgProvider.getByAlias(alias);
+        if (org == null) {
+            throw new SsfException("Cannot build tenant subject for purged user " + snapshot.getId()
+                    + ": organization '" + alias + "' no longer exists (stream "
+                    + (stream != null ? stream.getStreamId() : null) + ")");
+        }
+        return createTenantSubjectId(org, snapshot);
     }
 
     protected UriSubjectId createTenantSubjectId(OrganizationModel org, UserModel user) {
@@ -673,7 +765,9 @@ public class SecurityEventTokenMapper {
         if (realm == null) {
             return null;
         }
-        UserModel user = session.users().getUserById(realm, userId);
+        // Falls back to this request's purge snapshot when the row is already gone,
+        // so account-purged events can still carry an `email` subject.
+        UserModel user = PurgedUserSnapshot.resolveUserOrSnapshot(session, realm, userId);
         if (user == null) {
             return null;
         }
@@ -704,6 +798,10 @@ public class SecurityEventTokenMapper {
                  REMOVE_CREDENTIAL,
                  RESET_PASSWORD -> !shouldIgnoreCredentialChange(event);
             case USER_DISABLED_BY_PERMANENT_LOCKOUT -> true;
+            // Self-service account deletion from the account console. The account
+            // is genuinely purged, so unlike the admin path this needs no operation
+            // -type discriminator — DELETE_ACCOUNT has exactly one meaning.
+            case DELETE_ACCOUNT -> true;
             default -> false;
         };
     }
@@ -736,7 +834,30 @@ public class SecurityEventTokenMapper {
             }
         }
 
-        return isEnabledStateChangeAdminEvent(adminEvent);
+        return isEnabledStateChangeAdminEvent(adminEvent) || isUserPurgeAdminEvent(adminEvent);
+    }
+
+    /**
+     * True when {@code adminEvent} is an admin deletion of a user — bare
+     * {@code users/{id}} with {@link OperationType#DELETE}. Like
+     * {@link #isEnabledStateChangeAdminEvent}, the bare path is not in
+     * {@link #supportedAdminPathPatters()} because it serves several operations;
+     * the operation type is the discriminator.
+     *
+     * <p>The operation-type check is what keeps near-miss paths out. A partial
+     * import under the OVERWRITE policy also deletes a user and also fires a
+     * {@code users/{id}} admin event — but as {@link OperationType#UPDATE},
+     * because the account is recreated in the same request and was never purged.
+     * Deleting a client removes its service-account user, but reports that as
+     * {@link ResourceType#CLIENT} at {@code clients/{id}} and is filtered by the
+     * resource-type guard in {@link #canConvert(AdminEvent)}.
+     */
+    protected boolean isUserPurgeAdminEvent(AdminEvent adminEvent) {
+        if (adminEvent.getOperationType() != OperationType.DELETE) {
+            return false;
+        }
+        String path = adminEvent.getResourcePath();
+        return path != null && USER_DELETED_BY_ADMIN_PATH_PATTERN.matcher(path).matches();
     }
 
     protected List<Pattern> supportedAdminPathPatters() {
@@ -842,6 +963,11 @@ public class SecurityEventTokenMapper {
             case USER_DISABLED_BY_PERMANENT_LOCKOUT ->
                     generateAccountDisabledEvent(event, adminEvent, stream, RiscAccountDisabled.REASON_BRUTE_FORCE);
 
+            // Self-service deletion. The user row is already gone by the time this
+            // event fires, so the subject is resolved from the purge snapshot
+            // captured on UserPreRemovedEvent.
+            case DELETE_ACCOUNT -> generateAccountPurgedEvent(event, adminEvent, stream);
+
             // Add more event mappings here as needed.
             // Deliberately NOT mapped: UPDATE_PASSWORD / UPDATE_TOTP /
             // REMOVE_TOTP — these are deprecated event types Keycloak
@@ -916,7 +1042,25 @@ public class SecurityEventTokenMapper {
             return generateAccountStateChangeEventForAdminAction(userId, adminEvent, stream, nowEnabled);
         }
 
+        if (isUserPurgeAdminEvent(adminEvent)) {
+            return generateAccountPurgedEventForAdminAction(userId, adminEvent, stream);
+        }
+
         return null;
+    }
+
+    /**
+     * Builds a synthetic {@link Event} carrying just the user id so the admin
+     * deletion path can reuse {@link #generateAccountPurgedEvent}, whose signature
+     * is shared with the self-service ({@code DELETE_ACCOUNT}) path.
+     */
+    protected SsfSecurityEventToken generateAccountPurgedEventForAdminAction(String userId, AdminEvent adminEvent, StreamConfig stream) {
+
+        Event event = new Event();
+        event.setType(EventType.DELETE_ACCOUNT);
+        event.setUserId(userId);
+
+        return generateAccountPurgedEvent(event, adminEvent, stream);
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -429,6 +429,23 @@ public class SecurityEventTokenMapper {
         try {
             String userId = userEvent.getUserId();
 
+            // A federated user under a READ_ONLY / UNSYNCED provider reports a
+            // successful deletion while the authoritative store keeps the account, so
+            // the account was never purged and receivers must not be told it was.
+            // See PurgedUserSnapshot.isLocalRemovalOnly.
+            // Resolved defensively: the context realm is set on every path that emits,
+            // but an NPE here would be swallowed by the catch below and turn every
+            // purge into a silent "error generating" null.
+            RealmModel contextRealm = session != null && session.getContext() != null
+                    ? session.getContext().getRealm()
+                    : null;
+            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, contextRealm, userId);
+            if (snapshot != null && snapshot.isLocalRemovalOnly()) {
+                log.debugf("Skipping account-purged for user %s: the removal only dropped Keycloak's "
+                        + "local copy and the account still exists in its federated store", userId);
+                return null;
+            }
+
             SsfSecurityEventToken eventToken = newSecurityEventToken(stream);
             eventToken.setTxn(UUID.randomUUID().toString());
             eventToken.setSubjectId(composeUserSubject(eventToken, userId, stream));

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapper.java
@@ -693,7 +693,7 @@ public class SecurityEventTokenMapper {
             // membership is an id-keyed query rather than an attribute read, so the
             // snapshot cannot answer getByMember — it carries the alias that was
             // resolved while the membership still existed instead.
-            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, userId);
+            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, realm, userId);
             if (snapshot != null) {
                 return buildTenantSubjectFromSnapshot(snapshot, orgProvider, stream);
             }
@@ -811,10 +811,14 @@ public class SecurityEventTokenMapper {
      * {@link #toSecurityEventToken(AdminEvent, StreamConfig)} would produce a
      * non-null SET for {@code adminEvent} — the admin paths mapped are
      * "log out all user sessions" ({@code users/{userId}/logout}),
-     * admin-initiated password reset / credential management, and an
+     * admin-initiated password reset / credential management, an
      * enable/disable transition on the generic user update endpoint (see
-     * {@link #isEnabledStateChangeAdminEvent}); everything else returns
+     * {@link #isEnabledStateChangeAdminEvent}), and deletion of the user
+     * itself (see {@link #isUserPurgeAdminEvent}); everything else returns
      * null and should short-circuit before any stream lookup happens.
+     *
+     * <p>The last two share the bare {@code users/{id}} resource path and are
+     * told apart by operation type, so both gates check it explicitly.
      */
     public boolean canConvert(AdminEvent adminEvent) {
         if (adminEvent == null) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -72,11 +72,18 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
             return;
         }
 
-        var streamTokens = generateSecurityTokensForUserEvent(event, transmitter);
-        if (streamTokens == null || streamTokens.isEmpty()) {
-            return;
+        try {
+            var streamTokens = generateSecurityTokensForUserEvent(event, transmitter);
+            if (streamTokens == null || streamTokens.isEmpty()) {
+                return;
+            }
+            dispatchSecurityEventTokens(streamTokens, transmitter);
+        } finally {
+            // Release any purge snapshot now that this event has been emitted. Keeps
+            // a request that deletes many users and emits for each from ever
+            // approaching the retention bound — see PurgedUserSnapshot.discard.
+            PurgedUserSnapshot.discard(session, session.getContext().getRealm(), event.getUserId());
         }
-        dispatchSecurityEventTokens(streamTokens, transmitter);
     }
 
     protected List<Map.Entry<SsfSecurityEventToken, StreamConfig>> generateSecurityTokensForUserEvent(Event event, SsfTransmitterProvider transmitter) {
@@ -323,11 +330,16 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
             return;
         }
 
-        var streamTokens = generateSecurityEventTokensForAdminEvent(adminEvent, transmitter);
-        if (streamTokens == null || streamTokens.isEmpty()) {
-            return;
+        try {
+            var streamTokens = generateSecurityEventTokensForAdminEvent(adminEvent, transmitter);
+            if (streamTokens == null || streamTokens.isEmpty()) {
+                return;
+            }
+            dispatchSecurityEventTokens(streamTokens, transmitter);
+        } finally {
+            PurgedUserSnapshot.discard(session, session.realms().getRealm(adminEvent.getRealmId()),
+                    SsfUtil.userIdFromAdminEventPath(adminEvent));
         }
-        dispatchSecurityEventTokens(streamTokens, transmitter);
     }
 
     protected boolean shouldIgnoreEvent(AdminEvent adminEvent) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import org.keycloak.events.Details;
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventType;
@@ -309,9 +310,13 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         }
         OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
         String receiverClientId = client.getClientId();
-        return orgProvider.getByMember(user)
-                .anyMatch(org -> transmitter.subjectInclusionResolver()
-                        .isOrganizationNotified(session, org, receiverClientId));
+        // As the system, not as the acting admin — see
+        // PurgedUserSnapshot.organizationsOf. The stream is consumed inside the
+        // scope, so the suppression still applies when the query runs.
+        return AdminPermissionsSchema.runWithoutAuthorization(session, () ->
+                orgProvider.getByMember(user)
+                        .anyMatch(org -> transmitter.subjectInclusionResolver()
+                                .isOrganizationNotified(session, org, receiverClientId)));
     }
 
     protected boolean shouldIgnoreEvent(Event event) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -5,8 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.keycloak.events.Details;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.events.Details;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventType;

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -23,6 +23,7 @@ import org.keycloak.ssf.transmitter.SsfTransmitterProvider;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
 import org.keycloak.ssf.transmitter.stream.StreamService;
 import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
+import org.keycloak.ssf.transmitter.subject.PurgedUserSnapshot;
 import org.keycloak.ssf.transmitter.subject.SsfNotifyAttributes;
 import org.keycloak.ssf.transmitter.support.SsfUtil;
 import org.keycloak.storage.ReadOnlyException;
@@ -138,7 +139,11 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         if (realm == null) {
             return null;
         }
-        return session.users().getUserById(realm, userId);
+        // Falls back to this request's purge snapshot for DELETE_ACCOUNT, where the
+        // user row is already gone by the time the event fires. Without it the
+        // subject gate below would see an unresolvable user and — under the default
+        // default_subjects=NONE — silently drop every self-service deletion.
+        return PurgedUserSnapshot.resolveUserOrSnapshot(session, realm, userId);
     }
 
     /**
@@ -354,7 +359,11 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
         }
 
         RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
-        UserModel eventUser = session.users().getUserById(realm, SsfUtil.userIdFromAdminEventPath(adminEvent));
+        // Resolve through the purge snapshot so an admin user deletion — where the
+        // row is gone before this event fires — still produces a subject. Bailing
+        // here was previously the hard stop that made account-purged impossible.
+        UserModel eventUser = PurgedUserSnapshot.resolveUserOrSnapshot(
+                session, realm, SsfUtil.userIdFromAdminEventPath(adminEvent));
         if (eventUser == null) {
             return List.of();
         }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -3,6 +3,7 @@ package org.keycloak.ssf.transmitter.event;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.keycloak.events.Details;
 import org.keycloak.events.Event;
@@ -82,7 +83,7 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
             // Release any purge snapshot now that this event has been emitted. Keeps
             // a request that deletes many users and emits for each from ever
             // approaching the retention bound — see PurgedUserSnapshot.discard.
-            PurgedUserSnapshot.discard(session, session.getContext().getRealm(), event.getUserId());
+            discardSnapshotQuietly(() -> session.getContext().getRealm(), event.getUserId());
         }
     }
 
@@ -135,6 +136,24 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
             streamTokens.add(Map.entry(securityEventToken, stream));
         }
         return streamTokens;
+    }
+
+    /**
+     * Releases a purge snapshot without ever letting cleanup break event handling.
+     *
+     * <p>Called from a {@code finally}, by which point the event has already been
+     * emitted, so a failure here must not propagate: resolving the realm can throw
+     * on its own (an inactive context, a realm that no longer resolves), and turning
+     * that into a listener failure would discard work that had already succeeded.
+     * The cost of swallowing it is one snapshot retained until the session ends.
+     */
+    protected void discardSnapshotQuietly(Supplier<RealmModel> realmSupplier, String userId) {
+        try {
+            PurgedUserSnapshot.discard(session, realmSupplier.get(), userId);
+        } catch (RuntimeException e) {
+            log.debugf(e, "SSF: could not release the purge snapshot for user %s; "
+                    + "it will be discarded with the session", userId);
+        }
     }
 
     protected UserModel resolveEventUser(Event event) {
@@ -337,7 +356,7 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
             }
             dispatchSecurityEventTokens(streamTokens, transmitter);
         } finally {
-            PurgedUserSnapshot.discard(session, session.realms().getRealm(adminEvent.getRealmId()),
+            discardSnapshotQuietly(() -> session.realms().getRealm(adminEvent.getRealmId()),
                     SsfUtil.userIdFromAdminEventPath(adminEvent));
         }
     }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerFactory.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerFactory.java
@@ -63,9 +63,14 @@ public class SsfTransmitterEventListenerFactory implements EventListenerProvider
                 PurgedUserSnapshot.capture(preRemoved.getKeycloakSession(), realm, preRemoved.getUser());
             } catch (RuntimeException e) {
                 // Never let a snapshot failure break the deletion itself — the user
-                // removal is the operator's actual intent. Losing the snapshot costs
-                // one undelivered purge SET, which the debug log below makes traceable.
-                log.debugf(e, "SSF: could not snapshot user %s before removal; no purge event will be emitted",
+                // removal is the operator's actual intent.
+                //
+                // Losing the snapshot costs one undelivered purge SET. It is logged at
+                // WARN rather than DEBUG because that is a silent gap in a data-retention
+                // signal, and because the generator refuses to emit without a snapshot:
+                // a miss here is the difference between a receiver being told late and a
+                // federated account being reported as purged while it still exists.
+                log.warnf(e, "SSF: could not snapshot user %s before removal; no purge event will be emitted",
                         preRemoved.getUser() != null ? preRemoved.getUser().getId() : null);
             }
         });

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerFactory.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerFactory.java
@@ -6,9 +6,17 @@ import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventListenerProviderFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.ssf.Ssf;
+import org.keycloak.ssf.transmitter.subject.PurgedUserSnapshot;
+
+import org.jboss.logging.Logger;
 
 public class SsfTransmitterEventListenerFactory implements EventListenerProviderFactory, EnvironmentDependentProviderFactory {
+
+    protected static final Logger log = Logger.getLogger(SsfTransmitterEventListenerFactory.class);
 
     private static final String ID = "ssf-events";
 
@@ -28,9 +36,39 @@ public class SsfTransmitterEventListenerFactory implements EventListenerProvider
         // No initialization needed
     }
 
+    /**
+     * Subscribes to {@link UserModel.UserPreRemovedEvent} so a purged user can still
+     * be described after its row is gone.
+     *
+     * <p>Keycloak deletes the user before firing the admin / user event that drives SSF
+     * emission, so the transmitter would otherwise have nothing to build a subject from.
+     * This is the last hook that runs while the user still exists. It only captures —
+     * emission stays entirely on the event-listener path, because a pre-remove hook
+     * cannot know whether the removal will actually succeed.
+     *
+     * <p>Gated on the realm's transmitter flag so realms not using SSF pay nothing
+     * beyond one attribute read per user deletion.
+     */
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        // NOOP
+        factory.register(event -> {
+            if (!(event instanceof UserModel.UserPreRemovedEvent preRemoved)) {
+                return;
+            }
+            RealmModel realm = preRemoved.getRealm();
+            if (realm == null || !Ssf.isTransmitterEnabled(realm)) {
+                return;
+            }
+            try {
+                PurgedUserSnapshot.capture(preRemoved.getKeycloakSession(), realm, preRemoved.getUser());
+            } catch (RuntimeException e) {
+                // Never let a snapshot failure break the deletion itself — the user
+                // removal is the operator's actual intent. Losing the snapshot costs
+                // one undelivered purge SET, which the debug log below makes traceable.
+                log.debugf(e, "SSF: could not snapshot user %s before removal; no purge event will be emitted",
+                        preRemoved.getUser() != null ? preRemoved.getUser().getId() : null);
+            }
+        });
     }
 
     @Override

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -1,0 +1,316 @@
+package org.keycloak.ssf.transmitter.subject;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.utils.Organizations;
+import org.keycloak.ssf.subject.ComplexSubjectId;
+import org.keycloak.ssf.subject.EmailSubjectId;
+import org.keycloak.ssf.subject.IssuerSubjectId;
+import org.keycloak.ssf.subject.OpaqueSubjectId;
+import org.keycloak.ssf.subject.SubjectId;
+import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
+
+/**
+ * A detached, read-only stand-in for a user that is about to be deleted.
+ *
+ * <p>Keycloak removes the user row before it fires the admin / user event that
+ * drives SSF emission, so by the time the transmitter runs, every
+ * {@code session.users().getUserById(...)} in the pipeline returns {@code null}.
+ * This snapshot is captured on {@link UserModel.UserPreRemovedEvent} — the one
+ * hook that still runs while the user exists — and stashed on the
+ * {@link KeycloakSession} so the emission path can substitute it wherever the
+ * live lookup misses.
+ *
+ * <p>It deliberately <em>is</em> a {@link UserModel} rather than a bag of fields.
+ * Everything downstream that needs the user does attribute reads —
+ * {@link SubjectSubscriptionFilter} and {@link SsfSubjectInclusionResolver} read
+ * {@code ssf.notify.<clientId>}, and the mapper's email subject format reads
+ * {@code getEmail()}, which is itself an attribute read. Copying the attribute map
+ * into an in-memory adapter therefore makes those call sites work unmodified.
+ *
+ * <p><b>Organizations are the exception.</b> {@code OrganizationProvider.getByMember(user)}
+ * is an id-keyed database query, not an attribute read, so a detached user cannot
+ * answer it. The organization-derived facts the pipeline needs — the tenant alias for
+ * {@code +tenant} subject formats, and the org-level notify / tombstone verdicts —
+ * are resolved eagerly at capture time and served from the fields below.
+ *
+ * <p>The snapshot lives only as long as the request. Everything that reads it
+ * (token construction, the subject gates, narrowing and signing) runs inline on the
+ * deleting thread before the transaction commits; the outbox stores an already-signed
+ * SET and never resolves a user again.
+ */
+public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
+
+    private static final String SESSION_ATTRIBUTE_PREFIX = "ssf.purgedUser.";
+
+    /**
+     * Secondary index. The dispatcher's subject gate re-resolves the user from the
+     * token's own {@code sub_id} rather than from the event's user id, and for a
+     * stream configured with the {@code email} subject format that identifier is an
+     * address, not a UUID. Stashing the snapshot under both keys lets that gate find
+     * it without the filter having to know how the subject was built.
+     */
+    private static final String SESSION_ATTRIBUTE_EMAIL_PREFIX = "ssf.purgedUserByEmail.";
+
+    /**
+     * The user's primary organization alias, resolved managed-preferred to mirror
+     * {@code SecurityEventTokenMapper.buildTenantSubject}. {@code null} when the
+     * organization feature is off or the user belonged to no organization.
+     */
+    private final String tenantAlias;
+
+    /**
+     * The {@code ssf.*} attributes of every organization the user belonged to, in
+     * membership order. Backs the org legs of the subject filter, which ask
+     * "is <em>any</em> of the user's organizations notified / excluded".
+     */
+    private final List<Map<String, List<String>>> organizationSsfAttributes;
+
+    protected PurgedUserSnapshot(KeycloakSession session,
+                                 RealmModel realm,
+                                 String id,
+                                 String tenantAlias,
+                                 List<Map<String, List<String>>> organizationSsfAttributes) {
+        super(session, realm, id);
+        this.tenantAlias = tenantAlias;
+        this.organizationSsfAttributes = organizationSsfAttributes;
+    }
+
+    public String getTenantAlias() {
+        return tenantAlias;
+    }
+
+    /**
+     * Always throws. A purged user has no credentials to manage — the rows are gone
+     * along with the user. Nothing on the SSF emission path asks for them (credential
+     * events are a separate mapper branch that only ever runs for live users), so a
+     * caller reaching this is a bug worth surfacing rather than papering over with a
+     * no-op manager that would silently report "no credentials".
+     */
+    @Override
+    public SubjectCredentialManager credentialManager() {
+        throw new UnsupportedOperationException(
+                "Purged user " + getId() + " has no credential manager; the user no longer exists");
+    }
+
+    /**
+     * Captures {@code user} and stashes it on the session under its user id.
+     * No-op when the user is a service account — those are not human subjects and
+     * never produce a purge SET, so capturing one would only cost an organization
+     * query on every client deletion.
+     *
+     * <p>Callers invoke this from the pre-remove hook, which fires before Keycloak
+     * knows whether the removal will succeed. Capturing is therefore deliberately
+     * side-effect free: a failed delete leaves an unread snapshot that dies with
+     * the session.
+     */
+    public static void capture(KeycloakSession session, RealmModel realm, UserModel user) {
+        if (session == null || realm == null || user == null || user.getId() == null) {
+            return;
+        }
+        if (user.getServiceAccountClientLink() != null) {
+            return;
+        }
+
+        String tenantAlias = null;
+        List<Map<String, List<String>>> orgAttributes = new ArrayList<>();
+        if (Organizations.isEnabled(session)) {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            List<OrganizationModel> organizations = orgProvider.getByMember(user).toList();
+            for (OrganizationModel org : organizations) {
+                orgAttributes.add(copySsfAttributes(org.getAttributes()));
+            }
+            // Managed-preferred, matching the mapper's multi-org resolution policy:
+            // the organization that provisioned the user wins, otherwise the first
+            // membership. Keeps the purge event's tenant subject identical to the
+            // one every earlier event for this user carried.
+            OrganizationModel tenant = organizations.stream()
+                    .filter(candidate -> orgProvider.isManagedMember(candidate, user))
+                    .findFirst()
+                    .orElseGet(() -> organizations.stream().findFirst().orElse(null));
+            if (tenant != null) {
+                tenantAlias = tenant.getAlias();
+            }
+        }
+
+        PurgedUserSnapshot snapshot = new PurgedUserSnapshot(session, realm, user.getId(),
+                tenantAlias, List.copyOf(orgAttributes));
+
+        // Copy the whole attribute map first — it carries username, email and every
+        // ssf.notify.* / ssf.notifyRemovedAt.* entry the subject gates read.
+        Map<String, List<String>> attributes = user.getAttributes();
+        if (attributes != null) {
+            for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
+                if (entry.getValue() != null) {
+                    snapshot.setAttribute(entry.getKey(), new ArrayList<>(entry.getValue()));
+                }
+            }
+        }
+        // Then re-assert the two identity fields through their typed setters. The
+        // attribute map is expected to carry both, but a custom user storage provider
+        // is free to surface them only via the getters, and losing the email would
+        // silently degrade streams configured for the `email` subject format.
+        if (user.getUsername() != null) {
+            snapshot.setUsername(user.getUsername());
+        }
+        if (user.getEmail() != null) {
+            snapshot.setEmail(user.getEmail());
+        }
+        snapshot.setEnabled(user.isEnabled());
+        snapshot.setReadonly(true);
+
+        session.setAttribute(sessionAttributeKey(user.getId()), snapshot);
+        if (snapshot.getEmail() != null) {
+            session.setAttribute(sessionEmailAttributeKey(snapshot.getEmail()), snapshot);
+        }
+    }
+
+    /**
+     * Returns the snapshot captured for {@code userId} in this session, or
+     * {@code null} when the user was not deleted on this request.
+     */
+    public static PurgedUserSnapshot lookup(KeycloakSession session, String userId) {
+        if (session == null || userId == null) {
+            return null;
+        }
+        return session.getAttribute(sessionAttributeKey(userId), PurgedUserSnapshot.class);
+    }
+
+    /**
+     * Resolves a snapshot from an RFC 9493 subject identifier, mirroring the
+     * identifier shapes {@code SubjectUserLookup} understands. Used by the
+     * dispatcher-side subject gate, which re-resolves the user from the token's own
+     * {@code sub_id} rather than from the originating event.
+     *
+     * <p>Complex subjects are drilled into their {@code user} member, matching how
+     * the filter unwraps them for live users.
+     */
+    public static PurgedUserSnapshot lookupBySubject(KeycloakSession session, SubjectId subjectId) {
+        if (session == null || subjectId == null) {
+            return null;
+        }
+        if (subjectId instanceof ComplexSubjectId complex) {
+            return lookupBySubject(session, complex.getUser());
+        }
+        if (subjectId instanceof IssuerSubjectId issuerSubject) {
+            return lookup(session, issuerSubject.getSub());
+        }
+        if (subjectId instanceof OpaqueSubjectId opaqueSubject) {
+            return lookup(session, opaqueSubject.getId());
+        }
+        if (subjectId instanceof EmailSubjectId emailSubject) {
+            String email = emailSubject.getEmail();
+            if (email == null || email.isBlank()) {
+                return null;
+            }
+            return session.getAttribute(sessionEmailAttributeKey(email), PurgedUserSnapshot.class);
+        }
+        return null;
+    }
+
+    /**
+     * Resolves {@code userId} to a live user, falling back to this request's
+     * purge snapshot when the row is already gone. The single substitution point
+     * the emission path uses in place of a bare {@code getUserById}.
+     */
+    public static UserModel resolveUserOrSnapshot(KeycloakSession session, RealmModel realm, String userId) {
+        if (session == null || userId == null) {
+            return null;
+        }
+        UserModel user = realm != null ? session.users().getUserById(realm, userId) : null;
+        return user != null ? user : lookup(session, userId);
+    }
+
+    public boolean isAnyOrganizationNotified(String clientId) {
+        return anyOrganizationHasValue(SsfNotifyAttributes.attributeKey(clientId),
+                SsfNotifyAttributes.ATTRIBUTE_VALUE_TRUE);
+    }
+
+    public boolean isAnyOrganizationExcluded(String clientId) {
+        return anyOrganizationHasValue(SsfNotifyAttributes.attributeKey(clientId),
+                SsfNotifyAttributes.ATTRIBUTE_VALUE_FALSE);
+    }
+
+    /**
+     * The most recent org-level removal tombstone across the user's organizations,
+     * or {@code null} when none carry one. Most-recent mirrors the live filter's
+     * {@code anyMatch} over memberships — if any organization is still inside the
+     * grace window, the event is delivered.
+     */
+    public Long getOrganizationRemovedAt(String clientId) {
+        String key = SsfNotifyAttributes.removedAtKey(clientId);
+        Long latest = null;
+        for (Map<String, List<String>> attributes : organizationSsfAttributes) {
+            List<String> values = attributes.get(key);
+            if (values == null || values.isEmpty()) {
+                continue;
+            }
+            Long parsed = parseEpochSeconds(values.get(0));
+            if (parsed != null && (latest == null || parsed > latest)) {
+                latest = parsed;
+            }
+        }
+        return latest;
+    }
+
+    private boolean anyOrganizationHasValue(String key, String value) {
+        for (Map<String, List<String>> attributes : organizationSsfAttributes) {
+            List<String> values = attributes.get(key);
+            if (values != null && values.contains(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Long parseEpochSeconds(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Narrows an organization's attribute map to the {@code ssf.*} keys. Organization
+     * attributes are operator-defined and unbounded; only the SSF ones are ever read
+     * back, so the snapshot does not retain the rest.
+     */
+    private static Map<String, List<String>> copySsfAttributes(Map<String, List<String>> attributes) {
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        if (attributes == null) {
+            return copy;
+        }
+        for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || entry.getValue() == null) {
+                continue;
+            }
+            if (key.startsWith(SsfNotifyAttributes.ATTRIBUTE_PREFIX)
+                    || key.startsWith(SsfNotifyAttributes.REMOVED_AT_PREFIX)) {
+                copy.put(key, List.copyOf(entry.getValue()));
+            }
+        }
+        return copy;
+    }
+
+    private static String sessionAttributeKey(String userId) {
+        return SESSION_ATTRIBUTE_PREFIX + userId;
+    }
+
+    private static String sessionEmailAttributeKey(String email) {
+        return SESSION_ATTRIBUTE_EMAIL_PREFIX + email.toLowerCase();
+    }
+}

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
@@ -162,20 +163,11 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         String tenantAlias = null;
         List<String> organizationAliases = List.of();
         if (Organizations.isEnabled(session)) {
-            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
-            List<OrganizationModel> organizations = orgProvider.getByMember(user).toList();
-            organizationAliases = organizations.stream().map(OrganizationModel::getAlias).toList();
-            // Managed-preferred, matching the mapper's multi-org resolution policy:
-            // the organization that provisioned the user wins, otherwise the first
-            // membership. Keeps the purge event's tenant subject identical to the
-            // one every earlier event for this user carried.
-            OrganizationModel tenant = organizations.stream()
-                    .filter(candidate -> orgProvider.isManagedMember(candidate, user))
-                    .findFirst()
-                    .orElseGet(() -> organizations.stream().findFirst().orElse(null));
-            if (tenant != null) {
-                tenantAlias = tenant.getAlias();
-            }
+            // Read without authorization filtering — see organizationsOf.
+            CapturedOrganizations organizations = AdminPermissionsSchema.runWithoutAuthorization(
+                    session, () -> captureOrganizations(session, user));
+            organizationAliases = organizations.aliases();
+            tenantAlias = organizations.tenantAlias();
         }
 
         PurgedUserSnapshot snapshot = new PurgedUserSnapshot(session, realm, user.getId(),
@@ -219,6 +211,33 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         snapshot.setReadonly(true);
 
         snapshots.put(idKey(realm, user.getId()), emailKey(realm, snapshot.getEmail()), snapshot);
+    }
+
+    /**
+     * The organization facts the snapshot keeps: the alias of every membership, and
+     * the managed-preferred primary used for {@code +tenant} subjects.
+     */
+    private record CapturedOrganizations(List<String> aliases, String tenantAlias) {
+    }
+
+    /**
+     * Reads the user's memberships while the user still exists. Must be called inside
+     * {@code runWithoutAuthorization} — see {@link #organizationsOf}.
+     */
+    private static CapturedOrganizations captureOrganizations(KeycloakSession session, UserModel user) {
+        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        List<OrganizationModel> organizations = orgProvider.getByMember(user).toList();
+        // Managed-preferred, matching the mapper's multi-org resolution policy:
+        // the organization that provisioned the user wins, otherwise the first
+        // membership. Keeps the purge event's tenant subject identical to the
+        // one every earlier event for this user carried.
+        OrganizationModel tenant = organizations.stream()
+                .filter(candidate -> orgProvider.isManagedMember(candidate, user))
+                .findFirst()
+                .orElseGet(() -> organizations.stream().findFirst().orElse(null));
+        return new CapturedOrganizations(
+                organizations.stream().map(OrganizationModel::getAlias).toList(),
+                tenant == null ? null : tenant.getAlias());
     }
 
     /**
@@ -354,23 +373,43 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * outlive the user, so callers get real models and can apply the same logic in
      * both cases. Aliases that no longer resolve (the organization was deleted in the
      * same request) are dropped.
+     *
+     * <p><b>Read without authorization filtering.</b> Both lookups are FGAP-filtered:
+     * {@code getByMember} applies {@code AdminPermissionsSchema.applyAuthorizationFilters}
+     * directly, and {@code getByAlias} defaults to {@code getAllStream}, which does the
+     * same. Under fine-grained admin permissions an admin who may manage a user but not
+     * view organizations would therefore see no memberships, and the org-derived
+     * verdicts would silently change with the identity of whoever triggered the event:
+     * an org-excluded subject would be delivered under {@code default_subjects=ALL}, an
+     * org-notified one dropped under {@code NONE}, and a {@code +tenant} subject would
+     * fail to build. What a receiver is told about a subject is system bookkeeping — it
+     * cannot depend on the acting admin's visibility — so this reads as the system,
+     * mirroring {@code UserStorageManager.isReadOnlyOrganizationMember} and
+     * {@code DefaultLazyLoader}.
+     *
+     * <p>The result is materialized <em>inside</em> the unfiltered scope on purpose.
+     * {@code runWithoutAuthorization} suppresses filtering by setting a session
+     * attribute and clearing it in a {@code finally}, so a lazily returned stream would
+     * run its query after the scope closed and be filtered after all.
      */
     public static List<OrganizationModel> organizationsOf(KeycloakSession session, UserModel user) {
         if (session == null || user == null || !Organizations.isEnabled(session)) {
             return List.of();
         }
-        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
-        if (user instanceof PurgedUserSnapshot snapshot) {
-            List<OrganizationModel> resolved = new ArrayList<>();
-            for (String alias : snapshot.getOrganizationAliases()) {
-                OrganizationModel org = orgProvider.getByAlias(alias);
-                if (org != null) {
-                    resolved.add(org);
+        return AdminPermissionsSchema.runWithoutAuthorization(session, () -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            if (user instanceof PurgedUserSnapshot snapshot) {
+                List<OrganizationModel> resolved = new ArrayList<>();
+                for (String alias : snapshot.getOrganizationAliases()) {
+                    OrganizationModel org = orgProvider.getByAlias(alias);
+                    if (org != null) {
+                        resolved.add(org);
+                    }
                 }
+                return resolved;
             }
-            return resolved;
-        }
-        return orgProvider.getByMember(user).toList();
+            return orgProvider.getByMember(user).toList();
+        });
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -111,10 +111,11 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * therefore drops the event when this is set. {@code READ_ONLY} is the default LDAP
      * edit mode, so this is the common federation setup rather than an edge case.
      *
-     * <p>{@code UNSYNCED} is included deliberately. Local state is authoritative there
-     * for credentials, so the deletion does destroy something real — but the identity
-     * itself persists in the directory and re-imports, which is what {@code
-     * account-purged} makes a claim about.
+     * <p>LDAP is the motivating case, not the rule. Because a wrongly emitted purge is
+     * not recoverable downstream, the test is deliberately conservative: everything is
+     * treated as a local removal unless the deletion is known to be authoritative — see
+     * {@link #isLocalRemovalOnly(RealmModel, UserModel)} for what qualifies and why an
+     * absent edit mode does not.
      */
     public boolean isLocalRemovalOnly() {
         return localRemovalOnly;
@@ -283,9 +284,29 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * authoritative store — see {@link #isLocalRemovalOnly()}.
      *
      * <p>Read while the user still exists, because the answer lives on the federation
-     * provider the user links to and nothing can be asked about it afterwards. A local
-     * user, a user whose federation link no longer resolves to a component, or a
-     * provider with no edit mode configured all count as a real removal.
+     * provider the user links to and nothing can be asked about it afterwards.
+     *
+     * <p><b>Unknown never means "purged".</b> Only two cases are treated as a real
+     * removal: a user with no federation link at all, and a provider whose edit mode is
+     * explicitly {@code WRITABLE}, which is the mode that propagates the delete
+     * upstream. Everything else — {@code READ_ONLY}, {@code UNSYNCED}, an edit mode that
+     * is absent, or a federation link that no longer resolves — is treated as a local
+     * removal and suppresses the event.
+     *
+     * <p>Erring this way is not symmetric bookkeeping. A purge a receiver should not
+     * have been told about drives data-retention deletion that cannot be undone; a purge
+     * it is not told about only costs it a signal. Reading an absent edit mode as a real
+     * removal was wrong for exactly that reason: providers disagree on what the missing
+     * value means, and {@code KerberosConfig.getEditMode} defaults it to
+     * {@code UNSYNCED} while {@code KerberosFederationProvider.removeUser} returns
+     * {@code true} without deleting the principal at any edit mode.
+     *
+     * <p>{@code WRITABLE} stays an allowlist rather than provider-specific knowledge.
+     * Kerberos does not offer it — {@code KerberosFederationProviderFactory} exposes only
+     * {@code READ_ONLY} and {@code UNSYNCED} — so in practice it selects LDAP, plus any
+     * third-party provider that declares the mode. A provider declaring {@code WRITABLE}
+     * without actually deleting upstream would still emit; that is its own claim to make,
+     * and an allowlist of provider ids here would only go stale.
      */
     private static boolean isLocalRemovalOnly(RealmModel realm, UserModel user) {
         String federationLink = user.getFederationLink();
@@ -294,14 +315,10 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         }
         ComponentModel component = realm.getComponent(federationLink);
         if (component == null) {
-            return false;
+            return true;
         }
         String editMode = component.getConfig().getFirst(LDAPConstants.EDIT_MODE);
-        if (editMode == null) {
-            return false;
-        }
-        return UserStorageProvider.EditMode.READ_ONLY.name().equals(editMode)
-                || UserStorageProvider.EditMode.UNSYNCED.name().equals(editMode);
+        return !UserStorageProvider.EditMode.WRITABLE.name().equals(editMode);
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -547,11 +547,14 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * address, not a UUID. Indexing the snapshot by email as well lets that gate find
      * it without the filter having to know how the subject was built.
      *
-     * <p>{@code null} for a user with no email, which the set stores as "no secondary
-     * index entry" rather than indexing under a null key.
+     * <p>{@code null} for a user with no usable email, which the set stores as "no
+     * secondary index entry" rather than indexing under a null key. Blank counts as
+     * missing so that indexing matches lookup: {@link #lookupBySubject} rejects a blank
+     * {@code EmailSubjectId} before it looks, so indexing one would only park a snapshot
+     * under a key nothing can ever ask for.
      */
     private static String emailKey(RealmModel realm, String email) {
-        if (email == null) {
+        if (email == null || email.isBlank()) {
             return null;
         }
         // Same normalization AbstractInMemoryUserAdapter applies when storing the

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -5,7 +5,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.SubjectCredentialManager;
@@ -19,6 +21,7 @@ import org.keycloak.ssf.subject.IssuerSubjectId;
 import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.ssf.transmitter.support.SsfUtil;
+import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
 
 import org.jboss.logging.Logger;
@@ -72,14 +75,49 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      */
     private final List<String> organizationAliases;
 
+    /**
+     * Whether the removal only dropped Keycloak's local copy, leaving the account
+     * itself in place — see {@link #isLocalRemovalOnly}.
+     */
+    private final boolean localRemovalOnly;
+
     protected PurgedUserSnapshot(KeycloakSession session,
                                  RealmModel realm,
                                  String id,
                                  String tenantAlias,
-                                 List<String> organizationAliases) {
+                                 List<String> organizationAliases,
+                                 boolean localRemovalOnly) {
         super(session, realm, id);
         this.tenantAlias = tenantAlias;
         this.organizationAliases = organizationAliases;
+        this.localRemovalOnly = localRemovalOnly;
+    }
+
+    /**
+     * True when the deletion removed only Keycloak's local copy of a federated user
+     * while the authoritative store kept the account.
+     *
+     * <p>{@code LDAPStorageProvider.removeUser} returns {@code true} without touching
+     * the directory when the provider's edit mode is {@code READ_ONLY} or
+     * {@code UNSYNCED} — its own log line says the user "will be re-imported from LDAP
+     * again once searched in Keycloak". That {@code true} reaches
+     * {@code UserResource.deleteUser} and {@code DeleteAccount} as a successful
+     * deletion, and both then fire the event this transmitter maps to
+     * {@code account-purged}.
+     *
+     * <p>Receivers drive data-retention deletion off that event, so emitting it for an
+     * account that still exists and will reappear at the next lookup is worse than
+     * emitting nothing: the downstream deletion is not reversible. The purge generator
+     * therefore drops the event when this is set. {@code READ_ONLY} is the default LDAP
+     * edit mode, so this is the common federation setup rather than an edge case.
+     *
+     * <p>{@code UNSYNCED} is included deliberately. Local state is authoritative there
+     * for credentials, so the deletion does destroy something real — but the identity
+     * itself persists in the directory and re-imports, which is what {@code
+     * account-purged} makes a claim about.
+     */
+    public boolean isLocalRemovalOnly() {
+        return localRemovalOnly;
     }
 
     public String getTenantAlias() {
@@ -171,7 +209,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         }
 
         PurgedUserSnapshot snapshot = new PurgedUserSnapshot(session, realm, user.getId(),
-                tenantAlias, organizationAliases);
+                tenantAlias, organizationAliases, isLocalRemovalOnly(realm, user));
 
         // Copy the whole attribute map first — it carries username, email and every
         // ssf.notify.* / ssf.notifyRemovedAt.* entry the subject gates read.
@@ -238,6 +276,32 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         return new CapturedOrganizations(
                 organizations.stream().map(OrganizationModel::getAlias).toList(),
                 tenant == null ? null : tenant.getAlias());
+    }
+
+    /**
+     * Resolves whether removing {@code user} will leave the account in place in its
+     * authoritative store — see {@link #isLocalRemovalOnly()}.
+     *
+     * <p>Read while the user still exists, because the answer lives on the federation
+     * provider the user links to and nothing can be asked about it afterwards. A local
+     * user, a user whose federation link no longer resolves to a component, or a
+     * provider with no edit mode configured all count as a real removal.
+     */
+    private static boolean isLocalRemovalOnly(RealmModel realm, UserModel user) {
+        String federationLink = user.getFederationLink();
+        if (federationLink == null) {
+            return false;
+        }
+        ComponentModel component = realm.getComponent(federationLink);
+        if (component == null) {
+            return false;
+        }
+        String editMode = component.getConfig().getFirst(LDAPConstants.EDIT_MODE);
+        if (editMode == null) {
+            return false;
+        }
+        return UserStorageProvider.EditMode.READ_ONLY.name().equals(editMode)
+                || UserStorageProvider.EditMode.UNSYNCED.name().equals(editMode);
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -81,6 +81,14 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      */
     private final boolean localRemovalOnly;
 
+    /**
+     * Organizations resolved from {@link #organizationAliases}, memoized after the
+     * first call — see {@link #organizationsOf}. Not volatile: a snapshot belongs to
+     * one request on one thread, the same scope that makes it safe to hold live
+     * {@link OrganizationModel}s at all.
+     */
+    private List<OrganizationModel> resolvedOrganizations;
+
     protected PurgedUserSnapshot(KeycloakSession session,
                                  RealmModel realm,
                                  String id,
@@ -387,11 +395,12 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (snapshots == null) {
             return;
         }
-        PurgedUserSnapshot snapshot = snapshots.byId(idKey(realm, userId));
+        String idKey = idKey(realm, userId);
+        PurgedUserSnapshot snapshot = snapshots.byId(idKey);
         if (snapshot == null) {
             return;
         }
-        snapshots.remove(idKey(realm, userId), emailKey(realm, snapshot.getEmail()));
+        snapshots.remove(idKey, emailKey(realm, snapshot.getEmail()));
     }
 
     /**
@@ -472,12 +481,28 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * {@code runWithoutAuthorization} suppresses filtering by setting a session
      * attribute and clearing it in a {@code finally}, so a lazily returned stream would
      * run its query after the scope closed and be filtered after all.
+     *
+     * <p>For a snapshot the answer is memoized. The subject gate asks three separate
+     * questions — notified, excluded, and inside the removal grace — and asks them once
+     * per receiving stream, so without this a user in N organizations costs N alias
+     * lookups times three times the number of streams. There is no bulk alias API to
+     * reach for: {@code getByAlias} resolves one alias per query, and fetching every
+     * organization to index them locally trades a per-membership cost for a per-realm
+     * one. Caching is safe here because the snapshot is request-scoped and read-only,
+     * which is the same reason it can hold live models at all.
+     *
+     * <p>The trade is that an organization deleted later in the same request stays in a
+     * list already resolved. That matches what the snapshot is — a point-in-time
+     * capture — and no purge request deletes organizations.
      */
     public static List<OrganizationModel> organizationsOf(KeycloakSession session, UserModel user) {
         if (session == null || user == null || !Organizations.isEnabled(session)) {
             return List.of();
         }
-        return AdminPermissionsSchema.runWithoutAuthorization(session, () -> {
+        if (user instanceof PurgedUserSnapshot snapshot && snapshot.resolvedOrganizations != null) {
+            return snapshot.resolvedOrganizations;
+        }
+        List<OrganizationModel> organizations = AdminPermissionsSchema.runWithoutAuthorization(session, () -> {
             OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
             if (user instanceof PurgedUserSnapshot snapshot) {
                 List<OrganizationModel> resolved = new ArrayList<>();
@@ -491,6 +516,10 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             }
             return orgProvider.getByMember(user).toList();
         });
+        if (user instanceof PurgedUserSnapshot snapshot) {
+            snapshot.resolvedOrganizations = organizations;
+        }
+        return organizations;
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -1,7 +1,6 @@
 package org.keycloak.ssf.transmitter.subject;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -10,6 +9,7 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.ssf.subject.ComplexSubjectId;
@@ -18,6 +18,8 @@ import org.keycloak.ssf.subject.IssuerSubjectId;
 import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
+
+import org.jboss.logging.Logger;
 
 /**
  * A detached, read-only stand-in for a user that is about to be deleted.
@@ -37,11 +39,14 @@ import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
  * {@code getEmail()}, which is itself an attribute read. Copying the attribute map
  * into an in-memory adapter therefore makes those call sites work unmodified.
  *
- * <p><b>Organizations are the exception.</b> {@code OrganizationProvider.getByMember(user)}
- * is an id-keyed database query, not an attribute read, so a detached user cannot
- * answer it. The organization-derived facts the pipeline needs — the tenant alias for
- * {@code +tenant} subject formats, and the org-level notify / tombstone verdicts —
- * are resolved eagerly at capture time and served from the fields below.
+ * <p><b>Organization membership is the single exception.</b>
+ * {@code OrganizationProvider.getByMember(user)} is an id-keyed database query, not
+ * an attribute read, so a detached user cannot answer it. Only that one fact is
+ * captured here, as a list of aliases: the organizations themselves outlive the
+ * user, so callers re-resolve live {@link OrganizationModel}s through
+ * {@code getByAlias} and then run exactly the same logic they run for a live user.
+ * Nothing about the organizations' own state is copied, which keeps the pluggable
+ * {@link SsfSubjectInclusionResolver} authoritative for purged users as well.
  *
  * <p>The snapshot lives only as long as the request. Everything that reads it
  * (token construction, the subject gates, narrowing and signing) runs inline on the
@@ -49,6 +54,8 @@ import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
  * SET and never resolves a user again.
  */
 public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
+
+    private static final Logger log = Logger.getLogger(PurgedUserSnapshot.class);
 
     private static final String SESSION_ATTRIBUTE_PREFIX = "ssf.purgedUser.";
 
@@ -61,6 +68,25 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      */
     private static final String SESSION_ATTRIBUTE_EMAIL_PREFIX = "ssf.purgedUserByEmail.";
 
+    private static final String SESSION_ATTRIBUTE_COUNT = "ssf.purgedUser.count";
+
+    /**
+     * Upper bound on snapshots retained per session.
+     *
+     * <p>A snapshot is only ever read by the admin / user event that follows the
+     * deletion in the same request, so in the paths that emit there is exactly one
+     * live at a time. Bulk paths are the problem: the workflow delete step
+     * ({@code DeleteUserStepProvider}) removes every due user on a single session and
+     * fires no admin or user event at all, and deleting an organization removes each
+     * managed member in one request. Those snapshots would never be read, so without a
+     * bound a retention run purging tens of thousands of accounts would hold every
+     * one of them for the life of the session.
+     *
+     * <p>The cap is deliberately far above what any emitting request needs, so hitting
+     * it means the caller is a bulk path whose snapshots are dead weight anyway.
+     */
+    private static final int MAX_SNAPSHOTS_PER_SESSION = 64;
+
     /**
      * The user's primary organization alias, resolved managed-preferred to mirror
      * {@code SecurityEventTokenMapper.buildTenantSubject}. {@code null} when the
@@ -69,24 +95,40 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
     private final String tenantAlias;
 
     /**
-     * The {@code ssf.*} attributes of every organization the user belonged to, in
-     * membership order. Backs the org legs of the subject filter, which ask
-     * "is <em>any</em> of the user's organizations notified / excluded".
+     * Aliases of every organization the user belonged to, in membership order. The
+     * stand-in for {@code getByMember} — see the class javadoc.
      */
-    private final List<Map<String, List<String>>> organizationSsfAttributes;
+    private final List<String> organizationAliases;
 
     protected PurgedUserSnapshot(KeycloakSession session,
                                  RealmModel realm,
                                  String id,
                                  String tenantAlias,
-                                 List<Map<String, List<String>>> organizationSsfAttributes) {
+                                 List<String> organizationAliases) {
         super(session, realm, id);
         this.tenantAlias = tenantAlias;
-        this.organizationSsfAttributes = organizationSsfAttributes;
+        this.organizationAliases = organizationAliases;
     }
 
     public String getTenantAlias() {
         return tenantAlias;
+    }
+
+    /**
+     * Aliases of the organizations this user belonged to at deletion time. Callers
+     * resolve them to live {@link OrganizationModel}s rather than reading captured
+     * organization state.
+     */
+    public List<String> getOrganizationAliases() {
+        return organizationAliases;
+    }
+
+    /**
+     * The realm the user was deleted from. Snapshots are keyed by user id alone, so
+     * callers use this to reject a snapshot from a different realm.
+     */
+    public RealmModel getRealm() {
+        return realm;
     }
 
     /**
@@ -106,7 +148,8 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * Captures {@code user} and stashes it on the session under its user id.
      * No-op when the user is a service account — those are not human subjects and
      * never produce a purge SET, so capturing one would only cost an organization
-     * query on every client deletion.
+     * query on every client deletion — and no-op once
+     * {@link #MAX_SNAPSHOTS_PER_SESSION} snapshots are already held.
      *
      * <p>Callers invoke this from the pre-remove hook, which fires before Keycloak
      * knows whether the removal will succeed. Capturing is therefore deliberately
@@ -121,14 +164,24 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             return;
         }
 
+        Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
+        int count = held == null ? 0 : held;
+        if (count >= MAX_SNAPSHOTS_PER_SESSION) {
+            if (count == MAX_SNAPSHOTS_PER_SESSION) {
+                log.debugf("SSF: reached %d purge snapshots on this session; not capturing further deletions. "
+                                + "This is expected for bulk deletion paths, which emit no purge events.",
+                        MAX_SNAPSHOTS_PER_SESSION);
+                session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
+            }
+            return;
+        }
+
         String tenantAlias = null;
-        List<Map<String, List<String>>> orgAttributes = new ArrayList<>();
+        List<String> organizationAliases = List.of();
         if (Organizations.isEnabled(session)) {
             OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
             List<OrganizationModel> organizations = orgProvider.getByMember(user).toList();
-            for (OrganizationModel org : organizations) {
-                orgAttributes.add(copySsfAttributes(org.getAttributes()));
-            }
+            organizationAliases = organizations.stream().map(OrganizationModel::getAlias).toList();
             // Managed-preferred, matching the mapper's multi-org resolution policy:
             // the organization that provisioned the user wins, otherwise the first
             // membership. Keeps the purge event's tenant subject identical to the
@@ -143,7 +196,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         }
 
         PurgedUserSnapshot snapshot = new PurgedUserSnapshot(session, realm, user.getId(),
-                tenantAlias, List.copyOf(orgAttributes));
+                tenantAlias, organizationAliases);
 
         // Copy the whole attribute map first — it carries username, email and every
         // ssf.notify.* / ssf.notifyRemovedAt.* entry the subject gates read.
@@ -172,17 +225,19 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (snapshot.getEmail() != null) {
             session.setAttribute(sessionEmailAttributeKey(snapshot.getEmail()), snapshot);
         }
+        session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
     }
 
     /**
      * Returns the snapshot captured for {@code userId} in this session, or
      * {@code null} when the user was not deleted on this request.
      */
-    public static PurgedUserSnapshot lookup(KeycloakSession session, String userId) {
+    public static PurgedUserSnapshot lookup(KeycloakSession session, RealmModel realm, String userId) {
         if (session == null || userId == null) {
             return null;
         }
-        return session.getAttribute(sessionAttributeKey(userId), PurgedUserSnapshot.class);
+        PurgedUserSnapshot snapshot = session.getAttribute(sessionAttributeKey(userId), PurgedUserSnapshot.class);
+        return matchesRealm(snapshot, realm) ? snapshot : null;
     }
 
     /**
@@ -194,25 +249,27 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * <p>Complex subjects are drilled into their {@code user} member, matching how
      * the filter unwraps them for live users.
      */
-    public static PurgedUserSnapshot lookupBySubject(KeycloakSession session, SubjectId subjectId) {
+    public static PurgedUserSnapshot lookupBySubject(KeycloakSession session, RealmModel realm, SubjectId subjectId) {
         if (session == null || subjectId == null) {
             return null;
         }
         if (subjectId instanceof ComplexSubjectId complex) {
-            return lookupBySubject(session, complex.getUser());
+            return lookupBySubject(session, realm, complex.getUser());
         }
         if (subjectId instanceof IssuerSubjectId issuerSubject) {
-            return lookup(session, issuerSubject.getSub());
+            return lookup(session, realm, issuerSubject.getSub());
         }
         if (subjectId instanceof OpaqueSubjectId opaqueSubject) {
-            return lookup(session, opaqueSubject.getId());
+            return lookup(session, realm, opaqueSubject.getId());
         }
         if (subjectId instanceof EmailSubjectId emailSubject) {
             String email = emailSubject.getEmail();
             if (email == null || email.isBlank()) {
                 return null;
             }
-            return session.getAttribute(sessionEmailAttributeKey(email), PurgedUserSnapshot.class);
+            PurgedUserSnapshot snapshot =
+                    session.getAttribute(sessionEmailAttributeKey(email), PurgedUserSnapshot.class);
+            return matchesRealm(snapshot, realm) ? snapshot : null;
         }
         return null;
     }
@@ -223,87 +280,48 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * the emission path uses in place of a bare {@code getUserById}.
      */
     public static UserModel resolveUserOrSnapshot(KeycloakSession session, RealmModel realm, String userId) {
-        if (session == null || userId == null) {
+        if (session == null || realm == null || userId == null) {
             return null;
         }
-        UserModel user = realm != null ? session.users().getUserById(realm, userId) : null;
-        return user != null ? user : lookup(session, userId);
-    }
-
-    public boolean isAnyOrganizationNotified(String clientId) {
-        return anyOrganizationHasValue(SsfNotifyAttributes.attributeKey(clientId),
-                SsfNotifyAttributes.ATTRIBUTE_VALUE_TRUE);
-    }
-
-    public boolean isAnyOrganizationExcluded(String clientId) {
-        return anyOrganizationHasValue(SsfNotifyAttributes.attributeKey(clientId),
-                SsfNotifyAttributes.ATTRIBUTE_VALUE_FALSE);
+        UserModel user = session.users().getUserById(realm, userId);
+        return user != null ? user : lookup(session, realm, userId);
     }
 
     /**
-     * The most recent org-level removal tombstone across the user's organizations,
-     * or {@code null} when none carry one. Most-recent mirrors the live filter's
-     * {@code anyMatch} over memberships — if any organization is still inside the
-     * grace window, the event is delivered.
+     * Resolves the organizations a user belonged to, whether live or purged.
+     *
+     * <p>For a live user this is {@code getByMember}. For a snapshot the captured
+     * aliases are resolved back to live {@link OrganizationModel}s — the organizations
+     * outlive the user, so callers get real models and can apply the same logic in
+     * both cases. Aliases that no longer resolve (the organization was deleted in the
+     * same request) are dropped.
      */
-    public Long getOrganizationRemovedAt(String clientId) {
-        String key = SsfNotifyAttributes.removedAtKey(clientId);
-        Long latest = null;
-        for (Map<String, List<String>> attributes : organizationSsfAttributes) {
-            List<String> values = attributes.get(key);
-            if (values == null || values.isEmpty()) {
-                continue;
-            }
-            Long parsed = parseEpochSeconds(values.get(0));
-            if (parsed != null && (latest == null || parsed > latest)) {
-                latest = parsed;
-            }
+    public static List<OrganizationModel> organizationsOf(KeycloakSession session, UserModel user) {
+        if (session == null || user == null || !Organizations.isEnabled(session)) {
+            return List.of();
         }
-        return latest;
+        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        if (user instanceof PurgedUserSnapshot snapshot) {
+            List<OrganizationModel> resolved = new ArrayList<>();
+            for (String alias : snapshot.getOrganizationAliases()) {
+                OrganizationModel org = orgProvider.getByAlias(alias);
+                if (org != null) {
+                    resolved.add(org);
+                }
+            }
+            return resolved;
+        }
+        return orgProvider.getByMember(user).toList();
     }
 
-    private boolean anyOrganizationHasValue(String key, String value) {
-        for (Map<String, List<String>> attributes : organizationSsfAttributes) {
-            List<String> values = attributes.get(key);
-            if (values != null && values.contains(value)) {
-                return true;
-            }
+    private static boolean matchesRealm(PurgedUserSnapshot snapshot, RealmModel realm) {
+        if (snapshot == null) {
+            return false;
         }
-        return false;
-    }
-
-    private static Long parseEpochSeconds(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return null;
+        if (realm == null || snapshot.getRealm() == null) {
+            return true;
         }
-        try {
-            return Long.parseLong(raw.trim());
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    /**
-     * Narrows an organization's attribute map to the {@code ssf.*} keys. Organization
-     * attributes are operator-defined and unbounded; only the SSF ones are ever read
-     * back, so the snapshot does not retain the rest.
-     */
-    private static Map<String, List<String>> copySsfAttributes(Map<String, List<String>> attributes) {
-        Map<String, List<String>> copy = new LinkedHashMap<>();
-        if (attributes == null) {
-            return copy;
-        }
-        for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
-            String key = entry.getKey();
-            if (key == null || entry.getValue() == null) {
-                continue;
-            }
-            if (key.startsWith(SsfNotifyAttributes.ATTRIBUTE_PREFIX)
-                    || key.startsWith(SsfNotifyAttributes.REMOVED_AT_PREFIX)) {
-                copy.put(key, List.copyOf(entry.getValue()));
-            }
-        }
-        return copy;
+        return realm.getId().equals(snapshot.getRealm().getId());
     }
 
     private static String sessionAttributeKey(String userId) {
@@ -311,6 +329,8 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
     }
 
     private static String sessionEmailAttributeKey(String email) {
-        return SESSION_ATTRIBUTE_EMAIL_PREFIX + email.toLowerCase();
+        // Same normalization AbstractInMemoryUserAdapter applies when storing the
+        // email, so the index key matches what getEmail() returns.
+        return SESSION_ATTRIBUTE_EMAIL_PREFIX + KeycloakModelUtils.toLowerCaseSafe(email);
     }
 }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -57,37 +57,6 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
 
     private static final Logger log = Logger.getLogger(PurgedUserSnapshot.class);
 
-    private static final String SESSION_ATTRIBUTE_PREFIX = "ssf.purgedUser.";
-
-    private static final String SESSION_ATTRIBUTE_COUNT = "ssf.purgedUser.count";
-
-    /**
-     * Upper bound on snapshots retained per session, complementing
-     * {@link #isRequestBound}.
-     *
-     * <p>The request gate excludes deletions with no request behind them, but bulk
-     * deletion still happens <em>inside</em> a request: a partial import under the
-     * {@code OVERWRITE} policy replaces many users in one call, and deleting an
-     * organization removes each of its managed members. Neither emits a purge event,
-     * so their snapshots are never read — and without a bound, one such request would
-     * retain a copied attribute map per account until it finishes.
-     *
-     * <p>An emitting request needs exactly one snapshot live at a time, so this bound
-     * is unreachable on the paths that matter. Being truncated is logged at WARN
-     * rather than DEBUG: dropping a snapshot can only ever cost an event, and that
-     * must never happen quietly.
-     */
-    private static final int MAX_SNAPSHOTS_PER_SESSION = 64;
-
-    /**
-     * Secondary index. The dispatcher's subject gate re-resolves the user from the
-     * token's own {@code sub_id} rather than from the event's user id, and for a
-     * stream configured with the {@code email} subject format that identifier is an
-     * address, not a UUID. Stashing the snapshot under both keys lets that gate find
-     * it without the filter having to know how the subject was built.
-     */
-    private static final String SESSION_ATTRIBUTE_EMAIL_PREFIX = "ssf.purgedUserByEmail.";
-
     /**
      * The user's primary organization alias, resolved managed-preferred to mirror
      * {@code SecurityEventTokenMapper.buildTenantSubject}. {@code null} when the
@@ -146,12 +115,15 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
     }
 
     /**
-     * Captures {@code user} and stashes it on the session under its user id.
-     * No-op when the user is a service account — those are not human subjects and
+     * Captures {@code user} into this request's {@link PurgedUserSnapshots}, indexed by
+     * user id and, when the user has one, by email.
+     *
+     * <p>No-op when the user is a service account — those are not human subjects and
      * never produce a purge SET, so capturing one would only cost an organization
      * query on every client deletion; when the deletion is not bound to an HTTP
      * request (see {@link #isRequestBound}); and once
-     * {@link #MAX_SNAPSHOTS_PER_SESSION} snapshots are already held for this request.
+     * {@link PurgedUserSnapshots#MAX_SNAPSHOTS_PER_SESSION} snapshots are already
+     * held for this request.
      *
      * <p>Callers invoke this from the pre-remove hook, which fires before Keycloak
      * knows whether the removal will succeed. Capturing is therefore deliberately
@@ -169,18 +141,19 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             return;
         }
 
-        Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
-        int count = held == null ? 0 : held;
-        if (count >= MAX_SNAPSHOTS_PER_SESSION) {
-            if (count == MAX_SNAPSHOTS_PER_SESSION) {
-                // Warn exactly once per session rather than per deletion, so a bulk
-                // request leaves one line instead of thousands.
-                log.warnf("SSF: reached %d purge snapshots in a single request; no further deletions in it "
-                                + "will be captured, and any purge events they would have produced are lost. "
-                                + "Expected for bulk deletion (partial import OVERWRITE, organization removal), "
-                                + "which do not emit purge events.",
-                        MAX_SNAPSHOTS_PER_SESSION);
-                session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
+        PurgedUserSnapshots snapshots = PurgedUserSnapshots.of(session);
+        if (snapshots.isFull()) {
+            // Truncation is logged at WARN rather than DEBUG: dropping a snapshot can
+            // only ever cost an event, and that must never happen quietly. The latch
+            // lives on the set rather than being inferred from its size, so a bulk
+            // request leaves one line instead of thousands while a later discard still
+            // frees a slot that the next capture can use.
+            if (snapshots.markBoundWarned()) {
+                log.warnf("SSF: reached %d purge snapshots in a single request; further deletions in it "
+                                + "will not be captured while the set stays full, and any purge events they "
+                                + "would have produced are lost. Expected for bulk deletion (partial import "
+                                + "OVERWRITE, organization removal), which do not emit purge events.",
+                        PurgedUserSnapshots.MAX_SNAPSHOTS_PER_SESSION);
             }
             return;
         }
@@ -244,11 +217,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
 
         snapshot.setReadonly(true);
 
-        session.setAttribute(sessionAttributeKey(realm, user.getId()), snapshot);
-        if (snapshot.getEmail() != null) {
-            session.setAttribute(sessionEmailAttributeKey(realm, snapshot.getEmail()), snapshot);
-        }
-        session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
+        snapshots.put(idKey(realm, user.getId()), emailKey(realm, snapshot.getEmail()), snapshot);
     }
 
     /**
@@ -289,15 +258,16 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (session == null || realm == null || userId == null) {
             return null;
         }
-        return session.getAttribute(sessionAttributeKey(realm, userId), PurgedUserSnapshot.class);
+        PurgedUserSnapshots snapshots = PurgedUserSnapshots.find(session);
+        return snapshots == null ? null : snapshots.byId(idKey(realm, userId));
     }
 
     /**
      * Drops the snapshot for {@code userId}, called by the event listener once it has
      * finished emitting for that deletion.
      *
-     * <p>This is what keeps {@link #MAX_SNAPSHOTS_PER_SESSION} out of the way of the
-     * paths that matter. A request that deletes users <em>and</em> emits for them
+     * <p>This is what keeps {@link PurgedUserSnapshots#MAX_SNAPSHOTS_PER_SESSION} out
+     * of the way of the paths that matter. A request that deletes users <em>and</em> emits for them
      * returns to zero retained snapshots after each one, so it can delete any number
      * without approaching the bound. Only snapshots that are never consumed accumulate
      * — which is precisely the bulk deletion case (partial import {@code OVERWRITE},
@@ -312,18 +282,15 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (session == null || realm == null || userId == null) {
             return;
         }
-        PurgedUserSnapshot snapshot = lookup(session, realm, userId);
+        PurgedUserSnapshots snapshots = PurgedUserSnapshots.find(session);
+        if (snapshots == null) {
+            return;
+        }
+        PurgedUserSnapshot snapshot = snapshots.byId(idKey(realm, userId));
         if (snapshot == null) {
             return;
         }
-        session.removeAttribute(sessionAttributeKey(realm, userId));
-        if (snapshot.getEmail() != null) {
-            session.removeAttribute(sessionEmailAttributeKey(realm, snapshot.getEmail()));
-        }
-        Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
-        if (held != null && held > 0) {
-            session.setAttribute(SESSION_ATTRIBUTE_COUNT, held - 1);
-        }
+        snapshots.remove(idKey(realm, userId), emailKey(realm, snapshot.getEmail()));
     }
 
     /**
@@ -353,7 +320,8 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             if (email == null || email.isBlank()) {
                 return null;
             }
-            return session.getAttribute(sessionEmailAttributeKey(realm, email), PurgedUserSnapshot.class);
+            PurgedUserSnapshots snapshots = PurgedUserSnapshots.find(session);
+            return snapshots == null ? null : snapshots.byEmail(emailKey(realm, email));
         }
         return null;
     }
@@ -399,20 +367,32 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
     }
 
     /**
-     * Session keys are scoped by realm id so a snapshot can only ever be found from
-     * the realm it was captured in. User ids are realm-unique in practice, but the
+     * Index keys are scoped by realm id so a snapshot can only ever be found from the
+     * realm it was captured in. User ids are realm-unique in practice, but the
      * external-id component of a federated id is not guaranteed to be, and a
      * cross-realm hit would gate one realm's event on another realm's subject.
      * Scoping is free and removes the need to compare realms after the fact.
      */
-    private static String sessionAttributeKey(RealmModel realm, String userId) {
-        return SESSION_ATTRIBUTE_PREFIX + realm.getId() + "." + userId;
+    private static String idKey(RealmModel realm, String userId) {
+        return realm.getId() + "." + userId;
     }
 
-    private static String sessionEmailAttributeKey(RealmModel realm, String email) {
+    /**
+     * Key into the secondary index. The dispatcher's subject gate re-resolves the user
+     * from the token's own {@code sub_id} rather than from the event's user id, and for
+     * a stream configured with the {@code email} subject format that identifier is an
+     * address, not a UUID. Indexing the snapshot by email as well lets that gate find
+     * it without the filter having to know how the subject was built.
+     *
+     * <p>{@code null} for a user with no email, which the set stores as "no secondary
+     * index entry" rather than indexing under a null key.
+     */
+    private static String emailKey(RealmModel realm, String email) {
+        if (email == null) {
+            return null;
+        }
         // Same normalization AbstractInMemoryUserAdapter applies when storing the
         // email, so the index key matches what getEmail() returns.
-        return SESSION_ATTRIBUTE_EMAIL_PREFIX + realm.getId() + "."
-                + KeycloakModelUtils.toLowerCaseSafe(email);
+        return realm.getId() + "." + KeycloakModelUtils.toLowerCaseSafe(email);
     }
 }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -3,6 +3,7 @@ package org.keycloak.ssf.transmitter.subject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.component.ComponentModel;
@@ -122,8 +123,8 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * <p>LDAP is the motivating case, not the rule. Because a wrongly emitted purge is
      * not recoverable downstream, the test is deliberately conservative: everything is
      * treated as a local removal unless the deletion is known to be authoritative — see
-     * {@link #isLocalRemovalOnly(RealmModel, UserModel)} for what qualifies and why an
-     * absent edit mode does not.
+     * {@link #resolveLocalRemovalOnly} for what qualifies and why an absent edit mode
+     * does not.
      */
     public boolean isLocalRemovalOnly() {
         return localRemovalOnly;
@@ -218,7 +219,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         }
 
         PurgedUserSnapshot snapshot = new PurgedUserSnapshot(session, realm, user.getId(),
-                tenantAlias, organizationAliases, isLocalRemovalOnly(realm, user));
+                tenantAlias, organizationAliases, resolveLocalRemovalOnly(realm, user));
 
         // Copy the whole attribute map first — it carries username, email and every
         // ssf.notify.* / ssf.notifyRemovedAt.* entry the subject gates read.
@@ -316,7 +317,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * without actually deleting upstream would still emit; that is its own claim to make,
      * and an allowlist of provider ids here would only go stale.
      */
-    private static boolean isLocalRemovalOnly(RealmModel realm, UserModel user) {
+    private static boolean resolveLocalRemovalOnly(RealmModel realm, UserModel user) {
         String federationLink = user.getFederationLink();
         if (federationLink == null) {
             return false;
@@ -523,6 +524,32 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             snapshot.resolvedOrganizations = organizations;
         }
         return organizations;
+    }
+
+    /**
+     * Whether any of the user's organizations satisfies {@code predicate}.
+     *
+     * <p>The subject gate only ever asks "is any of them …", so the predicate is passed
+     * in rather than the collection handed out. That keeps a live user's membership
+     * stream short-circuiting — {@code anyMatch} stops at the first hit instead of
+     * loading every membership — while a snapshot still answers from its memoized list.
+     *
+     * <p>Passing the predicate in is also what makes the short-circuit compatible with
+     * the unfiltered read: the stream is consumed <em>inside</em>
+     * {@code runWithoutAuthorization}, where returning a lazy stream from
+     * {@link #organizationsOf} would have run the query after the scope closed and been
+     * filtered after all.
+     */
+    public static boolean anyOrganizationMatches(KeycloakSession session, UserModel user,
+                                                 Predicate<OrganizationModel> predicate) {
+        if (session == null || user == null || predicate == null || !Organizations.isEnabled(session)) {
+            return false;
+        }
+        if (user instanceof PurgedUserSnapshot) {
+            return organizationsOf(session, user).stream().anyMatch(predicate);
+        }
+        return AdminPermissionsSchema.runWithoutAuthorization(session, () ->
+                session.getProvider(OrganizationProvider.class).getByMember(user).anyMatch(predicate));
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -512,7 +512,10 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
                         resolved.add(org);
                     }
                 }
-                return resolved;
+                // Unmodifiable because it is memoized: a caller mutating the returned
+                // list would otherwise change later subject-gate verdicts in the same
+                // request. The live branch below already returns an immutable list.
+                return List.copyOf(resolved);
             }
             return orgProvider.getByMember(user).toList();
         });

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -17,6 +17,7 @@ import org.keycloak.ssf.subject.EmailSubjectId;
 import org.keycloak.ssf.subject.IssuerSubjectId;
 import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
+import org.keycloak.ssf.transmitter.support.SsfUtil;
 import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
 
 import org.jboss.logging.Logger;
@@ -301,6 +302,9 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      *
      * <p>Complex subjects are drilled into their {@code user} member, matching how
      * the filter unwraps them for live users.
+     *
+     * <p>An {@code iss_sub} subject only names a Keycloak user id when this
+     * transmitter issued it — see {@link #isOwnIssuer}.
      */
     public static PurgedUserSnapshot lookupBySubject(KeycloakSession session, RealmModel realm, SubjectId subjectId) {
         if (session == null || realm == null || subjectId == null) {
@@ -310,6 +314,9 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             return lookupBySubject(session, realm, complex.getUser());
         }
         if (subjectId instanceof IssuerSubjectId issuerSubject) {
+            if (!isOwnIssuer(session, issuerSubject.getIss())) {
+                return null;
+            }
             return lookup(session, realm, issuerSubject.getSub());
         }
         if (subjectId instanceof OpaqueSubjectId opaqueSubject) {
@@ -364,6 +371,42 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             return resolved;
         }
         return orgProvider.getByMember(user).toList();
+    }
+
+    /**
+     * Whether {@code iss} is the issuer this transmitter stamps onto the subjects it
+     * builds, and therefore whether an {@code iss_sub} subject's {@code sub} is a
+     * Keycloak user id at all.
+     *
+     * <p>Without this, the snapshot index would answer for any issuer:
+     * {@code SubjectUserLookup} reads {@code sub} as an <em>external</em> IdP subject
+     * whenever {@code iss} is not ours, resolving it through federated identity, and a
+     * foreign {@code sub} that happened to equal a captured user id would otherwise
+     * short-circuit to the wrong subject. Keeping the two in agreement matters more
+     * now that the filter consults the snapshot <em>before</em> the live lookup for
+     * purge events.
+     *
+     * <p>Compared against {@link SsfUtil#getIssuerUrl} rather than
+     * {@code SubjectUserLookup.isRealmIssuer}: the transmitter's issuer is what
+     * {@code SecurityEventTokenMapper.buildUserSubjectId} actually stamps, and it is
+     * not always the realm issuer — a realm carrying a {@code frontendUrl} attribute
+     * uses that value verbatim, and the fallback resolves the base URI without the
+     * {@code FRONTEND} url type. Gating on the realm issuer would reject the
+     * transmitter's own subjects in those deployments and drop every purge.
+     *
+     * <p>Any failure to resolve the issuer is treated as "not ours", which costs at
+     * most a snapshot miss that the live lookup then handles.
+     */
+    private static boolean isOwnIssuer(KeycloakSession session, String iss) {
+        if (iss == null) {
+            return false;
+        }
+        try {
+            return iss.equals(SsfUtil.getIssuerUrl(session));
+        } catch (RuntimeException e) {
+            log.debugf(e, "SSF: could not resolve transmitter issuer while matching purge snapshot for iss=%s", iss);
+            return false;
+        }
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -19,8 +19,6 @@ import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
 
-import org.jboss.logging.Logger;
-
 /**
  * A detached, read-only stand-in for a user that is about to be deleted.
  *
@@ -55,8 +53,6 @@ import org.jboss.logging.Logger;
  */
 public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
 
-    private static final Logger log = Logger.getLogger(PurgedUserSnapshot.class);
-
     private static final String SESSION_ATTRIBUTE_PREFIX = "ssf.purgedUser.";
 
     /**
@@ -67,25 +63,6 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * it without the filter having to know how the subject was built.
      */
     private static final String SESSION_ATTRIBUTE_EMAIL_PREFIX = "ssf.purgedUserByEmail.";
-
-    private static final String SESSION_ATTRIBUTE_COUNT = "ssf.purgedUser.count";
-
-    /**
-     * Upper bound on snapshots retained per session.
-     *
-     * <p>A snapshot is only ever read by the admin / user event that follows the
-     * deletion in the same request, so in the paths that emit there is exactly one
-     * live at a time. Bulk paths are the problem: the workflow delete step
-     * ({@code DeleteUserStepProvider}) removes every due user on a single session and
-     * fires no admin or user event at all, and deleting an organization removes each
-     * managed member in one request. Those snapshots would never be read, so without a
-     * bound a retention run purging tens of thousands of accounts would hold every
-     * one of them for the life of the session.
-     *
-     * <p>The cap is deliberately far above what any emitting request needs, so hitting
-     * it means the caller is a bulk path whose snapshots are dead weight anyway.
-     */
-    private static final int MAX_SNAPSHOTS_PER_SESSION = 64;
 
     /**
      * The user's primary organization alias, resolved managed-preferred to mirror
@@ -148,8 +125,8 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * Captures {@code user} and stashes it on the session under its user id.
      * No-op when the user is a service account — those are not human subjects and
      * never produce a purge SET, so capturing one would only cost an organization
-     * query on every client deletion — and no-op once
-     * {@link #MAX_SNAPSHOTS_PER_SESSION} snapshots are already held.
+     * query on every client deletion — and no-op when the deletion is not bound to
+     * an HTTP request (see {@link #isRequestBound}).
      *
      * <p>Callers invoke this from the pre-remove hook, which fires before Keycloak
      * knows whether the removal will succeed. Capturing is therefore deliberately
@@ -163,16 +140,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (user.getServiceAccountClientLink() != null) {
             return;
         }
-
-        Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
-        int count = held == null ? 0 : held;
-        if (count >= MAX_SNAPSHOTS_PER_SESSION) {
-            if (count == MAX_SNAPSHOTS_PER_SESSION) {
-                log.debugf("SSF: reached %d purge snapshots on this session; not capturing further deletions. "
-                                + "This is expected for bulk deletion paths, which emit no purge events.",
-                        MAX_SNAPSHOTS_PER_SESSION);
-                session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
-            }
+        if (!isRequestBound(session)) {
             return;
         }
 
@@ -225,7 +193,36 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (snapshot.getEmail() != null) {
             session.setAttribute(sessionEmailAttributeKey(snapshot.getEmail()), snapshot);
         }
-        session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
+    }
+
+    /**
+     * True when this deletion is happening inside an HTTP request.
+     *
+     * <p>A snapshot exists solely to serve the admin or user event fired later in the
+     * same request, so a deletion with no request behind it can never produce one and
+     * capturing would retain data nothing will ever read. That is not hypothetical:
+     * {@code DefaultWorkflowProvider.runScheduledSteps} drives every due step for every
+     * enabled workflow on a single session, and its delete step removes one user per
+     * iteration — so a retention run purging tens of thousands of accounts would
+     * otherwise hold a snapshot for each, for the life of that session.
+     *
+     * <p>Deliberately a gate rather than a cap on retained snapshots. A cap would
+     * silently stop capturing partway through a bulk run, which becomes silently
+     * dropped events the day those paths do emit; this stays correct either way,
+     * because emission for them cannot use the request-bound listener path anyway.
+     *
+     * <p>{@code getHttpRequest()} throws {@link RuntimeException}
+     * ({@code ContextNotActiveException}) rather than returning null when no request
+     * context is active, so absence has to be detected by catching. Any failure is
+     * treated as "no request": the cost is a purge event not emitted on a path that
+     * has none to emit, which is strictly better than unbounded retention.
+     */
+    private static boolean isRequestBound(KeycloakSession session) {
+        try {
+            return session.getContext() != null && session.getContext().getHttpRequest() != null;
+        } catch (RuntimeException e) {
+            return false;
+        }
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -228,6 +228,20 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             snapshot.setEmail(user.getEmail());
         }
         snapshot.setEnabled(user.isEnabled());
+
+        // Group and role memberships matter because SsfSubjectInclusionResolver
+        // documents group-attribute lookups and role-based opt-ins as supported
+        // extension points: a resolver doing either would see an empty membership
+        // set for a purged user and silently reach a different verdict than it does
+        // for a live one. AbstractInMemoryUserAdapter stores only the ids and
+        // resolves them back through the realm on read, so — exactly like the
+        // organization aliases above — nothing about the groups or roles themselves
+        // is copied, and they outlive the user. The membership rows are deleted by
+        // JpaUserProvider.removeUser, which runs after this hook, so they are still
+        // readable here.
+        user.getGroupsStream().forEach(snapshot::joinGroup);
+        user.getRoleMappingsStream().forEach(snapshot::grantRole);
+
         snapshot.setReadonly(true);
 
         session.setAttribute(sessionAttributeKey(user.getId()), snapshot);

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -125,8 +125,8 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
     }
 
     /**
-     * The realm the user was deleted from. Snapshots are keyed by user id alone, so
-     * callers use this to reject a snapshot from a different realm.
+     * The realm the user was deleted from. Session keys are scoped by realm id, so
+     * a snapshot can only be found from the realm it was captured in.
      */
     public RealmModel getRealm() {
         return realm;
@@ -244,9 +244,9 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
 
         snapshot.setReadonly(true);
 
-        session.setAttribute(sessionAttributeKey(user.getId()), snapshot);
+        session.setAttribute(sessionAttributeKey(realm, user.getId()), snapshot);
         if (snapshot.getEmail() != null) {
-            session.setAttribute(sessionEmailAttributeKey(snapshot.getEmail()), snapshot);
+            session.setAttribute(sessionEmailAttributeKey(realm, snapshot.getEmail()), snapshot);
         }
         session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
     }
@@ -286,11 +286,10 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * {@code null} when the user was not deleted on this request.
      */
     public static PurgedUserSnapshot lookup(KeycloakSession session, RealmModel realm, String userId) {
-        if (session == null || userId == null) {
+        if (session == null || realm == null || userId == null) {
             return null;
         }
-        PurgedUserSnapshot snapshot = session.getAttribute(sessionAttributeKey(userId), PurgedUserSnapshot.class);
-        return matchesRealm(snapshot, realm) ? snapshot : null;
+        return session.getAttribute(sessionAttributeKey(realm, userId), PurgedUserSnapshot.class);
     }
 
     /**
@@ -310,16 +309,16 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * and a miss here costs nothing beyond retention.
      */
     public static void discard(KeycloakSession session, RealmModel realm, String userId) {
-        if (session == null || userId == null) {
+        if (session == null || realm == null || userId == null) {
             return;
         }
         PurgedUserSnapshot snapshot = lookup(session, realm, userId);
         if (snapshot == null) {
             return;
         }
-        session.removeAttribute(sessionAttributeKey(userId));
+        session.removeAttribute(sessionAttributeKey(realm, userId));
         if (snapshot.getEmail() != null) {
-            session.removeAttribute(sessionEmailAttributeKey(snapshot.getEmail()));
+            session.removeAttribute(sessionEmailAttributeKey(realm, snapshot.getEmail()));
         }
         Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
         if (held != null && held > 0) {
@@ -337,7 +336,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * the filter unwraps them for live users.
      */
     public static PurgedUserSnapshot lookupBySubject(KeycloakSession session, RealmModel realm, SubjectId subjectId) {
-        if (session == null || subjectId == null) {
+        if (session == null || realm == null || subjectId == null) {
             return null;
         }
         if (subjectId instanceof ComplexSubjectId complex) {
@@ -354,9 +353,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             if (email == null || email.isBlank()) {
                 return null;
             }
-            PurgedUserSnapshot snapshot =
-                    session.getAttribute(sessionEmailAttributeKey(email), PurgedUserSnapshot.class);
-            return matchesRealm(snapshot, realm) ? snapshot : null;
+            return session.getAttribute(sessionEmailAttributeKey(realm, email), PurgedUserSnapshot.class);
         }
         return null;
     }
@@ -401,23 +398,21 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         return orgProvider.getByMember(user).toList();
     }
 
-    private static boolean matchesRealm(PurgedUserSnapshot snapshot, RealmModel realm) {
-        if (snapshot == null) {
-            return false;
-        }
-        if (realm == null || snapshot.getRealm() == null) {
-            return true;
-        }
-        return realm.getId().equals(snapshot.getRealm().getId());
+    /**
+     * Session keys are scoped by realm id so a snapshot can only ever be found from
+     * the realm it was captured in. User ids are realm-unique in practice, but the
+     * external-id component of a federated id is not guaranteed to be, and a
+     * cross-realm hit would gate one realm's event on another realm's subject.
+     * Scoping is free and removes the need to compare realms after the fact.
+     */
+    private static String sessionAttributeKey(RealmModel realm, String userId) {
+        return SESSION_ATTRIBUTE_PREFIX + realm.getId() + "." + userId;
     }
 
-    private static String sessionAttributeKey(String userId) {
-        return SESSION_ATTRIBUTE_PREFIX + userId;
-    }
-
-    private static String sessionEmailAttributeKey(String email) {
+    private static String sessionEmailAttributeKey(RealmModel realm, String email) {
         // Same normalization AbstractInMemoryUserAdapter applies when storing the
         // email, so the index key matches what getEmail() returns.
-        return SESSION_ATTRIBUTE_EMAIL_PREFIX + KeycloakModelUtils.toLowerCaseSafe(email);
+        return SESSION_ATTRIBUTE_EMAIL_PREFIX + realm.getId() + "."
+                + KeycloakModelUtils.toLowerCaseSafe(email);
     }
 }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshot.java
@@ -19,6 +19,8 @@ import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
 
+import org.jboss.logging.Logger;
+
 /**
  * A detached, read-only stand-in for a user that is about to be deleted.
  *
@@ -53,7 +55,29 @@ import org.keycloak.storage.adapter.AbstractInMemoryUserAdapter;
  */
 public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
 
+    private static final Logger log = Logger.getLogger(PurgedUserSnapshot.class);
+
     private static final String SESSION_ATTRIBUTE_PREFIX = "ssf.purgedUser.";
+
+    private static final String SESSION_ATTRIBUTE_COUNT = "ssf.purgedUser.count";
+
+    /**
+     * Upper bound on snapshots retained per session, complementing
+     * {@link #isRequestBound}.
+     *
+     * <p>The request gate excludes deletions with no request behind them, but bulk
+     * deletion still happens <em>inside</em> a request: a partial import under the
+     * {@code OVERWRITE} policy replaces many users in one call, and deleting an
+     * organization removes each of its managed members. Neither emits a purge event,
+     * so their snapshots are never read — and without a bound, one such request would
+     * retain a copied attribute map per account until it finishes.
+     *
+     * <p>An emitting request needs exactly one snapshot live at a time, so this bound
+     * is unreachable on the paths that matter. Being truncated is logged at WARN
+     * rather than DEBUG: dropping a snapshot can only ever cost an event, and that
+     * must never happen quietly.
+     */
+    private static final int MAX_SNAPSHOTS_PER_SESSION = 64;
 
     /**
      * Secondary index. The dispatcher's subject gate re-resolves the user from the
@@ -125,8 +149,9 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
      * Captures {@code user} and stashes it on the session under its user id.
      * No-op when the user is a service account — those are not human subjects and
      * never produce a purge SET, so capturing one would only cost an organization
-     * query on every client deletion — and no-op when the deletion is not bound to
-     * an HTTP request (see {@link #isRequestBound}).
+     * query on every client deletion; when the deletion is not bound to an HTTP
+     * request (see {@link #isRequestBound}); and once
+     * {@link #MAX_SNAPSHOTS_PER_SESSION} snapshots are already held for this request.
      *
      * <p>Callers invoke this from the pre-remove hook, which fires before Keycloak
      * knows whether the removal will succeed. Capturing is therefore deliberately
@@ -141,6 +166,22 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
             return;
         }
         if (!isRequestBound(session)) {
+            return;
+        }
+
+        Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
+        int count = held == null ? 0 : held;
+        if (count >= MAX_SNAPSHOTS_PER_SESSION) {
+            if (count == MAX_SNAPSHOTS_PER_SESSION) {
+                // Warn exactly once per session rather than per deletion, so a bulk
+                // request leaves one line instead of thousands.
+                log.warnf("SSF: reached %d purge snapshots in a single request; no further deletions in it "
+                                + "will be captured, and any purge events they would have produced are lost. "
+                                + "Expected for bulk deletion (partial import OVERWRITE, organization removal), "
+                                + "which do not emit purge events.",
+                        MAX_SNAPSHOTS_PER_SESSION);
+                session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
+            }
             return;
         }
 
@@ -193,6 +234,7 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         if (snapshot.getEmail() != null) {
             session.setAttribute(sessionEmailAttributeKey(snapshot.getEmail()), snapshot);
         }
+        session.setAttribute(SESSION_ATTRIBUTE_COUNT, count + 1);
     }
 
     /**
@@ -235,6 +277,40 @@ public class PurgedUserSnapshot extends AbstractInMemoryUserAdapter {
         }
         PurgedUserSnapshot snapshot = session.getAttribute(sessionAttributeKey(userId), PurgedUserSnapshot.class);
         return matchesRealm(snapshot, realm) ? snapshot : null;
+    }
+
+    /**
+     * Drops the snapshot for {@code userId}, called by the event listener once it has
+     * finished emitting for that deletion.
+     *
+     * <p>This is what keeps {@link #MAX_SNAPSHOTS_PER_SESSION} out of the way of the
+     * paths that matter. A request that deletes users <em>and</em> emits for them
+     * returns to zero retained snapshots after each one, so it can delete any number
+     * without approaching the bound. Only snapshots that are never consumed accumulate
+     * — which is precisely the bulk deletion case (partial import {@code OVERWRITE},
+     * organization removal), where no purge event is produced and the snapshot was
+     * dead weight from the moment it was taken.
+     *
+     * <p>Deliberately not conditional on the event being a purge: a user can only be
+     * deleted once per request, so discarding after any event for that user is safe,
+     * and a miss here costs nothing beyond retention.
+     */
+    public static void discard(KeycloakSession session, RealmModel realm, String userId) {
+        if (session == null || userId == null) {
+            return;
+        }
+        PurgedUserSnapshot snapshot = lookup(session, realm, userId);
+        if (snapshot == null) {
+            return;
+        }
+        session.removeAttribute(sessionAttributeKey(userId));
+        if (snapshot.getEmail() != null) {
+            session.removeAttribute(sessionEmailAttributeKey(snapshot.getEmail()));
+        }
+        Integer held = session.getAttribute(SESSION_ATTRIBUTE_COUNT, Integer.class);
+        if (held != null && held > 0) {
+            session.setAttribute(SESSION_ATTRIBUTE_COUNT, held - 1);
+        }
     }
 
     /**

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshots.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshots.java
@@ -93,7 +93,18 @@ class PurgedUserSnapshots {
 
     /** Indexes {@code snapshot} under both keys. {@code emailKey} is null when the user had no email. */
     void put(String idKey, String emailKey, PurgedUserSnapshot snapshot) {
-        byId.put(idKey, snapshot);
+        PurgedUserSnapshot previous = byId.put(idKey, snapshot);
+        if (previous != null) {
+            // Replacing an id drops the snapshot it replaced from the email index too.
+            // Otherwise a re-capture under a different (or newly absent) address would
+            // leave the old key pointing at a stale snapshot, and discard — which clears
+            // only the current snapshot's key — could never reach it. Keeping the two
+            // indexes in step is the reason this class exists, so put() should not be a
+            // way for them to diverge. Identity rather than key, because the email key
+            // format lives in PurgedUserSnapshot; the scan is bounded by
+            // MAX_SNAPSHOTS_PER_SESSION.
+            byEmail.values().removeIf(candidate -> candidate == previous);
+        }
         if (emailKey != null) {
             byEmail.put(emailKey, snapshot);
         }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshots.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshots.java
@@ -1,0 +1,129 @@
+package org.keycloak.ssf.transmitter.subject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.models.KeycloakSession;
+
+/**
+ * The set of {@link PurgedUserSnapshot}s captured during one request, held under a
+ * single {@link KeycloakSession} attribute.
+ *
+ * <p>Snapshots were originally stashed one session attribute per user, which read
+ * back typed with no cast and matched how Keycloak stashes other request-scoped
+ * per-id state ({@code AuthenticationSessionAdapter} keys on
+ * {@code "authSession.user." + parentSessionId}). That stopped paying once the set
+ * grew a retention bound and a discard hook: enforcing those across N independent
+ * attributes meant three writes that had to stay in step — the id index, the email
+ * index, and a hand-maintained count — and a count maintained by hand is a count
+ * that can drift from what is actually held.
+ *
+ * <p>Collecting them here makes the size exact and free, keeps the SSF footprint in
+ * the session's shared attribute namespace to one entry rather than two per user
+ * plus a counter, and puts the bound next to the collection it bounds. The holder is
+ * what keeps the reads typed: {@code getAttribute(KEY, PurgedUserSnapshots.class)}
+ * needs no unchecked cast, where a bare {@code Map} would.
+ *
+ * <p>Purely request-scoped bookkeeping — it lives and dies with the session, is never
+ * persisted, and is not an extension point. {@link PurgedUserSnapshot} owns the key
+ * format and is the only caller.
+ */
+class PurgedUserSnapshots {
+
+    private static final String SESSION_ATTRIBUTE_KEY = "ssf.purgedUsers";
+
+    /**
+     * Upper bound on snapshots retained per session, complementing
+     * {@link PurgedUserSnapshot#isRequestBound}.
+     *
+     * <p>The request gate excludes deletions with no request behind them, but bulk
+     * deletion still happens <em>inside</em> a request: a partial import under the
+     * {@code OVERWRITE} policy replaces many users in one call, and deleting an
+     * organization removes each of its managed members. Neither emits a purge event,
+     * so their snapshots are never read — and without a bound, one such request would
+     * retain a copied attribute map per account until it finishes.
+     *
+     * <p>An emitting request releases each snapshot as soon as it has emitted for it
+     * (see {@link PurgedUserSnapshot#discard}), so it holds one at a time and cannot
+     * approach this bound however many users it deletes.
+     */
+    static final int MAX_SNAPSHOTS_PER_SESSION = 64;
+
+    /** Primary index, keyed by realm-scoped user id. Its size is the retained count. */
+    private final Map<String, PurgedUserSnapshot> byId = new HashMap<>();
+
+    /** Secondary index, keyed by realm-scoped email. See {@link PurgedUserSnapshot}. */
+    private final Map<String, PurgedUserSnapshot> byEmail = new HashMap<>();
+
+    /**
+     * Whether the bound has already been reported for this session. Deliberately not
+     * derived from {@link #size()}: the two answer different questions, and folding
+     * the "already warned" latch into the count is what let the count drift above the
+     * number actually held — which in turn wedged the gate closed even after a
+     * {@code discard} had freed a slot.
+     */
+    private boolean boundWarned;
+
+    /**
+     * Returns the set for this session, creating and stashing it on first use. Only
+     * the capture path calls this; readers use {@link #find} so a lookup never
+     * allocates.
+     */
+    static PurgedUserSnapshots of(KeycloakSession session) {
+        PurgedUserSnapshots snapshots = find(session);
+        if (snapshots == null) {
+            snapshots = new PurgedUserSnapshots();
+            session.setAttribute(SESSION_ATTRIBUTE_KEY, snapshots);
+        }
+        return snapshots;
+    }
+
+    /** Returns the set for this session, or {@code null} if nothing was captured. */
+    static PurgedUserSnapshots find(KeycloakSession session) {
+        return session.getAttribute(SESSION_ATTRIBUTE_KEY, PurgedUserSnapshots.class);
+    }
+
+    PurgedUserSnapshot byId(String idKey) {
+        return byId.get(idKey);
+    }
+
+    PurgedUserSnapshot byEmail(String emailKey) {
+        return byEmail.get(emailKey);
+    }
+
+    /** Indexes {@code snapshot} under both keys. {@code emailKey} is null when the user had no email. */
+    void put(String idKey, String emailKey, PurgedUserSnapshot snapshot) {
+        byId.put(idKey, snapshot);
+        if (emailKey != null) {
+            byEmail.put(emailKey, snapshot);
+        }
+    }
+
+    /** Drops both index entries, freeing a slot against {@link #MAX_SNAPSHOTS_PER_SESSION}. */
+    void remove(String idKey, String emailKey) {
+        byId.remove(idKey);
+        if (emailKey != null) {
+            byEmail.remove(emailKey);
+        }
+    }
+
+    int size() {
+        return byId.size();
+    }
+
+    boolean isFull() {
+        return byId.size() >= MAX_SNAPSHOTS_PER_SESSION;
+    }
+
+    /**
+     * Latches the bound warning, returning {@code true} only for the caller that
+     * flips it — so a bulk request leaves one log line rather than one per deletion.
+     */
+    boolean markBoundWarned() {
+        if (boundWarned) {
+            return false;
+        }
+        boundWarned = true;
+        return true;
+    }
+}

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
@@ -218,6 +218,10 @@ public class SubjectSubscriptionFilter {
         if (userTombstone != null && now - userTombstone < graceSeconds) {
             return true;
         }
+        if (user instanceof PurgedUserSnapshot snapshot) {
+            Long orgTombstone = snapshot.getOrganizationRemovedAt(receiverClientId);
+            return orgTombstone != null && now - orgTombstone < graceSeconds;
+        }
         if (Organizations.isEnabled(session)) {
             return session.getProvider(OrganizationProvider.class).getByMember(user)
                     .anyMatch(org -> {
@@ -270,7 +274,15 @@ public class SubjectSubscriptionFilter {
     }
 
     protected UserModel lookupUserBySubject(KeycloakSession session, RealmModel realm, SubjectId userSubject) {
-        return SubjectUserLookup.lookupUser(session, realm, userSubject);
+        UserModel user = SubjectUserLookup.lookupUser(session, realm, userSubject);
+        if (user != null) {
+            return user;
+        }
+        // An account-purged SET names a user that no longer exists, so the lookup
+        // above can never succeed for one. Falling back to this request's snapshot
+        // keeps the gate meaningful: without it every purge would be evaluated as an
+        // unresolvable subject and dropped under the default default_subjects=NONE.
+        return PurgedUserSnapshot.lookupBySubject(session, userSubject);
     }
 
     /**
@@ -282,6 +294,13 @@ public class SubjectSubscriptionFilter {
      * "is the user excluded *via* one of their orgs" question.
      */
     protected boolean isOrganizationExcluded(UserModel user, String receiverClientId, KeycloakSession session) {
+        // A purged user cannot be resolved back to its memberships — getByMember is
+        // an id-keyed query, not an attribute read — so the verdict comes from the
+        // organization attributes captured before the deletion. This is the one place
+        // the snapshot cannot pose transparently as a live user.
+        if (user instanceof PurgedUserSnapshot snapshot) {
+            return snapshot.isAnyOrganizationExcluded(receiverClientId);
+        }
         if (!Organizations.isEnabled(session)) {
             return false;
         }
@@ -294,6 +313,10 @@ public class SubjectSubscriptionFilter {
      * per the {@link #subjectInclusionResolver}.
      */
     protected boolean isOrganizationNotified(UserModel user, String receiverClientId, KeycloakSession session) {
+        // See isOrganizationExcluded — same reason the snapshot answers this itself.
+        if (user instanceof PurgedUserSnapshot snapshot) {
+            return snapshot.isAnyOrganizationNotified(receiverClientId);
+        }
         if (!Organizations.isEnabled(session)) {
             return false;
         }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
@@ -5,6 +5,7 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.ssf.event.risc.RiscAccountPurged;
 import org.keycloak.ssf.event.stream.SsfStreamUpdatedEvent;
 import org.keycloak.ssf.event.stream.SsfStreamVerificationEvent;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
@@ -253,26 +254,56 @@ public class SubjectSubscriptionFilter {
             return null;
         }
 
+        boolean purged = isAccountPurgedEvent(eventToken);
+
         if (subjectId instanceof ComplexSubjectId complex) {
             SubjectId userSubject = complex.getUser();
             if (userSubject == null) {
                 return null;
             }
-            return lookupUserBySubject(session, realm, userSubject);
+            return lookupUserBySubject(session, realm, userSubject, purged);
         }
 
-        return lookupUserBySubject(session, realm, subjectId);
+        return lookupUserBySubject(session, realm, subjectId, purged);
+    }
+
+    /**
+     * Returns {@code true} when the token carries a RISC {@code account-purged}
+     * event — the one case where the subject names a user that no longer exists, so
+     * a live lookup must not be preferred over this request's snapshot.
+     */
+    protected boolean isAccountPurgedEvent(SsfSecurityEventToken eventToken) {
+        var events = eventToken.getEvents();
+        return events != null && events.containsKey(RiscAccountPurged.TYPE);
     }
 
     protected UserModel lookupUserBySubject(KeycloakSession session, RealmModel realm, SubjectId userSubject) {
+        return lookupUserBySubject(session, realm, userSubject, false);
+    }
+
+    protected UserModel lookupUserBySubject(KeycloakSession session, RealmModel realm, SubjectId userSubject,
+                                            boolean preferSnapshot) {
+        // For a purge the subject names a user that was just deleted, so the snapshot
+        // is authoritative and is consulted first. Live-first would be wrong here:
+        // in a realm that allows duplicate emails, getUserByEmail returns the first
+        // surviving match, so an `email` subject could resolve to a *different*
+        // account and the gate would evaluate that user's notification state instead
+        // of the purged user's — silently dropping the purge under the default
+        // default_subjects=NONE.
+        if (preferSnapshot) {
+            PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookupBySubject(session, realm, userSubject);
+            if (snapshot != null) {
+                return snapshot;
+            }
+        }
+
         UserModel user = SubjectUserLookup.lookupUser(session, realm, userSubject);
         if (user != null) {
             return user;
         }
-        // An account-purged SET names a user that no longer exists, so the lookup
-        // above can never succeed for one. Falling back to this request's snapshot
-        // keeps the gate meaningful: without it every purge would be evaluated as an
-        // unresolvable subject and dropped under the default default_subjects=NONE.
+        // Non-purge events still fall back to a snapshot: the subject may name a user
+        // deleted earlier in this same request, and evaluating it as unresolvable
+        // would drop the event under default_subjects=NONE.
         return PurgedUserSnapshot.lookupBySubject(session, realm, userSubject);
     }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
@@ -5,8 +5,6 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.organization.OrganizationProvider;
-import org.keycloak.organization.utils.Organizations;
 import org.keycloak.ssf.event.stream.SsfStreamUpdatedEvent;
 import org.keycloak.ssf.event.stream.SsfStreamVerificationEvent;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
@@ -218,19 +216,12 @@ public class SubjectSubscriptionFilter {
         if (userTombstone != null && now - userTombstone < graceSeconds) {
             return true;
         }
-        if (user instanceof PurgedUserSnapshot snapshot) {
-            Long orgTombstone = snapshot.getOrganizationRemovedAt(receiverClientId);
-            return orgTombstone != null && now - orgTombstone < graceSeconds;
-        }
-        if (Organizations.isEnabled(session)) {
-            return session.getProvider(OrganizationProvider.class).getByMember(user)
-                    .anyMatch(org -> {
-                        Long orgTombstone = SsfNotifyAttributes.getRemovedAtForOrganization(org, receiverClientId);
-                        return orgTombstone != null
-                                && now - orgTombstone < graceSeconds;
-                    });
-        }
-        return false;
+        return PurgedUserSnapshot.organizationsOf(session, user).stream()
+                .anyMatch(org -> {
+                    Long orgTombstone = SsfNotifyAttributes.getRemovedAtForOrganization(org, receiverClientId);
+                    return orgTombstone != null
+                            && now - orgTombstone < graceSeconds;
+                });
     }
 
     /**
@@ -282,7 +273,7 @@ public class SubjectSubscriptionFilter {
         // above can never succeed for one. Falling back to this request's snapshot
         // keeps the gate meaningful: without it every purge would be evaluated as an
         // unresolvable subject and dropped under the default default_subjects=NONE.
-        return PurgedUserSnapshot.lookupBySubject(session, userSubject);
+        return PurgedUserSnapshot.lookupBySubject(session, realm, userSubject);
     }
 
     /**
@@ -294,17 +285,7 @@ public class SubjectSubscriptionFilter {
      * "is the user excluded *via* one of their orgs" question.
      */
     protected boolean isOrganizationExcluded(UserModel user, String receiverClientId, KeycloakSession session) {
-        // A purged user cannot be resolved back to its memberships — getByMember is
-        // an id-keyed query, not an attribute read — so the verdict comes from the
-        // organization attributes captured before the deletion. This is the one place
-        // the snapshot cannot pose transparently as a live user.
-        if (user instanceof PurgedUserSnapshot snapshot) {
-            return snapshot.isAnyOrganizationExcluded(receiverClientId);
-        }
-        if (!Organizations.isEnabled(session)) {
-            return false;
-        }
-        return session.getProvider(OrganizationProvider.class).getByMember(user)
+        return PurgedUserSnapshot.organizationsOf(session, user).stream()
                 .anyMatch(org -> subjectInclusionResolver.isOrganizationExcluded(session, org, receiverClientId));
     }
 
@@ -313,14 +294,7 @@ public class SubjectSubscriptionFilter {
      * per the {@link #subjectInclusionResolver}.
      */
     protected boolean isOrganizationNotified(UserModel user, String receiverClientId, KeycloakSession session) {
-        // See isOrganizationExcluded — same reason the snapshot answers this itself.
-        if (user instanceof PurgedUserSnapshot snapshot) {
-            return snapshot.isAnyOrganizationNotified(receiverClientId);
-        }
-        if (!Organizations.isEnabled(session)) {
-            return false;
-        }
-        return session.getProvider(OrganizationProvider.class).getByMember(user)
+        return PurgedUserSnapshot.organizationsOf(session, user).stream()
                 .anyMatch(org -> subjectInclusionResolver.isOrganizationNotified(session, org, receiverClientId));
     }
 }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/subject/SubjectSubscriptionFilter.java
@@ -217,12 +217,11 @@ public class SubjectSubscriptionFilter {
         if (userTombstone != null && now - userTombstone < graceSeconds) {
             return true;
         }
-        return PurgedUserSnapshot.organizationsOf(session, user).stream()
-                .anyMatch(org -> {
-                    Long orgTombstone = SsfNotifyAttributes.getRemovedAtForOrganization(org, receiverClientId);
-                    return orgTombstone != null
-                            && now - orgTombstone < graceSeconds;
-                });
+        return PurgedUserSnapshot.anyOrganizationMatches(session, user, org -> {
+            Long orgTombstone = SsfNotifyAttributes.getRemovedAtForOrganization(org, receiverClientId);
+            return orgTombstone != null
+                    && now - orgTombstone < graceSeconds;
+        });
     }
 
     /**
@@ -301,6 +300,11 @@ public class SubjectSubscriptionFilter {
         if (user != null) {
             return user;
         }
+        if (preferSnapshot) {
+            // Already asked above, and nothing between the two calls captures a
+            // snapshot, so the answer cannot have changed.
+            return null;
+        }
         // Non-purge events still fall back to a snapshot: the subject may name a user
         // deleted earlier in this same request, and evaluating it as unresolvable
         // would drop the event under default_subjects=NONE.
@@ -316,8 +320,8 @@ public class SubjectSubscriptionFilter {
      * "is the user excluded *via* one of their orgs" question.
      */
     protected boolean isOrganizationExcluded(UserModel user, String receiverClientId, KeycloakSession session) {
-        return PurgedUserSnapshot.organizationsOf(session, user).stream()
-                .anyMatch(org -> subjectInclusionResolver.isOrganizationExcluded(session, org, receiverClientId));
+        return PurgedUserSnapshot.anyOrganizationMatches(session, user,
+                org -> subjectInclusionResolver.isOrganizationExcluded(session, org, receiverClientId));
     }
 
     /**
@@ -325,7 +329,7 @@ public class SubjectSubscriptionFilter {
      * per the {@link #subjectInclusionResolver}.
      */
     protected boolean isOrganizationNotified(UserModel user, String receiverClientId, KeycloakSession session) {
-        return PurgedUserSnapshot.organizationsOf(session, user).stream()
-                .anyMatch(org -> subjectInclusionResolver.isOrganizationNotified(session, org, receiverClientId));
+        return PurgedUserSnapshot.anyOrganizationMatches(session, user,
+                org -> subjectInclusionResolver.isOrganizationNotified(session, org, receiverClientId));
     }
 }

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
@@ -12,6 +12,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.ssf.event.InitiatingEntity;
 import org.keycloak.ssf.event.risc.RiscAccountDisabled;
 import org.keycloak.ssf.event.risc.RiscAccountEnabled;
+import org.keycloak.ssf.event.risc.RiscAccountPurged;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
 
@@ -23,10 +24,17 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for the RISC {@code account-disabled} / {@code account-enabled}
- * mapping added to {@link SecurityEventTokenMapper}: the brute-force
- * permanent-lockout {@link Event} path and the admin "enable/disable a user"
- * {@link AdminEvent} path (see {@link SecurityEventTokenMapper#isEnabledStateChangeAdminEvent}).
+ * Unit tests for the RISC {@code account-disabled} / {@code account-enabled} /
+ * {@code account-purged} mapping added to {@link SecurityEventTokenMapper}: the
+ * brute-force permanent-lockout {@link Event} path, the admin "enable/disable a
+ * user" {@link AdminEvent} path (see
+ * {@link SecurityEventTokenMapper#isEnabledStateChangeAdminEvent}), and the two
+ * deletion paths (see {@link SecurityEventTokenMapper#isUserPurgeAdminEvent}).
+ *
+ * <p>The purge tests cover the near misses as well as the hits: Keycloak has
+ * several paths that delete a user row without the account ceasing to exist, and
+ * they are kept out by the operation type and resource type rather than by
+ * anything deliberate, so they are pinned here.
  *
  * <p>Session-independent methods only — subject resolution defaults to
  * {@code iss_sub} (no organization/email lookups), so the mapper is
@@ -98,9 +106,23 @@ class SecurityEventTokenMapperTest {
     }
 
     @Test
-    void canConvert_nonUpdateOperation_false() {
+    void isEnabledStateChangeAdminEvent_nonUpdateOperation_false() {
+        // The enabled-state gate requires UPDATE: the same bare users/{id} path with
+        // a different verb is never an enable/disable transition, whatever details it
+        // happens to carry. DELETE on this path is a purge, which canConvert()
+        // accepts through a different gate — hence the assertion on the specific
+        // predicate rather than on canConvert().
         AdminEvent adminEvent = adminUserUpdateEvent("true", "false");
         adminEvent.setOperationType(OperationType.DELETE);
+
+        assertFalse(mapper.isEnabledStateChangeAdminEvent(adminEvent));
+        assertTrue(mapper.isUserPurgeAdminEvent(adminEvent));
+    }
+
+    @Test
+    void canConvert_createOperationOnUserPath_false() {
+        AdminEvent adminEvent = adminUserUpdateEvent("true", "false");
+        adminEvent.setOperationType(OperationType.CREATE);
 
         assertFalse(mapper.canConvert(adminEvent));
     }
@@ -179,8 +201,109 @@ class SecurityEventTokenMapperTest {
                 "details without a REASON entry must be treated like a real logout");
     }
 
+    // ----- account purge (admin DELETE + self-service DELETE_ACCOUNT) -----
+
+    @Test
+    void canConvert_adminUserDelete_true() {
+        assertTrue(mapper.canConvert(adminUserDeleteEvent("users/" + USER_ID)));
+    }
+
+    @Test
+    void toSecurityEventToken_adminDeletesUser_producesAccountPurgedWithAdminEntity() {
+        SsfSecurityEventToken token = mapper.toSecurityEventToken(
+                adminUserDeleteEvent("users/" + USER_ID), streamConfig());
+
+        assertNotNull(token);
+        Object payload = token.getEvents().get(RiscAccountPurged.TYPE);
+        assertTrue(payload instanceof RiscAccountPurged);
+        assertEquals(InitiatingEntity.ADMIN, ((RiscAccountPurged) payload).getInitiatingEntity());
+    }
+
+    @Test
+    void canConvert_deleteAccountEvent_true() {
+        assertTrue(mapper.canConvert(deleteAccountEvent()));
+    }
+
+    @Test
+    void toSecurityEventToken_deleteAccountEvent_producesAccountPurgedWithUserEntity() {
+        SsfSecurityEventToken token = mapper.toSecurityEventToken(deleteAccountEvent(), streamConfig());
+
+        assertNotNull(token);
+        Object payload = token.getEvents().get(RiscAccountPurged.TYPE);
+        assertTrue(payload instanceof RiscAccountPurged);
+        // Self-service deletion has no AdminEvent, and unlike the disable path
+        // "not admin-initiated" here genuinely does mean the user did it.
+        assertEquals(InitiatingEntity.USER, ((RiscAccountPurged) payload).getInitiatingEntity());
+    }
+
+    @Test
+    void canConvert_userSubResourceDelete_notPurge() {
+        // Only the bare users/{id} path is a purge. A DELETE deeper in the user
+        // resource removes part of the user, not the account.
+        AdminEvent adminEvent = adminUserDeleteEvent("users/" + USER_ID + "/groups");
+
+        assertFalse(mapper.isUserPurgeAdminEvent(adminEvent));
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
+    // ----- near misses: paths that delete a user without purging an account -----
+
+    @Test
+    void canConvert_partialImportOverwrite_false() {
+        // A partial import under the OVERWRITE policy really does delete the user
+        // row — then recreates it in the same request. It reports that as UPDATE on
+        // users/{id}, one enum value away from the purge gate. The account never
+        // ceased to exist, so no purge SET may be emitted.
+        AdminEvent adminEvent = adminUserUpdateEvent(null, null);
+
+        assertFalse(mapper.isUserPurgeAdminEvent(adminEvent));
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
+    @Test
+    void canConvert_clientDeleteRemovingServiceAccount_false() {
+        // Deleting a client removes its service-account user, but reports the
+        // deletion as ResourceType.CLIENT at clients/{id}. Service accounts are not
+        // human subjects and must never produce a purge SET.
+        AdminEvent adminEvent = new AdminEvent();
+        adminEvent.setResourceType(ResourceType.CLIENT);
+        adminEvent.setOperationType(OperationType.DELETE);
+        adminEvent.setResourcePath("clients/client-123");
+        adminEvent.setDetails(new HashMap<>());
+
+        assertFalse(mapper.canConvert(adminEvent));
+    }
+
     private StreamConfig streamConfig() {
         return new StreamConfig();
+    }
+
+    /**
+     * Builds the {@link AdminEvent} shape {@code UserResource.deleteUser} produces
+     * for {@code DELETE /admin/realms/{realm}/users/{id}} — same bare resource path
+     * as the update event, distinguished only by {@link OperationType#DELETE}.
+     */
+    private AdminEvent adminUserDeleteEvent(String resourcePath) {
+        AdminEvent adminEvent = new AdminEvent();
+        adminEvent.setResourceType(ResourceType.USER);
+        adminEvent.setOperationType(OperationType.DELETE);
+        adminEvent.setResourcePath(resourcePath);
+        adminEvent.setDetails(new HashMap<>());
+
+        return adminEvent;
+    }
+
+    /**
+     * Builds the {@code DELETE_ACCOUNT} {@link Event} the account console's
+     * delete-account required action fires after removing the user.
+     */
+    private Event deleteAccountEvent() {
+        Event event = new Event();
+        event.setType(EventType.DELETE_ACCOUNT);
+        event.setUserId(USER_ID);
+        event.setDetails(new HashMap<>());
+
+        return event;
     }
 
     /**

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SecurityEventTokenMapperTest.java
@@ -1,27 +1,46 @@
 package org.keycloak.ssf.transmitter.event;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
 
+import org.keycloak.common.Profile;
+import org.keycloak.common.profile.PropertiesProfileConfigResolver;
 import org.keycloak.events.Details;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventType;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.ssf.event.InitiatingEntity;
 import org.keycloak.ssf.event.risc.RiscAccountDisabled;
 import org.keycloak.ssf.event.risc.RiscAccountEnabled;
 import org.keycloak.ssf.event.risc.RiscAccountPurged;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
+import org.keycloak.ssf.transmitter.subject.PurgedUserSnapshot;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit tests for the RISC {@code account-disabled} / {@code account-enabled} /
@@ -36,18 +55,75 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * they are kept out by the operation type and resource type rather than by
  * anything deliberate, so they are pinned here.
  *
- * <p>Session-independent methods only — subject resolution defaults to
- * {@code iss_sub} (no organization/email lookups), so the mapper is
+ * <p>Most methods here are session-independent — subject resolution defaults to
+ * {@code iss_sub} (no organization/email lookups), so the shared mapper is
  * constructed with a {@code null} session and a stub issuer, mirroring how
  * {@link SsfTransmitterEventListenerTest} constructs the listener with a
  * {@code null} session for predicates that don't touch it.
+ *
+ * <p>The purge generator is the exception: it refuses to emit without a
+ * pre-removal snapshot, since that snapshot is the only evidence the deletion was
+ * a real purge rather than a federated local-only removal. Those tests use
+ * {@link #purgeMapper()}, which carries a session with a captured snapshot.
  */
 class SecurityEventTokenMapperTest {
 
     private static final String USER_ID = "user-123";
 
+    private static final String REALM_ID = "realm-1";
+
+    @BeforeAll
+    static void initProfile() {
+        // PurgedUserSnapshot.capture consults Organizations.isEnabled, which reads the profile.
+        Profile.configure(new PropertiesProfileConfigResolver(new Properties()));
+    }
+
     private final SecurityEventTokenMapper mapper =
             new SecurityEventTokenMapper(null, null, session -> "https://issuer.example/realms/test");
+
+    /**
+     * A mapper whose session carries a snapshot for {@link #USER_ID}, as the real
+     * emission path always does — capture runs on {@code UserPreRemovedEvent} before
+     * the event this mapper converts is fired.
+     */
+    private SecurityEventTokenMapper purgeMapper() {
+        RealmModel realm = mock(RealmModel.class);
+        lenient().when(realm.getId()).thenReturn(REALM_ID);
+
+        KeycloakContext context = mock(KeycloakContext.class);
+        lenient().when(context.getRealm()).thenReturn(realm);
+        lenient().when(context.getHttpRequest()).thenReturn(mock(HttpRequest.class));
+
+        KeycloakSession session = mock(KeycloakSession.class);
+        lenient().when(session.getContext()).thenReturn(context);
+
+        Map<String, Object> attributes = new HashMap<>();
+        doAnswer(invocation -> {
+            attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(session).setAttribute(anyString(), any());
+        lenient().when(session.getAttribute(anyString(), any(Class.class))).thenAnswer(invocation -> {
+            Object value = attributes.get(invocation.<String>getArgument(0));
+            return value == null ? null : invocation.<Class<?>>getArgument(1).cast(value);
+        });
+
+        OrganizationProvider orgProvider = mock(OrganizationProvider.class);
+        lenient().when(orgProvider.isEnabled()).thenReturn(false);
+        lenient().when(session.getProvider(OrganizationProvider.class)).thenReturn(orgProvider);
+
+        UserModel user = mock(UserModel.class);
+        lenient().when(user.getId()).thenReturn(USER_ID);
+        lenient().when(user.getUsername()).thenReturn("purged");
+        lenient().when(user.getAttributes()).thenReturn(Map.of(UserModel.USERNAME, List.of("purged")));
+        // A local user: no federation link, so the removal is a real purge.
+        lenient().when(user.getFederationLink()).thenReturn(null);
+        lenient().when(user.getGroupsStream()).thenAnswer(invocation -> Stream.empty());
+        lenient().when(user.getRoleMappingsStream()).thenAnswer(invocation -> Stream.empty());
+
+        PurgedUserSnapshot.capture(session, realm, user);
+
+        return new SecurityEventTokenMapper(session, null, ignored -> "https://issuer.example/realms/test");
+    }
 
     // ----- brute-force permanent lockout (Event path) -----
 
@@ -209,8 +285,18 @@ class SecurityEventTokenMapperTest {
     }
 
     @Test
+    void toSecurityEventToken_withoutSnapshot_doesNotEmit() {
+        // The snapshot is the only evidence the deletion was a real purge. The shared
+        // mapper has no session and therefore no snapshot, which stands in for the
+        // production case where capture failed and swallowed its own exception.
+        assertNull(mapper.toSecurityEventToken(deleteAccountEvent(), streamConfig()));
+        assertNull(mapper.toSecurityEventToken(
+                adminUserDeleteEvent("users/" + USER_ID), streamConfig()));
+    }
+
+    @Test
     void toSecurityEventToken_adminDeletesUser_producesAccountPurgedWithAdminEntity() {
-        SsfSecurityEventToken token = mapper.toSecurityEventToken(
+        SsfSecurityEventToken token = purgeMapper().toSecurityEventToken(
                 adminUserDeleteEvent("users/" + USER_ID), streamConfig());
 
         assertNotNull(token);
@@ -226,7 +312,7 @@ class SecurityEventTokenMapperTest {
 
     @Test
     void toSecurityEventToken_deleteAccountEvent_producesAccountPurgedWithUserEntity() {
-        SsfSecurityEventToken token = mapper.toSecurityEventToken(deleteAccountEvent(), streamConfig());
+        SsfSecurityEventToken token = purgeMapper().toSecurityEventToken(deleteAccountEvent(), streamConfig());
 
         assertNotNull(token);
         Object payload = token.getEvents().get(RiscAccountPurged.TYPE);

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerTest.java
@@ -1,31 +1,48 @@
 package org.keycloak.ssf.transmitter.event;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
+import org.keycloak.common.Profile;
+import org.keycloak.common.profile.PropertiesProfileConfigResolver;
 import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.http.HttpRequest;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.ssf.event.caep.CaepCredentialChange;
 import org.keycloak.ssf.event.caep.CaepSessionRevoked;
 import org.keycloak.ssf.event.token.SsfSecurityEventToken;
 import org.keycloak.ssf.transmitter.SsfTransmitterProvider;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
 import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
+import org.keycloak.ssf.transmitter.subject.PurgedUserSnapshot;
 import org.keycloak.storage.ReadOnlyException;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +62,12 @@ import static org.mockito.Mockito.when;
  * the predicate doesn't touch it; only its arguments matter.
  */
 class SsfTransmitterEventListenerTest {
+
+    @BeforeAll
+    static void initProfile() {
+        // PurgedUserSnapshot.capture consults Organizations.isEnabled, which reads the profile.
+        Profile.configure(new PropertiesProfileConfigResolver(new Properties()));
+    }
 
     private final SsfTransmitterEventListener listener = new SsfTransmitterEventListener(null);
 
@@ -246,5 +269,114 @@ class SsfTransmitterEventListenerTest {
         event.setClientId(RECEIVER_CLIENT_ID);
         event.setUserId(LOGIN_USER_ID);
         return event;
+    }
+
+    // ----- self-service deletion (DELETE_ACCOUNT) -----
+    //
+    // The account console's delete-account action fires DELETE_ACCOUNT *after* the user
+    // row is gone, so resolveEventUser is the one place that decides whether the
+    // self-service purge has a subject at all. Nothing else covers it: the integration
+    // tests drive admin deletion over REST, and the mapper tests hand-build the event
+    // and never reach the listener.
+
+    static final String PURGED_USER_ID = "1c9a1a0e-0000-4000-8000-000000000009";
+
+    @Test
+    void resolveEventUser_deletedUser_fallsBackToTheSnapshot() {
+        KeycloakSession session = purgeSession(true);
+        SsfTransmitterEventListener listener = new SsfTransmitterEventListener(session);
+
+        UserModel resolved = listener.resolveEventUser(deleteAccountEvent(PURGED_USER_ID));
+
+        // Without this the subject gate sees an unresolvable user and drops every
+        // self-service deletion under the default default_subjects=NONE.
+        assertSame(PurgedUserSnapshot.lookup(session, session.getContext().getRealm(), PURGED_USER_ID),
+                resolved, "a DELETE_ACCOUNT subject can only come from the snapshot");
+    }
+
+    @Test
+    void resolveEventUser_liveUser_isPreferredOverAnySnapshot() {
+        KeycloakSession session = purgeSession(true);
+        UserModel live = mock(UserModel.class);
+        when(session.users().getUserById(session.getContext().getRealm(), PURGED_USER_ID)).thenReturn(live);
+        SsfTransmitterEventListener listener = new SsfTransmitterEventListener(session);
+
+        assertSame(live, listener.resolveEventUser(deleteAccountEvent(PURGED_USER_ID)));
+    }
+
+    @Test
+    void resolveEventUser_noUserAndNoSnapshot_isNull() {
+        KeycloakSession session = purgeSession(false);
+        SsfTransmitterEventListener listener = new SsfTransmitterEventListener(session);
+
+        assertNull(listener.resolveEventUser(deleteAccountEvent(PURGED_USER_ID)));
+    }
+
+    @Test
+    void resolveEventUser_eventWithoutUserId_isNull() {
+        KeycloakSession session = purgeSession(true);
+        SsfTransmitterEventListener listener = new SsfTransmitterEventListener(session);
+
+        assertNull(listener.resolveEventUser(deleteAccountEvent(null)));
+    }
+
+    /**
+     * The {@code DELETE_ACCOUNT} event {@code DeleteAccount} fires once the user has
+     * already been removed — it carries the id and nothing else to resolve from.
+     */
+    private Event deleteAccountEvent(String userId) {
+        Event event = new Event();
+        event.setType(EventType.DELETE_ACCOUNT);
+        event.setUserId(userId);
+        return event;
+    }
+
+    /**
+     * A session standing in for the request that just deleted a user: the live lookup
+     * misses, and (when {@code captured}) this request's snapshot holds the user.
+     */
+    private KeycloakSession purgeSession(boolean captured) {
+        RealmModel realm = mock(RealmModel.class);
+        lenient().when(realm.getId()).thenReturn("realm-1");
+        lenient().when(realm.getName()).thenReturn("test");
+
+        KeycloakContext context = mock(KeycloakContext.class);
+        lenient().when(context.getRealm()).thenReturn(realm);
+        lenient().when(context.getHttpRequest()).thenReturn(mock(HttpRequest.class));
+
+        KeycloakSession session = mock(KeycloakSession.class);
+        lenient().when(session.getContext()).thenReturn(context);
+
+        Map<String, Object> attributes = new HashMap<>();
+        doAnswer(invocation -> {
+            attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(session).setAttribute(anyString(), any());
+        lenient().when(session.getAttribute(anyString(), any(Class.class))).thenAnswer(invocation -> {
+            Object value = attributes.get(invocation.<String>getArgument(0));
+            return value == null ? null : invocation.<Class<?>>getArgument(1).cast(value);
+        });
+
+        UserProvider users = mock(UserProvider.class);
+        lenient().when(session.users()).thenReturn(users);
+        // The row is gone by the time the event fires — this is the whole point.
+        lenient().when(users.getUserById(realm, PURGED_USER_ID)).thenReturn(null);
+
+        OrganizationProvider orgProvider = mock(OrganizationProvider.class);
+        lenient().when(orgProvider.isEnabled()).thenReturn(false);
+        lenient().when(session.getProvider(OrganizationProvider.class)).thenReturn(orgProvider);
+
+        if (captured) {
+            UserModel user = mock(UserModel.class);
+            lenient().when(user.getId()).thenReturn(PURGED_USER_ID);
+            lenient().when(user.getUsername()).thenReturn("purged");
+            lenient().when(user.getAttributes()).thenReturn(
+                    Map.of(UserModel.USERNAME, List.of("purged")));
+            lenient().when(user.getGroupsStream()).thenAnswer(invocation -> Stream.empty());
+            lenient().when(user.getRoleMappingsStream()).thenAnswer(invocation -> Stream.empty());
+            PurgedUserSnapshot.capture(session, realm, user);
+        }
+
+        return session;
     }
 }

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -232,6 +232,22 @@ class PurgedUserSnapshotTest {
     }
 
     @Test
+    void blankEmail_isNotIndexed() {
+        // lookupBySubject rejects a blank EmailSubjectId before it looks, so indexing
+        // one would park the snapshot under a key nothing can ask for. The id index is
+        // unaffected either way — it stays the one that matters.
+        lenient().when(user.getEmail()).thenReturn("   ");
+        lenient().when(user.getAttributes()).thenReturn(Map.of(UserModel.USERNAME, List.of("purged")));
+        recaptureAsIs();
+
+        assertNotNull(PurgedUserSnapshot.lookup(session, realm, USER_ID));
+
+        EmailSubjectId blank = new EmailSubjectId();
+        blank.setEmail("   ");
+        assertNull(PurgedUserSnapshot.lookupBySubject(session, realm, blank));
+    }
+
+    @Test
     void discard_removesBothIndexes() {
         PurgedUserSnapshot.discard(session, realm, USER_ID);
 

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for resolving a captured snapshot back from a subject identifier.

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -1,0 +1,185 @@
+package org.keycloak.ssf.transmitter.subject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import org.keycloak.common.Profile;
+import org.keycloak.common.profile.PropertiesProfileConfigResolver;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.ssf.subject.ComplexSubjectId;
+import org.keycloak.ssf.subject.EmailSubjectId;
+import org.keycloak.ssf.subject.IssuerSubjectId;
+import org.keycloak.ssf.subject.OpaqueSubjectId;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for resolving a captured snapshot back from a subject identifier.
+ *
+ * <p>Focused on the issuer gate: an {@code iss_sub} subject only names a Keycloak
+ * user id when this transmitter issued it, because {@code SubjectUserLookup} reads
+ * {@code sub} as an external IdP subject for any other issuer. The filter consults
+ * the snapshot before the live lookup for purge events, so the two have to agree on
+ * what {@code sub} means.
+ *
+ * <p>The realm here carries a {@code frontendUrl} attribute, which makes the
+ * transmitter's issuer differ from the realm issuer — the configuration that would
+ * break if the gate were written against {@code SubjectUserLookup.isRealmIssuer}
+ * instead of the transmitter's own issuer.
+ */
+class PurgedUserSnapshotTest {
+
+    static final String REALM_ID = "realm-1";
+    static final String USER_ID = "1c9a1a0e-0000-4000-8000-000000000001";
+    static final String EMAIL = "purged@local.test";
+
+    /** What SsfUtil.getIssuerUrl returns for this realm: the frontendUrl attribute, verbatim. */
+    static final String TRANSMITTER_ISSUER = "https://ssf.example/auth/realms/test";
+
+    static final String FOREIGN_ISSUER = "https://idp.partner.example";
+
+    @BeforeAll
+    static void initProfile() {
+        Profile.configure(new PropertiesProfileConfigResolver(new Properties()));
+    }
+
+    KeycloakSession session;
+    RealmModel realm;
+    UserModel user;
+
+    @BeforeEach
+    void setUp() {
+        realm = mock(RealmModel.class);
+        lenient().when(realm.getId()).thenReturn(REALM_ID);
+        lenient().when(realm.getName()).thenReturn("test");
+        lenient().when(realm.getAttribute("frontendUrl")).thenReturn(TRANSMITTER_ISSUER);
+
+        KeycloakContext context = mock(KeycloakContext.class);
+        lenient().when(context.getRealm()).thenReturn(realm);
+        lenient().when(context.getHttpRequest()).thenReturn(mock(HttpRequest.class));
+
+        session = mock(KeycloakSession.class);
+        lenient().when(session.getContext()).thenReturn(context);
+
+        Map<String, Object> attributes = new HashMap<>();
+        doAnswer(invocation -> {
+            attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(session).setAttribute(anyString(), any());
+        lenient().when(session.getAttribute(anyString(), any(Class.class))).thenAnswer(invocation -> {
+            Object value = attributes.get(invocation.<String>getArgument(0));
+            return value == null ? null : invocation.<Class<?>>getArgument(1).cast(value);
+        });
+
+        // Organizations off, so capture skips the membership query entirely.
+        OrganizationProvider orgProvider = mock(OrganizationProvider.class);
+        lenient().when(orgProvider.isEnabled()).thenReturn(false);
+        lenient().when(session.getProvider(OrganizationProvider.class)).thenReturn(orgProvider);
+
+        user = mock(UserModel.class);
+        lenient().when(user.getId()).thenReturn(USER_ID);
+        lenient().when(user.getServiceAccountClientLink()).thenReturn(null);
+        lenient().when(user.getUsername()).thenReturn("purged");
+        lenient().when(user.getEmail()).thenReturn(EMAIL);
+        lenient().when(user.isEnabled()).thenReturn(true);
+        lenient().when(user.getAttributes()).thenReturn(Map.of(
+                UserModel.USERNAME, List.of("purged"),
+                UserModel.EMAIL, List.of(EMAIL),
+                "ssf.notify.receiver-client-id", List.of("true")));
+        lenient().when(user.getGroupsStream()).thenReturn(Stream.empty());
+        lenient().when(user.getRoleMappingsStream()).thenReturn(Stream.empty());
+
+        PurgedUserSnapshot.capture(session, realm, user);
+    }
+
+    @Test
+    void capture_isFoundByUserId() {
+        assertNotNull(PurgedUserSnapshot.lookup(session, realm, USER_ID),
+                "the snapshot must be retrievable for the rest of the request");
+    }
+
+    @Test
+    void issuerSubject_fromThisTransmitter_resolvesTheSnapshot() {
+        PurgedUserSnapshot resolved =
+                PurgedUserSnapshot.lookupBySubject(session, realm, issuerSubject(TRANSMITTER_ISSUER, USER_ID));
+
+        assertNotNull(resolved);
+        assertSame(PurgedUserSnapshot.lookup(session, realm, USER_ID), resolved);
+    }
+
+    @Test
+    void issuerSubject_fromForeignIssuer_doesNotResolve() {
+        // For a foreign issuer SubjectUserLookup treats sub as an external IdP
+        // subject and resolves it through federated identity. The snapshot index is
+        // keyed by internal id, so answering here would short-circuit to the wrong
+        // subject whenever a foreign sub happened to equal a captured user id.
+        assertNull(PurgedUserSnapshot.lookupBySubject(session, realm, issuerSubject(FOREIGN_ISSUER, USER_ID)));
+    }
+
+    @Test
+    void issuerSubject_withoutIssuer_doesNotResolve() {
+        assertNull(PurgedUserSnapshot.lookupBySubject(session, realm, issuerSubject(null, USER_ID)));
+    }
+
+    @Test
+    void complexSubject_isGatedOnItsUserMemberIssuer() {
+        ComplexSubjectId ours = new ComplexSubjectId();
+        ours.setUser(issuerSubject(TRANSMITTER_ISSUER, USER_ID));
+        assertNotNull(PurgedUserSnapshot.lookupBySubject(session, realm, ours));
+
+        ComplexSubjectId foreign = new ComplexSubjectId();
+        foreign.setUser(issuerSubject(FOREIGN_ISSUER, USER_ID));
+        assertNull(PurgedUserSnapshot.lookupBySubject(session, realm, foreign));
+    }
+
+    @Test
+    void opaqueAndEmailSubjects_areNotIssuerGated() {
+        // Neither carries an issuer: an opaque id is transmitter-scoped by definition,
+        // and the email index is populated from the captured user's own address.
+        OpaqueSubjectId opaque = new OpaqueSubjectId();
+        opaque.setId(USER_ID);
+        assertNotNull(PurgedUserSnapshot.lookupBySubject(session, realm, opaque));
+
+        EmailSubjectId email = new EmailSubjectId();
+        email.setEmail(EMAIL);
+        assertNotNull(PurgedUserSnapshot.lookupBySubject(session, realm, email));
+    }
+
+    @Test
+    void discard_removesBothIndexes() {
+        PurgedUserSnapshot.discard(session, realm, USER_ID);
+
+        assertNull(PurgedUserSnapshot.lookup(session, realm, USER_ID));
+
+        EmailSubjectId email = new EmailSubjectId();
+        email.setEmail(EMAIL);
+        assertNull(PurgedUserSnapshot.lookupBySubject(session, realm, email));
+    }
+
+    private IssuerSubjectId issuerSubject(String iss, String sub) {
+        IssuerSubjectId subject = new IssuerSubjectId();
+        subject.setIss(iss);
+        subject.setSub(sub);
+        return subject;
+    }
+}

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -201,28 +201,34 @@ class PurgedUserSnapshotTest {
 
     @Test
     void writableFederatedUser_isARealRemoval() {
-        // WRITABLE propagates the delete to the directory, so the account really is gone.
+        // WRITABLE is the one federated mode that propagates the delete upstream, so
+        // the account really is gone. It is also the only thing that lifts the
+        // suppression below — unknown never means purged.
         recapture(federationComponent(UserStorageProvider.EditMode.WRITABLE.name()));
 
         assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
     }
 
     @Test
-    void federationLinkWithoutComponent_isARealRemoval() {
-        // A dangling link tells us nothing; treat it as a real removal rather than
-        // silently suppressing the event.
+    void federationProviderWithoutEditMode_isLocalRemovalOnly() {
+        // The Kerberos shape: the field is optional, and KerberosConfig.getEditMode
+        // defaults a missing value to UNSYNCED while KerberosFederationProvider
+        // .removeUser returns true without deleting the principal at any edit mode.
+        // Providers disagree on what absent means, so absent cannot mean purged.
+        recapture(federationComponent(null));
+
+        assertTrue(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
+    @Test
+    void federationLinkWithoutComponent_isLocalRemovalOnly() {
+        // A dangling link tells us nothing about whether the account survived, and a
+        // wrongly emitted purge drives irreversible deletion downstream.
         lenient().when(user.getFederationLink()).thenReturn("gone-provider");
         lenient().when(realm.getComponent("gone-provider")).thenReturn(null);
         recaptureAsIs();
 
-        assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
-    }
-
-    @Test
-    void federationProviderWithoutEditMode_isARealRemoval() {
-        recapture(federationComponent(null));
-
-        assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+        assertTrue(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
     }
 
     @Test

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -259,6 +259,30 @@ class PurgedUserSnapshotTest {
     }
 
     @Test
+    void anyOrganizationMatches_answersFromTheMemoForSnapshots() {
+        // The gate asks three of these per stream. Passing the predicate in keeps a
+        // live user short-circuiting; for a snapshot it must reuse the memoized list
+        // rather than re-resolving every alias per question.
+        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        lenient().when(orgProvider.isEnabled()).thenReturn(true);
+        OrganizationModel org = mock(OrganizationModel.class);
+        lenient().when(org.getAlias()).thenReturn("acme");
+        lenient().when(orgProvider.getByAlias("acme")).thenReturn(org);
+        lenient().when(orgProvider.getByMember(any())).thenAnswer(invocation -> Stream.of(org));
+        lenient().when(orgProvider.isManagedMember(any(), any())).thenReturn(false);
+        recaptureAsIs();
+
+        PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, realm, USER_ID);
+
+        assertTrue(PurgedUserSnapshot.anyOrganizationMatches(session, snapshot, candidate -> true));
+        assertFalse(PurgedUserSnapshot.anyOrganizationMatches(session, snapshot, candidate -> false));
+        assertTrue(PurgedUserSnapshot.anyOrganizationMatches(session, snapshot,
+                candidate -> "acme".equals(candidate.getAlias())));
+
+        verify(orgProvider, times(1)).getByAlias("acme");
+    }
+
+    @Test
     void blankEmail_isNotIndexed() {
         // lookupBySubject rejects a blank EmailSubjectId before it looks, so indexing
         // one would park the snapshot under a key nothing can ask for. The id index is

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -14,6 +14,7 @@ import org.keycloak.http.HttpRequest;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -37,6 +39,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -229,6 +233,29 @@ class PurgedUserSnapshotTest {
         recaptureAsIs();
 
         assertTrue(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
+    @Test
+    void organizationsOf_resolvesAliasesOncePerSnapshot() {
+        // The subject gate asks three questions per receiving stream, so re-resolving
+        // on every call multiplies alias lookups by streams. Organizations are enabled
+        // only for this test; the shared fixture leaves them off.
+        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        lenient().when(orgProvider.isEnabled()).thenReturn(true);
+        OrganizationModel org = mock(OrganizationModel.class);
+        lenient().when(orgProvider.getByAlias("acme")).thenReturn(org);
+        lenient().when(orgProvider.getByMember(any())).thenAnswer(invocation -> Stream.of(org));
+        lenient().when(orgProvider.isManagedMember(any(), any())).thenReturn(false);
+        lenient().when(org.getAlias()).thenReturn("acme");
+        recaptureAsIs();
+
+        PurgedUserSnapshot snapshot = PurgedUserSnapshot.lookup(session, realm, USER_ID);
+        List<OrganizationModel> first = PurgedUserSnapshot.organizationsOf(session, snapshot);
+        List<OrganizationModel> second = PurgedUserSnapshot.organizationsOf(session, snapshot);
+
+        assertEquals(List.of(org), first);
+        assertSame(first, second, "the resolved list is memoized on the snapshot");
+        verify(orgProvider, times(1)).getByAlias("acme");
     }
 
     @Test

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotTest.java
@@ -8,9 +8,12 @@ import java.util.stream.Stream;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.component.ComponentModel;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
@@ -18,14 +21,17 @@ import org.keycloak.ssf.subject.ComplexSubjectId;
 import org.keycloak.ssf.subject.EmailSubjectId;
 import org.keycloak.ssf.subject.IssuerSubjectId;
 import org.keycloak.ssf.subject.OpaqueSubjectId;
+import org.keycloak.storage.UserStorageProvider;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -106,8 +112,10 @@ class PurgedUserSnapshotTest {
                 UserModel.USERNAME, List.of("purged"),
                 UserModel.EMAIL, List.of(EMAIL),
                 "ssf.notify.receiver-client-id", List.of("true")));
-        lenient().when(user.getGroupsStream()).thenReturn(Stream.empty());
-        lenient().when(user.getRoleMappingsStream()).thenReturn(Stream.empty());
+        // Answers, not fixed returns: a Stream is single-use, and tests that re-capture
+        // would otherwise re-consume the one instance handed out here.
+        lenient().when(user.getGroupsStream()).thenAnswer(invocation -> Stream.empty());
+        lenient().when(user.getRoleMappingsStream()).thenAnswer(invocation -> Stream.empty());
 
         PurgedUserSnapshot.capture(session, realm, user);
     }
@@ -165,6 +173,58 @@ class PurgedUserSnapshotTest {
         assertNotNull(PurgedUserSnapshot.lookupBySubject(session, realm, email));
     }
 
+    // ----- federated users whose account outlives the local record -----
+
+    @Test
+    void localUser_isARealRemoval() {
+        assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly(),
+                "a user with no federation link is genuinely gone");
+    }
+
+    @Test
+    void readOnlyFederatedUser_isLocalRemovalOnly() {
+        // LDAPStorageProvider.removeUser returns true without touching the directory in
+        // READ_ONLY mode, so the deletion reports success while the account survives and
+        // will be re-imported. Emitting account-purged there would drive irreversible
+        // data-retention deletion downstream for a user who comes back.
+        recapture(federationComponent(UserStorageProvider.EditMode.READ_ONLY.name()));
+
+        assertTrue(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
+    @Test
+    void unsyncedFederatedUser_isLocalRemovalOnly() {
+        recapture(federationComponent(UserStorageProvider.EditMode.UNSYNCED.name()));
+
+        assertTrue(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
+    @Test
+    void writableFederatedUser_isARealRemoval() {
+        // WRITABLE propagates the delete to the directory, so the account really is gone.
+        recapture(federationComponent(UserStorageProvider.EditMode.WRITABLE.name()));
+
+        assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
+    @Test
+    void federationLinkWithoutComponent_isARealRemoval() {
+        // A dangling link tells us nothing; treat it as a real removal rather than
+        // silently suppressing the event.
+        lenient().when(user.getFederationLink()).thenReturn("gone-provider");
+        lenient().when(realm.getComponent("gone-provider")).thenReturn(null);
+        recaptureAsIs();
+
+        assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
+    @Test
+    void federationProviderWithoutEditMode_isARealRemoval() {
+        recapture(federationComponent(null));
+
+        assertFalse(PurgedUserSnapshot.lookup(session, realm, USER_ID).isLocalRemovalOnly());
+    }
+
     @Test
     void discard_removesBothIndexes() {
         PurgedUserSnapshot.discard(session, realm, USER_ID);
@@ -174,6 +234,28 @@ class PurgedUserSnapshotTest {
         EmailSubjectId email = new EmailSubjectId();
         email.setEmail(EMAIL);
         assertNull(PurgedUserSnapshot.lookupBySubject(session, realm, email));
+    }
+
+    /** Re-captures the user behind a federation provider configured with {@code editMode}. */
+    private void recapture(ComponentModel component) {
+        lenient().when(user.getFederationLink()).thenReturn("ldap-provider");
+        lenient().when(realm.getComponent("ldap-provider")).thenReturn(component);
+        recaptureAsIs();
+    }
+
+    private void recaptureAsIs() {
+        PurgedUserSnapshot.discard(session, realm, USER_ID);
+        PurgedUserSnapshot.capture(session, realm, user);
+    }
+
+    private ComponentModel federationComponent(String editMode) {
+        ComponentModel component = new ComponentModel();
+        MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>();
+        if (editMode != null) {
+            config.putSingle(LDAPConstants.EDIT_MODE, editMode);
+        }
+        component.setConfig(config);
+        return component;
     }
 
     private IssuerSubjectId issuerSubject(String iss, String sub) {

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotsTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotsTest.java
@@ -70,6 +70,46 @@ class PurgedUserSnapshotsTest {
     }
 
     @Test
+    void replacingAnId_dropsThePreviousEmailEntry() {
+        // Both indexes have to agree after a replace. Without this, re-capturing the
+        // same user under a different address leaves the old key pointing at the
+        // superseded snapshot, and discard clears only the current key — so the stale
+        // entry would outlive every cleanup path.
+        PurgedUserSnapshot first = snapshot("user-1");
+        PurgedUserSnapshot second = snapshot("user-1");
+        snapshots.put("realm.user-1", "realm.old@local.test", first);
+
+        snapshots.put("realm.user-1", "realm.new@local.test", second);
+
+        assertEquals(1, snapshots.size());
+        assertSame(second, snapshots.byId("realm.user-1"));
+        assertSame(second, snapshots.byEmail("realm.new@local.test"));
+        assertNull(snapshots.byEmail("realm.old@local.test"), "the superseded address must not resolve");
+    }
+
+    @Test
+    void replacingAnIdWithAnEmaillessSnapshot_clearsTheEmailIndex() {
+        snapshots.put("realm.user-1", "realm.old@local.test", snapshot("user-1"));
+
+        snapshots.put("realm.user-1", null, snapshot("user-1"));
+
+        assertNull(snapshots.byEmail("realm.old@local.test"));
+        assertEquals(1, snapshots.size());
+    }
+
+    @Test
+    void replacingAnId_leavesOtherSnapshotsIndexed() {
+        PurgedUserSnapshot other = snapshot("user-2");
+        snapshots.put("realm.user-1", "realm.one@local.test", snapshot("user-1"));
+        snapshots.put("realm.user-2", "realm.two@local.test", other);
+
+        snapshots.put("realm.user-1", "realm.oneprime@local.test", snapshot("user-1"));
+
+        assertSame(other, snapshots.byEmail("realm.two@local.test"), "an unrelated entry must survive");
+        assertEquals(2, snapshots.size());
+    }
+
+    @Test
     void userWithoutEmail_isIndexedByIdOnly() {
         // capture() passes a null email key for a user with no email rather than
         // indexing under a null, so the secondary index stays addressable.

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotsTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotsTest.java
@@ -158,7 +158,7 @@ class PurgedUserSnapshotsTest {
     }
 
     private PurgedUserSnapshot snapshot(String userId) {
-        return new PurgedUserSnapshot(null, null, userId, null, List.of());
+        return new PurgedUserSnapshot(null, null, userId, null, List.of(), false);
     }
 
     /**

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotsTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/subject/PurgedUserSnapshotsTest.java
@@ -1,0 +1,185 @@
+package org.keycloak.ssf.transmitter.subject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.models.KeycloakSession;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the request-scoped snapshot set: its two indexes, the retention
+ * bound, and the warn-once latch.
+ *
+ * <p>The bound and the latch used to be one hand-maintained counter attribute, which
+ * meant the "already warned" marker was written by pushing the count one past the
+ * maximum. That made the count stop matching the number actually held, and the
+ * regressions it caused are pinned here: a freed slot has to become reusable, and the
+ * warning has to stay fired exactly once however the set churns.
+ */
+class PurgedUserSnapshotsTest {
+
+    PurgedUserSnapshots snapshots;
+
+    @BeforeEach
+    void setUp() {
+        snapshots = new PurgedUserSnapshots();
+    }
+
+    @Test
+    void size_tracksPutsAndRemoves() {
+        snapshots.put("realm.user-1", "realm.one@local.test", snapshot("user-1"));
+        snapshots.put("realm.user-2", "realm.two@local.test", snapshot("user-2"));
+        assertEquals(2, snapshots.size());
+
+        snapshots.remove("realm.user-1", "realm.one@local.test");
+        assertEquals(1, snapshots.size());
+    }
+
+    @Test
+    void bothIndexesResolveTheSameSnapshot() {
+        PurgedUserSnapshot captured = snapshot("user-1");
+        snapshots.put("realm.user-1", "realm.one@local.test", captured);
+
+        assertSame(captured, snapshots.byId("realm.user-1"));
+        assertSame(captured, snapshots.byEmail("realm.one@local.test"));
+    }
+
+    @Test
+    void removeClearsBothIndexes() {
+        snapshots.put("realm.user-1", "realm.one@local.test", snapshot("user-1"));
+
+        snapshots.remove("realm.user-1", "realm.one@local.test");
+
+        assertNull(snapshots.byId("realm.user-1"));
+        assertNull(snapshots.byEmail("realm.one@local.test"));
+    }
+
+    @Test
+    void userWithoutEmail_isIndexedByIdOnly() {
+        // capture() passes a null email key for a user with no email rather than
+        // indexing under a null, so the secondary index stays addressable.
+        PurgedUserSnapshot captured = snapshot("user-1");
+        snapshots.put("realm.user-1", null, captured);
+
+        assertSame(captured, snapshots.byId("realm.user-1"));
+        assertEquals(1, snapshots.size());
+        assertNull(snapshots.byEmail(null));
+
+        snapshots.remove("realm.user-1", null);
+        assertEquals(0, snapshots.size());
+    }
+
+    @Test
+    void isFull_onlyAtTheBound() {
+        for (int i = 0; i < PurgedUserSnapshots.MAX_SNAPSHOTS_PER_SESSION - 1; i++) {
+            snapshots.put("realm.user-" + i, null, snapshot("user-" + i));
+            assertFalse(snapshots.isFull(), "not full below the bound");
+        }
+
+        snapshots.put("realm.user-last", null, snapshot("user-last"));
+
+        assertTrue(snapshots.isFull());
+        assertEquals(PurgedUserSnapshots.MAX_SNAPSHOTS_PER_SESSION, snapshots.size());
+    }
+
+    @Test
+    void discardingFreesASlotForTheNextCapture() {
+        // The regression. A request that hits the bound and then discards a snapshot
+        // it has finished emitting for must be able to capture again — the count is
+        // the set's real size, so it drops back below the bound. Backed by a counter
+        // that had been pushed past the maximum to double as a warned-flag, the gate
+        // stayed shut for the rest of the request instead.
+        fillToBound();
+        assertTrue(snapshots.isFull());
+
+        snapshots.remove("realm.user-0", null);
+
+        assertFalse(snapshots.isFull(), "a freed slot must be reusable");
+        snapshots.put("realm.user-new", null, snapshot("user-new"));
+        assertNotNull(snapshots.byId("realm.user-new"), "capture must succeed after a discard");
+    }
+
+    @Test
+    void boundWarning_firesExactlyOncePerSession() {
+        assertTrue(snapshots.markBoundWarned(), "first caller flips the latch");
+        assertFalse(snapshots.markBoundWarned());
+        assertFalse(snapshots.markBoundWarned());
+    }
+
+    @Test
+    void boundWarning_staysLatchedAcrossChurn() {
+        // Same regression seen from the logging side: with the latch inferred from the
+        // count, every discard dropped it back to the warn-again value, so a bulk
+        // request emitted a WARN per deletion rather than the one line intended.
+        fillToBound();
+        assertTrue(snapshots.markBoundWarned());
+
+        snapshots.remove("realm.user-0", null);
+        snapshots.put("realm.user-0", null, snapshot("user-0"));
+
+        assertFalse(snapshots.markBoundWarned(), "churn must not re-arm the warning");
+    }
+
+    @Test
+    void find_returnsNullBeforeAnythingIsCaptured() {
+        assertNull(PurgedUserSnapshots.find(sessionWithAttributes()));
+    }
+
+    @Test
+    void of_createsOnceAndStashesOnTheSession() {
+        KeycloakSession session = sessionWithAttributes();
+
+        PurgedUserSnapshots first = PurgedUserSnapshots.of(session);
+        PurgedUserSnapshots second = PurgedUserSnapshots.of(session);
+
+        assertSame(first, second, "the set is created once per session");
+        assertSame(first, PurgedUserSnapshots.find(session));
+    }
+
+    private void fillToBound() {
+        for (int i = 0; i < PurgedUserSnapshots.MAX_SNAPSHOTS_PER_SESSION; i++) {
+            snapshots.put("realm.user-" + i, null, snapshot("user-" + i));
+        }
+    }
+
+    private PurgedUserSnapshot snapshot(String userId) {
+        return new PurgedUserSnapshot(null, null, userId, null, List.of());
+    }
+
+    /**
+     * A session whose attribute map behaves like the real one — {@code setAttribute}
+     * stores and the typed {@code getAttribute} reads back — so {@code of} / {@code find}
+     * are exercised against get-or-create semantics rather than a stubbed return.
+     */
+    private KeycloakSession sessionWithAttributes() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        Map<String, Object> attributes = new HashMap<>();
+
+        doAnswer(invocation -> {
+            attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(session).setAttribute(anyString(), any());
+
+        when(session.getAttribute(anyString(), any(Class.class))).thenAnswer(invocation -> {
+            Object value = attributes.get(invocation.<String>getArgument(0));
+            return value == null ? null : invocation.<Class<?>>getArgument(1).cast(value);
+        });
+
+        return session;
+    }
+}


### PR DESCRIPTION
Adds the RISC `account-purged` event, so SSF receivers learn when a Keycloak account is deleted and can run their own data-retention cleanup.

Closes #48899

## The problem

Keycloak deletes the user row *before* firing the admin or user event that drives SSF emission, so by the time the transmitter runs every lookup of that user returns `null`. That affected the whole pipeline, not just the subject:

- the admin path bailed out in `SsfTransmitterEventListener` before building a token at all;
- the `email` and `+tenant` subject formats had nothing to resolve and threw;
- the dispatch-time subject gate saw an unresolvable subject and dropped the event under the default `default_subjects=NONE`.

That last one is the nastiest, because its failure mode is a silent drop rather than an error.

## The approach

Capture a read-only snapshot of the user on `UserModel.UserPreRemovedEvent` — the last hook that runs while the user still exists — and stash it on the session for the rest of the request. No new SPI was needed; that provider event already exists and is already published from `UserStorageManager.removeUser`.

The snapshot **is** a `UserModel` (extending `AbstractInMemoryUserAdapter`) rather than a bag of fields. Everything downstream that needs the user does attribute reads — the subject filter and inclusion resolver read `ssf.notify.<clientId>`, and the mapper's email format reads `getEmail()` — so copying the attribute map makes those call sites work unmodified.

Organization membership is the one exception: `getByMember` is an id-keyed query, not an attribute read. The snapshot captures only the organization *aliases*; since organizations outlive the user, callers re-resolve live `OrganizationModel`s via `getByAlias` and then run exactly the same logic as for a live user. That keeps the pluggable `SsfSubjectInclusionResolver` authoritative for purged users too.

The snapshot never has to outlive the request: narrowing, signing and encoding all happen inline on the request thread, and the outbox replays already-signed bytes. Capture is skipped entirely when a deletion is not bound to an HTTP request, since nothing could consume the snapshot, and retention within a request is bounded — together those stop bulk deletion paths accumulating snapshots that will never be read.

## Deletions that are not purges

Emission stays on the admin/user event path rather than on the provider events, because those fire for deletions where the account does not cease to exist:

- a partial import under the `OVERWRITE` policy deletes and immediately recreates the user — it reports `OperationType.UPDATE` on `users/{id}`, one enum value away from the purge gate;
- deleting a client removes its service-account user — reported as `ResourceType.CLIENT` at `clients/{id}`.

Both are safe by construction rather than by an explicit guard, so both are pinned by tests to stop a future widening of the path matching from emitting spurious data-retention signals.

## Known gap

`account-purged` is emitted only for deletions through the admin API or the account console. The workflow delete step (`DeleteUserStepProvider`) fires no Keycloak events at all, so scheduled data-retention deletions are currently silent — arguably the case receivers would most expect to hear about. Deleting an organization that owns managed members is silent for the same reason, as it bypasses `UserManager`.

Both are documented on `RiscAccountPurged` and in the guide, and are worth follow-up issues rather than growing this PR.

## Testing

- 9 integration tests in `SsfTransmitterAccountPurgedEventTests`: both subject formats, both `default_subjects` modes with a negative control, the org-notified and org-excluded legs, and both near-miss paths above.
- Unit tests for both `canConvert` gates, the emitted token shape, and the wire format (including that `account-purged` carries no `reason` claim, which RISC does not define for it).
- The self-service `DELETE_ACCOUNT` path is covered by unit tests and verified by hand; an end-to-end test would need a new `DeleteAccountPage` page object, which felt disproportionate for asserting one field. Happy to add it if reviewers disagree.
- The removal-grace org branch is shared code with the two org branches that are covered; testing it directly needs the grace SPI configured.

## Notes for review

The second commit is a design correction from an internal review, not a fixup — it explains why organizations are re-resolved live rather than snapshotted, so it may be worth keeping separate. Squash if you prefer.

`USER_DELETED_BY_ADMIN_PATH_PATTERN` is deliberately a separate constant from `USER_UPDATED_BY_ADMIN_PATH_PATTERN` despite being an identical regex — the two gates differ by operation type, and naming them separately keeps each readable on its own. Happy to collapse them into one shared constant if preferred.

