### PR TITLE
Fix for #51328 Client-type bypass for fullScopeAllowed, nodeReRegistrationTimeout, and authorizationServicesEnabled

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -559,7 +559,21 @@ public class RepresentationToModel {
             add(updatePropertyAction(client::setProtocol, rep::getProtocol, client::getProtocol, () -> DEFAULT_PROTOCOL));
             add(updatePropertyAction(client::setNodeReRegistrationTimeout, rep::getNodeReRegistrationTimeout, () -> defaultNodeReRegistrationTimeout(client, isNew)));
             add(updatePropertyAction(client::setClientAuthenticatorType, rep::getClientAuthenticatorType, client::getClientAuthenticatorType, KeycloakModelUtils::getDefaultClientAuthenticatorType));
-            add(updatePropertyAction(client::setFullScopeAllowed, rep::isFullScopeAllowed, () -> defaultFullScopeAllowed(client, isNew)));
+            if (rep.isFullScopeAllowed() != null) {
+                add(updatePropertyAction(client::setFullScopeAllowed, rep::isFullScopeAllowed));
+            } else {
+                add(() -> {
+                    Boolean fullScopeDefault = defaultFullScopeAllowed(client, isNew);
+                    if (fullScopeDefault != null) {
+                        try {
+                            client.setFullScopeAllowed(fullScopeDefault);
+                        } catch (ClientTypeException e) {
+                            logger.debugf("Default fullScopeAllowed conflicts with client type constraint for client '%s' — preserving typed value", client.getClientId());
+                        }
+                    }
+                    return null;
+                });
+            }
             // Client Secret
             add(updatePropertyAction(client::setSecret, () -> determineNewSecret(client, rep)));
             // Redirect uris / Web origins

--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -31,6 +31,9 @@ import java.util.stream.Stream;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.client.clienttype.ClientType;
+import org.keycloak.client.clienttype.ClientTypeManager;
+import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
@@ -59,6 +62,8 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.ClientResource;
 import org.keycloak.validation.ValidationUtil;
 
+import org.jboss.logging.Logger;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -67,6 +72,7 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
     protected KeycloakSession session;
     protected EventBuilder event;
     protected ClientRegistrationAuth auth;
+    protected static final Logger logger = Logger.getLogger(AbstractClientRegistrationProvider.class);
 
     public AbstractClientRegistrationProvider(KeycloakSession session) {
         this.session = session;
@@ -102,7 +108,22 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
             }
 
             if (Boolean.TRUE.equals(client.getAuthorizationServicesEnabled())) {
-                RepresentationToModel.createResourceServer(clientModel, session, true);
+                boolean typeBlocksAuthorization = false;
+                if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && clientModel.getType() != null) {
+                    ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, clientModel.getType());
+                    if (!clientType.isApplicable("authorizationServicesEnabled")) {
+                        logger.warnf("Property authorizationServicesEnabled is not-applicable to client type %s and can not be enabled.",
+                                clientType.getName());
+                        typeBlocksAuthorization = true;
+                    } else if (Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
+                        logger.warnf("Property authorizationServicesEnabled is fixed to false by client type %s and can not be enabled.",
+                                clientType.getName());
+                        typeBlocksAuthorization = true;
+                    }
+                }
+                if (!typeBlocksAuthorization) {
+                    RepresentationToModel.createResourceServer(clientModel, session, true);
+                }
             }
 
             session.getContext().setClient(clientModel);

--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -32,6 +32,7 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.client.clienttype.ClientType;
+import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
@@ -62,8 +63,6 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.admin.ClientResource;
 import org.keycloak.validation.ValidationUtil;
 
-import org.jboss.logging.Logger;
-
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -72,7 +71,6 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
     protected KeycloakSession session;
     protected EventBuilder event;
     protected ClientRegistrationAuth auth;
-    protected static final Logger logger = Logger.getLogger(AbstractClientRegistrationProvider.class);
 
     public AbstractClientRegistrationProvider(KeycloakSession session) {
         this.session = session;
@@ -108,22 +106,14 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
             }
 
             if (Boolean.TRUE.equals(client.getAuthorizationServicesEnabled())) {
-                boolean typeBlocksAuthorization = false;
                 if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && clientModel.getType() != null) {
                     ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, clientModel.getType());
-                    if (!clientType.isApplicable("authorizationServicesEnabled")) {
-                        logger.warnf("Property authorizationServicesEnabled is not-applicable to client type %s and can not be enabled.",
-                                clientType.getName());
-                        typeBlocksAuthorization = true;
-                    } else if (Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
-                        logger.warnf("Property authorizationServicesEnabled is fixed to false by client type %s and can not be enabled.",
-                                clientType.getName());
-                        typeBlocksAuthorization = true;
+                    if (!clientType.isApplicable("authorizationServicesEnabled") ||
+                            Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
+                        throw ClientTypeException.Message.CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION.exception("authorizationServicesEnabled");
                     }
                 }
-                if (!typeBlocksAuthorization) {
-                    RepresentationToModel.createResourceServer(clientModel, session, true);
-                }
+                RepresentationToModel.createResourceServer(clientModel, session, true);
             }
 
             session.getContext().setClient(clientModel);
@@ -159,6 +149,8 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
             event.error(cpe.getError());
             throw new ErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+        } catch (ClientTypeException cte) {
+            throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, cte.getMessage(), Response.Status.BAD_REQUEST);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -282,7 +282,7 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
     }
 
     @Override
-    public void setNodeReRegistrationTimeout(int nodeReRegistrationTimeout){
+    public void setNodeReRegistrationTimeout(int nodeReRegistrationTimeout) {
         TypedClientSimpleAttribute.NODE_RE_REGISTRATION_TIMEOUT
                 .setClientAttribute(clientType, nodeReRegistrationTimeout, super::setNodeReRegistrationTimeout, Integer.class);
     }

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypeAwareClientModelDelegate.java
@@ -262,4 +262,28 @@ public class TypeAwareClientModelDelegate extends ClientModelLazyDelegate {
 
         return attributes;
     }
+
+    @Override
+    public boolean isFullScopeAllowed() {
+        return TypedClientSimpleAttribute.FULL_SCOPE_ALLOWED
+                .getClientAttribute(clientType, super::isFullScopeAllowed, Boolean.class);
+    }
+
+    @Override
+    public void setFullScopeAllowed(boolean fullScopeAllowed) {
+        TypedClientSimpleAttribute.FULL_SCOPE_ALLOWED
+                .setClientAttribute(clientType, fullScopeAllowed, super::setFullScopeAllowed, Boolean.class);
+    }
+
+    @Override
+    public int getNodeReRegistrationTimeout() {
+        return TypedClientSimpleAttribute.NODE_RE_REGISTRATION_TIMEOUT
+                .getClientAttribute(clientType, super::getNodeReRegistrationTimeout, Integer.class);
+    }
+
+    @Override
+    public void setNodeReRegistrationTimeout(int nodeReRegistrationTimeout){
+        TypedClientSimpleAttribute.NODE_RE_REGISTRATION_TIMEOUT
+                .setClientAttribute(clientType, nodeReRegistrationTimeout, super::setNodeReRegistrationTimeout, Integer.class);
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/client/TypedClientAttribute.java
@@ -27,6 +27,8 @@ enum TypedClientSimpleAttribute implements TypedClientAttribute {
     REDIRECT_URIS("redirectUris", Set.of()),
     SERVICE_ACCOUNTS_ENABLED("serviceAccountsEnabled", false),
     WEB_ORIGINS("webOrigins", Set.of()),
+    FULL_SCOPE_ALLOWED("fullScopeAllowed", false),
+    NODE_RE_REGISTRATION_TIMEOUT("nodeReRegistrationTimeout", -1)
     ;
 
     private final String propertyName;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -895,18 +895,12 @@ public class ClientResource {
             if (Boolean.TRUE.equals(rep.getAuthorizationServicesEnabled())) {
                 if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && client.getType() != null) {
                     ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, client.getType());
-                    if (!clientType.isApplicable("authorizationServicesEnabled")) {
-                        logger.warnf("Property authorizationServicesEnabled is not-applicable to client type %s and can not be enabled.",
-                                clientType.getName());
-                    } else if (Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
-                        logger.warnf("Property authorizationServicesEnabled is fixed to false by client type %s and can not be enabled.",
-                                clientType.getName());
-                    } else {
-                        authorization().enable(false);
+                    if (!clientType.isApplicable("authorizationServicesEnabled") ||
+                            Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
+                        throw ClientTypeException.Message.CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION.exception("authorizationServicesEnabled");
                     }
-                } else {
-                    authorization().enable(false);
                 }
+                authorization().enable(false);
             } else {
                 authorization().disable();
             }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -40,7 +40,9 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authorization.admin.AuthorizationService;
+import org.keycloak.client.clienttype.ClientType;
 import org.keycloak.client.clienttype.ClientTypeException;
+import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
@@ -891,7 +893,20 @@ public class ClientResource {
     private void updateAuthorizationSettings(ClientRepresentation rep) {
         if (Profile.isFeatureEnabled(Profile.Feature.AUTHORIZATION)) {
             if (Boolean.TRUE.equals(rep.getAuthorizationServicesEnabled())) {
-                authorization().enable(false);
+                if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && client.getType() != null) {
+                    ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, client.getType());
+                    if (!clientType.isApplicable("authorizationServicesEnabled")) {
+                        logger.warnf("Property authorizationServicesEnabled is not-applicable to client type %s and can not be enabled.",
+                                clientType.getName());
+                    } else if (Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
+                        logger.warnf("Property authorizationServicesEnabled is fixed to false by client type %s and can not be enabled.",
+                                clientType.getName());
+                    } else {
+                        authorization().enable(false);
+                    }
+                } else {
+                    authorization().enable(false);
+                }
             } else {
                 authorization().disable();
             }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -34,7 +34,9 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.authorization.admin.AuthorizationService;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.client.clienttype.ClientType;
 import org.keycloak.client.clienttype.ClientTypeException;
+import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.Profile;
 import org.keycloak.events.Errors;
 import org.keycloak.events.admin.OperationType;
@@ -222,14 +224,29 @@ public class ClientsResource {
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), clientModel.getId()).representation(rep).success();
 
             if (Profile.isFeatureEnabled(Profile.Feature.AUTHORIZATION) && TRUE.equals(rep.getAuthorizationServicesEnabled())) {
-                AuthorizationService authorizationService = getAuthorizationService(clientModel);
+                boolean typeBlocksAuthorization = false;
+                if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && clientModel.getType() != null) {
+                    ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, clientModel.getType());
+                    if (!clientType.isApplicable("authorizationServicesEnabled")) {
+                        logger.warnf("Property authorizationServicesEnabled is not-applicable to client type %s and can not be enabled.",
+                                clientType.getName());
+                        typeBlocksAuthorization = true;
+                    } else if (Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
+                        logger.warnf("Property authorizationServicesEnabled is fixed to false by client type %s and can not be enabled.",
+                                clientType.getName());
+                        typeBlocksAuthorization = true;
+                    }
+                }
+                if (!typeBlocksAuthorization) {
+                    AuthorizationService authorizationService = getAuthorizationService(clientModel);
 
-                authorizationService.enable(true);
+                    authorizationService.enable(true);
 
-                ResourceServerRepresentation authorizationSettings = rep.getAuthorizationSettings();
+                    ResourceServerRepresentation authorizationSettings = rep.getAuthorizationSettings();
 
-                if (authorizationSettings != null) {
-                    authorizationService.getResourceServerService().importSettings(authorizationSettings);
+                    if (authorizationSettings != null) {
+                        authorizationService.getResourceServerService().importSettings(authorizationSettings);
+                    }
                 }
             }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -224,29 +224,22 @@ public class ClientsResource {
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), clientModel.getId()).representation(rep).success();
 
             if (Profile.isFeatureEnabled(Profile.Feature.AUTHORIZATION) && TRUE.equals(rep.getAuthorizationServicesEnabled())) {
-                boolean typeBlocksAuthorization = false;
                 if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && clientModel.getType() != null) {
                     ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, clientModel.getType());
-                    if (!clientType.isApplicable("authorizationServicesEnabled")) {
-                        logger.warnf("Property authorizationServicesEnabled is not-applicable to client type %s and can not be enabled.",
-                                clientType.getName());
-                        typeBlocksAuthorization = true;
-                    } else if (Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
-                        logger.warnf("Property authorizationServicesEnabled is fixed to false by client type %s and can not be enabled.",
-                                clientType.getName());
-                        typeBlocksAuthorization = true;
+                    if (!clientType.isApplicable("authorizationServicesEnabled") ||
+                            Boolean.FALSE.equals(clientType.getTypeValue("authorizationServicesEnabled", Boolean.class))) {
+                        throw ClientTypeException.Message.CLIENT_UPDATE_FAILED_CLIENT_TYPE_VALIDATION.exception("authorizationServicesEnabled");
                     }
                 }
-                if (!typeBlocksAuthorization) {
-                    AuthorizationService authorizationService = getAuthorizationService(clientModel);
 
-                    authorizationService.enable(true);
+                AuthorizationService authorizationService = getAuthorizationService(clientModel);
 
-                    ResourceServerRepresentation authorizationSettings = rep.getAuthorizationSettings();
+                authorizationService.enable(true);
 
-                    if (authorizationSettings != null) {
-                        authorizationService.getResourceServerService().importSettings(authorizationSettings);
-                    }
+                ResourceServerRepresentation authorizationSettings = rep.getAuthorizationSettings();
+
+                if (authorizationSettings != null) {
+                    authorizationService.getResourceServerService().importSettings(authorizationSettings);
                 }
             }
 

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientTypesFeatureDisabledTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientTypesFeatureDisabledTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.keycloak.tests.client;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KeycloakIntegrationTest
+public class ClientTypesFeatureDisabledTest {
+
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @Test
+    public void testFeatureDoesntWorkWhenDisabled() {
+        assertThrows(Exception.class, () -> managedRealm.admin().clientTypes().getClientTypes());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientTypesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientTypesTest.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.keycloak.testsuite.client;
+package org.keycloak.tests.client;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,25 +29,24 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.client.clienttype.ClientTypeManager;
+import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientTypeRepresentation;
 import org.keycloak.representations.idm.ClientTypesRepresentation;
 import org.keycloak.representations.idm.ErrorRepresentation;
-import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.services.clienttype.impl.DefaultClientTypeProviderFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ClientBuilder;
-import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
-import org.keycloak.testsuite.admin.ApiUtil;
-import org.keycloak.testsuite.arquillian.annotation.DisableFeature;
-import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
-import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.util.ApiUtil;
 
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-
-import static org.keycloak.common.Profile.Feature.CLIENT_TYPES;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.everyItem;
@@ -57,31 +56,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/**
- * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
- */
-@EnableFeature(value = CLIENT_TYPES, skipRestart = true)
-public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
+@KeycloakIntegrationTest(config = ClientTypesTest.ClientTypesServerConfig.class)
+public class ClientTypesTest {
 
-    @Override
-    public void configureTestRealm(RealmRepresentation testRealm) {
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @BeforeEach
+    public void cleanupRealmClientTypes() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+        if (!clientTypes.getRealmClientTypes().isEmpty()) {
+            clientTypes.setRealmClientTypes(new ArrayList<>());
+            managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+        }
     }
 
     @Test
     public void testFeatureWorksWhenEnabled() {
-        checkIfFeatureWorks(true);
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+        assertTrue(clientTypes.getRealmClientTypes().isEmpty());
     }
 
-    @Test
-    @UncaughtServerErrorExpected
-    @DisableFeature(value = CLIENT_TYPES, skipRestart = true)
-    public void testFeatureDoesntWorkWhenDisabled() {
-        checkIfFeatureWorks(false);
-    }
-
-    // Test create client with clientType filled. Check default properties are filled
     @Test
     public void testCreateClientWithClientType() {
         ClientRepresentation clientRep = createClientWithType("foo", ClientTypeManager.SERVICE_ACCOUNT);
@@ -91,11 +89,10 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertFalse(clientRep.isStandardFlowEnabled());
         assertFalse(clientRep.isImplicitFlowEnabled());
         assertFalse(clientRep.isDirectAccessGrantsEnabled());
-        Assertions.assertTrue(clientRep.isServiceAccountsEnabled());
+        assertTrue(clientRep.isServiceAccountsEnabled());
         assertFalse(clientRep.isPublicClient());
         assertFalse(clientRep.isBearerOnly());
 
-        // Check type not included as client attribute
         assertFalse(clientRep.getAttributes().containsKey(ClientModel.TYPE));
     }
 
@@ -106,41 +103,38 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
                 .type("DNE")
                 .build();
 
-        Response response = managedRealm.admin().clients().create(clientRep);
-        assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
+        try(Response response = managedRealm.admin().clients().create(clientRep)) {
+            assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
+        }
     }
 
     @Test
     public void testUpdateClientWithClientType() {
-        ClientRepresentation clientRep = createClientWithType("foo", ClientTypeManager.SERVICE_ACCOUNT);
+        ClientRepresentation clientRep = createClientWithType("foo-update", ClientTypeManager.SERVICE_ACCOUNT);
 
-        // Changing type should fail
         clientRep.setType(ClientTypeManager.STANDARD);
         try {
             managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
-            Assertions.fail("Not expected to update client");
+            fail("Not expected to update client");
         } catch (BadRequestException bre) {
             assertErrorContainsMessage(bre, ClientTypeException.Message.CANNOT_CHANGE_CLIENT_TYPE);
         }
 
-        // Updating read-only attribute should fail
         clientRep.setType(ClientTypeManager.SERVICE_ACCOUNT);
         clientRep.setServiceAccountsEnabled(false);
         try {
             managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
-            Assertions.fail("Not expected to update client");
+            fail("Not expected to update client");
         } catch (BadRequestException bre) {
             assertErrorResponseContainsParams(bre.getResponse(), "serviceAccountsEnabled");
         }
 
         clientRep.setServiceAccountsEnabled(true);
 
-        // Adding non-applicable attribute should not fail but not update client attribute
         clientRep.getAttributes().put(ClientModel.LOGO_URI, "https://foo");
         managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
         assertNull(managedRealm.admin().clients().get(clientRep.getId()).toRepresentation().getAttributes().get(ClientModel.LOGO_URI));
 
-        // Update of supported attribute should be successful
         clientRep.getAttributes().remove(ClientModel.LOGO_URI);
         clientRep.setRootUrl("https://foo");
         managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
@@ -175,7 +169,7 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertEquals("default", serviceAccountType.getProvider());
 
         ClientTypeRepresentation.PropertyConfig cfg = serviceAccountType.getConfig().get("standardFlowEnabled");
-        assertPropertyConfig("standardFlowEnabled", cfg,  false, null);
+        assertPropertyConfig("standardFlowEnabled", cfg, false, null);
 
         cfg = serviceAccountType.getConfig().get("serviceAccountsEnabled");
         assertPropertyConfig("serviceAccountsEnabled", cfg, true, true);
@@ -188,7 +182,6 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
     public void testClientTypesAdminRestAPI_realmTypes() {
         ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
 
-        // Test invalid provider type should fail
         ClientTypeRepresentation clientType = new ClientTypeRepresentation();
         try {
             clientType.setName("sla1");
@@ -196,39 +189,35 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
             clientType.setConfig(new HashMap<>());
             clientTypes.setRealmClientTypes(List.of(clientType));
             managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
-            Assertions.fail("Not expected to update client types");
+            fail("Not expected to update client types");
         } catch (BadRequestException bre) {
             assertErrorContainsMessage(bre, ClientTypeException.Message.INVALID_CLIENT_TYPE_PROVIDER);
         }
 
-        // Test attribute without applicable should fail
         try {
             clientType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
             ClientTypeRepresentation.PropertyConfig cfg = new ClientTypeRepresentation.PropertyConfig();
             clientType.getConfig().put("standardFlowEnabled", cfg);
             managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
-            Assertions.fail("Not expected to update client types");
+            fail("Not expected to update client types");
         } catch (BadRequestException bre) {
             assertErrorContainsMessage(bre, ClientTypeException.Message.CLIENT_TYPE_FIELD_NOT_APPLICABLE);
         }
 
-        // Test non-applicable attribute with default-value should fail
         try {
             ClientTypeRepresentation.PropertyConfig cfg = clientType.getConfig().get("standardFlowEnabled");
             cfg.setApplicable(false);
             cfg.setValue(true);
             managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
-            Assertions.fail("Not expected to update client types");
+            fail("Not expected to update client types");
         } catch (BadRequestException bre) {
             assertErrorContainsMessage(bre, ClientTypeException.Message.INVALID_CLIENT_TYPE_CONFIGURATION);
         }
 
-        // Update should be successful
         ClientTypeRepresentation.PropertyConfig cfg = clientType.getConfig().get("standardFlowEnabled");
         cfg.setApplicable(true);
         managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
 
-        // Test duplicate name should fail
         ClientTypeRepresentation clientType2 = new ClientTypeRepresentation();
         try {
             clientTypes = managedRealm.admin().clientTypes().getClientTypes();
@@ -238,30 +227,26 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
             clientType2.setConfig(new HashMap<>());
             clientTypes.getRealmClientTypes().add(clientType2);
             managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
-            Assertions.fail("Not expected to update client types");
+            fail("Not expected to update client types");
         } catch (BadRequestException bre) {
             assertErrorContainsMessage(bre, ClientTypeException.Message.DUPLICATE_CLIENT_TYPE);
         }
 
-        // Also test duplicated global name should fail
         try {
             clientType2.setName("service-account");
             managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
-            Assertions.fail("Not expected to update client types");
+            fail("Not expected to update client types");
         } catch (BadRequestException bre) {
             assertErrorContainsMessage(bre, ClientTypeException.Message.DUPLICATE_CLIENT_TYPE);
         }
 
-        // Different name should be fine
         clientType2.setName("different");
         managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
 
-        // Assert updated
         clientTypes = managedRealm.admin().clientTypes().getClientTypes();
         assertNames(clientTypes.getRealmClientTypes(), "sla1", "different");
         assertNames(clientTypes.getGlobalClientTypes(), "sla", "service-account");
 
-        // Test updating global won't update anything. Nothing will be added to globalTypes
         clientType2.setName("moreDifferent");
         clientTypes.getGlobalClientTypes().add(clientType2);
         managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
@@ -299,14 +284,15 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
 
         ClientRepresentation childClient = createClientWithType("child-client", childClientType.getName());
-        assertEquals(childClient.getProtocol(), "openid-connect");
-        assertEquals(childClient.isStandardFlowEnabled(), true);
-        assertEquals(childClient.isConsentRequired(), false);
-
         ClientRepresentation subClient = createClientWithType("sub-client", subClientType.getName());
-        assertEquals(subClient.getProtocol(), "openid-connect");
-        assertEquals(subClient.isStandardFlowEnabled(), true);
-        assertEquals(subClient.isConsentRequired(), true);
+
+        assertEquals( "openid-connect", childClient.getProtocol());
+        assertEquals(true, childClient.isStandardFlowEnabled());
+        assertEquals(false, childClient.isConsentRequired());
+
+        assertEquals("openid-connect", subClient.getProtocol());
+        assertEquals(true, subClient.isStandardFlowEnabled());
+        assertEquals(true, subClient.isConsentRequired());
     }
 
     @Test
@@ -329,7 +315,6 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
 
         managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
 
-        // Attempt to create a client with fullScopeAllowed=true on a type that fixes it to false
         ClientRepresentation clientRep = ClientBuilder.create()
                 .clientId("full-scope-override-test")
                 .type("no-full-scope")
@@ -370,6 +355,155 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertErrorResponseContainsParams(response, "nodeReRegistrationTimeout");
     }
 
+    @Test
+    public void testCreateClientSucceedsWithOmittedFullScopeAllowed() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig fullScopeConfig = new ClientTypeRepresentation.PropertyConfig();
+        fullScopeConfig.setApplicable(true);
+        fullScopeConfig.setValue(false);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("no-full-scope-omit");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("fullScopeAllowed", fullScopeConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        ClientRepresentation clientRep = createClientWithType("full-scope-omit-test", "no-full-scope-omit");
+        assertFalse(clientRep.isFullScopeAllowed());
+    }
+
+    @Test
+    public void testUpdateClientFailsWithFullScopeAllowedOverride() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig fullScopeConfig = new ClientTypeRepresentation.PropertyConfig();
+        fullScopeConfig.setApplicable(true);
+        fullScopeConfig.setValue(false);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("no-full-scope-update");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("fullScopeAllowed", fullScopeConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        ClientRepresentation clientRep = createClientWithType("full-scope-update-test", "no-full-scope-update");
+        assertFalse(clientRep.isFullScopeAllowed());
+
+        clientRep.setFullScopeAllowed(true);
+        try {
+            managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
+            fail("Not expected to update client");
+        } catch (BadRequestException bre) {
+            assertErrorResponseContainsParams(bre.getResponse(), "fullScopeAllowed");
+        }
+    }
+
+    @Test
+    public void testUpdateClientFailsWithNodeReRegistrationTimeoutOverride() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig timeoutConfig = new ClientTypeRepresentation.PropertyConfig();
+        timeoutConfig.setApplicable(true);
+        timeoutConfig.setValue(-1);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("fixed-timeout-update");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("nodeReRegistrationTimeout", timeoutConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        ClientRepresentation clientRep = createClientWithType("timeout-update-test", "fixed-timeout-update");
+        assertEquals(-1, clientRep.getNodeReRegistrationTimeout());
+
+        clientRep.setNodeReRegistrationTimeout(300);
+        try {
+            managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
+            fail("Not expected to update client");
+        } catch (BadRequestException bre) {
+            assertErrorResponseContainsParams(bre.getResponse(), "nodeReRegistrationTimeout");
+        }
+    }
+
+    @Test
+    public void testCreateClientFailsWithAuthorizationServicesEnabledOverride() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig authzConfig = new ClientTypeRepresentation.PropertyConfig();
+        authzConfig.setApplicable(true);
+        authzConfig.setValue(false);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("no-authz");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("authorizationServicesEnabled", authzConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        ClientRepresentation clientRep = ClientBuilder.create()
+                .clientId("authz-override-test")
+                .type("no-authz")
+                .authorizationServicesEnabled(true)
+                .build();
+
+        Response response = managedRealm.admin().clients().create(clientRep);
+        assertErrorResponseContainsParams(response, "authorizationServicesEnabled");
+    }
+
+    @Test
+    public void testUpdateClientFailsWithAuthorizationServicesEnabledOverride() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig authzConfig = new ClientTypeRepresentation.PropertyConfig();
+        authzConfig.setApplicable(true);
+        authzConfig.setValue(false);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("no-authz-update");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("authorizationServicesEnabled", authzConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        ClientRepresentation clientRep = createClientWithType("authz-update-test", "no-authz-update");
+
+        clientRep.setAuthorizationServicesEnabled(true);
+        try {
+            managedRealm.admin().clients().get(clientRep.getId()).update(clientRep);
+            fail("Not expected to update client");
+        } catch (BadRequestException bre) {
+            assertErrorResponseContainsParams(bre.getResponse(), "authorizationServicesEnabled");
+        }
+    }
+
     private void assertErrorResponseContainsParams(Response response, String... items) {
         assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
         ErrorRepresentation errorRepresentation = response.readEntity(ErrorRepresentation.class);
@@ -391,7 +525,6 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertThat(names, hasItems(expectedNames));
     }
 
-
     private void assertPropertyConfig(String propertyName, ClientTypeRepresentation.PropertyConfig cfg, Boolean expectedApplicable, Object expectedValue) {
         assertEquals(expectedApplicable, cfg.getApplicable(), "'applicable' for property " + propertyName + " not equal");
         assertEquals(expectedValue, cfg.getValue(), "'value' for property " + propertyName + " not equal");
@@ -404,24 +537,15 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
                 .build();
         Response response = managedRealm.admin().clients().create(clientRep);
         String clientUUID = ApiUtil.getCreatedId(response);
-        getCleanup().addClientUuid(clientUUID);
+        managedRealm.cleanup().add(r -> r.clients().get(clientUUID).remove());
 
         return managedRealm.admin().clients().get(clientUUID).toRepresentation();
     }
 
-    // Check if the feature really works
-    private void checkIfFeatureWorks(boolean shouldWork) {
-        try {
-            ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
-            Assertions.assertTrue(clientTypes.getRealmClientTypes().isEmpty());
-            if (!shouldWork)
-                fail("Feature is available, but at this moment should be disabled");
-
-        } catch (Exception e) {
-            if (shouldWork) {
-                e.printStackTrace();
-                fail("Feature is not available");
-            }
+    public static class ClientTypesServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.CLIENT_TYPES);
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientTypesTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -87,15 +88,15 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertEquals("foo", clientRep.getClientId());
         assertEquals(ClientTypeManager.SERVICE_ACCOUNT, clientRep.getType());
         assertEquals(OIDCLoginProtocol.LOGIN_PROTOCOL, clientRep.getProtocol());
-        Assertions.assertFalse(clientRep.isStandardFlowEnabled());
-        Assertions.assertFalse(clientRep.isImplicitFlowEnabled());
-        Assertions.assertFalse(clientRep.isDirectAccessGrantsEnabled());
+        assertFalse(clientRep.isStandardFlowEnabled());
+        assertFalse(clientRep.isImplicitFlowEnabled());
+        assertFalse(clientRep.isDirectAccessGrantsEnabled());
         Assertions.assertTrue(clientRep.isServiceAccountsEnabled());
-        Assertions.assertFalse(clientRep.isPublicClient());
-        Assertions.assertFalse(clientRep.isBearerOnly());
+        assertFalse(clientRep.isPublicClient());
+        assertFalse(clientRep.isBearerOnly());
 
         // Check type not included as client attribute
-        Assertions.assertFalse(clientRep.getAttributes().containsKey(ClientModel.TYPE));
+        assertFalse(clientRep.getAttributes().containsKey(ClientModel.TYPE));
     }
 
     @Test
@@ -306,6 +307,67 @@ public class ClientTypesTest extends AbstractTestRealmKeycloakTest {
         assertEquals(subClient.getProtocol(), "openid-connect");
         assertEquals(subClient.isStandardFlowEnabled(), true);
         assertEquals(subClient.isConsentRequired(), true);
+    }
+
+    @Test
+    public void testCreateClientFailsWithFullScopeAllowedOverride() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig fullScopeConfig = new ClientTypeRepresentation.PropertyConfig();
+        fullScopeConfig.setApplicable(true);
+        fullScopeConfig.setValue(false);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("no-full-scope");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("fullScopeAllowed", fullScopeConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        // Attempt to create a client with fullScopeAllowed=true on a type that fixes it to false
+        ClientRepresentation clientRep = ClientBuilder.create()
+                .clientId("full-scope-override-test")
+                .type("no-full-scope")
+                .fullScopeEnabled(true)
+                .build();
+
+        Response response = managedRealm.admin().clients().create(clientRep);
+        assertErrorResponseContainsParams(response, "fullScopeAllowed");
+    }
+
+    @Test
+    public void testCreateClientFailsWithNodeReRegistrationTimeoutOverride() {
+        ClientTypesRepresentation clientTypes = managedRealm.admin().clientTypes().getClientTypes();
+
+        ClientTypeRepresentation.PropertyConfig timeoutConfig = new ClientTypeRepresentation.PropertyConfig();
+        timeoutConfig.setApplicable(true);
+        timeoutConfig.setValue(-1);
+
+        ClientTypeRepresentation customType = new ClientTypeRepresentation();
+        customType.setName("fixed-timeout");
+        customType.setProvider(DefaultClientTypeProviderFactory.PROVIDER_ID);
+        customType.setParent("oidc");
+        customType.setConfig(Map.of("nodeReRegistrationTimeout", timeoutConfig));
+
+        List<ClientTypeRepresentation> realmClientTypes = clientTypes.getRealmClientTypes();
+        realmClientTypes.add(customType);
+        clientTypes.setRealmClientTypes(realmClientTypes);
+
+        managedRealm.admin().clientTypes().updateClientTypes(clientTypes);
+
+        ClientRepresentation clientRep = ClientBuilder.create()
+                .clientId("timeout-override-test")
+                .type("fixed-timeout")
+                .build();
+        clientRep.setNodeReRegistrationTimeout(300);
+
+        Response response = managedRealm.admin().clients().create(clientRep);
+        assertErrorResponseContainsParams(response, "nodeReRegistrationTimeout");
     }
 
     private void assertErrorResponseContainsParams(Response response, String... items) {


### PR DESCRIPTION
Fixes a bypass where client-type property constraints could be circumvented for fullScopeAllowed, nodeReRegistrationTimeout, and authorizationServicesEnabled.                                                         
                                                                                                                                                                                                                         
  - fullScopeAllowed and nodeReRegistrationTimeout: Added to TypedClientSimpleAttribute enum and
    TypeAwareClientModelDelegate so client-type constraints are enforced at the model layer (consistent with existing       
    properties like standardFlowEnabled, publicClient, etc.)                                                                                                                                                             
  - authorizationServicesEnabled: Enforced at the REST layer in ClientsResource (create) and
    AbstractClientRegistrationProvider (DCR), and at the update path in ClientResource. This property is not a 
    ClientModel attribute — it's derived from ResourceServer existence — so it cannot be handled via
     TypeAwareClientModelDelegate.   
  
Closes #51328

                                                                                                                                                                                                 
