### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/quarkus-next.yml
+++ b/.github/workflows/quarkus-next.yml
@@ -50,7 +50,7 @@ jobs:
 
       # JDK 17 to match how Quarkus and QOSDK build and publish their own snapshots
       - name: Setup Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           cache: true
           version: v0.70.0 # There's an issue in v0.71.0 that makes it not work with Keycloak
-      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '25'


### PR DESCRIPTION
Closes #52005

## Summary

Upgrade all active `actions/setup-java` workflow references from v5.7.0 to v6.0.0. This preserves the repository's SHA-pinned action style and updates the accompanying version comments.

## Validation

Reviewed all active `.github/workflows/*.yml` and `.yaml` files and confirmed no older `actions/setup-java` references remain.

## AI disclosure

GitHub Copilot CLI was used as an AI agent to prepare this focused workflow update. The changes were reviewed and verified before submission.