### PR TITLE
Avoid updates to IDX_USER_SESSION_EXPIRATION_LAST_REFRESH on every token refresh

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -87,10 +87,9 @@ This changes the behavior of identity provider account linking by email, of admi
 and of the verifiable credential offer emails of the experimental OID4VCI feature.
 The *Trust Email* setting of identity providers and LDAP federation is not affected, as it is an explicit decision of the administrator to trust the email from the external source.
 
-=== Offline session expiration indexes rebuilt with session bucket column
+=== Offline session expiration indexes rebuilt with session bucket column and refresh epoch
 
-The `OFFLINE_USER_SESSION` table now has updated indexes `IDX_USER_SESSION_EXPIRATION_CREATED` and `IDX_USER_SESSION_EXPIRATION_LAST_REFRESH`. On PostgreSQL and Microsoft SQL Server, `IDX_OFFLINE_USS_BY_BROKER_SESSION_ID` is also rebuilt as a filtered index.
-
+The `OFFLINE_USER_SESSION` table has a new `LAST_REFRESH_EPOCH` column and updated indexes `IDX_USER_SESSION_EXPIRATION_CREATED` and `IDX_USER_SESSION_EXPIRATION_LAST_REFRESH`. On PostgreSQL and Microsoft SQL Server, `IDX_OFFLINE_USS_BY_BROKER_SESSION_ID` is also rebuilt as a filtered index.
 If the table contains more than 300000 entries, {project_name} will skip the index creation by default during the automatic schema migration and instead log the SQL statement on the console during migration to be applied manually after {project_name}'s startup.
 See the link:{upgradingguide_link}[{upgradingguide_name}] for details on how to configure a different limit.
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -87,9 +87,9 @@ This changes the behavior of identity provider account linking by email, of admi
 and of the verifiable credential offer emails of the experimental OID4VCI feature.
 The *Trust Email* setting of identity providers and LDAP federation is not affected, as it is an explicit decision of the administrator to trust the email from the external source.
 
-=== Offline session expiration indexes rebuilt with session bucket column and refresh epoch
+=== Offline session expiration indexes rebuilt with session bucket and coarse refresh columns
 
-The `OFFLINE_USER_SESSION` table has a new `LAST_REFRESH_EPOCH` column and updated indexes `IDX_USER_SESSION_EXPIRATION_CREATED` and `IDX_USER_SESSION_EXPIRATION_LAST_REFRESH`. On PostgreSQL and Microsoft SQL Server, `IDX_OFFLINE_USS_BY_BROKER_SESSION_ID` is also rebuilt as a filtered index.
+The `OFFLINE_USER_SESSION` table has a new `LAST_SESSION_REFRESH_COARSE` column and updated indexes `IDX_USER_SESSION_EXPIRATION_CREATED` and `IDX_USER_SESSION_EXPIRATION_LAST_REFRESH`. On PostgreSQL and Microsoft SQL Server, `IDX_OFFLINE_USS_BY_BROKER_SESSION_ID` is also rebuilt as a filtered index.
 If the table contains more than 300000 entries, {project_name} will skip the index creation by default during the automatic schema migration and instead log the SQL statement on the console during migration to be applied manually after {project_name}'s startup.
 See the link:{upgradingguide_link}[{upgradingguide_name}] for details on how to configure a different limit.
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
@@ -399,7 +399,7 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
                     }
                     mergeUserSession(session, entry, userSessionModel, realm, sessionUpdates, userSessionPersister, entity);
                 } else {
-                    createUserSession(userSessionPersister, entity);
+                    createUserSession(userSessionPersister, entity, realm);
                 }
             }
             case REPLACE -> {
@@ -413,7 +413,7 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
         }
     }
 
-    private static void createUserSession(UserSessionPersisterProvider userSessionPersister, UserSessionEntity entity) {
+    private static void createUserSession(UserSessionPersisterProvider userSessionPersister, UserSessionEntity entity, RealmModel realm) {
         userSessionPersister.createUserSession(new UserSessionModel() {
             @Override
             public String getId() {
@@ -422,7 +422,7 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
 
             @Override
             public RealmModel getRealm() {
-                return new RealmModelDelegate(null) {
+                return new RealmModelDelegate(realm) {
                     @Override
                     public String getId() {
                         return entity.getRealmId();

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/ImmutablePersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/ImmutablePersistentUserSessionEntity.java
@@ -64,6 +64,16 @@ public record ImmutablePersistentUserSessionEntity(
     }
 
     @Override
+    public int getLastRefreshEpoch() {
+        return 0;
+    }
+
+    @Override
+    public void setLastRefreshEpoch(int lastRefreshEpoch) {
+        readOnly();
+    }
+
+    @Override
     public boolean isOffline() {
         return JpaSessionUtil.offlineFromString(offline);
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/ImmutablePersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/ImmutablePersistentUserSessionEntity.java
@@ -64,12 +64,12 @@ public record ImmutablePersistentUserSessionEntity(
     }
 
     @Override
-    public int getLastRefreshEpoch() {
+    public int getLastSessionRefreshCoarse() {
         return 0;
     }
 
     @Override
-    public void setLastRefreshEpoch(int lastRefreshEpoch) {
+    public void setLastSessionRefreshCoarse(int lastSessionRefreshCoarse) {
         readOnly();
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -95,6 +95,10 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         String offlineStr = offlineToString(offline);
         entity.setOffline(offlineStr);
         entity.setLastSessionRefresh(model.getLastSessionRefresh());
+        RealmModel realm = adapter.getRealm();
+        int maxIdle = offline ? SessionExpirationUtils.getOfflineSessionIdleTimeout(realm)
+                              : SessionExpirationUtils.getSsoSessionIdleTimeout(realm);
+        entity.setLastRefreshEpoch(SessionExpirationUtils.computeEpoch(model.getLastSessionRefresh(), maxIdle));
         entity.setData(model.getData());
         entity.setBrokerSessionId(userSession.getBrokerSessionId());
         entity.setRememberMe(userSession.isRememberMe());
@@ -247,9 +251,13 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     @Override
     public void updateLastSessionRefreshes(RealmModel realm, int lastSessionRefresh, Collection<String> userSessionIds, boolean offline) {
         String offlineStr = offlineToString(offline);
+        int maxIdle = offline ? SessionExpirationUtils.getOfflineSessionIdleTimeout(realm)
+                              : SessionExpirationUtils.getSsoSessionIdleTimeout(realm);
+        int epoch = SessionExpirationUtils.computeEpoch(lastSessionRefresh, maxIdle);
 
         int us = em.createNamedQuery("updateUserSessionLastSessionRefresh")
                 .setParameter("lastSessionRefresh", lastSessionRefresh)
+                .setParameter("lastRefreshEpoch", epoch)
                 .setParameter("realmId", realm.getId())
                 .setParameter("offline", offlineStr)
                 .setParameter("userSessionIds", userSessionIds)
@@ -715,6 +723,16 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             @Override
             public void setLastSessionRefresh(int lastSessionRefresh) {
                 entity.setLastSessionRefresh(lastSessionRefresh);
+            }
+
+            @Override
+            public int getLastRefreshEpoch() {
+                return entity.getLastRefreshEpoch();
+            }
+
+            @Override
+            public void setLastRefreshEpoch(int lastRefreshEpoch) {
+                entity.setLastRefreshEpoch(lastRefreshEpoch);
             }
 
             @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -98,7 +98,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         RealmModel realm = adapter.getRealm();
         int maxIdle = offline ? SessionExpirationUtils.getOfflineSessionIdleTimeout(realm)
                               : SessionExpirationUtils.getSsoSessionIdleTimeout(realm);
-        entity.setLastRefreshEpoch(SessionExpirationUtils.computeEpoch(model.getLastSessionRefresh(), maxIdle));
+        entity.setLastSessionRefreshCoarse(SessionExpirationUtils.computeLastSessionRefreshCoarse(model.getLastSessionRefresh(), maxIdle, model.getStarted()));
         entity.setData(model.getData());
         entity.setBrokerSessionId(userSession.getBrokerSessionId());
         entity.setRememberMe(userSession.isRememberMe());
@@ -253,11 +253,11 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         String offlineStr = offlineToString(offline);
         int maxIdle = offline ? SessionExpirationUtils.getOfflineSessionIdleTimeout(realm)
                               : SessionExpirationUtils.getSsoSessionIdleTimeout(realm);
-        int epoch = SessionExpirationUtils.computeEpoch(lastSessionRefresh, maxIdle);
+        int granularity = Math.max(maxIdle / 2, 1);
 
         int us = em.createNamedQuery("updateUserSessionLastSessionRefresh")
                 .setParameter("lastSessionRefresh", lastSessionRefresh)
-                .setParameter("lastRefreshEpoch", epoch)
+                .setParameter("granularity", granularity)
                 .setParameter("realmId", realm.getId())
                 .setParameter("offline", offlineStr)
                 .setParameter("userSessionIds", userSessionIds)
@@ -726,13 +726,13 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             }
 
             @Override
-            public int getLastRefreshEpoch() {
-                return entity.getLastRefreshEpoch();
+            public int getLastSessionRefreshCoarse() {
+                return entity.getLastSessionRefreshCoarse();
             }
 
             @Override
-            public void setLastRefreshEpoch(int lastRefreshEpoch) {
-                entity.setLastRefreshEpoch(lastRefreshEpoch);
+            public void setLastSessionRefreshCoarse(int lastSessionRefreshCoarse) {
+                entity.setLastSessionRefreshCoarse(lastSessionRefreshCoarse);
             }
 
             @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -47,7 +47,7 @@ import org.hibernate.annotations.DynamicUpdate;
         @NamedQuery(name="deleteUserSessions", query="delete from PersistentUserSessionEntity sess where sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         // The query "findExpiredUserSessions" is deprecated (since 26.5) and may be removed in the future.
         @NamedQuery(name="findExpiredUserSessions", query="select sess.userSessionId, sess.userId from PersistentUserSessionEntity sess where sess.realmId = :realmId AND sess.offline = :offline AND sess.lastSessionRefresh < :lastSessionRefresh"),
-        @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh where sess.realmId = :realmId" +
+        @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh, lastRefreshEpoch = :lastRefreshEpoch where sess.realmId = :realmId" +
                 " AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline"),
         @NamedQuery(name="findUserSessionsOrderedById", query="select sess from PersistentUserSessionEntity sess, RealmEntity realm where realm.id = sess.realmId AND sess.offline = :offline" +
@@ -79,17 +79,21 @@ import org.hibernate.annotations.DynamicUpdate;
                         " SET sess.rememberMe = :rememberMe" +
                         " WHERE sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name = "findExpiredOfflineUserSessionsLastRefresh",
-                query = "SELECT sess.userSessionId, sess.userId" +
+                query = "SELECT sess.userSessionId, sess.userId, sess.lastSessionRefresh" +
                         " FROM PersistentUserSessionEntity sess" +
-                        " WHERE sess.realmId = :realmId AND sess.offline = '1' AND sess.sessionBucket = :sessionBucket AND sess.lastSessionRefresh < :lastSessionRefresh"),
+                        " WHERE sess.realmId = :realmId AND sess.offline = '1' AND sess.sessionBucket = :sessionBucket AND sess.lastRefreshEpoch < :lastRefreshEpoch"),
         @NamedQuery(name = "findExpiredOfflineUserSessionsCreatedOn",
                 query = "SELECT sess.userSessionId, sess.userId" +
                         " FROM PersistentUserSessionEntity sess" +
                         " WHERE sess.realmId = :realmId AND sess.offline = '1' AND sess.sessionBucket = :sessionBucket AND sess.createdOn < :createdOn"),
+        @NamedQuery(name = "setExactEpochForSessions",
+                query = "UPDATE PersistentUserSessionEntity sess" +
+                        " SET sess.lastRefreshEpoch = sess.lastSessionRefresh" +
+                        " WHERE sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name = "findExpiredRegularUserSessionsLastRefresh",
-                query = "SELECT sess.userSessionId, sess.userId" +
+                query = "SELECT sess.userSessionId, sess.userId, sess.lastSessionRefresh" +
                         " FROM PersistentUserSessionEntity sess" +
-                        " WHERE sess.realmId = :realmId AND sess.offline = '0' AND sess.rememberMe = :rememberMe AND sess.sessionBucket = :sessionBucket AND sess.lastSessionRefresh < :lastSessionRefresh"),
+                        " WHERE sess.realmId = :realmId AND sess.offline = '0' AND sess.rememberMe = :rememberMe AND sess.sessionBucket = :sessionBucket AND sess.lastRefreshEpoch < :lastRefreshEpoch"),
         @NamedQuery(name = "findExpiredRegularUserSessionsCreatedOn",
                 query = "SELECT sess.userSessionId, sess.userId" +
                         " FROM PersistentUserSessionEntity sess" +
@@ -171,6 +175,9 @@ public class PersistentUserSessionEntity implements AsynchronousCommitAllowed {
 
     @Column(name="SESSION_BUCKET")
     protected Integer sessionBucket;
+
+    @Column(name="LAST_REFRESH_EPOCH")
+    protected int lastRefreshEpoch;
 
     @PrePersist
     void computeSessionBucket() {
@@ -258,6 +265,14 @@ public class PersistentUserSessionEntity implements AsynchronousCommitAllowed {
 
     public void setSessionBucket(Integer sessionBucket) {
         this.sessionBucket = sessionBucket;
+    }
+
+    public int getLastRefreshEpoch() {
+        return lastRefreshEpoch;
+    }
+
+    public void setLastRefreshEpoch(int lastRefreshEpoch) {
+        this.lastRefreshEpoch = lastRefreshEpoch;
     }
 
     public int getVersion() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -48,7 +48,7 @@ import org.hibernate.annotations.DynamicUpdate;
         // The query "findExpiredUserSessions" is deprecated (since 26.5) and may be removed in the future.
         @NamedQuery(name="findExpiredUserSessions", query="select sess.userSessionId, sess.userId from PersistentUserSessionEntity sess where sess.realmId = :realmId AND sess.offline = :offline AND sess.lastSessionRefresh < :lastSessionRefresh"),
         @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh," +
-                " lastSessionRefreshCoarse = ((:lastSessionRefresh - MOD(sess.createdOn, :granularity)) / :granularity) * :granularity + MOD(sess.createdOn, :granularity)" +
+                " lastSessionRefreshCoarse = FLOOR((:lastSessionRefresh - MOD(sess.createdOn, :granularity)) / :granularity) * :granularity + MOD(sess.createdOn, :granularity)" +
                 " where sess.realmId = :realmId AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline"),
         @NamedQuery(name="findUserSessionsOrderedById", query="select sess from PersistentUserSessionEntity sess, RealmEntity realm where realm.id = sess.realmId AND sess.offline = :offline" +

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -47,8 +47,9 @@ import org.hibernate.annotations.DynamicUpdate;
         @NamedQuery(name="deleteUserSessions", query="delete from PersistentUserSessionEntity sess where sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         // The query "findExpiredUserSessions" is deprecated (since 26.5) and may be removed in the future.
         @NamedQuery(name="findExpiredUserSessions", query="select sess.userSessionId, sess.userId from PersistentUserSessionEntity sess where sess.realmId = :realmId AND sess.offline = :offline AND sess.lastSessionRefresh < :lastSessionRefresh"),
-        @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh, lastRefreshEpoch = :lastRefreshEpoch where sess.realmId = :realmId" +
-                " AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
+        @NamedQuery(name="updateUserSessionLastSessionRefresh", query="update PersistentUserSessionEntity sess set lastSessionRefresh = :lastSessionRefresh," +
+                " lastSessionRefreshCoarse = ((:lastSessionRefresh - MOD(sess.createdOn, :granularity)) / :granularity) * :granularity + MOD(sess.createdOn, :granularity)" +
+                " where sess.realmId = :realmId AND sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name="findUserSessionsCount", query="select count(sess) from PersistentUserSessionEntity sess where sess.offline = :offline"),
         @NamedQuery(name="findUserSessionsOrderedById", query="select sess from PersistentUserSessionEntity sess, RealmEntity realm where realm.id = sess.realmId AND sess.offline = :offline" +
                 " AND sess.userSessionId > :lastSessionId" +
@@ -81,19 +82,19 @@ import org.hibernate.annotations.DynamicUpdate;
         @NamedQuery(name = "findExpiredOfflineUserSessionsLastRefresh",
                 query = "SELECT sess.userSessionId, sess.userId, sess.lastSessionRefresh" +
                         " FROM PersistentUserSessionEntity sess" +
-                        " WHERE sess.realmId = :realmId AND sess.offline = '1' AND sess.sessionBucket = :sessionBucket AND sess.lastRefreshEpoch < :lastRefreshEpoch"),
+                        " WHERE sess.realmId = :realmId AND sess.offline = '1' AND sess.sessionBucket = :sessionBucket AND sess.lastSessionRefreshCoarse < :lastSessionRefreshCoarse"),
         @NamedQuery(name = "findExpiredOfflineUserSessionsCreatedOn",
                 query = "SELECT sess.userSessionId, sess.userId" +
                         " FROM PersistentUserSessionEntity sess" +
                         " WHERE sess.realmId = :realmId AND sess.offline = '1' AND sess.sessionBucket = :sessionBucket AND sess.createdOn < :createdOn"),
-        @NamedQuery(name = "setExactEpochForSessions",
+        @NamedQuery(name = "setLastSessionRefreshCoarseToExact",
                 query = "UPDATE PersistentUserSessionEntity sess" +
-                        " SET sess.lastRefreshEpoch = sess.lastSessionRefresh" +
+                        " SET sess.lastSessionRefreshCoarse = sess.lastSessionRefresh" +
                         " WHERE sess.offline = :offline AND sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name = "findExpiredRegularUserSessionsLastRefresh",
                 query = "SELECT sess.userSessionId, sess.userId, sess.lastSessionRefresh" +
                         " FROM PersistentUserSessionEntity sess" +
-                        " WHERE sess.realmId = :realmId AND sess.offline = '0' AND sess.rememberMe = :rememberMe AND sess.sessionBucket = :sessionBucket AND sess.lastRefreshEpoch < :lastRefreshEpoch"),
+                        " WHERE sess.realmId = :realmId AND sess.offline = '0' AND sess.rememberMe = :rememberMe AND sess.sessionBucket = :sessionBucket AND sess.lastSessionRefreshCoarse < :lastSessionRefreshCoarse"),
         @NamedQuery(name = "findExpiredRegularUserSessionsCreatedOn",
                 query = "SELECT sess.userSessionId, sess.userId" +
                         " FROM PersistentUserSessionEntity sess" +
@@ -176,8 +177,8 @@ public class PersistentUserSessionEntity implements AsynchronousCommitAllowed {
     @Column(name="SESSION_BUCKET")
     protected Integer sessionBucket;
 
-    @Column(name="LAST_REFRESH_EPOCH")
-    protected int lastRefreshEpoch;
+    @Column(name="LAST_SESSION_REFRESH_COARSE")
+    protected int lastSessionRefreshCoarse;
 
     @PrePersist
     void computeSessionBucket() {
@@ -267,12 +268,12 @@ public class PersistentUserSessionEntity implements AsynchronousCommitAllowed {
         this.sessionBucket = sessionBucket;
     }
 
-    public int getLastRefreshEpoch() {
-        return lastRefreshEpoch;
+    public int getLastSessionRefreshCoarse() {
+        return lastSessionRefreshCoarse;
     }
 
-    public void setLastRefreshEpoch(int lastRefreshEpoch) {
-        this.lastRefreshEpoch = lastRefreshEpoch;
+    public void setLastSessionRefreshCoarse(int lastSessionRefreshCoarse) {
+        this.lastSessionRefreshCoarse = lastSessionRefreshCoarse;
     }
 
     public int getVersion() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/UserSessionExpirationLogic.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/UserSessionExpirationLogic.java
@@ -81,12 +81,14 @@ final class UserSessionExpirationLogic {
         String realmId = realm.getId();
         final List<UserSessionAndUser> expiredSessions = new ArrayList<>(batchSize);
 
+        final List<String> nearMissSessions = new ArrayList<>(batchSize);
+
         for (int bucket = 0; bucket < PersistentUserSessionEntity.SESSION_BUCKET_COUNT; bucket++) {
-            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastSessionRefresh(oldestLastSessionRefresh)
+            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastRefreshEpoch(oldestLastSessionRefresh)
                     .andThen(setSessionBucket(bucket));
             runInBatches(sessionFactory,
-                    s -> findAndRemoveSessions(s, realmId, batchSize, true, Details.USER_SESSION_EXPIRED_REASON, "(by last refresh)", "findExpiredOfflineUserSessionsLastRefresh", lsrParams, expiredSessions),
-                    expiredSessions::clear);
+                    s -> findAndExpireSessionsByEpoch(s, realmId, batchSize, true, oldestLastSessionRefresh, "findExpiredOfflineUserSessionsLastRefresh", lsrParams, expiredSessions, nearMissSessions),
+                    () -> { expiredSessions.clear(); nearMissSessions.clear(); });
 
             Consumer<TypedQuery<Object[]>> coParams = UserSessionExpirationLogic.<Object[]>setCreatedOn(oldestCreatedOn)
                     .andThen(setSessionBucket(bucket));
@@ -120,13 +122,14 @@ final class UserSessionExpirationLogic {
 
         String realmId = realm.getId();
         final List<UserSessionAndUser> expiredSessions = new ArrayList<>(batchSize);
+        final List<String> nearMissSessions = new ArrayList<>(batchSize);
 
         for (int bucket = 0; bucket < PersistentUserSessionEntity.SESSION_BUCKET_COUNT; bucket++) {
-            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastSessionRefresh(oldestLastSessionRefresh)
+            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastRefreshEpoch(oldestLastSessionRefresh)
                     .andThen(setRememberMe).andThen(setSessionBucket(bucket));
             runInBatches(sessionFactory,
-                    s -> findAndRemoveSessions(s, realmId, batchSize, false, Details.USER_SESSION_EXPIRED_REASON, "(by last refresh)", "findExpiredRegularUserSessionsLastRefresh", lsrParams, expiredSessions),
-                    expiredSessions::clear);
+                    s -> findAndExpireSessionsByEpoch(s, realmId, batchSize, false, oldestLastSessionRefresh, "findExpiredRegularUserSessionsLastRefresh", lsrParams, expiredSessions, nearMissSessions),
+                    () -> { expiredSessions.clear(); nearMissSessions.clear(); });
 
             Consumer<TypedQuery<Object[]>> coParams = UserSessionExpirationLogic.<Object[]>setCreatedOn(oldestCreatedOn)
                     .andThen(setRememberMe).andThen(setSessionBucket(bucket));
@@ -247,6 +250,41 @@ final class UserSessionExpirationLogic {
                 .success();
     }
 
+    private static boolean findAndExpireSessionsByEpoch(KeycloakSession session, String realmId, int batchSize, boolean offline, int exactThreshold, String queryName, Consumer<TypedQuery<Object[]>> queryParameters, List<UserSessionAndUser> expiredSessions, List<String> nearMissSessions) {
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+
+        TypedQuery<Object[]> query = em.createNamedQuery(queryName, Object[].class);
+        queryParameters.accept(query);
+        int candidateCount = 0;
+        for (Object[] row : query.setParameter("realmId", realmId)
+                .setHint(AvailableHints.HINT_READ_ONLY, true)
+                .setMaxResults(batchSize)
+                .getResultList()) {
+            candidateCount++;
+            String userSessionId = (String) row[0];
+            String userId = (String) row[1];
+            int lastSessionRefresh = (int) row[2];
+            if (lastSessionRefresh < exactThreshold) {
+                expiredSessions.add(new UserSessionAndUser(userSessionId, userId));
+            } else {
+                nearMissSessions.add(userSessionId);
+            }
+        }
+
+        handleResultsToRemove(session, em, realmId, offline, Details.USER_SESSION_EXPIRED_REASON, "(by last refresh epoch)", expiredSessions);
+
+        if (!nearMissSessions.isEmpty()) {
+            String offlineStr = offlineToString(offline);
+            int updated = em.createNamedQuery("setExactEpochForSessions")
+                    .setParameter("offline", offlineStr)
+                    .setParameter("userSessionIds", nearMissSessions)
+                    .executeUpdate();
+            logger.debugf("Set exact epoch for %d near-miss sessions in realm query '%s'", updated, realmId);
+        }
+
+        return candidateCount >= batchSize;
+    }
+
     // returns true if it has more rows to check
     private static boolean findAndRemoveSessions(KeycloakSession session, String realmId, int batchSize, boolean offline, String eventReason, String detailsForLog, String queryName, Consumer<TypedQuery<Object[]>> queryParameters, List<UserSessionAndUser> expiredSessions) {
         EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
@@ -316,6 +354,10 @@ final class UserSessionExpirationLogic {
 
     private static <T> Consumer<TypedQuery<T>> setLastSessionRefresh(int value) {
         return query -> query.setParameter("lastSessionRefresh", value);
+    }
+
+    private static <T> Consumer<TypedQuery<T>> setLastRefreshEpoch(int value) {
+        return query -> query.setParameter("lastRefreshEpoch", value);
     }
 
     private static <T> Consumer<TypedQuery<T>> setCreatedOn(int value) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/UserSessionExpirationLogic.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/UserSessionExpirationLogic.java
@@ -84,10 +84,10 @@ final class UserSessionExpirationLogic {
         final List<String> nearMissSessions = new ArrayList<>(batchSize);
 
         for (int bucket = 0; bucket < PersistentUserSessionEntity.SESSION_BUCKET_COUNT; bucket++) {
-            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastRefreshEpoch(oldestLastSessionRefresh)
+            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastSessionRefreshCoarse(oldestLastSessionRefresh)
                     .andThen(setSessionBucket(bucket));
             runInBatches(sessionFactory,
-                    s -> findAndExpireSessionsByEpoch(s, realmId, batchSize, true, oldestLastSessionRefresh, "findExpiredOfflineUserSessionsLastRefresh", lsrParams, expiredSessions, nearMissSessions),
+                    s -> findAndExpireSessionsByCoarseRefresh(s, realmId, batchSize, true, oldestLastSessionRefresh, "findExpiredOfflineUserSessionsLastRefresh", lsrParams, expiredSessions, nearMissSessions),
                     () -> { expiredSessions.clear(); nearMissSessions.clear(); });
 
             Consumer<TypedQuery<Object[]>> coParams = UserSessionExpirationLogic.<Object[]>setCreatedOn(oldestCreatedOn)
@@ -125,10 +125,10 @@ final class UserSessionExpirationLogic {
         final List<String> nearMissSessions = new ArrayList<>(batchSize);
 
         for (int bucket = 0; bucket < PersistentUserSessionEntity.SESSION_BUCKET_COUNT; bucket++) {
-            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastRefreshEpoch(oldestLastSessionRefresh)
+            Consumer<TypedQuery<Object[]>> lsrParams = UserSessionExpirationLogic.<Object[]>setLastSessionRefreshCoarse(oldestLastSessionRefresh)
                     .andThen(setRememberMe).andThen(setSessionBucket(bucket));
             runInBatches(sessionFactory,
-                    s -> findAndExpireSessionsByEpoch(s, realmId, batchSize, false, oldestLastSessionRefresh, "findExpiredRegularUserSessionsLastRefresh", lsrParams, expiredSessions, nearMissSessions),
+                    s -> findAndExpireSessionsByCoarseRefresh(s, realmId, batchSize, false, oldestLastSessionRefresh, "findExpiredRegularUserSessionsLastRefresh", lsrParams, expiredSessions, nearMissSessions),
                     () -> { expiredSessions.clear(); nearMissSessions.clear(); });
 
             Consumer<TypedQuery<Object[]>> coParams = UserSessionExpirationLogic.<Object[]>setCreatedOn(oldestCreatedOn)
@@ -250,7 +250,7 @@ final class UserSessionExpirationLogic {
                 .success();
     }
 
-    private static boolean findAndExpireSessionsByEpoch(KeycloakSession session, String realmId, int batchSize, boolean offline, int exactThreshold, String queryName, Consumer<TypedQuery<Object[]>> queryParameters, List<UserSessionAndUser> expiredSessions, List<String> nearMissSessions) {
+    private static boolean findAndExpireSessionsByCoarseRefresh(KeycloakSession session, String realmId, int batchSize, boolean offline, int exactThreshold, String queryName, Consumer<TypedQuery<Object[]>> queryParameters, List<UserSessionAndUser> expiredSessions, List<String> nearMissSessions) {
         EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
 
         TypedQuery<Object[]> query = em.createNamedQuery(queryName, Object[].class);
@@ -271,15 +271,15 @@ final class UserSessionExpirationLogic {
             }
         }
 
-        handleResultsToRemove(session, em, realmId, offline, Details.USER_SESSION_EXPIRED_REASON, "(by last refresh epoch)", expiredSessions);
+        handleResultsToRemove(session, em, realmId, offline, Details.USER_SESSION_EXPIRED_REASON, "(by coarse last refresh)", expiredSessions);
 
         if (!nearMissSessions.isEmpty()) {
             String offlineStr = offlineToString(offline);
-            int updated = em.createNamedQuery("setExactEpochForSessions")
+            int updated = em.createNamedQuery("setLastSessionRefreshCoarseToExact")
                     .setParameter("offline", offlineStr)
                     .setParameter("userSessionIds", nearMissSessions)
                     .executeUpdate();
-            logger.debugf("Set exact epoch for %d near-miss sessions in realm query '%s'", updated, realmId);
+            logger.debugf("Set coarse to exact for %d near-miss sessions in realm query '%s'", updated, realmId);
         }
 
         return candidateCount >= batchSize;
@@ -356,8 +356,8 @@ final class UserSessionExpirationLogic {
         return query -> query.setParameter("lastSessionRefresh", value);
     }
 
-    private static <T> Consumer<TypedQuery<T>> setLastRefreshEpoch(int value) {
-        return query -> query.setParameter("lastRefreshEpoch", value);
+    private static <T> Consumer<TypedQuery<T>> setLastSessionRefreshCoarse(int value) {
+        return query -> query.setParameter("lastSessionRefreshCoarse", value);
     }
 
     private static <T> Consumer<TypedQuery<T>> setCreatedOn(int value) {

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.8.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.8.0.xml
@@ -25,11 +25,11 @@
         </createIndex>
     </changeSet>
 
-    <!-- Add SESSION_BUCKET and LAST_REFRESH_EPOCH columns to OFFLINE_USER_SESSION, then rebuild
+    <!-- Add SESSION_BUCKET and LAST_SESSION_REFRESH_COARSE columns to OFFLINE_USER_SESSION, then rebuild
          expiration indexes. SESSION_BUCKET distributes inserts across multiple B-tree leaf pages,
-         reducing PAGELATCH_EX contention. LAST_REFRESH_EPOCH is a coarse-grained version of
+         reducing PAGELATCH_EX contention. LAST_SESSION_REFRESH_COARSE is a coarse-grained version of
          LAST_SESSION_REFRESH (rounded to maxIdle/2 boundaries), reducing index repositions by ~83%
-         since the epoch only changes every maxIdle/2 seconds instead of on every refresh. -->
+         since the coarse value only changes every maxIdle/2 seconds instead of on every refresh. -->
 
     <changeSet id="26.8.0-51851-add-session-bucket" author="keycloak">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
@@ -44,14 +44,14 @@
         </addColumn>
     </changeSet>
 
-    <changeSet id="26.8.0-51900-add-last-refresh-epoch" author="keycloak">
+    <changeSet id="26.8.0-51900-add-last-session-refresh-coarse" author="keycloak">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
             <not>
-                <columnExists tableName="OFFLINE_USER_SESSION" columnName="LAST_REFRESH_EPOCH"/>
+                <columnExists tableName="OFFLINE_USER_SESSION" columnName="LAST_SESSION_REFRESH_COARSE"/>
             </not>
         </preConditions>
         <addColumn tableName="OFFLINE_USER_SESSION">
-            <column name="LAST_REFRESH_EPOCH" type="BIGINT" defaultValueNumeric="0">
+            <column name="LAST_SESSION_REFRESH_COARSE" type="BIGINT" defaultValueNumeric="0">
                 <constraints nullable="false"/>
             </column>
         </addColumn>
@@ -94,13 +94,13 @@
         </modifySql>
     </changeSet>
 
-    <changeSet id="26.8.0-51900-51851-add-bucketed-and-epoch-expiration-idx-last-refresh" author="keycloak">
+    <changeSet id="26.8.0-51900-51851-add-bucketed-and-coarse-expiration-idx-last-refresh" author="keycloak">
         <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_USER_SESSION_EXPIRATION_LAST_REFRESH">
             <column name="REALM_ID" type="VARCHAR(36)"/>
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
             <column name="REMEMBER_ME" type="BOOLEAN"/>
             <column name="SESSION_BUCKET" type="SMALLINT"/>
-            <column name="LAST_REFRESH_EPOCH" type="BIGINT"/>
+            <column name="LAST_SESSION_REFRESH_COARSE" type="BIGINT"/>
             <column name="USER_SESSION_ID" type="VARCHAR(36)"/>
             <column name="USER_ID" type="VARCHAR(255)"/>
         </createIndex>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.8.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.8.0.xml
@@ -25,9 +25,11 @@
         </createIndex>
     </changeSet>
 
-    <!-- Add SESSION_BUCKET column to OFFLINE_USER_SESSION for distributing expiration index inserts
-         across multiple B-tree leaf pages, reducing PAGELATCH_EX contention on MSSQL and similar
-         page-level latch contention on other databases. -->
+    <!-- Add SESSION_BUCKET and LAST_REFRESH_EPOCH columns to OFFLINE_USER_SESSION, then rebuild
+         expiration indexes. SESSION_BUCKET distributes inserts across multiple B-tree leaf pages,
+         reducing PAGELATCH_EX contention. LAST_REFRESH_EPOCH is a coarse-grained version of
+         LAST_SESSION_REFRESH (rounded to maxIdle/2 boundaries), reducing index repositions by ~83%
+         since the epoch only changes every maxIdle/2 seconds instead of on every refresh. -->
 
     <changeSet id="26.8.0-51851-add-session-bucket" author="keycloak">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
@@ -40,6 +42,22 @@
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+    </changeSet>
+
+    <changeSet id="26.8.0-51900-add-last-refresh-epoch" author="keycloak">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <not>
+                <columnExists tableName="OFFLINE_USER_SESSION" columnName="LAST_REFRESH_EPOCH"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="OFFLINE_USER_SESSION">
+            <column name="LAST_REFRESH_EPOCH" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <modifySql dbms="mssql">
+            <replace replace="DEFAULT 0" with="DEFAULT 0 WITH VALUES"/>
+        </modifySql>
     </changeSet>
 
     <changeSet id="26.8.0-51851-drop-old-expiration-idx-created" author="keycloak">
@@ -76,13 +94,13 @@
         </modifySql>
     </changeSet>
 
-    <changeSet id="26.8.0-51851-add-bucketed-expiration-idx-last-refresh" author="keycloak">
+    <changeSet id="26.8.0-51900-51851-add-bucketed-and-epoch-expiration-idx-last-refresh" author="keycloak">
         <createIndex tableName="OFFLINE_USER_SESSION" indexName="IDX_USER_SESSION_EXPIRATION_LAST_REFRESH">
             <column name="REALM_ID" type="VARCHAR(36)"/>
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
             <column name="REMEMBER_ME" type="BOOLEAN"/>
             <column name="SESSION_BUCKET" type="SMALLINT"/>
-            <column name="LAST_SESSION_REFRESH" type="INT"/>
+            <column name="LAST_REFRESH_EPOCH" type="BIGINT"/>
             <column name="USER_SESSION_ID" type="VARCHAR(36)"/>
             <column name="USER_ID" type="VARCHAR(255)"/>
         </createIndex>

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
@@ -33,6 +33,8 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.models.utils.RealmExpiration;
+import org.keycloak.models.utils.SessionExpirationUtils;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -70,6 +72,7 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             private String userSessionId;
             private int started;
             private int lastSessionRefresh;
+            private int lastRefreshEpoch;
             private boolean offline;
             private String data;
             private boolean rememberMe;
@@ -102,6 +105,16 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             @Override
             public void setLastSessionRefresh(int lastSessionRefresh) {
                 this.lastSessionRefresh = lastSessionRefresh;
+            }
+
+            @Override
+            public int getLastRefreshEpoch() {
+                return lastRefreshEpoch;
+            }
+
+            @Override
+            public void setLastRefreshEpoch(int lastRefreshEpoch) {
+                this.lastRefreshEpoch = lastRefreshEpoch;
             }
 
             @Override
@@ -273,6 +286,11 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             return;
         }
         model.setLastSessionRefresh(seconds);
+        if (realm != null) {
+            RealmExpiration exp = RealmExpiration.fromRealm(realm);
+            int maxIdle = model.isOffline() ? exp.offlineMaxIdle() : exp.getMaxIdle(isRememberMe());
+            model.setLastRefreshEpoch(SessionExpirationUtils.computeEpoch(seconds, maxIdle));
+        }
     }
 
     @Override

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionAdapter.java
@@ -72,7 +72,7 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             private String userSessionId;
             private int started;
             private int lastSessionRefresh;
-            private int lastRefreshEpoch;
+            private int lastSessionRefreshCoarse;
             private boolean offline;
             private String data;
             private boolean rememberMe;
@@ -108,13 +108,13 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
             }
 
             @Override
-            public int getLastRefreshEpoch() {
-                return lastRefreshEpoch;
+            public int getLastSessionRefreshCoarse() {
+                return lastSessionRefreshCoarse;
             }
 
             @Override
-            public void setLastRefreshEpoch(int lastRefreshEpoch) {
-                this.lastRefreshEpoch = lastRefreshEpoch;
+            public void setLastSessionRefreshCoarse(int lastSessionRefreshCoarse) {
+                this.lastSessionRefreshCoarse = lastSessionRefreshCoarse;
             }
 
             @Override
@@ -289,7 +289,7 @@ public class PersistentUserSessionAdapter implements OfflineUserSessionModel {
         if (realm != null) {
             RealmExpiration exp = RealmExpiration.fromRealm(realm);
             int maxIdle = model.isOffline() ? exp.offlineMaxIdle() : exp.getMaxIdle(isRememberMe());
-            model.setLastRefreshEpoch(SessionExpirationUtils.computeEpoch(seconds, maxIdle));
+            model.setLastSessionRefreshCoarse(SessionExpirationUtils.computeLastSessionRefreshCoarse(seconds, maxIdle, model.getStarted()));
         }
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionModel.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionModel.java
@@ -42,6 +42,10 @@ public interface PersistentUserSessionModel {
 
     void setData(String data);
 
+    int getLastRefreshEpoch();
+
+    void setLastRefreshEpoch(int lastRefreshEpoch);
+
     void setRealmId(String realmId);
 
     void setUserId(String userId);

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionModel.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentUserSessionModel.java
@@ -42,9 +42,9 @@ public interface PersistentUserSessionModel {
 
     void setData(String data);
 
-    int getLastRefreshEpoch();
+    int getLastSessionRefreshCoarse();
 
-    void setLastRefreshEpoch(int lastRefreshEpoch);
+    void setLastSessionRefreshCoarse(int lastSessionRefreshCoarse);
 
     void setRealmId(String realmId);
 

--- a/model/storage-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
@@ -51,6 +51,7 @@ public interface UserSessionPersisterProvider extends Provider {
     void onUserRemoved(RealmModel realm, UserModel user);
 
     // Bulk update of lastSessionRefresh of all specified userSessions to the given value.
+    @Deprecated(forRemoval = true, since = "26.8")
     void updateLastSessionRefreshes(RealmModel realm, int lastSessionRefresh, Collection<String> userSessionIds, boolean offline);
 
     // Remove userSessions and clientSessions, which are expired

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
@@ -186,6 +186,14 @@ public class SessionExpirationUtils {
         return idle;
     }
 
+    /**
+     * Rounds {@code lastSessionRefresh} down to a coarse-grained epoch boundary of {@code maxIdle / 2} seconds.
+     */
+    public static int computeEpoch(int lastSessionRefresh, int maxIdle) {
+        int granularity = Math.max(maxIdle / 2, 1);
+        return (lastSessionRefresh / granularity) * granularity;
+    }
+
     private static long getClientAttributeTimeout(ClientModel client, String attr) {
         if (client != null) {
             final String value = client.getAttribute(attr);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
@@ -187,11 +187,15 @@ public class SessionExpirationUtils {
     }
 
     /**
-     * Rounds {@code lastSessionRefresh} down to a coarse-grained epoch boundary of {@code maxIdle / 2} seconds.
+     * Rounds {@code lastSessionRefresh} down to a coarse-grained boundary of {@code maxIdle / 2} seconds,
+     * offset by {@code createdOn % granularity} so that sessions created at different times have staggered
+     * boundaries and don't all become cleanup candidates at the same instant.
      */
-    public static int computeEpoch(int lastSessionRefresh, int maxIdle) {
+    public static int computeLastSessionRefreshCoarse(int lastSessionRefresh, int maxIdle, int createdOn) {
         int granularity = Math.max(maxIdle / 2, 1);
-        return (lastSessionRefresh / granularity) * granularity;
+        int offset = Math.floorMod(createdOn, granularity);
+        int aligned = lastSessionRefresh - offset;
+        return (aligned / granularity) * granularity + offset;
     }
 
     private static long getClientAttributeTimeout(ClientModel client, String attr) {

--- a/tests/base/src/test/java/org/keycloak/tests/model/UserSessionProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/UserSessionProviderTest.java
@@ -26,7 +26,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.EntityManager;
+
 import org.keycloak.common.util.Time;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -35,6 +38,7 @@ import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.UserManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.jpa.session.PersistentUserSessionEntity;
 import org.keycloak.models.session.UserSessionPersisterProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ResetTimeOffsetEvent;
@@ -57,6 +61,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.keycloak.models.jpa.session.JpaSessionUtil.offlineToString;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -1020,6 +1026,105 @@ public class UserSessionProviderTest {
         Arrays.sort(actualClients);
 
         assertArrayEquals(clients, actualClients);
+    }
+
+    /**
+     * Tests the two-pass expiration behavior for sessions where {@code lastSessionRefreshCoarse < threshold}
+     * but {@code lastSessionRefresh >= threshold} (near-miss). The session must survive the first pass
+     * with its coarse value advanced to the exact value, and subsequent batches must terminate.
+     */
+    @TestOnServer
+    public void testNearMissSessionSurvivesCoarseExpiration(KeycloakSession session) {
+        InfinispanTimeUtil.enableTestingTimeService(session);
+        try {
+            RealmModel realm = session.realms().getRealmByName("test");
+            session.getContext().setRealm(realm);
+            int idleTimeout = realm.getSsoSessionIdleTimeout();
+            int granularity = Math.max(idleTimeout / 2, 1);
+
+            // Step 1: Create a session at the current time
+            String sessionId = KeycloakModelUtils.runJobInTransactionWithResult(session.getKeycloakSessionFactory(), session1 -> {
+                session1.getContext().setRealm(realm);
+                UserSessionModel us = session1.sessions().createUserSession(null, realm,
+                        session1.users().getUserByUsername(realm, "user1"), "user1", "127.0.0.1",
+                        "form", false, null, null, UserSessionModel.SessionPersistenceState.PERSISTENT);
+                return us.getId();
+            });
+
+            // Step 2: Advance time to just before the next coarse boundary and refresh.
+            // This makes lastSessionRefresh advance but lastSessionRefreshCoarse stays at the same epoch.
+            int refreshAdvance = granularity - granularity / 5;
+            Time.setOffset(refreshAdvance);
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                session1.getContext().setRealm(realm);
+                UserSessionModel us = session1.sessions().getUserSession(realm, sessionId);
+                us.setLastSessionRefresh(Time.currentTime());
+            });
+
+            // Verify the near-miss condition: coarse < lastSessionRefresh
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                EntityManager em = session1.getProvider(JpaConnectionProvider.class).getEntityManager();
+                PersistentUserSessionEntity entity = em.find(PersistentUserSessionEntity.class,
+                        new PersistentUserSessionEntity.Key(sessionId, offlineToString(false)));
+                assertNotNull(entity);
+                assertTrue(entity.getLastSessionRefreshCoarse() < entity.getLastSessionRefresh(),
+                        "Precondition: coarse (" + entity.getLastSessionRefreshCoarse() + ") should be less than exact (" + entity.getLastSessionRefresh() + ")");
+            });
+
+            // Step 3: Advance time so threshold falls between coarse and exact.
+            // threshold = currentTime - idleTimeout - WINDOW
+            // We need: coarse < threshold <= lastSessionRefresh
+            int expirationOffset = idleTimeout + SessionTimeoutHelper.PERIODIC_CLEANER_IDLE_TIMEOUT_WINDOW_SECONDS + granularity / 2;
+            Time.setOffset(expirationOffset);
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                session1.getContext().setRealm(realm);
+                session1.getProvider(UserSessionPersisterProvider.class).removeExpired(realm);
+            });
+
+            // Step 4: Verify the session survived and its coarse value was advanced
+            int expectedCoarse = KeycloakModelUtils.runJobInTransactionWithResult(session.getKeycloakSessionFactory(), session1 -> {
+                EntityManager em = session1.getProvider(JpaConnectionProvider.class).getEntityManager();
+                PersistentUserSessionEntity entity = em.find(PersistentUserSessionEntity.class,
+                        new PersistentUserSessionEntity.Key(sessionId, offlineToString(false)));
+                assertNotNull(entity, "Near-miss session should survive the first expiration pass");
+                assertEquals(entity.getLastSessionRefresh(), entity.getLastSessionRefreshCoarse(),
+                        "Coarse value should be advanced to exact lastSessionRefresh");
+                return entity.getLastSessionRefreshCoarse();
+            });
+
+            // Step 5: Run expiration again at the same time — coarse is now above threshold
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                session1.getContext().setRealm(realm);
+                session1.getProvider(UserSessionPersisterProvider.class).removeExpired(realm);
+            });
+
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                EntityManager em = session1.getProvider(JpaConnectionProvider.class).getEntityManager();
+                PersistentUserSessionEntity entity = em.find(PersistentUserSessionEntity.class,
+                        new PersistentUserSessionEntity.Key(sessionId, offlineToString(false)));
+                assertNotNull(entity, "Session should still exist after second expiration pass");
+                assertEquals(expectedCoarse, entity.getLastSessionRefreshCoarse(),
+                        "Coarse value should remain unchanged");
+            });
+
+            // Step 6: Advance time far enough that lastSessionRefresh is truly expired
+            Time.setOffset(refreshAdvance + idleTimeout + SessionTimeoutHelper.PERIODIC_CLEANER_IDLE_TIMEOUT_WINDOW_SECONDS + 10);
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                session1.getContext().setRealm(realm);
+                session1.getProvider(UserSessionPersisterProvider.class).removeExpired(realm);
+            });
+
+            KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session1 -> {
+                EntityManager em = session1.getProvider(JpaConnectionProvider.class).getEntityManager();
+                PersistentUserSessionEntity entity = em.find(PersistentUserSessionEntity.class,
+                        new PersistentUserSessionEntity.Key(sessionId, offlineToString(false)));
+                assertNull(entity, "Session should be deleted after truly expiring");
+            });
+        } finally {
+            Time.setOffset(0);
+            session.getKeycloakSessionFactory().publish(new ResetTimeOffsetEvent());
+            InfinispanTimeUtil.disableTestingTimeService(session);
+        }
     }
 
     private static class UserSessionProviderRealm implements RealmConfig {

--- a/tests/base/src/test/java/org/keycloak/tests/model/UserSessionProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/UserSessionProviderTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import jakarta.persistence.EntityManager;
 
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.AuthenticatedClientSessionModel;
@@ -1035,6 +1036,11 @@ public class UserSessionProviderTest {
      */
     @TestOnServer
     public void testNearMissSessionSurvivesCoarseExpiration(KeycloakSession session) {
+        if (!Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
+            // Assume doesn't work here, yet.
+            // https://github.com/keycloak/keycloak/issues/51968
+            return;
+        }
         InfinispanTimeUtil.enableTestingTimeService(session);
         try {
             RealmModel realm = session.realms().getRealmByName("test");


### PR DESCRIPTION
Closes #51900

I did a minimal local performance test with MSSQL - just counting the updates on tables, not so much measuring congestion: 

> ./bin/kcb.sh --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=http://0.0.0.0:8080 --realm-name=test-realm --username=user-0 --users-per-sec=5 --ramp-up=1 --client-id=gatling --client-secret=setup-for-benchmark --client-redirect-uri=http://0.0.0.0:8080 --measurement=300 --log-http-on-failure --refresh-token-count=10 --refresh-token-period=2 --refresh-close-http-connection=false --logout-percentage=10

Before: `IDX_USER_SESSION_EXPIRATION_LAST_REFRESH` had 15020 leaf_inserts_delta

After: `IDX_USER_SESSION_EXPIRATION_LAST_REFRESH` had 1502 leaf_inserts_delta, matching the number of logins performed. 

The log volume didn't reduce much (66584 -> 62756). 

As I was comparing with 26.7.3, I saw that `IDX_OFFLINE_USS_BY_BROKER_SESSION_ID` now has zero leaf_inserts_delta due to the filtering applied. 

I also asked: 

> With the segmentation, I might no longer have PAGELATCH_EX contention. Is it still worth it?

Then Claude replied: 

> Yes, still worth it. Even without PAGELATCH_EX contention (which SESSION_BUCKET already solved), each index reposition still generates log records — a delete from the old B-tree position and an insert at the new position. On
  Azure SQL Hyperscale with its ~100 MB/sec log governance ceiling, every byte of log throughput matters.
>
>  Eliminating repositions means:
>  - Less log volume per refresh — the expiration index generates zero log records instead of two (delete + insert)
>  - Smaller working set — fewer index pages touched means less buffer pool pressure
>  - Cheaper I/O — fewer page writes to flush
>  
>  These benefits are independent of contention. SESSION_BUCKET solved the "many writers fighting over the same page" problem. LAST_SESSION_REFRESH_COARSE solves the "unnecessary work on every refresh" problem. They're complementary.
>
>  That said, the coarse column adds complexity (the two-pass cleanup, the per-session offset logic). If your production workload is nowhere near the log governance ceiling even without this change, the SESSION_BUCKET  optimization alone might be sufficient. The question is whether the reduced log volume justifies the added complexity for your deployment.

I also asked: 

> How costly is an index update on the different databases supported by Keycloak?

and Claude responded: 

  > ## Index update cost across databases supported by Keycloak
  >
  > ### SQL Server (MSSQL)
  >
  > Most affected. Uses PAGELATCH_EX for page-level concurrency, so concurrent inserts into the same B-tree leaf page serialize. The transaction log has a single sequential write point (log buffer), and Azure SQL Hyperscale has 
  a hard governance ceiling (~100 MB/sec). Index repositions directly reduce throughput capacity.
  > 
  > ### PostgreSQL
  > 
  > Uses a multi-version concurrency control (MVCC) model. Every UPDATE creates a new row version in the heap AND in every index — even indexes whose key columns didn't change (HOT updates are the exception, but only when the 
  updated columns aren't indexed and the new version fits on the same heap page). So PostgreSQL actually has a *worse* index write amplification than MSSQL for non-HOT updates. However, PostgreSQL handles concurrent writes to 
  the same page better (lighter-weight buffer locks) and WAL is typically less of a bottleneck. The coarse column helps PostgreSQL too by enabling HOT updates on more refreshes (the index key doesn't change).
  > 
  > ### MySQL/MariaDB (InnoDB)
  > 
  > Uses clustered index like MSSQL, but InnoDB has a change buffer that defers non-clustered index updates for non-unique indexes when the target page isn't in the buffer pool. This makes index repositions cheaper when pages 
  are cold. However, when pages are hot (high refresh rates), the change buffer doesn't help and repositions hit the buffer pool directly. Log writes (redo log) are still generated per operation.
  > 
  > ### Oracle
  > 
  > Similar to MSSQL in index maintenance cost. Uses redo log entries per operation. No change buffer optimization. Concurrent inserts into the same leaf block cause buffer busy waits (Oracle's equivalent of PAGELATCH_EX).
  >
  > ### Summary
  >
  > | Database       | Reposition cost                  | Concurrency bottleneck     | Coarse column benefit          |
  > | -------------- | -------------------------------- | -------------------------- | ------------------------------ |
  > | MSSQL          | High                             | PAGELATCH_EX + log ceiling | High                           |
  > | PostgreSQL     | High (MVCC write amplification)  | Moderate (lighter locks)   | High (enables HOT updates)     |
  > | MySQL/InnoDB   | Medium (change buffer helps)     | Moderate                   | Medium                         |
  > | Oracle         | High                             | Buffer busy waits          | High                           |
  > 
  > The optimization is beneficial across all supported databases, not just MSSQL.

After testing on PostgreSQL, I saw 99%+ hot updates on the offline user session table, where before I didn't see any hot updates due to updates to the indexed column. 

 > With 99% HOT updates on PostgreSQL:
  >
  > - **No index maintenance** on ~99% of refreshes — no writes to any non-clustered index, not just the expiration index
  > - **Less WAL volume** — HOT updates generate smaller WAL records since there are no index changes to log
  > - **Less VACUUM work** — HOT chains are pruned in-page on access, reducing autovacuum load
  > - **Less I/O** — only the heap page is dirtied, not the index pages
  >
  > This is a larger improvement on PostgreSQL than on MSSQL. On MSSQL, the coarse column eliminates repositions on the expiration index. On PostgreSQL, it enables HOT updates which skip ALL indexes on the table.
  >
  > Without the coarse column, `LAST_SESSION_REFRESH` being an index key column forced every refresh to be a non-HOT update, which wrote new entries into every index on the table — even indexes unrelated to
  `LAST_SESSION_REFRESH`.
  >
  > Note: the test ran for less than `maxIdle / 2`, so no session crossed a coarse boundary. In production with long-lived sessions, the HOT percentage would be slightly lower as boundary crossings trigger index writes.


SQL statement to extract the data on MSSQL:

```
truncate table OFFLINE_USER_SESSION;

truncate table OFFLINE_CLIENT_SESSION;

SELECT i.name AS index_name, ios.index_id,
       ios.leaf_insert_count, ios.leaf_delete_count, ios.leaf_update_count
INTO #idx_before
FROM sys.dm_db_index_operational_stats(DB_ID(), OBJECT_ID('OFFLINE_USER_SESSION'), NULL, NULL) ios
         JOIN sys.indexes i ON i.object_id = ios.object_id AND i.index_id = ios.index_id;

SELECT vfs.num_of_bytes_written AS log_bytes_written
INTO #log_before
FROM sys.dm_io_virtual_file_stats(DB_ID(), NULL) vfs
         JOIN sys.database_files f ON f.file_id = vfs.file_id
WHERE f.type_desc = 'LOG';

select count(*) from OFFLINE_USER_SESSION;

SELECT
    i.name AS index_name,
    a.leaf_insert_count - b.leaf_insert_count AS leaf_inserts_delta,
    a.leaf_delete_count - b.leaf_delete_count AS leaf_deletes_delta,
    a.leaf_update_count - b.leaf_update_count AS leaf_updates_delta
FROM sys.dm_db_index_operational_stats(DB_ID(), OBJECT_ID('OFFLINE_USER_SESSION'), NULL, NULL) a
         JOIN #idx_before b ON a.index_id = b.index_id
         JOIN sys.indexes i ON i.object_id = a.object_id AND i.index_id = a.index_id
ORDER BY i.name;

SELECT
    (vfs.num_of_bytes_written - b.log_bytes_written) / 1024 AS log_kb_written_delta
FROM sys.dm_io_virtual_file_stats(DB_ID(), NULL) vfs
         JOIN sys.database_files f ON f.file_id = vfs.file_id
         JOIN #log_before b ON 1=1
WHERE f.type_desc = 'LOG';

DROP TABLE #idx_before;
DROP TABLE #log_before;
```

Statement to extract the data on PostgreSQL: 

```

SELECT
    n_tup_upd AS total_updates,
    n_tup_hot_upd AS hot_updates,
    n_tup_upd - n_tup_hot_upd delta,
    CASE WHEN n_tup_upd > 0
             THEN round(100.0 * n_tup_hot_upd / n_tup_upd, 1)
         ELSE 0
        END AS hot_pct
FROM pg_stat_user_tables
WHERE relname = 'offline_user_session';

  -- Before
SELECT n_tup_upd, n_tup_hot_upd
INTO TEMP idx_before
FROM pg_stat_user_tables
WHERE relname = 'offline_user_session';

-- After
SELECT
    a.n_tup_upd - b.n_tup_upd AS updates_delta,
    a.n_tup_hot_upd - b.n_tup_hot_upd AS hot_updates_delta,
    round(100.0 * (a.n_tup_hot_upd - b.n_tup_hot_upd)
              / NULLIF(a.n_tup_upd - b.n_tup_upd, 0), 1) AS hot_pct
FROM pg_stat_user_tables a, idx_before b
WHERE a.relname = 'offline_user_session';

DROP TABLE idx_before;
well
``` 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
