### PR TITLE
Fix links to https://quarkus.io/guides

### DIFF
--- a/docs/documentation/authorization_services/topics/getting-started-overview.adoc
+++ b/docs/documentation/authorization_services/topics/getting-started-overview.adoc
@@ -6,5 +6,5 @@ get started with {project_name} Authorization Services:
 
 * {quickstartRepo_link}/tree/main/jakarta/servlet-authz-client[Securing a JakartaEE Application in Wildfly]
 * {quickstartRepo_link}/tree/main/spring/rest-authz-resource-server[Securing a Spring Boot Application]
-* link:https://quarkus.io/guides/security-keycloak-authorization[Securing Quarkus Applications]
+* link:https://quarkus.io/guides/security-keycloak-authorization/[Securing Quarkus Applications]
 * link:https://www.keycloak.org/securing-apps/nodejs-adapter[Keycloak Node.js adapter]

--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -172,7 +172,7 @@ For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guid
 
 === OpenTelemetry Metrics (experimental)
 
-{project_name} now provides the experimental support for exporting metrics to OpenTelemetry collectors by using the https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry[Micrometer-to-OpenTelemetry bridge].
+{project_name} now provides the experimental support for exporting metrics to OpenTelemetry collectors by using the https://quarkus.io/guides/telemetry-micrometer-to-opentelemetry/[Micrometer-to-OpenTelemetry bridge].
 This experimental feature allows you to export {project_name} metrics to any OpenTelemetry-compatible backend and use the same OpenTelemetry collector for logs, metrics and traces.
 
 For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.

--- a/docs/documentation/upgrading/topics/changes/changes-21_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-21_0_0.adoc
@@ -1,7 +1,7 @@
 = Keycloak uses Micrometer for metrics
 
 Keycloak provides an optional a metrics endpoint which exports metrics in the Prometheus format.
-In this release the implementation to provide this data switched from SmallRye to Micrometer, which is the https://quarkus.io/guides/telemetry-micrometer[recommended metrics library for Quarkus].
+In this release the implementation to provide this data switched from SmallRye to Micrometer, which is the https://quarkus.io/guides/telemetry-micrometer/[recommended metrics library for Quarkus].
 
 Due to this change, metrics have been renamed.
 The following table shows some examples.


### PR DESCRIPTION
Closes #52015

New links errors. This time with https://quarkus.io/guides.