### PR TITLE
Fix CVEs inherited from ApacheDS/Kerby dependencies (#51899)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <!-- Others -->
         <apacheds.version>2.0.0.AM27</apacheds.version>
         <apacheds.codec.version>2.1.8</apacheds.codec.version>
-        <kerby.version>2.1.0</kerby.version>
+        <kerby.version>2.1.2</kerby.version>
         <google.zxing.version>3.4.0</google.zxing.version>
         <freemarker.version>2.3.32</freemarker.version>
         <sundrio.version>0.200.0</sundrio.version>
@@ -708,6 +708,12 @@
                 <version>${apacheds.codec.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Override mina-core version from api-parent BOM to fix CVE-2026-47065 -->
+            <dependency>
+                <groupId>org.apache.mina</groupId>
+                <artifactId>mina-core</artifactId>
+                <version>2.2.9</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.jmeter</groupId>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -56,12 +56,6 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-util-embedded-ldap</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -242,6 +242,12 @@
             <groupId>org.apache.kerby</groupId>
             <artifactId>ldap-backend</artifactId>
             <version>${kerby.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -84,6 +84,12 @@
             <groupId>org.apache.kerby</groupId>
             <artifactId>ldap-backend</artifactId>
             <version>${kerby.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -99,11 +99,21 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
@@ -112,6 +122,10 @@
         <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-ldap-codec-standalone</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcutil-jdk18on</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- bump kerby from 2.1.0 to 2.1.2
- bump mina-core to 2.2.9 (fixes CVE-2026-47065)
- add BouncyCastle wildcard exclusion on the ldap-backend dependency to eliminate the transitive bcprov-jdk15on:1.70 pull (fixes CVE-2023-33201, CVE-2024-29857, CVE-2024-30171,CVE-2024-34447)

Closes #51785


(cherry picked from commit d7c392f1066972a494729b8fd28066ebc6d31f6e)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
---
**26.6-specific addition** (not in the original #51899): folds in the BouncyCastle-related changes from #49633, which was never backported to 26.6. Without them `apacheds-core` still pulls transitive `bcprov-jdk15on:1.70` into `util/embedded-ldap` (and downstream `testsuite/utils`/`tests/base`); combined with this PR removing the masking `bcprov-jdk15on` exclusion in `tests/base`, that broke test compilation (`OcspHandler.getOctetsLength()`, added in BC 1.71). Adds `org.bouncycastle:*` exclusions on `apacheds-core` and `apacheds-server-annotations` plus an explicit `bcutil-jdk18on` dep, matching main/26.7. The mina-core 2.1.13 pin and commons-collections exclusion from #49633 are intentionally omitted (the former would regress the mina-core 2.2.9 fix here).

Verified: `tests/base` test-compile passes; `dependency:tree` shows no `bcprov-jdk15on` in `util/embedded-ldap`, `testsuite/utils`, or `tests/base` (only `bcprov-jdk18on:1.84`).
