### PR TITLE
Validate group policy claims against realm memberships

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/group/GroupPolicyProvider.java
@@ -17,8 +17,11 @@
 package org.keycloak.authorization.policy.provider.group;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -45,6 +48,7 @@ import org.keycloak.representations.idm.authorization.ResourceType;
 
 import org.jboss.logging.Logger;
 
+import static org.keycloak.authorization.fgap.AdminPermissionsSchema.runWithoutAuthorization;
 import static org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome.DENY;
 import static org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome.GRANT;
 import static org.keycloak.authorization.fgap.evaluation.partial.PartialEvaluationPolicyProvider.Outcome.SKIP;
@@ -75,7 +79,8 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
             groupsClaim = new Entry(policy.getGroupsClaim(), userGroups);
         }
 
-        Outcome outcome = isGranted(realm, null, policy, groupsClaim);
+        KeycloakSession session = authorizationProvider.getKeycloakSession();
+        Outcome outcome = isGranted(session, realm, null, policy, groupsClaim);
 
         if (GRANT.equals(outcome)) {
             evaluation.grant();
@@ -84,8 +89,10 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
         logger.debugf("Groups policy %s evaluated to %s with identity groups %s", policy.getName(), evaluation.getEffect(), groupsClaim);
     }
 
-    private Outcome isGranted(RealmModel realm, UserModel subject, GroupPolicyRepresentation policy, Entry groupsClaim) {
+    private Outcome isGranted(KeycloakSession session, RealmModel realm, UserModel subject, GroupPolicyRepresentation policy, Entry groupsClaim) {
         boolean skipped = false;
+        // The realm cache does not cache misses, so resolve each distinct claim only once per evaluation.
+        Map<String, Optional<GroupModel>> topLevelGroupByClaim = new HashMap<>();
 
         for (GroupPolicyRepresentation.GroupDefinition definition : policy.getGroups()) {
             GroupModel allowedGroup = realm.getGroupById(definition.getId());
@@ -102,21 +109,25 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
             String allowedGroupPath = buildGroupPath(allowedGroup);
 
             for (int i = 0; i < groupsClaim.size(); i++) {
-                String group = groupsClaim.asString(i);
+                String groupPath = groupsClaim.asString(i);
+                GroupModel group = topLevelGroupByClaim.computeIfAbsent(groupPath, claim -> Optional.ofNullable(
+                        runWithoutAuthorization(session, () -> session.groups().getGroupByName(realm, null, claim)))).orElse(null);
 
-                if (group.indexOf('/') != -1) {
-                    if (group.equals(allowedGroupPath)) {
+                if (group != null) {
+                    if (group.getId().equals(allowedGroup.getId())) {
                         return GRANT;
                     }
-
-                    if (definition.isExtendChildren() && group.startsWith(allowedGroupPath + "/")) {
-                        return GRANT;
-                    }
+                    continue;
                 }
 
-                // in case the group from the claim does not represent a path, we just check an exact name match
-                if (group.equals(allowedGroup.getName())) {
-                    return GRANT;
+                if (groupPath.indexOf('/') != -1) {
+                    if (groupPath.equals(allowedGroupPath)) {
+                        return GRANT;
+                    }
+
+                    if (definition.isExtendChildren() && groupPath.startsWith(allowedGroupPath + "/")) {
+                        return GRANT;
+                    }
                 }
             }
         }
@@ -164,7 +175,7 @@ public class GroupPolicyProvider implements PolicyProvider, PartialEvaluationPol
         GroupPolicyRepresentation groupPolicy = representationFunction.apply(policy, authorizationProvider);
         List<String> userGroups = subject.getGroupsStream().map(ModelToRepresentation::buildGroupPath)
                 .collect(Collectors.toList());
-        return isGranted(realm, subject, groupPolicy, new Entry(groupPolicy.getGroupsClaim(), userGroups));
+        return isGranted(session, realm, subject, groupPolicy, new Entry(groupPolicy.getGroupsClaim(), userGroups));
     }
 
     @Override

--- a/docs/documentation/authorization_services/topics/policy-group-policy.adoc
+++ b/docs/documentation/authorization_services/topics/policy-group-policy.adoc
@@ -22,8 +22,15 @@ A string containing details about this policy.
 * *Groups Claim*
 +
 Specifies the name of the claim in the token holding the group names and/or paths. Usually, authorization requests are processed based on an ID Token or Access Token
-previously issued to a client acting on behalf of some user. If defined, the token must include a claim from where this policy is going to obtain the groups
-the user is a member of. If not defined, user's groups are obtained from your realm configuration.
+previously issued to a client acting on behalf of some user. If defined, the policy uses the claim as the first source of truth to obtain the groups the user is a member of.
+If not defined or if the claim is empty, the policy falls back to the user's actual group memberships from the realm configuration.
++
+When the claim contains full group paths (for example, `/Organization/Admins`), the policy matches groups by their exact path in the realm hierarchy.
+When the claim contains bare group names without a path prefix, the policy resolves each name against top-level realm groups only.
+If your realm has groups with duplicate names at different levels of the hierarchy, configure the Group Membership protocol mapper with *Full group path* enabled
+so that tokens include the complete group path and the policy can unambiguously identify the correct group.
+Group names that contain slashes (for example, a group named `/Organization/Admins`) are resolved as top-level group names first, before being treated as paths.
+This prevents a group name from being confused with a nested group path.
 +
 * *Groups*
 +

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -63,6 +63,16 @@ The token introspection endpoint previously set the `act.sub` field to the imper
 
 If you have resource servers that parse `act.sub` from introspection responses and expect a username, update them to read `act.preferred_username` instead.
 
+=== Group policy matching for bare group names
+
+Group-based policies in Authorization Services use the groups claim from the token as the first source of truth. When the claim is not defined or empty, the policy falls back to the user's actual group memberships from the realm. Bare group names in token claims are now resolved to top-level realm groups only. Previously, a bare name like `Admins` in a group claim would match any group named `Admins` regardless of its position in the group hierarchy. This allowed users who are members of one group to satisfy policies targeting a different group with the same name at a different path.
+
+If your deployment uses the Group Membership protocol mapper with *Full group path* disabled and relies on group policies targeting nested groups, enable *Full group path* in the protocol mapper configuration so that tokens include the complete group path (for example, `/Organization/Admins` instead of `Admins`).
+
+Group names that contain slashes (for example, a group named `/Organization/Admins`) are now resolved as top-level group names first, before being treated as paths. This prevents a group name from being confused with a nested group path.
+
+Group policies that use full group paths in claims are not affected unless a top-level group name is identical to a nested group path. In that ambiguous case, the top-level group name takes precedence.
+
 === Authorization services claim handling changes
 
 Two changes affect how claims are handled in the authorization services token endpoint:

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/GroupMembershipMapper.java
@@ -50,7 +50,7 @@ public class GroupMembershipMapper extends AbstractOIDCProtocolMapper implements
         property1.setLabel("Full group path");
         property1.setType(ProviderConfigProperty.BOOLEAN_TYPE);
         property1.setDefaultValue("true");
-        property1.setHelpText("Include full path to group i.e. /top/level1/level2, false will just specify the group name");
+        property1.setHelpText("Include full path to group i.e. /top/level1/level2, false will just specify the group name. Make sure to enable this setting if your realm has a group hierarchy with duplicated group names.");
         configProperties.add(property1);
 
         OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, GroupMembershipMapper.class);

--- a/tests/base/src/test/java/org/keycloak/tests/authz/services/GroupPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/authz/services/GroupPolicyTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.authz.services;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.GroupMembershipMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.GroupPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.GroupBuilder;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.authz.services.config.DefaultAuthzServicesServerConfig;
+import org.keycloak.tests.utils.admin.AdminApiUtil;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest(config = DefaultAuthzServicesServerConfig.class)
+public class GroupPolicyTest {
+
+    private static final String PASSWORD = "password";
+    private static final String NESTED_USER = "nested-user";
+    private static final String ROOT_USER = "root-user";
+    private static final String PATH_LIKE_USER = "path-like-user";
+    private static final String NESTED_GROUP_PATH = "/Group A/Group B/Group E";
+    private static final String ROOT_GROUP_PATH = "/Group E";
+    private static final String RESOURCE = "protected-resource";
+    private static final String POLICY = "group-policy";
+
+    @InjectRealm(config = GroupPolicyRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @InjectClient(config = ResourceServerConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedClient resourceServer;
+
+    @InjectOAuthClient(lifecycle = LifeCycle.METHOD)
+    OAuthClient oauth;
+
+    @Test
+    public void testBareGroupNameOnlyMatchesTopLevelGroup() {
+        configureGroupPolicy(ROOT_GROUP_PATH);
+
+        assertDecision(ROOT_USER, true);
+        assertDecision(NESTED_USER, true);
+    }
+
+    @Test
+    public void testBareGroupNameDoesNotMatchNestedGroup() {
+        configureGroupPolicy(NESTED_GROUP_PATH);
+
+        assertDecision(NESTED_USER, false);
+        assertDecision(ROOT_USER, false);
+    }
+
+    @Test
+    public void testFullGroupPathMatchesNestedGroup() {
+        setFullPathMapper(true);
+        configureGroupPolicy(NESTED_GROUP_PATH);
+
+        assertDecision(NESTED_USER, true);
+        assertDecision(ROOT_USER, false);
+    }
+
+    @Test
+    public void testPathLikeTopLevelGroupNameDoesNotMatchNestedGroup() {
+        GroupRepresentation group = GroupBuilder.create().name(NESTED_GROUP_PATH).build();
+        String groupId;
+
+        try (Response response = realm.admin().groups().add(group)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+            groupId = ApiUtil.getCreatedId(response);
+        }
+
+        UserRepresentation user = AdminApiUtil.findUserByUsername(realm.admin(), PATH_LIKE_USER);
+        realm.admin().users().get(user.getId()).joinGroup(groupId);
+        configureGroupPolicy(NESTED_GROUP_PATH);
+
+        assertDecision(PATH_LIKE_USER, false);
+    }
+
+    private void configureGroupPolicy(String groupPath) {
+        GroupPolicyRepresentation policy = new GroupPolicyRepresentation();
+        policy.setName(POLICY);
+        policy.setGroupsClaim("groups");
+        policy.addGroupPath(groupPath, false);
+
+        try (Response response = resourceServer.admin().authorization().policies().group().create(policy)) {
+            assertEquals(Status.CREATED.getStatusCode(), response.getStatus());
+        }
+
+        policy = resourceServer.admin().authorization().policies().group().findByName(POLICY);
+        assertNotNull(policy);
+
+        Authz.create(resourceServer, ResourceRepresentation.create()
+                .name(RESOURCE)
+                .build());
+        Authz.create(resourceServer, ResourcePermissionRepresentation.create()
+                .name("resource-permission")
+                .resources(Set.of(RESOURCE))
+                .policies(Set.of(policy.getId()))
+                .build());
+    }
+
+    private void assertDecision(String username, boolean granted) {
+        AccessTokenResponse tokenResponse = oauth.client(resourceServer.getClientId(), resourceServer.getSecret())
+                .doPasswordGrantRequest(username, PASSWORD);
+        assertNotNull(tokenResponse.getIdToken());
+
+        AccessTokenResponse authorizationResponse = oauth.client(resourceServer.getClientId(), resourceServer.getSecret())
+                .permissionGrantRequest()
+                .claimToken(tokenResponse.getIdToken())
+                .send();
+
+        assertEquals(granted, authorizationResponse.getAccessToken() != null,
+                () -> "Unexpected authorization decision: " + authorizationResponse.getErrorDescription());
+    }
+
+    private void setFullPathMapper(boolean fullPath) {
+        ProtocolMapperRepresentation mapper = resourceServer.admin().getProtocolMappers().getMappers().stream()
+                .filter(candidate -> "groups".equals(candidate.getName()))
+                .findFirst()
+                .orElseThrow();
+        mapper.getConfig().put("full.path", Boolean.toString(fullPath));
+        resourceServer.admin().getProtocolMappers().update(mapper.getId(), mapper);
+    }
+
+    public static class GroupPolicyRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm
+                    .groups(GroupBuilder.create("Group A")
+                            .subGroups(GroupBuilder.create("Group B").subGroups("Group E")))
+                    .groups(GroupBuilder.create("Group E"))
+                    .users(UserBuilder.create(NESTED_USER)
+                            .name("Nested", "User")
+                            .email("nested-user@localhost")
+                            .password(PASSWORD)
+                            .enabled(true)
+                            .groups("Group A/Group B/Group E"))
+                    .users(UserBuilder.create(ROOT_USER)
+                            .name("Root", "User")
+                            .email("root-user@localhost")
+                            .password(PASSWORD)
+                            .enabled(true)
+                            .groups("Group E"))
+                    .users(UserBuilder.create(PATH_LIKE_USER)
+                            .name("Path-like", "User")
+                            .email("path-like-user@localhost")
+                            .password(PASSWORD)
+                            .enabled(true));
+        }
+    }
+
+    public static class ResourceServerConfig implements ClientConfig {
+
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                    .secret("secret")
+                    .authorizationServicesEnabled(true)
+                    .directAccessGrantsEnabled(true)
+                    .protocolMappers(createGroupMapper());
+        }
+
+        private ProtocolMapperRepresentation createGroupMapper() {
+            ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+            mapper.setName("groups");
+            mapper.setProtocolMapper(GroupMembershipMapper.PROVIDER_ID);
+            mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+
+            Map<String, String> config = new HashMap<>();
+            config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "groups");
+            config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
+            config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
+            config.put("full.path", "false");
+            mapper.setConfig(config);
+            return mapper;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupNamePolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupNamePolicyTest.java
@@ -45,6 +45,7 @@ import org.keycloak.testframework.realm.GroupBuilder;
 import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,6 +68,7 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
         config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "groups");
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
+        config.put("full.path", "false");
         groupProtocolMapper.setConfig(config);
 
         testRealms.add(RealmBuilder.create().name("authz-test")
@@ -114,6 +116,11 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
         realm.users().get(user.getId()).joinGroup(group.getId());
     }
 
+    @After
+    public void resetFullPathMapper() {
+        setFullPathMapper(false);
+    }
+
     @Test
     public void testExactNameMatch() {
         AuthzClient authzClient = getAuthzClient();
@@ -143,29 +150,47 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
         } catch (AuthorizationDeniedException ignore) {
 
         }
+
+        RealmResource realm = getRealm();
+        UserRepresentation serviceAccount = getClient().getServiceAccountUser();
+        GroupRepresentation rootGroup = realm.groups().groups().stream()
+                .filter(group -> "Group A".equals(group.getName()))
+                .findFirst()
+                .orElseThrow();
+        realm.users().get(serviceAccount.getId()).joinGroup(rootGroup.getId());
+        ticket = authzClient.protection().permission().create(request).getTicket();
+        response = authzClient.authorization(authzClient.obtainAccessToken().getToken()).authorize(new AuthorizationRequest(ticket));
+        assertNotNull(response.getToken());
     }
 
     @Test
-    public void testOnlyChildrenPolicy() throws Exception {
-        RealmResource realm = getRealm();
+    public void testOnlyChildrenPolicy() {
+        setFullPathMapper(true);
+        assertGroupPolicyDecision("Resource B", "alice", true);
+        assertGroupPolicyDecision("Resource C", "kolo", true);
+    }
+
+    @Test
+    public void testOnlyChildrenPolicyWithFullGroupPath() {
+        setFullPathMapper(true);
+
         AuthzClient authzClient = getAuthzClient();
         PermissionRequest request = new PermissionRequest("Resource B");
         String ticket = authzClient.protection().permission().create(request).getTicket();
 
         try {
             authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
-            fail("Should fail because user is not granted with expected group");
+            fail("Should fail because user is not a direct member of the expected group");
         } catch (AuthorizationDeniedException ignore) {
 
         }
 
         AuthorizationResponse response = authzClient.authorization("alice", "password").authorize(new AuthorizationRequest(ticket));
-
         assertNotNull(response.getToken());
 
         try {
             authzClient.authorization("marta", "password").authorize(new AuthorizationRequest(ticket));
-            fail("Should fail because user is not granted with expected role");
+            fail("Should fail because user is not a member of the expected group");
         } catch (AuthorizationDeniedException ignore) {
 
         }
@@ -174,6 +199,44 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
         ticket = authzClient.protection().permission().create(request).getTicket();
         response = authzClient.authorization("kolo", "password").authorize(new AuthorizationRequest(ticket));
         assertNotNull(response.getToken());
+    }
+
+    @Test
+    public void testExactNameMatchWithFullGroupPath() {
+        setFullPathMapper(true);
+        assertGroupPolicyDecision("Resource A", "marta", true);
+        assertGroupPolicyDecision("Resource A", "kolo", true);
+        assertGroupPolicyDecision("Resource A", "alice", true);
+    }
+
+    private void assertGroupPolicyDecision(String resource, String username, boolean granted) {
+        AuthzClient authzClient = getAuthzClient();
+        PermissionRequest request = new PermissionRequest(resource);
+        String ticket = authzClient.protection().permission().create(request).getTicket();
+
+        try {
+            AuthorizationResponse response = authzClient.authorization(username, "password").authorize(new AuthorizationRequest(ticket));
+
+            if (!granted) {
+                fail("Should fail because user is not a member of the group configured by the policy");
+            }
+
+            assertNotNull(response.getToken());
+        } catch (AuthorizationDeniedException cause) {
+            if (granted) {
+                fail("Should grant access to a member of the group configured by the policy", cause);
+            }
+        }
+    }
+
+    private void setFullPathMapper(boolean fullPath) {
+        ClientResource client = getClient();
+        ProtocolMapperRepresentation mapper = client.getProtocolMappers().getMappers().stream()
+                .filter(m -> "groups".equals(m.getName()))
+                .findFirst()
+                .orElseThrow();
+        mapper.getConfig().put("full.path", String.valueOf(fullPath));
+        client.getProtocolMappers().update(mapper.getId(), mapper);
     }
 
     private void createGroupPolicy(String name, String groupPath, boolean extendChildren) {


### PR DESCRIPTION
- validate group claims against the subject's actual realm memberships
- reject homonymous groups from different paths while preserving name-only group mappers
- add regression coverage for duplicate names, path-shaped names, and service accounts

Closes #51865