### PR TITLE
fix: Prevent SAML OneTimeUse assertion replay in IdP-Initiated broker flow

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/validators/ConditionsValidator.java
+++ b/saml-core/src/main/java/org/keycloak/saml/validators/ConditionsValidator.java
@@ -190,6 +190,29 @@ public class ConditionsValidator {
     }
 
     /**
+     * Returns true if the conditions contain a OneTimeUse condition.
+     * @return true if OneTimeUse is present
+     */
+    public boolean isOneTimeUse() {
+        if (conditions instanceof ConditionsType) {
+            return hasOneTimeUseCondition((ConditionsType) conditions);
+        }
+        return false;
+    }
+
+    private boolean hasOneTimeUseCondition(ConditionsType conditionsType) {
+        if (conditionsType.getConditions() == null) {
+            return false;
+        }
+        for (ConditionAbstractType condition : conditionsType.getConditions()) {
+            if (condition instanceof OneTimeUseType) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Section 2.5.1.4
      * @return 
      */

--- a/saml-core/src/main/java/org/keycloak/saml/validators/ConditionsValidator.java
+++ b/saml-core/src/main/java/org/keycloak/saml/validators/ConditionsValidator.java
@@ -200,6 +200,17 @@ public class ConditionsValidator {
         return false;
     }
 
+    /**
+     * Returns true if the conditions contain a NotOnOrAfter element.
+     * @return true if NotOnOrAfter is present
+     */
+    public boolean hasNotOnOrAfter() {
+        if (conditions instanceof ConditionsType) {
+            return ((ConditionsType) conditions).getNotOnOrAfter() != null;
+        }
+        return false;
+    }
+
     private boolean hasOneTimeUseCondition(ConditionsType conditionsType) {
         if (conditionsType.getConditions() == null) {
             return false;

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -82,6 +82,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocolFactory;
@@ -671,23 +672,47 @@ public class SAMLEndpoint {
                     identity.setToken(samlResponse);
                 }
 
-                ConditionsValidator.Builder cvb = new ConditionsValidator.Builder(assertion.getID(), assertion.getConditions(), destinationValidator)
-                        .clockSkewInMillis(1000 * config.getAllowedClockSkew());
+                ConditionsValidator validator;
                 try {
+                    ConditionsValidator.Builder cvb = new ConditionsValidator.Builder(assertion.getID(), assertion.getConditions(), destinationValidator)
+                            .clockSkewInMillis(1000 * config.getAllowedClockSkew());
                     String issuerURL = getEntityId(session.getContext().getUri(), realm);
                     cvb.addAllowedAudience(URI.create(issuerURL));
                     // getDestination has been validated to match request URL already so it matches SAML endpoint
                     if (responseType.getDestination() != null) {
                         cvb.addAllowedAudience(URI.create(responseType.getDestination()));
                     }
+                    validator = cvb.build();
                 } catch (IllegalArgumentException ex) {
                     // warning has been already emitted in DeploymentBuilder
+                    validator = new ConditionsValidator.Builder(assertion.getID(), assertion.getConditions(), destinationValidator)
+                            .clockSkewInMillis(1000 * config.getAllowedClockSkew())
+                            .build();
                 }
-                if (! cvb.build().isValid()) {
+
+                // Validate expiration
+                if (! validator.isValid()) {
                     logger.error("Assertion expired.");
                     event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                     event.error(Errors.INVALID_SAML_RESPONSE);
                     return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, Messages.EXPIRED_CODE);
+                }
+
+                // CVE-2026-18967: Prevent OneTimeUse assertion replay attacks
+                if (validator.isOneTimeUse()) {
+                    String assertionId = assertion.getID();
+                    SingleUseObjectProvider singleUseObjects = session.singleUseObjects();
+                    // Calculate lifespan: use notOnOrAfter minus current time, with a reasonable maximum
+                    long maxIdleSeconds = calculateOneTimeUseMaxIdleSeconds(assertion.getConditions());
+                    // Atomically check-and-insert: returns true only if the assertion ID was not already present
+                    if (! singleUseObjects.putIfAbsent(assertionId, maxIdleSeconds)) {
+                        logger.warnf("Assertion %s contains OneTimeUse but was already used (potential replay attack).",
+                                assertionId);
+                        event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
+                        event.error(Errors.INVALID_SAML_RESPONSE);
+                        return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST,
+                                Messages.IDENTITY_PROVIDER_INVALID_SIGNATURE);
+                    }
                 }
 
                 AuthnStatementType authn = null;
@@ -1102,5 +1127,21 @@ public class SAMLEndpoint {
         }
 
         return true;
+    }
+
+    /**
+     * Calculates the maximum idle time (in seconds) for a OneTimeUse assertion ID.
+     * Uses the assertion's notOnOrAfter time if available, otherwise falls back to a default.
+     */
+    private long calculateOneTimeUseMaxIdleSeconds(org.keycloak.dom.saml.v2.assertion.ConditionsType conditions) {
+        if (conditions != null && conditions.getNotOnOrAfter() != null) {
+            long maxIdle = conditions.getNotOnOrAfter().toGregorianCalendar().getTimeInMillis() / 1000 - System.currentTimeMillis() / 1000;
+            // Use the calculated value if positive, otherwise use the default
+            if (maxIdle > 0) {
+                return maxIdle;
+            }
+        }
+        // Default to 1 hour as a safe upper bound for OneTimeUse assertion replay window
+        return 3600;
     }
 }

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -702,6 +702,17 @@ public class SAMLEndpoint {
 
                 // CVE-2026-18967: Prevent OneTimeUse assertion replay attacks
                 if (validator.isOneTimeUse()) {
+                    // Reject OneTimeUse assertions without a finite validity window.
+                    // Without NotOnOrAfter the assertion is valid indefinitely per SAML spec,
+                    // so we cannot provide meaningful replay protection.
+                    if (! validator.hasNotOnOrAfter()) {
+                        logger.warnf("Assertion contains OneTimeUse but no NotOnOrAfter condition (cannot enforce replay protection). AssertionId=%s, realm=%s, idp=%s",
+                                assertion.getID(), realm.getName(), config.getAlias());
+                        event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
+                        event.error(Errors.INVALID_SAML_RESPONSE);
+                        return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST,
+                                Messages.IDENTITY_PROVIDER_INVALID_RESPONSE);
+                    }
                     SingleUseObjectProvider singleUseObjects = session.singleUseObjects();
                     // Calculate lifespan: use notOnOrAfter minus current time, with a reasonable maximum
                     long maxIdleSeconds = calculateOneTimeUseMaxIdleSeconds(assertion.getConditions());

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -19,7 +19,9 @@ package org.keycloak.broker.saml;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.security.MessageDigest;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
@@ -700,14 +702,15 @@ public class SAMLEndpoint {
 
                 // CVE-2026-18967: Prevent OneTimeUse assertion replay attacks
                 if (validator.isOneTimeUse()) {
-                    String assertionId = assertion.getID();
                     SingleUseObjectProvider singleUseObjects = session.singleUseObjects();
                     // Calculate lifespan: use notOnOrAfter minus current time, with a reasonable maximum
                     long maxIdleSeconds = calculateOneTimeUseMaxIdleSeconds(assertion.getConditions());
+                    // Derive a namespaced, fixed-length key to avoid DB length limits and cross-realm collisions
+                    String singleUseKey = buildSingleUseKey(assertion.getID());
                     // Atomically check-and-insert: returns true only if the assertion ID was not already present
-                    if (! singleUseObjects.putIfAbsent(assertionId, maxIdleSeconds)) {
-                        logger.warnf("Assertion %s contains OneTimeUse but was already used (potential replay attack).",
-                                assertionId);
+                    if (! singleUseObjects.putIfAbsent(singleUseKey, maxIdleSeconds)) {
+                        logger.warnf("Assertion contains OneTimeUse but was already used (potential replay attack). AssertionId=%s, realm=%s, idp=%s",
+                                assertion.getID(), realm.getName(), config.getAlias());
                         event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                         event.error(Errors.INVALID_SAML_RESPONSE);
                         return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST,
@@ -1131,7 +1134,8 @@ public class SAMLEndpoint {
 
     /**
      * Calculates the maximum idle time (in seconds) for a OneTimeUse assertion ID.
-     * Uses the assertion's notOnOrAfter time if available, otherwise falls back to a default.
+     * Uses the assertion's notOnOrAfter time if available, otherwise uses a longer default
+     * to cover the entire acceptance window when NotOnOrAfter is absent.
      */
     private long calculateOneTimeUseMaxIdleSeconds(org.keycloak.dom.saml.v2.assertion.ConditionsType conditions) {
         if (conditions != null && conditions.getNotOnOrAfter() != null) {
@@ -1141,7 +1145,32 @@ public class SAMLEndpoint {
                 return maxIdle;
             }
         }
-        // Default to 1 hour as a safe upper bound for OneTimeUse assertion replay window
-        return 3600;
+        // If NotOnOrAfter is absent, use a longer default to cover the entire acceptance window.
+        // Without NotOnOrAfter the assertion is considered valid indefinitely, so use 24 hours
+        // as a practical upper bound for replay protection.
+        return 86400;
+    }
+
+    /**
+     * Builds a namespaced, fixed-length key for single-use assertion tracking.
+     * Combines realm name, IdP alias, and a SHA-256 hash of the assertion ID to:
+     * 1. Prevent database column length violations (key is always 64 hex chars)
+     * 2. Prevent cross-realm/cross-IdP assertion ID collisions
+     */
+    private String buildSingleUseKey(String assertionId) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            String input = realm.getName() + ":" + config.getAlias() + ":" + assertionId;
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            // SHA-256 is guaranteed to be available in all JVMs; this should never happen
+            logger.errorv("SHA-256 algorithm not available, falling back to assertion ID: {0}", assertionId);
+            return assertionId;
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -1152,8 +1152,8 @@ public class SAMLEndpoint {
     private long calculateOneTimeUseMaxIdleSeconds(org.keycloak.dom.saml.v2.assertion.ConditionsType conditions) {
         if (conditions != null && conditions.getNotOnOrAfter() != null) {
             long maxIdle = conditions.getNotOnOrAfter().toGregorianCalendar().getTimeInMillis() / 1000 - System.currentTimeMillis() / 1000;
-            // Add configured clock skew to match the ConditionsValidator acceptance window
-            maxIdle += config.getAllowedClockSkew();
+            // Add configured clock skew and one second to cover timestamp truncation.
+            maxIdle += config.getAllowedClockSkew() + 1;
             // Use the calculated value if positive, otherwise use the default
             if (maxIdle > 0) {
                 return maxIdle;

--- a/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLEndpoint.java
@@ -714,7 +714,7 @@ public class SAMLEndpoint {
                         event.event(EventType.IDENTITY_PROVIDER_RESPONSE);
                         event.error(Errors.INVALID_SAML_RESPONSE);
                         return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST,
-                                Messages.IDENTITY_PROVIDER_INVALID_SIGNATURE);
+                                Messages.IDENTITY_PROVIDER_INVALID_RESPONSE);
                     }
                 }
 
@@ -1136,10 +1136,13 @@ public class SAMLEndpoint {
      * Calculates the maximum idle time (in seconds) for a OneTimeUse assertion ID.
      * Uses the assertion's notOnOrAfter time if available, otherwise uses a longer default
      * to cover the entire acceptance window when NotOnOrAfter is absent.
+     * Includes configured clock skew to match ConditionsValidator's acceptance window.
      */
     private long calculateOneTimeUseMaxIdleSeconds(org.keycloak.dom.saml.v2.assertion.ConditionsType conditions) {
         if (conditions != null && conditions.getNotOnOrAfter() != null) {
             long maxIdle = conditions.getNotOnOrAfter().toGregorianCalendar().getTimeInMillis() / 1000 - System.currentTimeMillis() / 1000;
+            // Add configured clock skew to match the ConditionsValidator acceptance window
+            maxIdle += config.getAllowedClockSkew();
             // Use the calculated value if positive, otherwise use the default
             if (maxIdle > 0) {
                 return maxIdle;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BrokerTest.java
@@ -42,6 +42,7 @@ import org.keycloak.dom.saml.v2.assertion.AttributeStatementType.ASTChoiceType;
 import org.keycloak.dom.saml.v2.assertion.AttributeType;
 import org.keycloak.dom.saml.v2.assertion.ConditionsType;
 import org.keycloak.dom.saml.v2.assertion.NameIDType;
+import org.keycloak.dom.saml.v2.assertion.OneTimeUseType;
 import org.keycloak.dom.saml.v2.assertion.SubjectType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.dom.saml.v2.protocol.NameIDPolicyType;
@@ -496,6 +497,93 @@ public class BrokerTest extends AbstractSamlTest {
             }
         } catch (Exception ex) {
             fail("unexpected error");
+        }
+    }
+
+    // ---- CVE-2026-18967: OneTimeUse assertion replay protection tests ----
+    private ResponseType createAuthnResponseWithOneTimeUse(ResponseType resp, boolean withNotOnOrAfter) {
+        AssertionType assertion = resp.getAssertions().get(0).getAssertion();
+        ConditionsType conditions = assertion.getConditions();
+        conditions.addCondition(new OneTimeUseType());
+        if (withNotOnOrAfter) {
+            XMLGregorianCalendar notOnOrAfter = XMLTimeUtil.getIssueInstant();
+            notOnOrAfter = XMLTimeUtil.add(notOnOrAfter, 120_000); // +120s from now
+            conditions.setNotOnOrAfter(notOnOrAfter);
+        } else {
+            conditions.setNotOnOrAfter(null);
+        }
+        return resp;
+    }
+
+    @Test
+    public void testOneTimeUseAssertionAcceptedOnFirstUse() throws Exception {
+        final RealmResource realm = adminClient.realm(REALM_NAME);
+        try (IdentityProviderCreator idp = new IdentityProviderCreator(realm,
+                addIdentityProvider("https://saml.idp/"))) {
+            SAMLDocumentHolder samlResponse = new SamlClientBuilder().authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST,SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST)
+                    .build().login().idp(SAML_BROKER_ALIAS).build().processSamlResponse(REDIRECT).transformObject(this::createAuthnResponse)
+                    .transformObject(resp -> {
+                        return createAuthnResponseWithOneTimeUse((ResponseType) resp, true);
+                    }).targetAttributeSamlResponse().targetUri(getSamlBrokerUrl(REALM_NAME)).build().followOneRedirect().updateProfile().username("otusUser1").email("otus1@random.email.org").firstName("a").lastName("b").build().followOneRedirect().getSamlResponse(POST);
+            assertThat(samlResponse.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        } finally {
+            clearUsers(realm);
+        }
+    }
+
+    @Test
+    public void testOneTimeUseAssertionRejectedOnReplay() throws Exception {
+        final RealmResource realm = adminClient.realm(REALM_NAME);
+        try (IdentityProviderCreator idp = new IdentityProviderCreator(realm,
+                addIdentityProvider("https://saml.idp/"))) {
+            AtomicReference<String> capturedSamlResponse = new AtomicReference<>();
+            new SamlClientBuilder().authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST)
+                    .build().login().idp(SAML_BROKER_ALIAS).build().processSamlResponse(REDIRECT).transformObject(this::createAuthnResponse)
+                    .transformObject(resp -> {
+                        return createAuthnResponseWithOneTimeUse((ResponseType) resp, true);
+                    }).transformDocument(doc -> {
+                        capturedSamlResponse.set(org.keycloak.saml.common.util.DocumentUtil.getDocumentAsString(doc));
+                        return doc;
+                    }).targetAttributeSamlResponse().targetUri(getSamlBrokerUrl(REALM_NAME)).build().followOneRedirect().updateProfile().username("otusUser2").email("otus2@random.email.org").firstName("a").lastName("b").build().followOneRedirect().getSamlResponse(POST);
+            assertThat(capturedSamlResponse.get(), Matchers.notNullValue());
+            assertThat(capturedSamlResponse.get(), Matchers.containsString("OneTimeUse"));
+            clearUsers(realm);
+            String replayedDoc = capturedSamlResponse.get();
+            new SamlClientBuilder().authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST)
+                    .build().login().idp(SAML_BROKER_ALIAS).build().processSamlResponse(REDIRECT).documentSupplier(() -> replayedDoc).targetAttributeSamlResponse().targetUri(getSamlBrokerUrl(REALM_NAME)).build().assertResponse(org.keycloak.testsuite.util.Matchers.statusCodeIsHC(Status.BAD_REQUEST)).execute();
+        } finally {
+            clearUsers(realm);
+        }
+    }
+
+    @Test
+    public void testOneTimeUseWithoutNotOnOrAfterRejected() throws Exception {
+        final RealmResource realm = adminClient.realm(REALM_NAME);
+        try (IdentityProviderCreator idp = new IdentityProviderCreator(realm,
+                addIdentityProvider("https://saml.idp/"))) {
+            new SamlClientBuilder()
+                    .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build().login().idp(SAML_BROKER_ALIAS).build().processSamlResponse(REDIRECT).transformObject(this::createAuthnResponse)
+                    .transformObject(resp -> {
+                        return createAuthnResponseWithOneTimeUse((ResponseType) resp, false); 
+                    }).targetAttributeSamlResponse().targetUri(getSamlBrokerUrl(REALM_NAME)).build().assertResponse(org.keycloak.testsuite.util.Matchers.statusCodeIsHC(Status.BAD_REQUEST)).execute();
+        }
+    }
+
+    @Test
+    public void testNonOneTimeUseAssertionAllowedOnRepeat() throws Exception {
+        final RealmResource realm = adminClient.realm(REALM_NAME);
+        try (IdentityProviderCreator idp = new IdentityProviderCreator(realm,
+                addIdentityProvider("https://saml.idp"))) {
+            SAMLDocumentHolder samlResponse1 = new SamlClientBuilder().authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
+                    .login().idp(SAML_BROKER_ALIAS).build().processSamlResponse(REDIRECT).transformObject(this::createAuthnResponse).targetAttributeSamlResponse().targetUri(getSamlBrokerUrl(REALM_NAME)).build().followOneRedirect().updateProfile()
+                    .username("normalUser1").email("normal1@random.email.org").firstName("a").lastName("b").build().followOneRedirect().getSamlResponse(POST);
+            assertThat(samlResponse1.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+            clearUsers(realm);
+            SAMLDocumentHolder samlResponse2 = new SamlClientBuilder().authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build().login().idp(SAML_BROKER_ALIAS).build()
+            .processSamlResponse(REDIRECT).transformObject(this::createAuthnResponse).targetAttributeSamlResponse().targetUri(getSamlBrokerUrl(REALM_NAME)).build().followOneRedirect().updateProfile().username("normalUser2").email("normal2@random.email.org").firstName("a").lastName("b").build().followOneRedirect().getSamlResponse(POST);
+            assertThat(samlResponse2.getSamlObject(), isSamlStatusResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+        } finally {
+            clearUsers(realm);
         }
     }
 


### PR DESCRIPTION
When a SAML broker is configured using the IdP-Initiated flow, Keycloak failed to enforce the OneTimeUse condition in SAML assertions. This allowed an attacker who captured a valid, unused assertion to replay it multiple times and hijack the user session.

The fix adds replay detection by using the existing SingleUseObjectProvider to store assertion IDs atomically. When an assertion contains a OneTimeUse condition, its ID is checked and inserted into the distributed Infinispan cache. If the assertion ID is already present (putIfAbsent returns false), the request is rejected as a replay attack.

A public isOneTimeUse() method was added to ConditionsValidator to expose whether an assertion contains a OneTimeUse condition.

Closes #51782

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
