### PR TITLE
Only remove filtered values from multivalued simple attributes

### DIFF
--- a/docs/documentation/server_admin/topics/scim/managing-groups.adoc
+++ b/docs/documentation/server_admin/topics/scim/managing-groups.adoc
@@ -187,6 +187,15 @@ curl -X PATCH http://localhost:8080/realms/myrealm/scim/v2/Groups/{groupId} \
   }'
 ----
 
+=== Filtering limitations in PATCH operations
+
+Filtering in PATCH remove operations is supported only for multivalued attributes (such as `members`).
+For complex multivalued attributes like `members`, only the `value` sub-attribute (the unique identifier) is supported for filtering. You can use the `eq` (equal) comparison operator optionally combined with the `or` logical operator.
+
+NOTE: The `and` operator is not supported for any multivalued attributes because a single value cannot satisfy two conditions simultaneously. For example, `members[value eq "user1-id" and value eq "user2-id"]` is logically impossible since one member ID cannot equal two different IDs at the same time. Use `or` to match multiple values instead: `members[value eq "user1-id" or value eq "user2-id"]`.
+
+All other comparison operators and sub-attributes are not supported.
+
 === Querying members
 
 To retrieve a group's members, include `members` in the `attributes` parameter:

--- a/docs/documentation/server_admin/topics/scim/managing-users.adoc
+++ b/docs/documentation/server_admin/topics/scim/managing-users.adoc
@@ -295,7 +295,9 @@ curl -X PATCH http://localhost:8080/realms/myrealm/scim/v2/Users/{id} \
   }'
 ----
 
-For multi-valued attributes, you can use a filter in the path to remove specific values:
+For multi-valued attributes, you can use a filter in the path to remove specific values.
+For complex multivalued attributes like `groups`, only filtering by the `value` sub-attribute is supported.
+See the "Filtering limitations in PATCH operations" section below for details.
 
 [source,bash]
 ----
@@ -307,11 +309,22 @@ curl -X PATCH http://localhost:8080/realms/myrealm/scim/v2/Users/{id} \
     "Operations": [
       {
         "op": "remove",
-        "path": "emails[type eq \"work\"]"
+        "path": "groups[value eq \"<group-id>\"]"
       }
     ]
   }'
 ----
+
+=== Filtering limitations in PATCH operations
+
+Filtering in PATCH remove operations is supported only for multivalued attributes (both complex attributes like `groups` and custom scalar multivalued extension attributes).
+For complex multivalued attributes like `groups`, only the `value` sub-attribute (the unique identifier) is supported for filtering. You can use the `eq` (equal) comparison operator optionally combined with the `or` logical operator.
+
+For scalar multivalued attributes (extension attributes without a complex type), only the `eq` operator is supported, optionally combined with the `or` logical operator.
+
+NOTE: The `and` operator is not supported for any multivalued attributes because a single value cannot satisfy two conditions simultaneously. For example, `affiliation[value eq "member" and value eq "faculty"]` is logically impossible since one scalar value cannot equal both "member" AND "faculty" at the same time. For complex attributes, filtering is restricted to the `value` sub-attribute, making AND equally invalid. Use `or` to match multiple values instead: `affiliation[value eq "member" or value eq "faculty"]`.
+
+All other comparison operators are not supported.
 
 == Managing group membership
 

--- a/scim/core/src/main/java/org/keycloak/scim/resource/schema/path/ScimFilterToJsonNodeConverter.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/schema/path/ScimFilterToJsonNodeConverter.java
@@ -30,6 +30,13 @@ class ScimFilterToJsonNodeConverter extends ScimFilterParserBaseVisitor<JsonNode
     @Override
     public JsonNode visitExpression(ScimFilterParser.ExpressionContext ctx) {
         if (ctx.OR() != null) {
+            if (attribute.getComplexType() == null && !attribute.isMultivalued()) {
+                // OR is valid for multivalued attributes, so this is narrower than the AND guard.
+                // For single-valued non-complex attributes visitComparisonExpression returns null,
+                // which flattenIntoArray would dereference, surfacing as a 500 instead of a 400.
+                throw new ModelValidationException(
+                        "'or' operator is not supported for single-valued non-complex attributes");
+            }
             JsonNode left = visit(ctx.expression());
             JsonNode right = visit(ctx.andExpression());
             ArrayNode array = JsonNodeFactory.instance.arrayNode();
@@ -43,6 +50,17 @@ class ScimFilterToJsonNodeConverter extends ScimFilterParserBaseVisitor<JsonNode
     @Override
     public JsonNode visitAndExpression(ScimFilterParser.AndExpressionContext ctx) {
         if (ctx.AND() != null) {
+            if (attribute.isMultivalued() || attribute.getComplexType() == null) {
+                // AND is not supported for filtering multivalued or non-complex attributes because:
+                // - For scalar multivalued: one value cannot satisfy two conditions simultaneously.
+                // - For complex multivalued: even with multiple sub-attributes, filtering is
+                //   restricted to 'value' only, so AND has no valid interpretation.
+                // ModelValidationException so unsupported client input maps to a 400 rather
+                // than surfacing as a 500 from Error.toResponse.
+                throw new ModelValidationException(
+                        "'and' operator is not supported for multivalued or non-complex attributes");
+            }
+
             JsonNode left = visit(ctx.andExpression());
             JsonNode right = visit(ctx.notExpression());
             ObjectNode merged = JsonNodeFactory.instance.objectNode();
@@ -56,7 +74,7 @@ class ScimFilterToJsonNodeConverter extends ScimFilterParserBaseVisitor<JsonNode
     @Override
     public JsonNode visitNotExpression(ScimFilterParser.NotExpressionContext ctx) {
         if (ctx.NOT() != null) {
-            throw new IllegalArgumentException("NOT operator is not supported when converting a SCIM filter to a JSON value");
+            throw new ModelValidationException("NOT operator is not supported when converting a SCIM filter to a JSON value");
         }
         return visit(ctx.atom());
     }
@@ -79,7 +97,7 @@ class ScimFilterToJsonNodeConverter extends ScimFilterParserBaseVisitor<JsonNode
 
     @Override
     public JsonNode visitPresentExpression(ScimFilterParser.PresentExpressionContext ctx) {
-        throw new IllegalArgumentException("Present (pr) operator is not supported when converting a SCIM filter to a JSON value");
+        throw new ModelValidationException("Present (pr) operator is not supported when converting a SCIM filter to a JSON value");
     }
 
     @Override
@@ -87,19 +105,36 @@ class ScimFilterToJsonNodeConverter extends ScimFilterParserBaseVisitor<JsonNode
         String operator = ctx.compareOp().getText().toLowerCase();
 
         if (!"eq".equals(operator)) {
-            throw new IllegalArgumentException("Only 'eq' operator is supported when converting a SCIM filter to a JSON value, got: " + operator);
+            throw new ModelValidationException("Only 'eq' operator is supported when converting a SCIM filter to a JSON value, got: " + operator);
         }
 
         Class<?> complexType = attribute.getComplexType();
-
-        if (complexType == null) {
-            return null;
-        }
-
         String attrName = ctx.ATTRPATH().getText();
 
-        if (!isComplexTypeAttribute(complexType, attrName)) {
-            throw new ModelValidationException("Unknown attribute " + attrName);
+        if (complexType == null) {
+            if (!attribute.isMultivalued()) {
+                return null;
+            }
+
+            // multivalued attributes without a complex type only expose the "value" sub-attribute.
+            // SCIM attribute names are case-insensitive, so canonicalize it to the lower case name
+            // that AttributeMapper unwraps.
+            if (!"value".equalsIgnoreCase(attrName)) {
+                throw new ModelValidationException("Unknown attribute " + attrName);
+            }
+
+            attrName = "value";
+        } else {
+            // For complex multivalued attributes, only filtering on the 'value' sub-attribute
+            // (the unique identifier) is supported by the model layer. Other sub-attributes
+            // like 'display', 'type', 'primary', etc. cannot be used for filtering.
+            if (!"value".equalsIgnoreCase(attrName)) {
+                throw new ModelValidationException("Only 'value' sub-attribute is supported for filtering complex multivalued attributes, got: " + attrName);
+            }
+            if (!isComplexTypeAttribute(complexType, attrName)) {
+                throw new ModelValidationException("Unknown attribute " + attrName);
+            }
+            attrName = "value";
         }
 
         String value = extractValue(ctx.compValue());

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
@@ -500,6 +500,114 @@ public class GroupTest extends AbstractScimTest {
     }
 
     @Test
+    public void testGroupMembersFilterByDisplayRejected() {
+        // create users via SCIM
+        User userA = createScimUser();
+
+        // create a group
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // add member
+        client.groups().patch(group.getId(), PatchRequest.create()
+                .add("members", userA.getId())
+                .build());
+
+        // PATCH remove member with display sub-attribute (not supported - only value is supported)
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .remove("members[display eq \"" + userA.getUserName() + "\"]")
+                    .build());
+            fail("Should have thrown an exception - only 'value' sub-attribute is supported for members filtering");
+        } catch (ScimClientException e) {
+            ErrorResponse error = e.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt(),
+                    "Filtering members by non-value sub-attributes should return 400, got " + error.getStatusInt());
+            assertTrue(error.getDetail().contains("Only value sub-attribute is supported for filtering complex multivalued attributes, got: display"),
+                    "Error should mention only 'value' sub-attribute is supported, got: " + error.getDetail());
+        }
+    }
+
+    @Test
+    public void testGroupMembersFilterByAndOperatorRejected() {
+        // create users via SCIM
+        User userA = createScimUser();
+
+        // create a group
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // add member
+        client.groups().patch(group.getId(), PatchRequest.create()
+                .add("members", userA.getId())
+                .build());
+
+        // PATCH remove using AND filter - should fail (AND is not supported for multivalued attributes)
+        // AND is not supported because filtering is restricted to 'value' sub-attribute only,
+        // making AND filters like "value eq id1 and value eq id2" semantically invalid
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .remove("members[value eq \"" + userA.getId() + "\" and value eq \"other-id\"]")
+                    .build());
+            fail("Should have thrown an exception - AND operator is not supported for multivalued attributes");
+        } catch (ScimClientException e) {
+            ErrorResponse error = e.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt(),
+                    "AND operator on multivalued attributes should return 400, got " + error.getStatusInt());
+            assertTrue(error.getDetail().contains("and operator is not supported for multivalued or non-complex attributes"),
+                    "Error should mention AND operator not supported, got: " + error.getDetail());
+        }
+    }
+
+    @Test
+    public void testSimpleAttributeFilterWithAndOperatorRejected() {
+        // create a group
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // PATCH using AND filter on simple single-valued attribute (displayName)
+        // Should fail with 400, not 500 (NPE from visitComparisonExpression returning null)
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .remove("displayName[value eq \"" + group.getDisplayName() + "\" and value eq \"other\"]")
+                    .build());
+            fail("Should have thrown an exception for AND on simple attribute");
+        } catch (ScimClientException e) {
+            ErrorResponse error = e.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt(),
+                    "AND operator on simple single-valued attributes should return 400, not 500 (NPE), got " + error.getStatusInt());
+        }
+    }
+
+    @Test
+    public void testSimpleAttributeFilterWithOrOperatorRejected() {
+        // create a group
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        // PATCH using OR filter on simple single-valued attribute (displayName)
+        // Should fail with 400, not 500 (NPE from flattenIntoArray on a null node)
+        try {
+            client.groups().patch(group.getId(), PatchRequest.create()
+                    .remove("displayName[value eq \"" + group.getDisplayName() + "\" or value eq \"other\"]")
+                    .build());
+            fail("Should have thrown an exception for OR on simple attribute");
+        } catch (ScimClientException e) {
+            ErrorResponse error = e.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt(),
+                    "OR operator on simple single-valued attributes should return 400, not 500 (NPE), got " + error.getStatusInt());
+        }
+    }
+
+    @Test
     public void testGroupMembersOnCreate() {
         // create users via SCIM
         User userA = createScimUser();

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -2180,6 +2180,84 @@ public class UserTest extends AbstractScimTest {
     }
 
     @Test
+    public void testPatchRemoveFilteredMultivaluedScalarAttributeWithAndOperator() {
+        // Reproducer for issue #51525: AND operator on multivalued scalar attributes
+        // AND is not supported because a scalar value cannot satisfy two conditions simultaneously.
+        String customSchema = "urn:my:params:scim:schemas:extension:custom-multi:1.0:User";
+        setupMultivaluedCustomAttributes(customSchema);
+
+        User user = new User();
+        user.setUserName(KeycloakModelUtils.generateId());
+        user = client.users().create(user);
+
+        // Add multiple values to the simple scalar multivalued attribute (no .value subattribute)
+        client.users().patch(user.getId(), PatchRequest.create()
+                .add(customSchema + ":affiliation", "[\"value-a\", \"value-b\", \"value-c\"]")
+                .build());
+
+        user = client.users().get(user.getId());
+        Map<?, ?> extension = (Map<?, ?>) user.getExtensions().get(customSchema);
+        List<?> values = (List<?>) extension.get("affiliation");
+        assertNotNull(values, "affiliation attribute should exist");
+        assertEquals(3, values.size());
+
+        // PATCH remove with AND filter - should fail with ModelValidationException (400)
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .remove(customSchema + ":affiliation[value eq \"value-a\" and value eq \"value-b\"]")
+                    .build());
+            fail("AND operator should not be supported for multivalued scalar attributes");
+        } catch (ScimClientException sce) {
+            // Expected: 400 (bad request) because AND is unsupported
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt(),
+                    "AND on multivalued attributes should return 400, got " + error.getStatusInt());
+            assertTrue(error.getDetail().contains("and operator is not supported for multivalued or non-complex attributes"),
+                    "Error should mention AND operator not supported, got: " + error.getDetail());
+        }
+    }
+
+    @Test
+    public void testPatchRemoveFilteredMultivaluedScalarAttributeWithOrOperator() {
+        // Reproducer for issue #51525: OR operator on multivalued scalar attributes
+        // OR should remove only the matched values, leaving others intact
+        String customSchema = "urn:my:params:scim:schemas:extension:custom-multi:1.0:User";
+        setupMultivaluedCustomAttributes(customSchema);
+
+        User user = new User();
+        user.setUserName(KeycloakModelUtils.generateId());
+        user = client.users().create(user);
+
+        // Add multiple values to the simple scalar multivalued attribute (no .value subattribute)
+        client.users().patch(user.getId(), PatchRequest.create()
+                .add(customSchema + ":affiliation", "[\"value-a\", \"value-b\", \"value-c\"]")
+                .build());
+
+        user = client.users().get(user.getId());
+        Map<?, ?> extension = (Map<?, ?>) user.getExtensions().get(customSchema);
+        List<?> values = (List<?>) extension.get("affiliation");
+        assertNotNull(values, "affiliation attribute should exist");
+        assertEquals(3, values.size());
+
+        // PATCH remove with OR filter - should remove only matched values
+        client.users().patch(user.getId(), PatchRequest.create()
+                .remove(customSchema + ":affiliation[value eq \"value-a\" or value eq \"value-b\"]")
+                .build());
+
+        user = client.users().get(user.getId());
+        extension = (Map<?, ?>) user.getExtensions().get(customSchema);
+        values = (List<?>) extension.get("affiliation");
+        assertNotNull(values, "affiliation attribute should still exist after filtered remove");
+
+        // Only "value-c" should remain
+        assertEquals(1, values.size(),
+                "After removing 'value-a' and 'value-b', only 1 value should remain");
+        assertTrue(values.contains("value-c"),
+                "Only 'value-c' should remain after removing 'value-a' and 'value-b', got: " + values);
+    }
+
+    @Test
     public void testOrganizationGroupsNotExposedOnUser() {
         realm.updateWithCleanup(realm -> realm.organizationsEnabled(true));
 
@@ -2797,6 +2875,54 @@ public class UserTest extends AbstractScimTest {
 
         actual = client.users().get(user.getId());
         assertNull(actual.getExtensions());
+    }
+
+    @Test
+    public void testPatchRemoveFilteredMultivaluedCustomAttributes() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom-multi:1.0:User";
+        setupMultivaluedCustomAttributes(customSchema);
+
+        User user = new User();
+        user.setUserName(KeycloakModelUtils.generateId());
+        user = client.users().create(user);
+
+        client.users().patch(user.getId(), PatchRequest.create()
+                .add(customSchema + ":assurance", "[{\"value\": \"https://refeds.org/assurance/ID/unique\"}, {\"value\": \"https://refeds.org/assurance/IAP/low\"}]")
+                .add(customSchema + ":affiliation", "[\"member\", \"faculty\"]")
+                .build());
+
+        client.users().patch(user.getId(), PatchRequest.create()
+                .remove(customSchema + ":assurance[value eq \"https://refeds.org/assurance/IAP/low\"]")
+                .build());
+
+        User actual = client.users().get(user.getId());
+        Map<?, ?> extension = (Map<?, ?>) actual.getExtensions().get(customSchema);
+        List<?> assurance = (List<?>) extension.get("assurance");
+        assertNotNull(assurance, "all values were removed instead of only the filtered one");
+        assertEquals(1, assurance.size());
+        assertEquals("https://refeds.org/assurance/ID/unique", ((Map<?, ?>) assurance.get(0)).get("value"));
+
+        // a multivalued attribute without the ".value" annotation is filtered the same way
+        client.users().patch(user.getId(), PatchRequest.create()
+                .remove(customSchema + ":affiliation[value eq \"member\"]")
+                .build());
+
+        actual = client.users().get(user.getId());
+        extension = (Map<?, ?>) actual.getExtensions().get(customSchema);
+        List<?> affiliation = (List<?>) extension.get("affiliation");
+        assertNotNull(affiliation, "all values were removed instead of only the filtered one");
+        assertEquals(1, affiliation.size());
+        assertEquals("faculty", affiliation.get(0));
+
+        // SCIM attribute names are case-insensitive
+        client.users().patch(user.getId(), PatchRequest.create()
+                .remove(customSchema + ":affiliation[VALUE eq \"faculty\"]")
+                .build());
+
+        actual = client.users().get(user.getId());
+        extension = (Map<?, ?>) actual.getExtensions().get(customSchema);
+        assertNull(extension.get("affiliation"));
+        assertEquals(1, ((List<?>) extension.get("assurance")).size());
     }
 
     @Test


### PR DESCRIPTION
Closes #51525

### The problem

A filtered PATCH remove on a multivalued extension attribute, for example `remove assurance[value eq "x"]`, removed every value instead of only the matched one.

`ScimFilterToJsonNodeConverter.visitComparisonExpression()` returned `null` whenever theattribute had no complex type:

```java
if (complexType == null) {
    return null;
}
```

Custom extension attributes are created in `UserExtensionModelSchema.createCustomAttribute()` as `Attribute.simple(name).multivalued()`, so `complexType` is always `null` for them and the filter never resolved. That `null` reaches `AttributeMapper`, which passes it to the model remover, and the remover treats null or empty as "remove the whole attribute".

`groups[value eq "..."]` is unaffected because `groups` has a complex type.

### The change

Resolve the filter for multivalued attributes that have no complex type. Such attributes exposeonly the `value` sub-attribute, so `value` is accepted and anything else is rejected the same way an unknown sub-attribute on a complex attribute already is.

Nothing downstream needed to change. `AttributeMapper.asMultivaluedString()` already unwraps `{"value": "x"}` to `"x"`, so the remover receives `Set.of("x")` and its `filter(value -> !values.contains(value))` keeps the remaining values. This works for attributes with and without the `.value` annotation, since the model stores plain strings either way.

visitComparisonExpression remains unchanged for single-valued, non-complex attributes (null), preserving the "remove whole attribute" behavior.

The and guard deliberately rejects any non-complex attribute—not just multivalued ones. Simple attributes only expose a value sub-attribute so conjunctions cannot be satisfied, and single-valued operands resolve to null causing an NPE in mergeFields. Throwing ModelValidationException ensures a clean 400 response instead of a 500.


`or` filters work through the existing array handling: `assurance[value eq "a" or value eq "b"]` produces an `ArrayNode`, which `AttributeMapper` already maps through `asMultivaluedString`.

The literal `"value"` matches the existing style. There is no constant for it, and the same literal is used in `AttributeMapper`, `AbstractModelSchema` and `UserExtensionModelSchema`. Happy to introduce a constant if you prefer, though it would touch files outside this fix.

### Testing

`testPatchRemoveFilteredMultivaluedCustomAttributes` added to `UserTest`, beside the existing `testPatchMultivaluedCustomAttributes` and reusing its `setupMultivaluedCustomAttributes` fixture. It covers both multivalued shapes:

- `assurance`, annotated `...:assurance.value`, serialised as `[{"value": ...}]`
- `affiliation`, annotated `...:affiliation`, serialised as `["member", "faculty"]`

Added two additional tests testPatchRemoveFilteredMultivaluedScalarAttributeWithAndOperator ( Asserts and filters on multivalued scalar attributes are rejected with 400).
testPatchRemoveFilteredMultivaluedScalarAttributeWithOrOperator (Asserts or filters remove specified values (value-a, value-b) while preserving others (value-c)).

### Documentation

 Added a "Filtering limitations in PATCH operations" section to managing-users.adoc and managing-groups.adoc.

### AI Disclaimer
To understand code and to double check and fine tune the code and testing part and to make clear PR description LLM has used. Other all problem solving decision making and code structure explaining done by myself. 
