### PR TITLE
Fix refresh token same-second replay vulnerability

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -34,6 +34,7 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     final String REFRESH_TOKEN_PREFIX = "refreshTokenPrefix";
     final String REFRESH_TOKEN_USE_PREFIX = "refreshTokenUsePrefix";
     final String REFRESH_TOKEN_LAST_REFRESH_PREFIX = "refreshTokenLastRefreshPrefix";
+    final String REFRESH_TOKEN_LATEST_PREFIX = "refreshTokenLatestPrefix";
 
     String getId();
 
@@ -127,6 +128,12 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     }
     default void setRefreshTokenLastRefresh(String reuseId, int refreshTokenLastRefresh) {
         setNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + reuseId, String.valueOf(refreshTokenLastRefresh));
+    }
+    default String getLatestRefreshToken(String reuseId) {
+        return getNote(REFRESH_TOKEN_LATEST_PREFIX + reuseId);
+    }
+    default void setLatestRefreshToken(String reuseId, String refreshTokenId) {
+        setNote(REFRESH_TOKEN_LATEST_PREFIX + reuseId, refreshTokenId);
     }
 
     String getNote(String name);

--- a/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/AuthenticatedClientSessionModel.java
@@ -34,7 +34,7 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     final String REFRESH_TOKEN_PREFIX = "refreshTokenPrefix";
     final String REFRESH_TOKEN_USE_PREFIX = "refreshTokenUsePrefix";
     final String REFRESH_TOKEN_LAST_REFRESH_PREFIX = "refreshTokenLastRefreshPrefix";
-    final String REFRESH_TOKEN_LATEST_PREFIX = "refreshTokenLatestPrefix";
+    final String REFRESH_TOKEN_LATEST_GENERATED_PREFIX = "refreshTokenLatestGeneratedPrefix";
 
     String getId();
 
@@ -109,9 +109,15 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     default void setCurrentRefreshTokenUseCount(int currentRefreshTokenUseCount) {
     }
 
+    /**
+     * Returns the last refresh token that was successfully used for a token refresh.
+     */
     default String getRefreshToken(String reuseId) {
         return getNote(REFRESH_TOKEN_PREFIX + reuseId);
     }
+    /**
+     * Sets the last refresh token that was successfully used for a token refresh.
+     */
     default void setRefreshToken(String reuseId, String refreshTokenId) {
         setNote(REFRESH_TOKEN_PREFIX + reuseId, refreshTokenId);
     }
@@ -129,11 +135,18 @@ public interface AuthenticatedClientSessionModel extends CommonClientSessionMode
     default void setRefreshTokenLastRefresh(String reuseId, int refreshTokenLastRefresh) {
         setNote(REFRESH_TOKEN_LAST_REFRESH_PREFIX + reuseId, String.valueOf(refreshTokenLastRefresh));
     }
-    default String getLatestRefreshToken(String reuseId) {
-        return getNote(REFRESH_TOKEN_LATEST_PREFIX + reuseId);
+    /**
+     * Returns the latest generated refresh token, i.e. the newest token issued as a result of a token refresh.
+     */
+    default String getLatestGeneratedRefreshToken(String reuseId) {
+        return getNote(REFRESH_TOKEN_LATEST_GENERATED_PREFIX + reuseId);
     }
-    default void setLatestRefreshToken(String reuseId, String refreshTokenId) {
-        setNote(REFRESH_TOKEN_LATEST_PREFIX + reuseId, refreshTokenId);
+
+    /**
+     * Sets the latest generated refresh token, i.e. the newest token issued as a result of a token refresh.
+     */
+    default void setLatestGeneratedRefreshToken(String reuseId, String refreshTokenId) {
+        setNote(REFRESH_TOKEN_LATEST_GENERATED_PREFIX + reuseId, refreshTokenId);
     }
 
     String getNote(String name);

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -323,11 +323,20 @@ public class TokenManager {
     public void validateTokenReuse(KeycloakSession session, RealmModel realm, AccessToken refreshToken, AuthenticatedClientSessionModel clientSession, boolean refreshFlag) throws OAuthErrorException {
         String key = getReuseIdKey(refreshToken);
         String refreshTokenId = clientSession.getRefreshToken(key);
+        String latestRefreshTokenId = clientSession.getLatestRefreshToken(key);
         int lastRefresh = clientSession.getRefreshTokenLastRefresh(key);
 
         //check if a more recent refresh token is already used on this tab, if yes the refresh token is invalid
-        if (refreshTokenId != null && !refreshToken.getId().equals(refreshTokenId) && refreshToken.getIat() < lastRefresh) {
-            throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Stale token");
+        if (refreshTokenId != null && !refreshToken.getId().equals(refreshTokenId)) {
+            // When latestRefreshTokenId tracking is present, use <= to catch same-second replays.
+            // When absent (pre-upgrade sessions), fall back to strict < to avoid rejecting valid tokens.
+            if (latestRefreshTokenId != null) {
+                if (!refreshToken.getId().equals(latestRefreshTokenId) && refreshToken.getIat() <= lastRefresh) {
+                    throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Stale token");
+                }
+            } else if (refreshToken.getIat() < lastRefresh) {
+                throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Stale token");
+            }
         }
 
         if (!refreshToken.getId().equals(refreshTokenId)) {
@@ -1304,7 +1313,9 @@ public class TokenManager {
             generateRefreshToken(offlineTokenRequested);
             if (realm.isRevokeRefreshToken()) {
                 refreshToken.getOtherClaims().put(Constants.REUSE_ID, reuseId);
-                clientSession.setRefreshTokenLastRefresh(tokenManager.getReuseIdKey(oldRefreshToken), refreshToken.getIat().intValue());
+                String key = tokenManager.getReuseIdKey(oldRefreshToken);
+                clientSession.setRefreshTokenLastRefresh(key, refreshToken.getIat().intValue());
+                clientSession.setLatestRefreshToken(key, refreshToken.getId());
             }
             refreshToken.setScope(scope);
             return this;

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -323,7 +323,7 @@ public class TokenManager {
     public void validateTokenReuse(KeycloakSession session, RealmModel realm, AccessToken refreshToken, AuthenticatedClientSessionModel clientSession, boolean refreshFlag) throws OAuthErrorException {
         String key = getReuseIdKey(refreshToken);
         String refreshTokenId = clientSession.getRefreshToken(key);
-        String latestRefreshTokenId = clientSession.getLatestRefreshToken(key);
+        String latestRefreshTokenId = clientSession.getLatestGeneratedRefreshToken(key);
         int lastRefresh = clientSession.getRefreshTokenLastRefresh(key);
 
         //check if a more recent refresh token is already used on this tab, if yes the refresh token is invalid
@@ -1315,7 +1315,7 @@ public class TokenManager {
                 refreshToken.getOtherClaims().put(Constants.REUSE_ID, reuseId);
                 String key = tokenManager.getReuseIdKey(oldRefreshToken);
                 clientSession.setRefreshTokenLastRefresh(key, refreshToken.getIat().intValue());
-                clientSession.setLatestRefreshToken(key, refreshToken.getId());
+                clientSession.setLatestGeneratedRefreshToken(key, refreshToken.getId());
             }
             refreshToken.setScope(scope);
             return this;

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenRevokeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenRevokeTest.java
@@ -166,6 +166,67 @@ public class RefreshTokenRevokeTest {
                 .error("invalid_token");
     }
 
+    @Test
+    public void refreshTokenSameSecondReplayRejected() {
+        realm.updateWithCleanup(r -> r.revokeRefreshToken(true));
+
+        oauth.doLogin("test-user@localhost", "password");
+
+        EventRepresentation loginEvent = events.poll();
+        EventAssertion.assertSuccess(loginEvent).userId(user.getId());
+        String sessionId = loginEvent.getSessionId();
+        String authCode = oauth.parseLoginResponse().getCode();
+
+        // Obtain initial token pair — RT-0
+        AccessTokenResponse response1 = oauth.doAccessTokenRequest(authCode);
+        RefreshToken refreshToken1 = oauth.parseRefreshToken(response1.getRefreshToken());
+        EventAssertion.assertSuccess(events.poll()).type(EventType.CODE_TO_TOKEN);
+
+
+        // RT-0 → RT-1 (legitimate rotation)
+        AccessTokenResponse response2 = oauth.doRefreshTokenRequest(response1.getRefreshToken());
+        assertEquals(200, response2.getStatusCode());
+        RefreshToken refreshToken2 = oauth.parseRefreshToken(response2.getRefreshToken());
+        EventAssertion.assertSuccess(events.poll())
+                .sessionId(sessionId)
+                .details(Details.REFRESH_TOKEN_ID, refreshToken1.getId())
+                .type(EventType.REFRESH_TOKEN);
+
+        // RT-1 → RT-2 (legitimate rotation, same second — stored ID becomes RT-1)
+        AccessTokenResponse response3 = oauth.doRefreshTokenRequest(response2.getRefreshToken());
+        assertEquals(200, response3.getStatusCode());
+        RefreshToken refreshToken3 = oauth.parseRefreshToken(response3.getRefreshToken());
+        EventAssertion.assertSuccess(events.poll())
+                .sessionId(sessionId)
+                .details(Details.REFRESH_TOKEN_ID, refreshToken2.getId())
+                .type(EventType.REFRESH_TOKEN);
+
+        // Verify all tokens were issued in the same second — the precondition for this test
+        assertEquals(refreshToken1.getIat(), refreshToken2.getIat(), "RT-0 and RT-1 must share iat");
+        assertEquals(refreshToken2.getIat(), refreshToken3.getIat(), "RT-1 and RT-2 must share iat");
+
+        // Replay stale RT-0 — different ID from stored RT-1, but same iat second.
+        // The stale check must reject this even when iat == lastRefresh.
+        AccessTokenResponse replayResponse = oauth.doRefreshTokenRequest(response1.getRefreshToken());
+        assertEquals(400, replayResponse.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, replayResponse.getError());
+
+        EventAssertion.assertError(events.poll())
+                .sessionId(sessionId)
+                .details(Details.REFRESH_TOKEN_ID, refreshToken1.getId())
+                .type(EventType.REFRESH_TOKEN_ERROR)
+                .error("invalid_token");
+
+        // RT-2 must also be invalidated (client session detached on replay)
+        AccessTokenResponse response4 = oauth.doRefreshTokenRequest(response3.getRefreshToken());
+        assertEquals(400, response4.getStatusCode());
+
+        EventAssertion.assertError(events.poll())
+                .sessionId(sessionId)
+                .details(Details.REFRESH_TOKEN_ID, refreshToken3.getId())
+                .type(EventType.REFRESH_TOKEN_ERROR)
+                .error("invalid_token");
+    }
 
     @Test
     public void refreshTokenReuseOnDifferentTab() {

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenRevokeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenRevokeTest.java
@@ -201,9 +201,12 @@ public class RefreshTokenRevokeTest {
                 .details(Details.REFRESH_TOKEN_ID, refreshToken2.getId())
                 .type(EventType.REFRESH_TOKEN);
 
-        // Verify all tokens were issued in the same second — the precondition for this test
-        assertEquals(refreshToken1.getIat(), refreshToken2.getIat(), "RT-0 and RT-1 must share iat");
-        assertEquals(refreshToken2.getIat(), refreshToken3.getIat(), "RT-1 and RT-2 must share iat");
+        // Verify all tokens were issued close to each other
+        long TOLERANCE_INTERVAL = 5; // Helper interval to make sure that refresh tokens are issued close to each other
+        long diff_1 = refreshToken2.getIat() - refreshToken1.getIat();
+        assertTrue(diff_1 >=0 && diff_1 <= TOLERANCE_INTERVAL, "RT-0 and RT-1 must share iat (or very close to each other)");
+        long diff_2 = refreshToken3.getIat() - refreshToken2.getIat();
+        assertTrue(diff_2 >=0 && diff_2 <= TOLERANCE_INTERVAL, "RT-1 and RT-2 must share iat (or very close to each other)");
 
         // Replay stale RT-0 — different ID from stored RT-1, but same iat second.
         // The stale check must reject this even when iat == lastRefresh.


### PR DESCRIPTION
Add tracking of the latest refresh token ID to prevent replay attacks where multiple tokens are issued in the same second. When validating token reuse, check against both the stored token ID and the latest ID, and use <= comparison for iat/lastRefresh to catch same-second replays.

- Add getLatestRefreshToken/setLatestRefreshToken methods to AuthenticatedClientSessionModel
- Update validateTokenReuse to check latest token ID and use <= comparison for timestamp validation
- Store the latest refresh token ID when rotating tokens
- Add test case for same-second refresh token replay rejection

Closes #50999

