### PR TITLE
Fix client-side special character password policy validation

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
@@ -32,7 +32,7 @@ const policies = {
     }
   },
   specialChars: (policy, value) => {
-    let specialChars = value.split("").filter((char) => char.match(/\W/));
+    let specialChars = value.split("").filter((char) => char.match(/[^\p{L}\p{Nd}]/u));
     if (specialChars.length < policy.value) {
       return templateError(policy);
     }


### PR DESCRIPTION
When a special character password policy is set in the kc-client, the account registration UI will not consider '_' as a special character. This PR fixes that issue by adjusting the regex used in the frontend to match the backend validation.

Closes #51874