### PR TITLE
Honor an explicit migration strategy on an empty database

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -4,6 +4,15 @@
 Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
 In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
 
+=== Empty database and an explicit migration strategy
+
+An explicitly configured `migration-strategy` now wins over the implicit initialization of an empty database.
+Previously the default `initialize-empty=true` initialized the schema in place even when `manual` or `validate`
+was configured, so no export script was written and `validate` created the schema instead of failing.
+Now, on an empty database, the `manual` strategy writes the export script and exits, and the `validate`
+strategy fails startup. To restore the previous behavior, explicitly set the `initialize-empty` property of the
+`connections-jpa` provider to `true`.
+
 === Client scope assignment now enforces client scope permissions
 
 The client scope assignment endpoints on a specific client now require the caller to have `manage` permission on client scopes, in addition to the existing `manage` permission on the target client.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -651,10 +651,10 @@ To setup the JPA migrationStrategy (manual/update/validate) you should setup JPA
 .Setting the `migration-strategy` for the `quarkus` provider of the `connections-jpa` SPI
 <@kc.start parameters="--spi-connections-jpa--quarkus--migration-strategy=manual"/>
 
-If you want to get a SQL file for DB initialization, too, you have to add this additional SPI initializeEmpty (true/false):
+With the manual strategy, an empty database also results in a SQL file for the DB initialization. If you instead want an empty database to be initialized automatically while keeping manual migrations for upgrades, set the additional SPI option initializeEmpty to "true":
 
 .Setting the `initialize-empty` for the `quarkus` provider of the `connections-jpa` SPI
-<@kc.start parameters="--spi-connections-jpa--quarkus--initialize-empty=false"/>
+<@kc.start parameters="--spi-connections-jpa--quarkus--initialize-empty=true"/>
 
 In the same way the migrationExport to point to a specific file and location:
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -201,7 +201,9 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
                         }
 
                         MigrationStrategy migrationStrategy = getMigrationStrategy();
-                        boolean initializeEmpty = config.getBoolean("initializeEmpty", true);
+                        // An explicit migration strategy wins over the implicit initialization of an empty database, so the
+                        // default of initializeEmpty depends on the strategy. An explicitly configured value always wins.
+                        boolean initializeEmpty = config.getBoolean("initializeEmpty", migrationStrategy == MigrationStrategy.UPDATE);
                         File databaseUpdateFile = getDatabaseUpdateFile();
 
                         properties.put("hibernate.show_sql", config.getBoolean("showSql", false));

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -164,8 +164,7 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
                 .property()
                 .name("initializeEmpty")
                 .type("boolean")
-                .helpText("Initialize database if empty. If set to false the database has to be manually initialized. If you want to manually initialize the database set migrationStrategy to manual which will create a file with SQL commands to initialize the database.")
-                .defaultValue(true)
+                .helpText("Initialize database if empty. Defaults to true, unless migrationStrategy is set to manual or validate. If set to false the database has to be manually initialized. If you want to manually initialize the database set migrationStrategy to manual which will create a file with SQL commands to initialize the database.")
                 .add()
                 .property()
                 .name("migrationStrategy")
@@ -264,7 +263,9 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
 
     private boolean createOrUpdateSchema(String schema, String version, Connection connection, KeycloakSession session) {
         MigrationStrategy strategy = getMigrationStrategy();
-        boolean initializeEmpty = config.getBoolean("initializeEmpty", true);
+        // An explicit migration strategy wins over the implicit initialization of an empty database, so the
+        // default of initializeEmpty depends on the strategy. An explicitly configured value always wins.
+        boolean initializeEmpty = config.getBoolean("initializeEmpty", strategy == MigrationStrategy.UPDATE);
         File databaseUpdateFile = getDatabaseUpdateFile();
 
         JpaUpdaterProvider updater = session.getProvider(JpaUpdaterProvider.class);

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/EmptyDatabaseMigrationStrategyDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/EmptyDatabaseMigrationStrategyDistTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.KeycloakRunner;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.utils.RawDistRootPath;
+import org.keycloak.it.utils.RawKeycloakDistribution;
+
+import io.quarkus.deployment.util.FileUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An explicit migration strategy must win over the implicit initialization of an empty database.
+ * Without an explicit {@code initialize-empty}, {@code manual} has to produce the export script and
+ * {@code validate} has to fail startup instead of both being silently overridden by the default
+ * {@code initialize-empty=true} and initializing the schema in place.
+ */
+@DistributionTest
+@RawDistOnly(reason = "Containers are immutable")
+@Tag(DistributionTest.SLOW)
+public class EmptyDatabaseMigrationStrategyDistTest {
+
+    @Test
+    void testManualStrategyAloneExportsScriptForEmptyDatabase(KeycloakRunner runner, RawDistRootPath rawDistRootPath) throws IOException {
+        forceEmptyDatabase(runner);
+
+        CLIResult result = runner.run("start-dev",
+                "--spi-connections-jpa-quarkus-migration-strategy=manual");
+
+        result.assertMessage("Database not initialized, please initialize database with");
+
+        File script = rawDistRootPath.getDistRootPath().resolve("bin").resolve("keycloak-database-update.sql").toFile();
+        assertTrue(script.isFile(), "Export file must exist when migration-strategy=manual");
+    }
+
+    @Test
+    void testValidateStrategyAloneFailsStartupForEmptyDatabase(KeycloakRunner runner) throws IOException {
+        forceEmptyDatabase(runner);
+
+        CLIResult result = runner.run("start-dev",
+                "--spi-connections-jpa-quarkus-migration-strategy=validate");
+
+        result.assertMessage("Database not initialized, please enable database initialization");
+    }
+
+    @Test
+    void testExplicitInitializeEmptyStillOverridesManualStrategy(KeycloakRunner runner) throws IOException {
+        forceEmptyDatabase(runner);
+
+        CLIResult result = runner.run("start-dev",
+                "--spi-connections-jpa-quarkus-migration-strategy=manual",
+                "--spi-connections-jpa-quarkus-initialize-empty=true");
+
+        result.assertStartedDevMode();
+    }
+
+    private static void forceEmptyDatabase(KeycloakRunner runner) throws IOException {
+        RawKeycloakDistribution rawDist = runner.getDistribution(RawKeycloakDistribution.class);
+        FileUtil.deleteDirectory(rawDist.getDistPath().resolve("data").resolve("h2").toAbsolutePath());
+    }
+}


### PR DESCRIPTION
Closes #51932

## What

An explicitly configured `migration-strategy` is silently ignored when the database is empty:
`initializeEmpty` defaults to `true` and is checked before the strategy, so `manual` initializes the schema
in place without writing the export script, and `validate` creates the whole schema on a database it was told
to only validate. Follow-up requested in
https://github.com/keycloak/keycloak/pull/51730#discussion_r3812720679.

## How

The default of `initialize-empty` now depends on the strategy: `true` for `update` (unchanged), `false` for
`manual` and `validate`. An explicitly configured value wins in all cases:

| empty database + | before | after |
|---|---|---|
| `update` (no flag) | initialize | initialize |
| `manual` (no flag) | silent initialize | export + startup error |
| `validate` (no flag) | silent initialize | startup error |
| `manual`/`validate` + explicit `initialize-empty=true` | initialize | initialize |
| `manual` + explicit `initialize-empty=false` | export + startup error | export + startup error |

One line of logic in `QuarkusJpaConnectionProviderFactory` and the same in the legacy
`DefaultJpaConnectionProviderFactory`, plus the `initialize-empty` help text and an entry in the upgrading
guide, since the two fixed rows are a behavior change.

Note that `initialize-empty=false` combined with `update` already updates today, so the option only ever had
an effect on `manual` and `validate`; this change gives it a consistent meaning instead of a contradicting one.

## Testing

New `EmptyDatabaseMigrationStrategyDistTest` (H2, raw dist, empty database):

* `manual` alone produces the export script and the "Database not initialized" startup error (red without the fix);
* `validate` alone fails startup with "please enable database initialization" (red without the fix);
* `manual` with an explicit `initialize-empty=true` still initializes and starts (green before and after, pins the opt-in).

Existing manual-strategy tests (`ManualMigrationCustomProviderDistTest`, `LiquibaseDistTest`,
`PostgreSQLDistTest`/`MySQLDistTest`/`MariaDBDistTest`) all pass `initialize-empty` explicitly, so their
behavior is unchanged; the first two were re-run locally and are green.

## Note on AI assistance

AI agents were used while investigating this and while drafting the change, tests and documentation. I have
reviewed and understand every line, ran the verification described above myself, and will handle review
feedback directly.
