### PR TITLE
fix: Overal Admin API performance degradation

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -324,6 +324,10 @@ public class KeycloakIdentity implements Identity {
         return effectiveUserRoleIds.contains(role.getId());
     }
 
+    public void invalidateEffectiveUserRoles() {
+        effectiveUserRoleIds = null;
+    }
+
     public AccessToken getAccessToken() {
         return this.accessToken;
     }

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.Response.Status;
 
@@ -42,6 +44,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessToken.Access;
@@ -69,6 +72,7 @@ public class KeycloakIdentity implements Identity {
     private final boolean resourceServer;
     private final String id;
     private UserModel user;
+    private Set<String> effectiveUserRoleIds;
 
     public KeycloakIdentity(KeycloakSession keycloakSession) {
         this(Tokens.getAccessToken(keycloakSession), keycloakSession);
@@ -294,13 +298,7 @@ public class KeycloakIdentity implements Identity {
             return Identity.super.hasClientRole(clientId, roleName);
         }
 
-        RoleModel role = KeycloakModelUtils.getRoleByName(realm, clientId, roleName);
-
-        if (role == null) {
-            return false;
-        }
-
-        return user.hasRole(role);
+        return hasEffectiveUserRole(KeycloakModelUtils.getRoleByName(realm, clientId, roleName));
     }
 
     @Override
@@ -309,13 +307,21 @@ public class KeycloakIdentity implements Identity {
             return Identity.super.hasRealmRole(roleName);
         }
 
-        RoleModel role = KeycloakModelUtils.getRoleByName(realm, null, roleName);
+        return hasEffectiveUserRole(KeycloakModelUtils.getRoleByName(realm, null, roleName));
+    }
 
+    private boolean hasEffectiveUserRole(RoleModel role) {
         if (role == null) {
             return false;
         }
 
-        return user.hasRole(role);
+        if (effectiveUserRoleIds == null) {
+            effectiveUserRoleIds = RoleUtils.getDeepUserRoleMappings(user).stream()
+                    .map(RoleModel::getId)
+                    .collect(Collectors.toSet());
+        }
+
+        return effectiveUserRoleIds.contains(role.getId());
     }
 
     public AccessToken getAccessToken() {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -56,6 +56,7 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
+import org.keycloak.services.resources.admin.fgap.RealmsPermissionEvaluator;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.ExportImportManager;
 
@@ -120,14 +121,15 @@ public class RealmsAdminResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public Stream<RealmRepresentation> getRealms(@DefaultValue("false") @QueryParam("briefRepresentation") boolean briefRepresentation) {
+        RealmsPermissionEvaluator realmsAuth = AdminPermissions.realms(session, auth);
         Stream<RealmRepresentation> realms = session.realms().getRealmsStream()
-                .map(realm -> toRealmRep(realm, briefRepresentation))
+                .map(realm -> toRealmRep(realmsAuth, realm, briefRepresentation))
                 .filter(Objects::nonNull);
         return throwIfEmpty(realms, new ForbiddenException());
     }
 
-    protected RealmRepresentation toRealmRep(RealmModel realm, boolean briefRep) {
-        if (AdminPermissions.realms(session, auth).canView(realm)) {
+    protected RealmRepresentation toRealmRep(RealmsPermissionEvaluator realmsAuth, RealmModel realm, boolean briefRep) {
+        if (realmsAuth.canView(realm)) {
             if (briefRep) {
                 return ModelToRepresentation.toBriefRepresentation(realm);
             }
@@ -139,7 +141,7 @@ public class RealmsAdminResource {
                     .toList();
             rep.setDefaultGroups(filteredDefaultGroups.isEmpty() ? null : filteredDefaultGroups);
             return rep;
-        } else if (AdminPermissions.realms(session, auth).isAdmin(realm)) {
+        } else if (realmsAuth.isAdmin(realm)) {
             RealmRepresentation rep = new RealmRepresentation();
             rep.setRealm(realm.getName());
             return rep;

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
@@ -196,6 +196,9 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
         if (cache == null || !cache.refreshMasterAdminRole(masterAdminRole, clientId)) {
             return false;
         }
+        if (identity instanceof KeycloakIdentity keycloakIdentity) {
+            keycloakIdentity.invalidateEffectiveUserRoles();
+        }
         Set<String> roleNames = Set.of(adminRoles);
         return masterAdminRole.getCompositesStream().anyMatch(r -> (r.isClientRole()
                 && r.getContainerId().equals(clientId) && roleNames.contains(r.getName())));


### PR DESCRIPTION
Fixes #51931

## Root cause

Admin permission checks re-resolve the caller's effective roles from the role model on every single check

## Changes

- Resolve the admin caller's effective (composite-expanded) role set once per KeycloakIdentity and answer hasRealmRole/hasClientRole from that memoized set instead of calling UserModel.hasRole() (a full composite-tree walk) for every role name; and build the RealmsPermissionEvaluator once per GET /admin/realms request instead of twice per returned realm.