### PR TITLE
Fixes #51712 by improving post-logout redirect URI validation.

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -724,24 +725,9 @@ public class KeycloakUriBuilder {
             return this;
         }
 
-        String[] params = query.split("&");
-        query = null;
-
         String replacedName = Encode.encodeQueryParam(name);
+        removeQueryParams(rawName -> rawName.equals(replacedName));
 
-
-        for (String param : params) {
-            int pos = param.indexOf('=');
-            if (pos >= 0) {
-                String paramName = param.substring(0, pos);
-                if (paramName.equals(replacedName)) continue;
-            } else {
-                if (param.equals(replacedName)) continue;
-            }
-            if (query == null) query = "";
-            else query += "&";
-            query += param;
-        }
         // don't set values if values is null
         if (values == null) return this;
         return queryParam(name, values);
@@ -836,6 +822,39 @@ public class KeycloakUriBuilder {
         if (templateValues == null) throw new IllegalArgumentException("templateValues param null");
         String str = buildString(templateValues, false, true, true);
         return fromTemplate(str);
+    }
+
+    /**
+     * Removes all query parameters whose name, after percent-decoding, equals the given {@code name}.
+     * Unlike {@link #replaceQueryParam}, this catches encoded variants such as {@code st%61te} matching {@code state}.
+     *
+     * <pre>
+     * KeycloakUriBuilder.fromUri("http://example.com/path?st%61te=evil&amp;other=keep", false)
+     *     .removeQueryParamByDecodedName("state")
+     *     // result: http://example.com/path?other=keep
+     * </pre>
+     *
+     * @param name the decoded parameter name to match against
+     * @return this builder
+     */
+    public KeycloakUriBuilder removeQueryParamByDecodedName(String name) {
+        if (name == null) throw new IllegalArgumentException("name parameter is null");
+        if (query == null || query.isEmpty()) return this;
+        removeQueryParams(rawName -> name.equals(Encode.decode(rawName)));
+        return this;
+    }
+
+    private void removeQueryParams(Predicate<String> nameMatches) {
+        String[] params = query.split("&");
+        query = null;
+        for (String param : params) {
+            int pos = param.indexOf('=');
+            String rawName = pos >= 0 ? param.substring(0, pos) : param;
+            if (nameMatches.test(rawName)) continue;
+            if (query == null) query = "";
+            else query += "&";
+            query += param;
+        }
     }
 
     public KeycloakUriBuilder resolveTemplate(String name, Object value, boolean encodeSlashInPath) throws IllegalArgumentException {

--- a/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
+++ b/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
@@ -99,4 +99,27 @@ public class KeycloakUriBuilderTest {
         Assertions.assertEquals("app.immich:///oauth-callback", KeycloakUriBuilder.fromUri(
                 "app.immich:///oauth-callback").buildAsString());
     }
+
+    @Test
+    public void testRemoveQueryParamByDecodedName() {
+        Assertions.assertEquals("http://localhost/path?other=keep",
+                KeycloakUriBuilder.fromUri("http://localhost/path?state=val&other=keep", false)
+                        .removeQueryParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path?other=keep",
+                KeycloakUriBuilder.fromUri("http://localhost/path?st%61te=val&other=keep", false)
+                        .removeQueryParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path?other=keep",
+                KeycloakUriBuilder.fromUri("http://localhost/path?other=keep&%73%74%61%74%65=val", false)
+                        .removeQueryParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path",
+                KeycloakUriBuilder.fromUri("http://localhost/path?state=val", false)
+                        .removeQueryParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path?state=val",
+                KeycloakUriBuilder.fromUri("http://localhost/path?state=val", false)
+                        .removeQueryParamByDecodedName("other").buildAsString());
+    }
 }

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_2.adoc
@@ -9,10 +9,3 @@ In minor or patch releases, {project_name} will only introduce breaking changes 
 The deprecated link:{developerguide_link}#_legacy-client-initiated-account-linking[legacy client-initiated account linking] endpoint (`/realms/{realm}/broker/{provider}/link`) is now disabled by default. Migrate to link:{adminguide_link}#con-aia_server_administration_guide[Application Initiated Actions (AIA)] with `kc_action=idp_link`. See link:{developerguide_link}#_client-initiated-account-linking[Client initiated account linking] for details.
 
 To temporarily restore the previous behavior, see link:https://www.keycloak.org/server/all-provider-config#_openid_connect[OpenID Connect provider configuration] and enable `allow-client-initiated-account-linking` server option. This option is deprecated and will be removed in a future release.
-
-'''
-=== OIDC parameters in post_logout_redirect_uri deprecated
-
-Post-logout redirect URIs containing OIDC parameters such as `state`, `code`, or `session_state` are now deprecated. These parameters conflict with the spec-defined `state` parameter that Keycloak attaches after logout, potentially causing HTTP Parameter Pollution.
-
-To temporarily allow the previous behavior, enable the `allow-oidc-params-in-post-logout-redirect-uri` server option. This option is deprecated and will be removed in Keycloak 27.

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_2.adoc
@@ -9,3 +9,10 @@ In minor or patch releases, {project_name} will only introduce breaking changes 
 The deprecated link:{developerguide_link}#_legacy-client-initiated-account-linking[legacy client-initiated account linking] endpoint (`/realms/{realm}/broker/{provider}/link`) is now disabled by default. Migrate to link:{adminguide_link}#con-aia_server_administration_guide[Application Initiated Actions (AIA)] with `kc_action=idp_link`. See link:{developerguide_link}#_client-initiated-account-linking[Client initiated account linking] for details.
 
 To temporarily restore the previous behavior, see link:https://www.keycloak.org/server/all-provider-config#_openid_connect[OpenID Connect provider configuration] and enable `allow-client-initiated-account-linking` server option. This option is deprecated and will be removed in a future release.
+
+'''
+=== OIDC parameters in post_logout_redirect_uri deprecated
+
+Post-logout redirect URIs containing OIDC parameters such as `state`, `code`, or `session_state` are now deprecated. These parameters conflict with the spec-defined `state` parameter that Keycloak attaches after logout, potentially causing HTTP Parameter Pollution.
+
+To temporarily allow the previous behavior, enable the `allow-oidc-params-in-post-logout-redirect-uri` server option. This option is deprecated and will be removed in Keycloak 27.

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_3.adoc
@@ -1,0 +1,14 @@
+// ------------------------ Breaking changes ------------------------  //
+== Breaking changes
+
+Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
+In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
+
+
+=== OIDC parameters in redirect URIs rejected by default
+
+Redirect URIs (`redirect_uri` and `post_logout_redirect_uri`) containing OIDC response parameters such as `state`, `code`, or `session_state` are now rejected by default. These parameters conflict with the parameters that {project_name} attaches to the redirect URI after authentication or logout, potentially causing HTTP Parameter Pollution. This check also covers parameters in the URI fragment (used with `response_mode=fragment`).
+
+If you used `post_logout_redirect_uri` pointing directly to the {project_name} OIDC login page (for example `post_logout_redirect_uri=\https://mykchost/realms/myrealm/protocol/openid-connect/auth?response_type=code&client_id=myclient...`), replace it with a callback URL pointing to your application (for example `post_logout_redirect_uri=\https://myapp/logout-callback`) and ensure that opening that callback URL in your application redirects to {project_name} OIDC login.
+
+To temporarily allow the previous behavior, enable the `allow-oidc-params-in-redirect-uris` server option in the link:https://www.keycloak.org/server/all-provider-config#_openid_connect[OpenID Connect provider configuration]. A per-client override is also available via the `allow.oidc.params.in.redirect.uris` client attribute, allowing gradual migration of individual clients. Both options are deprecated and will be removed in {project_name} 27.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -5,6 +5,10 @@
 
 include::changes-26_8_0.adoc[leveloffset=2]
 
+=== Migrating to 26.7.3
+
+include::changes-26_7_3.adoc[leveloffset=2]
+
 === Migrating to 26.7.2
 
 include::changes-26_7_2.adoc[leveloffset=2]

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/OIDCConfigAttributes.java
@@ -111,6 +111,8 @@ public final class OIDCConfigAttributes {
 
     public static final String ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN = "allow.userinfo.with.lightweight.access.token";
 
+    public static final String ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS = "allow.oidc.params.in.redirect.uris";
+
     private OIDCConfigAttributes() {
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCAdvancedConfigWrapper.java
@@ -39,7 +39,7 @@ import static org.keycloak.protocol.oidc.OIDCConfigAttributes.USE_RFC9068_ACCESS
  */
 public class OIDCAdvancedConfigWrapper extends AbstractClientConfigWrapper {
 
-    public static enum TokenExchangeRefreshTokenEnabled {NO, SAME_SESSION};
+    public enum TokenExchangeRefreshTokenEnabled {NO, SAME_SESSION};
 
     private OIDCAdvancedConfigWrapper(ClientModel client, ClientRepresentation clientRep) {
         super(client,clientRep);
@@ -545,5 +545,14 @@ public class OIDCAdvancedConfigWrapper extends AbstractClientConfigWrapper {
 
     public void setAllowUserinfoWithLightweightAccessToken(boolean allow) {
         setAttribute(OIDCConfigAttributes.ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN, String.valueOf(allow));
+    }
+
+    public boolean isAllowOidcParamsInRedirectUris() {
+        String val = getAttribute(OIDCConfigAttributes.ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS, "false");
+        return Boolean.parseBoolean(val);
+    }
+
+    public void setAllowOidcParamsInRedirectUris(boolean allow) {
+        setAttribute(OIDCConfigAttributes.ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS, String.valueOf(allow));
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -149,7 +149,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     /**
      * @deprecated To be removed in Keycloak 27
      */
-    public static final String CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI = "allow-oidc-params-in-post-logout-redirect-uri";
+    public static final String CONFIG_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS = "allow-oidc-params-in-redirect-uris";
 
     public static final String CONFIG_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK = "allow-token-introspection-without-audience-check";
 
@@ -190,11 +190,11 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                     CONFIG_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING);
         }
 
-        if (this.providerConfig.isAllowOidcParamsInPostLogoutRedirectUri()) {
-            logger.warnf("OIDC parameters (e.g. 'state') are allowed in post_logout_redirect_uri. " +
+        if (this.providerConfig.isAllowOidcParamsInRedirectUris()) {
+            logger.warnf("OIDC parameters (e.g. 'state') are allowed in post_logout_redirect_uri and in redirect_uri. " +
                             "This is deprecated and will be rejected in Keycloak 27. " +
                             "Disable this option: %s=false",
-                    CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI);
+                    CONFIG_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS);
         }
 
         initBuiltIns();
@@ -712,10 +712,10 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                     .defaultValue(OIDCProviderConfig.DEFAULT_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING)
                     .add()
                 .property()
-                    .name(CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI)
+                    .name(CONFIG_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS)
                     .type("boolean")
-                    .helpText("Allows OIDC parameters (state, code, etc.) in post_logout_redirect_uri. Deprecated: will be removed in Keycloak 27.")
-                    .defaultValue(OIDCProviderConfig.DEFAULT_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI)
+                    .helpText("Allows OIDC parameters (state, code, etc.) in post_logout_redirect_uri and in redirect_uri. Deprecated: will be removed in Keycloak 27.")
+                    .defaultValue(OIDCProviderConfig.DEFAULT_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS)
                     .add()
                 .build();
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -146,6 +146,11 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
      */
     public static final String CONFIG_OIDC_ALLOW_MULTIPLE_AUDIENCES_FOR_JWT_CLIENT_AUTHENTICATION = "allow-multiple-audiences-for-jwt-client-authentication";
 
+    /**
+     * @deprecated To be removed in Keycloak 27
+     */
+    public static final String CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI = "allow-oidc-params-in-post-logout-redirect-uri";
+
     public static final String CONFIG_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK = "allow-token-introspection-without-audience-check";
 
     public static final String CONFIG_ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN = "allow-userinfo-with-lightweight-access-token";
@@ -183,6 +188,13 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             logger.warnf("Legacy client-initiated account linking endpoint is enabled. This endpoint is deprecated" +
                     "Migrate to Application Initiated Actions (AIA) with kc_action=idp_link and disable this option: %s=false",
                     CONFIG_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING);
+        }
+
+        if (this.providerConfig.isAllowOidcParamsInPostLogoutRedirectUri()) {
+            logger.warnf("OIDC parameters (e.g. 'state') are allowed in post_logout_redirect_uri. " +
+                            "This is deprecated and will be rejected in Keycloak 27. " +
+                            "Disable this option: %s=false",
+                    CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI);
         }
 
         initBuiltIns();
@@ -698,6 +710,12 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                     .type("boolean")
                     .helpText("Allows the deprecated client-initiated account linking endpoint (/broker/{provider}/link). This endpoint will be removed in a future release. Use AIA with kc_action=idp_link instead.")
                     .defaultValue(OIDCProviderConfig.DEFAULT_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING)
+                    .add()
+                .property()
+                    .name(CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI)
+                    .type("boolean")
+                    .helpText("Allows OIDC parameters (state, code, etc.) in post_logout_redirect_uri. Deprecated: will be removed in Keycloak 27.")
+                    .defaultValue(OIDCProviderConfig.DEFAULT_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI)
                     .add()
                 .build();
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCProviderConfig.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCProviderConfig.java
@@ -114,6 +114,11 @@ public class OIDCProviderConfig {
 
     private final boolean allowClientInitiatedAccountLinking;
 
+    // Default - false, change to true for backward compatibility, to be removed in KC 27
+    public static final boolean DEFAULT_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI = false;
+
+    private final boolean allowOidcParamsInPostLogoutRedirectUri;
+
     public OIDCProviderConfig(Config.Scope config) {
         this.config = config;
 
@@ -129,6 +134,7 @@ public class OIDCProviderConfig {
         this.allowTokenIntrospectionWithoutAudienceCheck = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK, DEFAULT_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK);
         this.allowUserinfoWithLightweightAccessToken = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN, DEFAULT_ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN);
         this.allowClientInitiatedAccountLinking = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING, DEFAULT_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING);
+        this.allowOidcParamsInPostLogoutRedirectUri = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI, DEFAULT_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI);
     }
 
     public int getAdditionalReqParamsMaxNumber() {
@@ -153,6 +159,10 @@ public class OIDCProviderConfig {
 
     public boolean isAllowTokenIntrospectionWithoutAudienceCheck() {
         return allowTokenIntrospectionWithoutAudienceCheck;
+    }
+
+    public boolean isAllowOidcParamsInPostLogoutRedirectUri() {
+        return allowOidcParamsInPostLogoutRedirectUri;
     }
 
     public boolean isAllowUserinfoWithLightweightAccessToken() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCProviderConfig.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCProviderConfig.java
@@ -115,9 +115,9 @@ public class OIDCProviderConfig {
     private final boolean allowClientInitiatedAccountLinking;
 
     // Default - false, change to true for backward compatibility, to be removed in KC 27
-    public static final boolean DEFAULT_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI = false;
+    public static final boolean DEFAULT_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS = false;
 
-    private final boolean allowOidcParamsInPostLogoutRedirectUri;
+    private final boolean allowOidcParamsInRedirectUris;
 
     public OIDCProviderConfig(Config.Scope config) {
         this.config = config;
@@ -134,7 +134,7 @@ public class OIDCProviderConfig {
         this.allowTokenIntrospectionWithoutAudienceCheck = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK, DEFAULT_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK);
         this.allowUserinfoWithLightweightAccessToken = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN, DEFAULT_ALLOW_USERINFO_WITH_LIGHTWEIGHT_ACCESS_TOKEN);
         this.allowClientInitiatedAccountLinking = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING, DEFAULT_ALLOW_CLIENT_INITIATED_ACCOUNT_LINKING);
-        this.allowOidcParamsInPostLogoutRedirectUri = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI, DEFAULT_ALLOW_OIDC_PARAMS_IN_POST_LOGOUT_REDIRECT_URI);
+        this.allowOidcParamsInRedirectUris = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS, DEFAULT_ALLOW_OIDC_PARAMS_IN_REDIRECT_URIS);
     }
 
     public int getAdditionalReqParamsMaxNumber() {
@@ -161,8 +161,8 @@ public class OIDCProviderConfig {
         return allowTokenIntrospectionWithoutAudienceCheck;
     }
 
-    public boolean isAllowOidcParamsInPostLogoutRedirectUri() {
-        return allowOidcParamsInPostLogoutRedirectUri;
+    public boolean isAllowOidcParamsInRedirectUris() {
+        return allowOidcParamsInRedirectUris;
     }
 
     public boolean isAllowUserinfoWithLightweightAccessToken() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -18,6 +18,7 @@
 
 package org.keycloak.protocol.oidc.endpoints;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,6 +34,7 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -157,12 +159,29 @@ public class AuthorizationEndpointChecker {
 
         event.detail(Details.REDIRECT_URI, redirectUri);
 
-        // redirect_uri parameter is required per OpenID Connect, but optional per OAuth2
-        this.redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client, isOIDCRequest);
+        if(isAllowOidcParamsInRedirectUris()) {
+            // Backward compat: skip forbidden params check
+            this.redirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(),
+                    redirectUri, client.getRedirectUris(), isOIDCRequest, Collections.emptySet());
+        } else {
+            // Default: use FORBIDDEN_OIDC_PARAMS (5-arg overload)
+            this.redirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(),
+                    redirectUri, client.getRedirectUris(), isOIDCRequest);
+        }
+
         if (this.redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
         }
+    }
+
+    private boolean isAllowOidcParamsInRedirectUris() {
+        OIDCLoginProtocol protocol = (OIDCLoginProtocol) session.getProvider(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);
+        if (protocol.getConfig().isAllowOidcParamsInRedirectUris()) {
+            return true;
+        }
+        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
+        return clientConfig.isAllowOidcParamsInRedirectUris();
     }
 
     public void checkResponseType() throws AuthorizationCheckException {
@@ -309,8 +328,6 @@ public class AuthorizationEndpointChecker {
             event.error(Errors.INVALID_REQUEST);
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
-
-        return;
     }
 
     // https://tools.ietf.org/html/rfc7636#section-4

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -64,7 +64,6 @@ import org.keycloak.protocol.oidc.LogoutTokenValidationCode;
 import org.keycloak.protocol.oidc.LogoutTokenValidationContext;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
-import org.keycloak.protocol.oidc.OIDCProviderConfig;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
 import org.keycloak.protocol.oidc.utils.ContentTypeValidationUtil;
@@ -94,7 +93,6 @@ import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
-import org.jspecify.annotations.Nullable;
 
 import static org.keycloak.models.UserSessionModel.State.LOGGED_OUT;
 import static org.keycloak.models.UserSessionModel.State.LOGGING_OUT;
@@ -226,10 +224,11 @@ public class LogoutEndpoint {
             if (client != null) {
                 OIDCAdvancedConfigWrapper wrapper = OIDCAdvancedConfigWrapper.fromClientModel(client);
                 Set<String> postLogoutRedirectUris = wrapper.getPostLogoutRedirectUris() != null ? new HashSet(wrapper.getPostLogoutRedirectUris()) : new HashSet<>();
-                Set<String> postLogoutForbiddenParams = determineAndGetPostLogoutForbiddenParams();
-                if (postLogoutForbiddenParams != null) {
-                    validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), postLogoutRedirectUri, postLogoutRedirectUris, true, postLogoutForbiddenParams);
+                if (isAllowOidcParamsInRedirectUris(client)) {
+                    // Backward compat: skip forbidden params check
+                    validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), postLogoutRedirectUri, postLogoutRedirectUris, true, Collections.emptySet());
                 } else {
+                    // Default: use FORBIDDEN_OIDC_PARAMS (5-arg overload)
                     validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), postLogoutRedirectUri, postLogoutRedirectUris, true);
                 }
             }
@@ -301,11 +300,13 @@ public class LogoutEndpoint {
         }
     }
 
-    private @Nullable Set<String> determineAndGetPostLogoutForbiddenParams() {
-        OIDCLoginProtocol loginProtocol = (OIDCLoginProtocol) session.getProvider(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);
-        OIDCProviderConfig oidcConfig = loginProtocol.getConfig();
-        Set<String> postLogoutForbiddenParams = oidcConfig.isAllowOidcParamsInPostLogoutRedirectUri() ? Collections.emptySet() : null; // null = use default FORBIDDEN_OIDC_PARAMS
-        return postLogoutForbiddenParams;
+    private boolean isAllowOidcParamsInRedirectUris(ClientModel client) {
+        OIDCLoginProtocol protocol = (OIDCLoginProtocol) session.getProvider(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);
+        if (protocol.getConfig().isAllowOidcParamsInRedirectUris()) {
+            return true;
+        }
+        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
+        return clientConfig.isAllowOidcParamsInRedirectUris();
     }
 
     private Response displayLogoutConfirmationScreen(LoginFormsProvider loginForm, AuthenticationSessionModel authSession) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -18,6 +18,7 @@
 package org.keycloak.protocol.oidc.endpoints;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -57,11 +58,13 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.SystemClientUtil;
+import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.BackchannelLogoutResponse;
 import org.keycloak.protocol.oidc.LogoutTokenValidationCode;
 import org.keycloak.protocol.oidc.LogoutTokenValidationContext;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.OIDCProviderConfig;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
 import org.keycloak.protocol.oidc.utils.ContentTypeValidationUtil;
@@ -91,6 +94,7 @@ import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
+import org.jspecify.annotations.Nullable;
 
 import static org.keycloak.models.UserSessionModel.State.LOGGED_OUT;
 import static org.keycloak.models.UserSessionModel.State.LOGGING_OUT;
@@ -222,7 +226,12 @@ public class LogoutEndpoint {
             if (client != null) {
                 OIDCAdvancedConfigWrapper wrapper = OIDCAdvancedConfigWrapper.fromClientModel(client);
                 Set<String> postLogoutRedirectUris = wrapper.getPostLogoutRedirectUris() != null ? new HashSet(wrapper.getPostLogoutRedirectUris()) : new HashSet<>();
-                validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), postLogoutRedirectUri, postLogoutRedirectUris, true);
+                Set<String> postLogoutForbiddenParams = determineAndGetPostLogoutForbiddenParams();
+                if (postLogoutForbiddenParams != null) {
+                    validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), postLogoutRedirectUri, postLogoutRedirectUris, true, postLogoutForbiddenParams);
+                } else {
+                    validatedRedirectUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), postLogoutRedirectUri, postLogoutRedirectUris, true);
+                }
             }
 
             if (validatedRedirectUri == null) {
@@ -290,6 +299,13 @@ public class LogoutEndpoint {
         } else {
             return doBrowserLogout(logoutSession);
         }
+    }
+
+    private @Nullable Set<String> determineAndGetPostLogoutForbiddenParams() {
+        OIDCLoginProtocol loginProtocol = (OIDCLoginProtocol) session.getProvider(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);
+        OIDCProviderConfig oidcConfig = loginProtocol.getConfig();
+        Set<String> postLogoutForbiddenParams = oidcConfig.isAllowOidcParamsInPostLogoutRedirectUri() ? Collections.emptySet() : null; // null = use default FORBIDDEN_OIDC_PARAMS
+        return postLogoutForbiddenParams;
     }
 
     private Response displayLogoutConfirmationScreen(LoginFormsProvider loginForm, AuthenticationSessionModel authSession) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/LogoutUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/LogoutUtil.java
@@ -22,7 +22,6 @@ import java.net.URI;
 
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.common.util.Encode;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
@@ -67,24 +66,9 @@ public class LogoutUtil {
 
         KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(redirectUri, false);
         if (state != null) {
-            removeQueryParamByDecodedName(uriBuilder, OIDCLoginProtocol.STATE_PARAM);
+            uriBuilder.removeQueryParamByDecodedName(OIDCLoginProtocol.STATE_PARAM);
             uriBuilder.queryParam(OIDCLoginProtocol.STATE_PARAM, state);
         }
         return uriBuilder.build();
-    }
-
-    private static void removeQueryParamByDecodedName(KeycloakUriBuilder uriBuilder, String name) {
-        String query = uriBuilder.getQuery();
-        if (query == null || query.isEmpty()) return;
-
-        StringBuilder cleaned = new StringBuilder();
-        for (String param : query.split("&")) {
-            int eqPos = param.indexOf('=');
-            String rawName = eqPos >= 0 ? param.substring(0, eqPos) : param;
-            if (name.equals(Encode.decode(rawName))) continue;
-            if (!cleaned.isEmpty()) cleaned.append("&");
-            cleaned.append(param);
-        }
-        uriBuilder.replaceQuery(!cleaned.isEmpty() ? cleaned.toString() : null, false);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/LogoutUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/LogoutUtil.java
@@ -21,8 +21,9 @@ package org.keycloak.protocol.oidc.utils;
 import java.net.URI;
 
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
 
+import org.keycloak.common.util.Encode;
+import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.SystemClientUtil;
@@ -64,10 +65,26 @@ public class LogoutUtil {
         if (redirectUri == null) return null;
         String state = logoutSession.getAuthNote(OIDCLoginProtocol.LOGOUT_STATE_PARAM);
 
-        UriBuilder uriBuilder = UriBuilder.fromUri(redirectUri);
+        KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(redirectUri, false);
         if (state != null) {
+            removeQueryParamByDecodedName(uriBuilder, OIDCLoginProtocol.STATE_PARAM);
             uriBuilder.queryParam(OIDCLoginProtocol.STATE_PARAM, state);
         }
         return uriBuilder.build();
+    }
+
+    private static void removeQueryParamByDecodedName(KeycloakUriBuilder uriBuilder, String name) {
+        String query = uriBuilder.getQuery();
+        if (query == null || query.isEmpty()) return;
+
+        StringBuilder cleaned = new StringBuilder();
+        for (String param : query.split("&")) {
+            int eqPos = param.indexOf('=');
+            String rawName = eqPos >= 0 ? param.substring(0, eqPos) : param;
+            if (name.equals(Encode.decode(rawName))) continue;
+            if (!cleaned.isEmpty()) cleaned.append("&");
+            cleaned.append(param);
+        }
+        uriBuilder.replaceQuery(!cleaned.isEmpty() ? cleaned.toString() : null, false);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
@@ -83,6 +83,7 @@ public abstract class OIDCRedirectUriBuilder {
 
         @Override
         public OIDCRedirectUriBuilder addParam(String paramName, String paramValue) {
+            uriBuilder.removeQueryParamByDecodedName(paramName);
             uriBuilder.queryParam(paramName, paramValue);
             return this;
         }
@@ -116,9 +117,22 @@ public abstract class OIDCRedirectUriBuilder {
             if (fragment == null) {
                 fragment = new StringBuilder(param);
             } else {
+                removeFragmentParamByDecodedName(paramName);
                 fragment.append("&").append(param);
             }
             return this;
+        }
+
+        private void removeFragmentParamByDecodedName(String name) {
+            StringBuilder cleaned = new StringBuilder();
+            for (String param : fragment.toString().split("&")) {
+                int eqPos = param.indexOf('=');
+                String rawName = eqPos >= 0 ? param.substring(0, eqPos) : param;
+                if (name.equals(Encode.decode(rawName))) continue;
+                if (!cleaned.isEmpty()) cleaned.append("&");
+                cleaned.append(param);
+            }
+            fragment = cleaned;
         }
 
         @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -92,6 +92,10 @@ public class RedirectUtils {
     }
 
     public static String verifyRedirectUri(KeycloakSession session, String rootUrl, String redirectUri, Set<String> validRedirects, boolean requireRedirectUri) {
+        return verifyRedirectUri(session, rootUrl, redirectUri, validRedirects, requireRedirectUri, FORBIDDEN_OIDC_PARAMS);
+    }
+
+    public static String verifyRedirectUri(KeycloakSession session, String rootUrl, String redirectUri, Set<String> validRedirects, boolean requireRedirectUri, Set<String> forbiddenParams) {
         KeycloakUriInfo uriInfo = session.getContext().getUri();
         RealmModel realm = session.getContext().getRealm();
 
@@ -115,7 +119,7 @@ public class RedirectUtils {
             }
 
             // Check for HTTP Parameter Pollution - forbidden OIDC response parameters in redirect URI
-            if (containsForbiddenOidcParameters(originalRedirect)){
+            if (containsForbiddenOidcParameters(originalRedirect, forbiddenParams)) {
                 return null;
             }
 
@@ -159,12 +163,17 @@ public class RedirectUtils {
         }
     }
 
-    private static boolean containsForbiddenOidcParameters(URI originalRedirect) {
+    private static boolean containsForbiddenOidcParameters(URI originalRedirect, Set<String> forbiddenParams) {
+        if (forbiddenParams == null || forbiddenParams.isEmpty()) {
+            return false;
+        }
+
         String query = originalRedirect.getRawQuery();
         if (query != null && !query.isEmpty()) {
             MultivaluedHashMap<String, String> params =UriUtils.decodeQueryString(query);
             for (String paramName : params.keySet()) {
-                if (FORBIDDEN_OIDC_PARAMS.contains(paramName.toLowerCase(Locale.ROOT))) {
+                if (forbiddenParams.stream().map(param -> param.toLowerCase(Locale.ROOT))
+                        .anyMatch(paramName.toLowerCase(Locale.ROOT)::equals)) {
                     logger.warnf("Redirect URI rejected: contains forbidden OIDC parameter '%s' in query string: scheme=%s, host=%s, path=%s",
                             paramName,
                             originalRedirect.getScheme(),

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -168,17 +168,17 @@ public class RedirectUtils {
             return false;
         }
         //Check query string
-        String query = originalRedirect.getQuery();
-        if (hasForbiddenParams(query, forbiddenParams)) {
+        String query = originalRedirect.getRawQuery();
+        if (hasForbiddenParams(query, forbiddenParams, "query", originalRedirect)) {
             return true;
         }
 
         // Check fragment (response_mode=fragment puts OIDC params here)
         String fragment = originalRedirect.getRawFragment();
-        return hasForbiddenParams(fragment, forbiddenParams);
+        return hasForbiddenParams(fragment, forbiddenParams, "fragment", originalRedirect);
     }
 
-    private static boolean hasForbiddenParams(String paramString, Set<String> forbiddenParams) {
+    private static boolean hasForbiddenParams(String paramString, Set<String> forbiddenParams, String component, URI originalRedirect) {
         if (paramString == null || paramString.isEmpty()) {
             return false;
         }
@@ -186,6 +186,8 @@ public class RedirectUtils {
         for (String paramName : params.keySet()) {
             if (forbiddenParams.stream().map(param -> param.toLowerCase(Locale.ROOT))
                     .anyMatch(paramName.toLowerCase(Locale.ROOT)::equals)) {
+                logger.warnf("Redirect URI rejected: contains forbidden OIDC parameter '%s' in %s: scheme=%s, host=%s, path=%s",
+                        paramName, component, originalRedirect.getScheme(), originalRedirect.getHost(), originalRedirect.getPath());
                 return true;
             }
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -167,20 +167,26 @@ public class RedirectUtils {
         if (forbiddenParams == null || forbiddenParams.isEmpty()) {
             return false;
         }
+        //Check query string
+        String query = originalRedirect.getQuery();
+        if (hasForbiddenParams(query, forbiddenParams)) {
+            return true;
+        }
 
-        String query = originalRedirect.getRawQuery();
-        if (query != null && !query.isEmpty()) {
-            MultivaluedHashMap<String, String> params =UriUtils.decodeQueryString(query);
-            for (String paramName : params.keySet()) {
-                if (forbiddenParams.stream().map(param -> param.toLowerCase(Locale.ROOT))
-                        .anyMatch(paramName.toLowerCase(Locale.ROOT)::equals)) {
-                    logger.warnf("Redirect URI rejected: contains forbidden OIDC parameter '%s' in query string: scheme=%s, host=%s, path=%s",
-                            paramName,
-                            originalRedirect.getScheme(),
-                            originalRedirect.getHost(),
-                            originalRedirect.getPath());
-                    return true;
-                }
+        // Check fragment (response_mode=fragment puts OIDC params here)
+        String fragment = originalRedirect.getRawFragment();
+        return hasForbiddenParams(fragment, forbiddenParams);
+    }
+
+    private static boolean hasForbiddenParams(String paramString, Set<String> forbiddenParams) {
+        if (paramString == null || paramString.isEmpty()) {
+            return false;
+        }
+        MultivaluedHashMap<String, String> params = UriUtils.decodeQueryString(paramString);
+        for (String paramName : params.keySet()) {
+            if (forbiddenParams.stream().map(param -> param.toLowerCase(Locale.ROOT))
+                    .anyMatch(paramName.toLowerCase(Locale.ROOT)::equals)) {
+                return true;
             }
         }
         return false;

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -17,6 +17,7 @@
 package org.keycloak.protocol.oidc.utils;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -338,5 +339,35 @@ public class RedirectUtilsTest {
         Assert.assertNull("Should reject URL-encoded 'session_state' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?session%5Fstate=attack", set, false));
         Assert.assertNull("Should reject mixed-case 'RESPONSE' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?RESPONSE=attack", set, false));
         Assert.assertEquals("Should allow legitimate query parameters that do not conflict with OIDC protocol variables", "https://example.com/callback?legit_param=123", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?legit_param=123", set, false));
+    }
+
+    @Test
+    public void testVerifyPostLogoutRedirectUriAndCustomParameters() {
+        Set<String> validWildcardRedirects = Collections.singleton("https://myhost/auth/realms/uka/protocol/openid-connect/auth*");
+        Set<String> validAppRedirects = Collections.singleton("https://example.com/callback*");
+
+        // 1. Post-logout redirect URI with full auth URL containing state parameter
+        String postLogoutWithState = "https://myhost/auth/realms/uka/protocol/openid-connect/auth"
+                + "?response_type=code&client_id=client&redirect_uri=urn:ietf:wg:oauth:2.0:oob"
+                + "&state=de43a890-30ae-4a76-bb7f-d4d090164d5a&login=true&scope=openid&kc_idp_hint=nosso";
+        Assert.assertEquals(postLogoutWithState, RedirectUtils.verifyRedirectUri(session, null, postLogoutWithState, validWildcardRedirects, false, Collections.emptySet()));
+
+        // 2. Post-logout redirect URI with auth URL without state parameter
+        String postLogoutWithoutState = "https://myhost/auth/realms/uka/protocol/openid-connect/auth"
+                + "?response_type=code&client_id=client&redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=openid";
+        Assert.assertEquals(postLogoutWithoutState, RedirectUtils.verifyRedirectUri(session, null, postLogoutWithoutState, validWildcardRedirects, false, Collections.emptySet()));
+
+        // 3. Plain post-logout redirect URI with no query parameters
+        String plainPostLogout = "https://myhost/auth/realms/uka/protocol/openid-connect/auth";
+        Assert.assertEquals(plainPostLogout, RedirectUtils.verifyRedirectUri(session, null, plainPostLogout, validWildcardRedirects, false, Collections.emptySet()));
+
+        // 4. Default verification allowing legitimate application query parameters
+        String customParamsUri = "https://example.com/callback?tab=profile&locale=en&app_param=123";
+        Assert.assertEquals(customParamsUri, RedirectUtils.verifyRedirectUri(session, null, customParamsUri, validAppRedirects, false));
+
+        // 5. Custom forbidden parameter set enforcement
+        String testParamUri = "https://example.com/callback?code=abc&custom=123";
+        Assert.assertEquals(testParamUri, RedirectUtils.verifyRedirectUri(session, null, testParamUri, validAppRedirects, false, Collections.emptySet()));
+        Assert.assertNull(RedirectUtils.verifyRedirectUri(session, null, testParamUri, validAppRedirects, false, Set.of("custom")));
     }
 }

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -339,6 +339,22 @@ public class RedirectUtilsTest {
         Assert.assertNull("Should reject URL-encoded 'session_state' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?session%5Fstate=attack", set, false));
         Assert.assertNull("Should reject mixed-case 'RESPONSE' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?RESPONSE=attack", set, false));
         Assert.assertEquals("Should allow legitimate query parameters that do not conflict with OIDC protocol variables", "https://example.com/callback?legit_param=123", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?legit_param=123", set, false));
+
+        // Fragment-based forbidden params (CVE #51286 - response_mode=fragment)
+        Assert.assertNull("Should reject forbidden 'state' parameter in fragment", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback#state=evil", set, false));
+        Assert.assertNull("Should reject forbidden 'code' parameter in fragment", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback#code=evil", set, false));
+        Assert.assertNull("Should reject forbidden param in fragment with legitimate query params", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?legit=123#state=evil", set, false));
+        Assert.assertNull("Should reject URL-encoded forbidden param in fragment", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback#st%61te=evil", set, false));
+        Assert.assertEquals("Should allow legitimate fragment without forbidden params", "https://example.com/callback#section1", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback#section1", set, false));
+
+        // URL-encoded variants of forbidden params in query
+        Assert.assertNull("Should reject URL-encoded 'state' (st%61te)", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?st%61te=evil", set, false));
+
+        // Backward compat: empty forbidden set allows everything (query and fragment)
+        Assert.assertEquals("Empty forbidden set should allow forbidden params in query", "https://example.com/callback?state=val",
+                RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?state=val", set, false, Collections.emptySet()));
+        Assert.assertEquals("Empty forbidden set should allow forbidden params in fragment", "https://example.com/callback#state=val",
+                RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback#state=val", set, false, Collections.emptySet()));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -1085,26 +1085,16 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
     public void logoutWithPostLogoutRedirectUriContainingAuthUrlAndState() throws Exception {
         allowOidcParamsInRedirectUris(true);
         try {
-            String authServerUrl = oauth.getBaseUrl();
-            String targetAuthUrl = authServerUrl + "/realms/test/protocol/openid-connect/auth"
-                    + "?response_type=code"
-                    + "&client_id=test-app"
+            String baseUrl = oauth.getBaseUrl();
+            String targetAuthUrl = baseUrl + "/realms/test/protocol/openid-connect/auth"
+                    + "?response_type=code&client_id=test-app"
                     + "&redirect_uri=" + URLEncoder.encode(APP_REDIRECT_URI, StandardCharsets.UTF_8)
-                    + "&state=downstream-state-123"
-                    + "&scope=openid";
-
+                    + "&state=downstream-state-123&scope=openid";
             try (Closeable ignore = ClientAttributeUpdater.forClient(adminClient, "test", "test-app")
-                    .setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, authServerUrl + "/realms/test/protocol/openid-connect/auth*")
+                    .setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, baseUrl + "/realms/test/protocol/openid-connect/auth*")
                     .update()) {
-
                 AccessTokenResponse tokenResponse = loginUser();
-                String idTokenString = tokenResponse.getIdToken();
-
-                oauth.logoutForm()
-                        .idTokenHint(idTokenString)
-                        .postLogoutRedirectUri(targetAuthUrl)
-                        .open();
-
+                oauth.logoutForm().idTokenHint(tokenResponse.getIdToken()).postLogoutRedirectUri(targetAuthUrl).open();
                 loginPage.assertCurrent();
                 MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
             }
@@ -1117,17 +1107,10 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
     public void logoutWithPostLogoutRedirectUriAndLogoutStateDeduplication() throws Exception {
         allowOidcParamsInRedirectUris(true);
         try {
-            String targetUri = APP_REDIRECT_URI + "?existing=true&st%61te=preloaded-state";
-
             AccessTokenResponse tokenResponse = loginUser();
-            String idTokenString = tokenResponse.getIdToken();
-
-            oauth.logoutForm()
-                    .idTokenHint(idTokenString)
-                    .postLogoutRedirectUri(targetUri)
-                    .state("logout-state-456")
-                    .open();
-
+            oauth.logoutForm().idTokenHint(tokenResponse.getIdToken())
+                    .postLogoutRedirectUri(APP_REDIRECT_URI + "?existing=true&st%61te=preloaded-state")
+                    .state("logout-state-456").open();
             String currentUrl = driver.getCurrentUrl();
             assertTrue(currentUrl.contains("existing=true"), "Should contain existing parameter");
             assertTrue(currentUrl.contains("state=logout-state-456"), "Should contain new state parameter");
@@ -1139,50 +1122,28 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    public void testPostLogoutRedirectWithStateRejectedByDefault() {
-        AccessTokenResponse tokenResponse = loginUser();
-        String idTokenString = tokenResponse.getIdToken();
+    public void testPostLogoutRedirectWithStateForbiddenByDefaultAndAllowedWhenConfigured() {
         String redirectUri = APP_REDIRECT_URI + "?state=injected";
-
-        List<String> postLogoutRedirectUris = Collections.singletonList(redirectUri);
-        ClientManager.realm(adminClient.realm("test")).clientId("test-app")
-                .setPostLogoutRedirectUri(postLogoutRedirectUris);
-
+        List<String> uris = Collections.singletonList(redirectUri);
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app").setPostLogoutRedirectUri(uris);
         try {
+            AccessTokenResponse tokenResponse = loginUser();
+            String idTokenString = tokenResponse.getIdToken();
             oauth.logoutForm().postLogoutRedirectUri(redirectUri).idTokenHint(idTokenString).open();
-            // Should fail — redirect URI contains forbidden 'state' param
-            EventAssertion.assertError(events.poll())
-                    .type(EventType.LOGOUT_ERROR)
-                    .error(OAuthErrorException.INVALID_REDIRECT_URI)
-                    .clientId("test-app");
-        } finally {
-            postLogoutRedirectUris = Collections.singletonList("+");
-            ClientManager.realm(adminClient.realm("test")).clientId("test-app")
-                    .setPostLogoutRedirectUri(postLogoutRedirectUris);
-        }
-    }
+            EventAssertion.assertError(events.poll()).type(EventType.LOGOUT_ERROR)
+                    .error(OAuthErrorException.INVALID_REDIRECT_URI).clientId("test-app");
 
-    @Test
-    public void testPostLogoutRedirectWithStateAllowedWhenConfigured() {
-        AccessTokenResponse tokenResponse = loginUser();
-        String idTokenString = tokenResponse.getIdToken();
-        String redirectUri = APP_REDIRECT_URI + "?state=injected";
+            // Failed logout leaves the session active; clear it before the next login
+            adminClient.realm("test").logoutAll();
 
-        List<String> postLogoutRedirectUris = Collections.singletonList(redirectUri);
-        ClientManager.realm(adminClient.realm("test")).clientId("test-app")
-                .setPostLogoutRedirectUri(postLogoutRedirectUris);
-
-        try {
             allowOidcParamsInRedirectUris(true);
-            oauth.logoutForm().postLogoutRedirectUri(redirectUri).idTokenHint(idTokenString).open();
-            // Should succeed — backward compat allows state param
-            EventAssertion.expectLogoutSuccess(events.poll())
-                    .type(EventType.LOGOUT);
+            tokenResponse = loginUser();
+            oauth.logoutForm().postLogoutRedirectUri(redirectUri).idTokenHint(tokenResponse.getIdToken()).open();
+            EventAssertion.expectLogoutSuccess(events.poll()).type(EventType.LOGOUT);
         } finally {
             allowOidcParamsInRedirectUris(false);
-            postLogoutRedirectUris = Collections.singletonList("+");
             ClientManager.realm(adminClient.realm("test")).clientId("test-app")
-                    .setPostLogoutRedirectUri(postLogoutRedirectUris);
+                    .setPostLogoutRedirectUri(Collections.singletonList("+"));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -67,7 +67,6 @@ import org.keycloak.testsuite.util.Matchers;
 import org.keycloak.testsuite.util.URLUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
-import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.runonserver.RunHelpers;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -87,7 +86,6 @@ import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1085,13 +1083,13 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void logoutWithPostLogoutRedirectUriContainingAuthUrlAndState() throws Exception {
-        allowOidcParamsInPostLogoutRedirectUri(true);
+        allowOidcParamsInRedirectUris(true);
         try {
             String authServerUrl = oauth.getBaseUrl();
             String targetAuthUrl = authServerUrl + "/realms/test/protocol/openid-connect/auth"
                     + "?response_type=code"
                     + "&client_id=test-app"
-                    + "&redirect_uri=" + URLEncoder.encode(OAuthClient.AUTH_SERVER_ROOT + "/foo", StandardCharsets.UTF_8)
+                    + "&redirect_uri=" + URLEncoder.encode(APP_REDIRECT_URI, StandardCharsets.UTF_8)
                     + "&state=downstream-state-123"
                     + "&scope=openid";
 
@@ -1102,57 +1100,93 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
                 AccessTokenResponse tokenResponse = loginUser();
                 String idTokenString = tokenResponse.getIdToken();
 
-                String logoutUrl = oauth.logoutForm()
+                oauth.logoutForm()
                         .idTokenHint(idTokenString)
                         .postLogoutRedirectUri(targetAuthUrl)
-                        .build();
+                        .open();
 
-                try (CloseableHttpClient c = HttpClientBuilder.create().disableRedirectHandling().build();
-                     CloseableHttpResponse response = c.execute(new HttpGet(logoutUrl))) {
-                    assertThat(response, Matchers.statusCodeIsHC(Response.Status.FOUND));
-                    String location = response.getFirstHeader(HttpHeaders.LOCATION).getValue();
-                    assertThat(location, startsWith(authServerUrl + "/realms/test/protocol/openid-connect/auth"));
-                    assertTrue(location.contains("state=downstream-state-123"));
-                }
-
+                loginPage.assertCurrent();
                 MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
             }
         } finally {
-            allowOidcParamsInPostLogoutRedirectUri(false);
+            allowOidcParamsInRedirectUris(false);
         }
-
     }
 
     @Test
     public void logoutWithPostLogoutRedirectUriAndLogoutStateDeduplication() throws Exception {
-        allowOidcParamsInPostLogoutRedirectUri(true);
+        allowOidcParamsInRedirectUris(true);
         try {
             String targetUri = APP_REDIRECT_URI + "?existing=true&st%61te=preloaded-state";
 
             AccessTokenResponse tokenResponse = loginUser();
             String idTokenString = tokenResponse.getIdToken();
 
-            String logoutUrl = oauth.logoutForm()
+            oauth.logoutForm()
                     .idTokenHint(idTokenString)
                     .postLogoutRedirectUri(targetUri)
                     .state("logout-state-456")
-                    .build();
+                    .open();
 
-            try(CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
-                CloseableHttpResponse response = client.execute(new HttpGet(logoutUrl))) {
-                assertThat(response, Matchers.statusCodeIsHC(Response.Status.FOUND));
-                String location = response.getFirstHeader(HttpHeaders.LOCATION).getValue();
-                assertEquals(Collections.singletonList("logout-state-456"),
-                        UriUtils.decodeQueryString(java.net.URI.create(location).getRawQuery()).get("state"));
-                assertTrue(location.contains("existing=true"));
-            }
+            String currentUrl = driver.getCurrentUrl();
+            assertTrue(currentUrl.contains("existing=true"), "Should contain existing parameter");
+            assertTrue(currentUrl.contains("state=logout-state-456"), "Should contain new state parameter");
+            assertFalse(currentUrl.contains("preloaded-state"), "Should not contain preloaded state parameter");
             MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
         } finally {
-            allowOidcParamsInPostLogoutRedirectUri(false);
+            allowOidcParamsInRedirectUris(false);
         }
     }
 
-    // SUPPORT METHODS
+    @Test
+    public void testPostLogoutRedirectWithStateRejectedByDefault() {
+        AccessTokenResponse tokenResponse = loginUser();
+        String idTokenString = tokenResponse.getIdToken();
+        String redirectUri = APP_REDIRECT_URI + "?state=injected";
+
+        List<String> postLogoutRedirectUris = Collections.singletonList(redirectUri);
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app")
+                .setPostLogoutRedirectUri(postLogoutRedirectUris);
+
+        try {
+            oauth.logoutForm().postLogoutRedirectUri(redirectUri).idTokenHint(idTokenString).open();
+            // Should fail — redirect URI contains forbidden 'state' param
+            EventAssertion.assertError(events.poll())
+                    .type(EventType.LOGOUT_ERROR)
+                    .error(OAuthErrorException.INVALID_REDIRECT_URI)
+                    .clientId("test-app");
+        } finally {
+            postLogoutRedirectUris = Collections.singletonList("+");
+            ClientManager.realm(adminClient.realm("test")).clientId("test-app")
+                    .setPostLogoutRedirectUri(postLogoutRedirectUris);
+        }
+    }
+
+    @Test
+    public void testPostLogoutRedirectWithStateAllowedWhenConfigured() {
+        AccessTokenResponse tokenResponse = loginUser();
+        String idTokenString = tokenResponse.getIdToken();
+        String redirectUri = APP_REDIRECT_URI + "?state=injected";
+
+        List<String> postLogoutRedirectUris = Collections.singletonList(redirectUri);
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app")
+                .setPostLogoutRedirectUri(postLogoutRedirectUris);
+
+        try {
+            allowOidcParamsInRedirectUris(true);
+            oauth.logoutForm().postLogoutRedirectUri(redirectUri).idTokenHint(idTokenString).open();
+            // Should succeed — backward compat allows state param
+            EventAssertion.expectLogoutSuccess(events.poll())
+                    .type(EventType.LOGOUT);
+        } finally {
+            allowOidcParamsInRedirectUris(false);
+            postLogoutRedirectUris = Collections.singletonList("+");
+            ClientManager.realm(adminClient.realm("test")).clientId("test-app")
+                    .setPostLogoutRedirectUri(postLogoutRedirectUris);
+        }
+    }
+
+        // SUPPORT METHODS
     private AccessTokenResponse loginUser() {
         return loginUser(false);
     }
@@ -1202,9 +1236,9 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
         }
     }
 
-    private void allowOidcParamsInPostLogoutRedirectUri(boolean allow) {
+    private void allowOidcParamsInRedirectUris(boolean allow) {
         runOnServerMaster.run(RunHelpers.setSystemPropertyOnServer(
-                "oidc.allow-oidc-params-in-post-logout-redirect-uri", String.valueOf(allow)));
+                "oidc.allow-oidc-params-in-redirect-uris", String.valueOf(allow)));
         runOnServerMaster.run(RunHelpers.reinitializeProviderFactoryWithSystemPropertiesScope(
                 LoginProtocol.class.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL, "oidc."));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -19,6 +19,8 @@ package org.keycloak.testsuite.oauth;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +40,7 @@ import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.models.Constants;
 import org.keycloak.models.UserModel;
+import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -64,6 +67,7 @@ import org.keycloak.testsuite.util.Matchers;
 import org.keycloak.testsuite.util.URLUtils;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.runonserver.RunHelpers;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -83,6 +87,7 @@ import static org.keycloak.testsuite.util.URLAssert.assertCurrentUrlEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1078,6 +1083,75 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
         }
     }
 
+    @Test
+    public void logoutWithPostLogoutRedirectUriContainingAuthUrlAndState() throws Exception {
+        allowOidcParamsInPostLogoutRedirectUri(true);
+        try {
+            String authServerUrl = oauth.getBaseUrl();
+            String targetAuthUrl = authServerUrl + "/realms/test/protocol/openid-connect/auth"
+                    + "?response_type=code"
+                    + "&client_id=test-app"
+                    + "&redirect_uri=" + URLEncoder.encode(OAuthClient.AUTH_SERVER_ROOT + "/foo", StandardCharsets.UTF_8)
+                    + "&state=downstream-state-123"
+                    + "&scope=openid";
+
+            try (Closeable ignore = ClientAttributeUpdater.forClient(adminClient, "test", "test-app")
+                    .setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, authServerUrl + "/realms/test/protocol/openid-connect/auth*")
+                    .update()) {
+
+                AccessTokenResponse tokenResponse = loginUser();
+                String idTokenString = tokenResponse.getIdToken();
+
+                String logoutUrl = oauth.logoutForm()
+                        .idTokenHint(idTokenString)
+                        .postLogoutRedirectUri(targetAuthUrl)
+                        .build();
+
+                try (CloseableHttpClient c = HttpClientBuilder.create().disableRedirectHandling().build();
+                     CloseableHttpResponse response = c.execute(new HttpGet(logoutUrl))) {
+                    assertThat(response, Matchers.statusCodeIsHC(Response.Status.FOUND));
+                    String location = response.getFirstHeader(HttpHeaders.LOCATION).getValue();
+                    assertThat(location, startsWith(authServerUrl + "/realms/test/protocol/openid-connect/auth"));
+                    assertTrue(location.contains("state=downstream-state-123"));
+                }
+
+                MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
+            }
+        } finally {
+            allowOidcParamsInPostLogoutRedirectUri(false);
+        }
+
+    }
+
+    @Test
+    public void logoutWithPostLogoutRedirectUriAndLogoutStateDeduplication() throws Exception {
+        allowOidcParamsInPostLogoutRedirectUri(true);
+        try {
+            String targetUri = APP_REDIRECT_URI + "?existing=true&st%61te=preloaded-state";
+
+            AccessTokenResponse tokenResponse = loginUser();
+            String idTokenString = tokenResponse.getIdToken();
+
+            String logoutUrl = oauth.logoutForm()
+                    .idTokenHint(idTokenString)
+                    .postLogoutRedirectUri(targetUri)
+                    .state("logout-state-456")
+                    .build();
+
+            try(CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
+                CloseableHttpResponse response = client.execute(new HttpGet(logoutUrl))) {
+                assertThat(response, Matchers.statusCodeIsHC(Response.Status.FOUND));
+                String location = response.getFirstHeader(HttpHeaders.LOCATION).getValue();
+                assertEquals(Collections.singletonList("logout-state-456"),
+                        UriUtils.decodeQueryString(java.net.URI.create(location).getRawQuery()).get("state"));
+                assertTrue(location.contains("existing=true"));
+            }
+            MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
+        } finally {
+            allowOidcParamsInPostLogoutRedirectUri(false);
+        }
+    }
+
     // SUPPORT METHODS
     private AccessTokenResponse loginUser() {
         return loginUser(false);
@@ -1126,5 +1200,12 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
 
             // We don't need to go further as the intent is that other tests will cover redirection
         }
+    }
+
+    private void allowOidcParamsInPostLogoutRedirectUri(boolean allow) {
+        runOnServerMaster.run(RunHelpers.setSystemPropertyOnServer(
+                "oidc.allow-oidc-params-in-post-logout-redirect-uri", String.valueOf(allow)));
+        runOnServerMaster.run(RunHelpers.reinitializeProviderFactoryWithSystemPropertiesScope(
+                LoginProtocol.class.getName(), OIDCLoginProtocol.LOGIN_PROTOCOL, "oidc."));
     }
 }


### PR DESCRIPTION
Key changes:

- Allow configurable forbidden parameters in RedirectUtils.verifyRedirectUri()
- Allow OIDC auth parameters in post-logout redirects while blocking malicious parameters
- Use KeycloakUriBuilder.replaceQueryParam() to prevent query parameter duplication
- Add tests for OIDC parameters, state deduplication, and custom forbidden parameters

Closes #51712

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
