### PR TITLE
(26.7) Full-scope-disabled client policy validation can be bypassed by omitting fullScopeAllowed

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/FullScopeDisabledExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/FullScopeDisabledExecutor.java
@@ -19,6 +19,7 @@
 package org.keycloak.services.clientpolicy.executor;
 
 import org.keycloak.events.Errors;
+import org.keycloak.models.ClientModel;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
@@ -40,10 +41,14 @@ public class FullScopeDisabledExecutor implements ClientPolicyExecutorProvider<F
     public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
         switch (context.getEvent()) {
             case REGISTER:
+                ClientCRUDContext clientRegisterContext = (ClientCRUDContext) context;
+                autoConfigure(clientRegisterContext.getProposedClientRepresentation());
+                validate(clientRegisterContext.getProposedClientRepresentation());
+                break;
             case UPDATE:
-                ClientCRUDContext clientUpdateContext = (ClientCRUDContext)context;
+                ClientCRUDContext clientUpdateContext = (ClientCRUDContext) context;
                 autoConfigure(clientUpdateContext.getProposedClientRepresentation());
-                validate(clientUpdateContext.getProposedClientRepresentation());
+                beforeUpdate(clientUpdateContext.getTargetClient(), clientUpdateContext.getProposedClientRepresentation());
                 break;
             default:
                 return;
@@ -85,8 +90,20 @@ public class FullScopeDisabledExecutor implements ClientPolicyExecutorProvider<F
     }
 
     private void validate(ClientRepresentation proposedClient) throws ClientPolicyException {
-        if (proposedClient.isFullScopeAllowed() != null && proposedClient.isFullScopeAllowed()) {
+        // null means fullScopeAllowed is not explicitly set; the server default is true, so treat null as true
+        if (proposedClient.isFullScopeAllowed() == null || proposedClient.isFullScopeAllowed()) {
             throw new ClientPolicyException(Errors.INVALID_REGISTRATION, "Not permitted to enable fullScopeAllowed");
         }
+    }
+
+    private void beforeUpdate(ClientModel existingClient, ClientRepresentation proposedClient) throws ClientPolicyException {
+        if (existingClient == null) {
+            return;
+        }
+        // fullScopeAllowed is not being updated in the representation, but existing client already has it disabled
+        if (proposedClient.isFullScopeAllowed() == null && !existingClient.isFullScopeAllowed()) {
+            return;
+        }
+        validate(proposedClient);
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientPoliciesClientCRUDTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientPoliciesClientCRUDTest.java
@@ -6,10 +6,12 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientProtocolCondition;
 import org.keycloak.services.clientpolicy.condition.ClientProtocolConditionFactory;
+import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory;
 import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutor;
 import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutorFactory;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -18,8 +20,10 @@ import org.keycloak.testframework.realm.ManagedRealm;
 
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.tests.utils.ClientPoliciesUtil.createAnyClientConditionConfig;
 import static org.keycloak.tests.utils.ClientPoliciesUtil.createClientAccessTypeConditionConfig;
 import static org.keycloak.tests.utils.ClientPoliciesUtil.createClientProtocolConditionConfig;
+import static org.keycloak.tests.utils.ClientPoliciesUtil.createFullScopeDisabledExecutorConfig;
 import static org.keycloak.tests.utils.ClientPoliciesUtil.createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -87,7 +91,7 @@ public class ClientPoliciesClientCRUDTest extends AbstractClientPoliciesTest {
         // Try to create OIDC client without directGrants - should be success
         createClientByAdmin(realm, "example-client-oidc", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {});
     }
-
+    
     @Test
     public void testClientAccessTypeConditionClientCRUD() throws Exception {
         // Setup policy: condition = confidential client access type, executor = reject resource owner password credentials grant
@@ -148,5 +152,59 @@ public class ClientPoliciesClientCRUDTest extends AbstractClientPoliciesTest {
         // Verify client is now confidential
         foundRep = realm.admin().clients().get(publicClientUUID).toRepresentation();
         assertFalse(foundRep.isPublicClient());
+    }
+
+    @Test
+    public void testFullScopeDisabledExecutorClientCRUD() throws Exception {
+        // Setup policy: any client condition + FullScopeDisabled executor (validate mode, not auto-configure)
+        setupPolicy(realm, FullScopeDisabledExecutorFactory.PROVIDER_ID, createFullScopeDisabledExecutorConfig(Boolean.FALSE),
+                AnyClientConditionFactory.PROVIDER_ID, createAnyClientConditionConfig());
+
+        // Register client without setting fullScopeAllowed (null → defaults to true). Should fail (bug #51382).
+        try {
+            createClientByAdmin(realm, "client-null-full-scope", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+                clientRep.setFullScopeAllowed(null);
+            });
+            fail("Registration should have failed because fullScopeAllowed defaults to true");
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Not permitted to enable fullScopeAllowed", cpe.getErrorDetail());
+        }
+
+        // Register client with fullScopeAllowed=true. Should also fail.
+        try {
+            createClientByAdmin(realm, "client-full-scope-true", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+                clientRep.setFullScopeAllowed(Boolean.TRUE);
+            });
+            fail("Registration should have failed because fullScopeAllowed is explicitly true");
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Not permitted to enable fullScopeAllowed", cpe.getErrorDetail());
+        }
+
+        // Register client with fullScopeAllowed=false. Should succeed.
+        String clientUUID = createClientByAdmin(realm, "client-full-scope-false", OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep -> {
+            clientRep.setFullScopeAllowed(Boolean.FALSE);
+        });
+        ClientRepresentation foundRep = realm.admin().clients().get(clientUUID).toRepresentation();
+        assertFalse(foundRep.isFullScopeAllowed());
+
+        // Update the client without touching fullScopeAllowed (null in the update rep). Should succeed
+        // because the existing client already has fullScopeAllowed=false.
+        updateClientByAdmin(realm, clientUUID, clientRep -> {
+            clientRep.setFullScopeAllowed(null);
+        });
+
+        // Update the client and explicitly set fullScopeAllowed=true. Should fail.
+        try {
+            updateClientByAdmin(realm, clientUUID, clientRep -> {
+                clientRep.setFullScopeAllowed(Boolean.TRUE);
+            });
+            fail("Update should have failed because fullScopeAllowed is being set to true");
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Not permitted to enable fullScopeAllowed", cpe.getErrorDetail());
+        }
+
+        // Verify fullScopeAllowed is still false on the client (update was rolled back)
+        foundRep = realm.admin().clients().get(clientUUID).toRepresentation();
+        assertFalse(foundRep.isFullScopeAllowed());
     }
 }


### PR DESCRIPTION
closes #51382


Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 10ffa4a188bc56b5cb03fbed5d14701d9fc1572c)
