### PR TITLE
Fix resource paths in generated provider JARs on Windows

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/MavenProjectUtil.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/MavenProjectUtil.java
@@ -96,7 +96,7 @@ public final class MavenProjectUtil {
                             providerJar.addClass(fullyQualifiedClassName);
                         } else {
                             File resourceFile = p.toFile();
-                            providerJar.addAsResource(resourceFile, relativeFilePath);
+                            providerJar.addAsResource(resourceFile, relativeFilePath.replace(File.separatorChar, '/'));
                         }
                     });
         } catch (IOException e) {

--- a/test-framework/core/src/test/java/org/keycloak/testframework/util/MavenProjectUtilTest.java
+++ b/test-framework/core/src/test/java/org/keycloak/testframework/util/MavenProjectUtilTest.java
@@ -1,0 +1,31 @@
+package org.keycloak.testframework.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipFile;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MavenProjectUtilTest {
+
+    private static final String SERVICE_ENTRY = "META-INF/services/org.keycloak.storage.UserStorageProviderFactory";
+
+    @Test
+    public void buildJarNormalizesResourceEntryPathSeparators(@TempDir Path tempDir) throws IOException {
+        Path classesPath = Files.createDirectory(tempDir.resolve("classes"));
+
+        Path serviceFile = classesPath.resolve(SERVICE_ENTRY);
+        Files.createDirectories(serviceFile.getParent());
+        Files.writeString(serviceFile, "com.example.TestUserStorageProviderFactory");
+
+        Path jarPath = tempDir.resolve("provider.jar");
+        MavenProjectUtil.buildJar("provider.jar", classesPath, jarPath);
+
+        try (ZipFile zipFile = new ZipFile(jarPath.toFile())) {
+            Assertions.assertNotNull(zipFile.getEntry(SERVICE_ENTRY));
+        }
+    }
+}


### PR DESCRIPTION
Closes #49602

## Summary

`MavenProjectUtil.buildJar` used the platform-dependent string returned by `classesPath.relativize(p).toString()` directly as the resource entry name.

On Windows, this produced JAR entries such as:

```text
META-INF\services\org.keycloak.storage.UserStorageProviderFactory
```

These entries cannot be discovered as standard `META-INF/services` descriptors.

This change:

- normalizes resource entry separators to `/` before adding them to the JAR;
- adds a regression test that verifies the resulting JAR contains the standard service entry.

## Testing

- `.\mvnw.cmd -pl test-framework/core -am -Dtest=MavenProjectUtilTest "-Dskip.pnpm=true" "-Dskip.installnodepnpm=true" package`
  - All 60 reactor modules succeeded.
  - `MavenProjectUtilTest`: 1 test passed.
- `.\mvnw.cmd -pl test-framework/core spotless:check`
- `git diff --check`

## AI assistance

OpenAI Codex was used to assist with investigating the issue and regression testing. I wrote the code and verified the fix.