### PR TITLE
Fix EnvUtil.replace for system property values containing '$'

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/EnvUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/EnvUtil.java
@@ -46,7 +46,7 @@ public final class EnvUtil {
             String envVar = matcher.group(1);
             String envVal = System.getProperty(envVar);
             if (envVal == null) envVal = "NOT-SPECIFIED";
-            matcher.appendReplacement(buf, envVal.replace("\\", "\\\\"));
+            matcher.appendReplacement(buf, Matcher.quoteReplacement(envVal));
         }
         matcher.appendTail(buf);
         return buf.toString();

--- a/common/src/test/java/org/keycloak/common/util/EnvUtilTest.java
+++ b/common/src/test/java/org/keycloak/common/util/EnvUtilTest.java
@@ -1,0 +1,40 @@
+package org.keycloak.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EnvUtilTest {
+
+    @Test
+    public void replaceValueContainingDollarSign() {
+        String key = "keycloak.test.envutil.dollar";
+        try {
+            // A resolved value containing '$' must be inserted literally.
+            System.setProperty(key, "abc$def");
+            assertEquals("abc$def", EnvUtil.replace("${" + key + "}"));
+
+            System.setProperty(key, "a$1b");
+            assertEquals("a$1b", EnvUtil.replace("${" + key + "}"));
+        } finally {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void replaceValueContainingBackslash() {
+        // Backslashes (e.g. Windows keystore paths) must still be preserved literally.
+        String key = "keycloak.test.envutil.backslash";
+        try {
+            System.setProperty(key, "C:\\keys\\truststore.jks");
+            assertEquals("C:\\keys\\truststore.jks", EnvUtil.replace("${" + key + "}"));
+        } finally {
+            System.clearProperty(key);
+        }
+    }
+
+    @Test
+    public void replaceUnspecifiedPropertyYieldsPlaceholder() {
+        assertEquals("NOT-SPECIFIED", EnvUtil.replace("${keycloak.test.envutil.missing}"));
+    }
+}


### PR DESCRIPTION
Closes #51709. Supersedes #51710 (that PR was accidentally force-pushed while closed, which GitHub does not allow to be reopened; this PR is the same branch with the review feedback applied).

## What

`org.keycloak.common.util.EnvUtil.replace(String)` built the replacement string for `Matcher.appendReplacement(...)` by escaping backslashes but not dollar signs:

```java
matcher.appendReplacement(buf, envVal.replace("\\", "\\\\"));
```

`appendReplacement` treats both `\` and `$` as special. So when a resolved system-property value contains `$`, it either throws `IllegalArgumentException: Illegal group reference` (for `$` + non-digit) or silently splices in a capture group (for `$<digit>`). This is reachable from real configuration — `EnvUtil.replace` expands keystore/truststore path properties in `HttpClientBuilder` and `DefaultHttpClientFactory`.

The same class of bug was previously fixed in `KeycloakUriBuilder` (#43118); `EnvUtil` had the same latent issue.

## Fix

Use `Matcher.quoteReplacement(envVal)`, which escapes both `\` and `$`, and drop the manual (incomplete) backslash escaping.

## Testing

Added `common/src/test/java/org/keycloak/common/util/EnvUtilTest.java` covering:
- a value containing `$` (both `$def` and `$1` forms) — fails before this change, passes after;
- a Windows-style path with backslashes — still preserved literally;
- an unspecified property — still yields `NOT-SPECIFIED`.

`mvn -pl common test` passes.

## Review feedback

Addressed @michalvavrik's note from #51710: trimmed the test comment so it describes only what the test asserts, not the pre-fix history.