### PR TITLE
Avoid aurora_version() probe on standard PostgreSQL

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
@@ -138,7 +138,8 @@ public class AsyncCommitIntegrator implements PreInsertEventListener, PreUpdateE
      * {@code SET LOCAL synchronous_commit TO OFF} can cause committed transactions to
      * never appear (or appear with extreme delay) in logical decoding consumers like Debezium.
      * <p>
-     * Detection: {@code SELECT aurora_version()} only exists on Aurora (throws on standard PG);
+     * Detection: {@code to_regproc('pg_catalog.aurora_version')} is non-null only on Aurora
+     * (standard PostgreSQL returns null without logging ERROR);
      * {@code SHOW wal_level = 'logical'} indicates a CDC consumer may be reading the WAL.
      * Fails safe (returns {@code true}) on unexpected errors to avoid silent CDC data loss.
      *
@@ -149,12 +150,7 @@ public class AsyncCommitIntegrator implements PreInsertEventListener, PreUpdateE
             JdbcConnectionAccess bootstrapJdbcConnectionAccess = sf.getJdbcServices().getBootstrapJdbcConnectionAccess();
             Connection connection = bootstrapJdbcConnectionAccess.obtainConnection();
             try {
-                try (Statement stmt = connection.createStatement();
-                     ResultSet rs = stmt.executeQuery("SELECT aurora_version()")) {
-                    if (!rs.next()) {
-                        return false;
-                    }
-                } catch (SQLException e) {
+                if (!auroraVersionFunctionExists(connection)) {
                     return false;
                 }
 
@@ -168,6 +164,18 @@ public class AsyncCommitIntegrator implements PreInsertEventListener, PreUpdateE
         } catch (SQLException e) {
             logger.warn("Failed to detect Aurora/logical replication status; disabling asynchronous commit optimization", e);
             return true;
+        }
+    }
+
+    /**
+     * Returns whether the Aurora-only {@code aurora_version()} function exists.
+     * Uses {@code to_regproc} so standard PostgreSQL does not log
+     * {@code ERROR: function aurora_version() does not exist}.
+     */
+    static boolean auroraVersionFunctionExists(Connection connection) throws SQLException {
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT to_regproc('pg_catalog.aurora_version') IS NOT NULL")) {
+            return rs.next() && rs.getBoolean(1);
         }
     }
 


### PR DESCRIPTION
Query to_regproc('...') so Aurora detection does not write ERROR to the PostgreSQL server log on every startup.

Closes #51792

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
