### PR TITLE
Fix CVEs inherited from ApacheDS/Kerby dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <!-- Others -->
         <apacheds.version>2.0.0.AM27</apacheds.version>
         <apacheds.codec.version>2.1.8</apacheds.codec.version>
-        <kerby.version>2.1.0</kerby.version>
+        <kerby.version>2.1.2</kerby.version>
         <google.zxing.version>3.4.0</google.zxing.version>
         <freemarker.version>2.3.32</freemarker.version>
         <sundrio.version>0.200.0</sundrio.version>
@@ -714,6 +714,12 @@
                 <version>${apacheds.codec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Override mina-core version from api-parent BOM to fix CVE-2026-47065 -->
+            <dependency>
+                <groupId>org.apache.mina</groupId>
+                <artifactId>mina-core</artifactId>
+                <version>2.2.9</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jmeter</groupId>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -61,12 +61,6 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-util-embedded-ldap</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -242,6 +242,12 @@
             <groupId>org.apache.kerby</groupId>
             <artifactId>ldap-backend</artifactId>
             <version>${kerby.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -88,6 +88,12 @@
             <groupId>org.apache.kerby</groupId>
             <artifactId>ldap-backend</artifactId>
             <version>${kerby.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>


### PR DESCRIPTION
- bump kerby from 2.1.0 to 2.1.2
- bump mina-core to 2.2.9 (fixes CVE-2026-47065)
- add BouncyCastle wildcard exclusion on the ldap-backend dependency to eliminate the transitive bcprov-jdk15on:1.70 pull (fixes CVE-2023-33201, CVE-2024-29857, CVE-2024-30171,CVE-2024-34447)

Closes #51785

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
