### PR TITLE
(26.7) Client access-type condition evaluates updates against the old client type

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
@@ -71,12 +71,14 @@ public class ClientAccessTypeCondition extends AbstractClientPolicyConditionProv
 
     @Override
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
-        if (context instanceof ClientModelContext) {
+        if (context.getEvent() == REGISTER) {
+            if (isProposedClientAccessTypeMatched((ClientCRUDContext) context)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else if (context instanceof ClientModelContext) {
             ClientModel client = ((ClientModelContext) context).getClient();
             if (isClientAccessTypeMatched(client)) return ClientPolicyVote.YES;
-            return ClientPolicyVote.NO;
-        } else if (context.getEvent() == REGISTER) {
-            if (isProposedClientAccessTypeMatched((ClientCRUDContext)context)) return ClientPolicyVote.YES;
+            // In case that there is an attempt to update the client to the target access type, condition should be also evaluated to success
+            if (context instanceof ClientCRUDContext && isProposedClientAccessTypeMatched((ClientCRUDContext) context)) return ClientPolicyVote.YES;
             return ClientPolicyVote.NO;
         } else {
             return ClientPolicyVote.ABSTAIN;

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientPoliciesClientCRUDTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientPoliciesClientCRUDTest.java
@@ -1,9 +1,13 @@
 package org.keycloak.tests.client.policies;
 
+import java.util.List;
+
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientProtocolCondition;
 import org.keycloak.services.clientpolicy.condition.ClientProtocolConditionFactory;
 import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutor;
@@ -14,10 +18,12 @@ import org.keycloak.testframework.realm.ManagedRealm;
 
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.tests.utils.ClientPoliciesUtil.createClientAccessTypeConditionConfig;
 import static org.keycloak.tests.utils.ClientPoliciesUtil.createClientProtocolConditionConfig;
 import static org.keycloak.tests.utils.ClientPoliciesUtil.createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -80,5 +86,67 @@ public class ClientPoliciesClientCRUDTest extends AbstractClientPoliciesTest {
 
         // Try to create OIDC client without directGrants - should be success
         createClientByAdmin(realm, "example-client-oidc", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {});
+    }
+
+    @Test
+    public void testClientAccessTypeConditionClientCRUD() throws Exception {
+        // Setup policy: condition = confidential client access type, executor = reject resource owner password credentials grant
+        RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration rejectResourceOwnerConfig =
+                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(false);
+        ClientAccessTypeCondition.Configuration accessTypeConditionConfig =
+                createClientAccessTypeConditionConfig(List.of(ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL));
+        setupPolicy(realm, RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID, rejectResourceOwnerConfig,
+                ClientAccessTypeConditionFactory.PROVIDER_ID, accessTypeConditionConfig);
+
+        // Attempt to create a confidential client with directAccessGrants enabled. Should fail because condition matches.
+        try {
+            createClientByAdmin(realm, "confidential-client", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+                clientRep.setPublicClient(Boolean.FALSE);
+                clientRep.setBearerOnly(Boolean.FALSE);
+                clientRep.setDirectAccessGrantsEnabled(true);
+            });
+            fail();
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Invalid client metadata: resource owner password credentials grant enabled", cpe.getErrorDetail());
+        }
+
+        // Create a public client with directAccessGrants enabled. Should succeed because condition does not match (public != confidential).
+        String publicClientUUID = createClientByAdmin(realm, "public-client", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+            clientRep.setPublicClient(Boolean.TRUE);
+            clientRep.setBearerOnly(Boolean.FALSE);
+            clientRep.setDirectAccessGrantsEnabled(true);
+        });
+
+        // Verify client is public
+        ClientRepresentation foundRep = realm.admin().clients().get(publicClientUUID).toRepresentation();
+        assertEquals(Boolean.TRUE, foundRep.isPublicClient());
+
+        // Attempt to update the public client to become confidential while keeping directAccessGrants enabled.
+        // Should fail because updating TO confidential must also trigger the condition (this is the bug fix of #51380).
+        try {
+            updateClientByAdmin(realm, publicClientUUID, clientRep -> {
+                clientRep.setPublicClient(Boolean.FALSE);
+                clientRep.setBearerOnly(Boolean.FALSE);
+                clientRep.setDirectAccessGrantsEnabled(true);
+            });
+            fail();
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Invalid client metadata: resource owner password credentials grant enabled", cpe.getErrorDetail());
+        }
+
+        // Verify client is still public (update was rolled back)
+        foundRep = realm.admin().clients().get(publicClientUUID).toRepresentation();
+        assertEquals(Boolean.TRUE, foundRep.isPublicClient());
+
+        // Update the public client to confidential WITHOUT directAccessGrants. Should succeed.
+        updateClientByAdmin(realm, publicClientUUID, clientRep -> {
+            clientRep.setPublicClient(Boolean.FALSE);
+            clientRep.setBearerOnly(Boolean.FALSE);
+            clientRep.setDirectAccessGrantsEnabled(false);
+        });
+
+        // Verify client is now confidential
+        foundRep = realm.admin().clients().get(publicClientUUID).toRepresentation();
+        assertFalse(foundRep.isPublicClient());
     }
 }


### PR DESCRIPTION
closes #51380


Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit ca0b006133c5b94ec8fb3f8321c717091607b2dd)
