### PR TITLE
fix: hoist AdminPermissions.realms evaluator out of per-realm loop in getRealms

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResource.java
@@ -56,6 +56,7 @@ import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
+import org.keycloak.services.resources.admin.fgap.RealmsPermissionEvaluator;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.ExportImportManager;
 
@@ -120,14 +121,15 @@ public class RealmsAdminResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public Stream<RealmRepresentation> getRealms(@DefaultValue("false") @QueryParam("briefRepresentation") boolean briefRepresentation) {
+        RealmsPermissionEvaluator realmsEvaluator = AdminPermissions.realms(session, auth);
         Stream<RealmRepresentation> realms = session.realms().getRealmsStream()
-                .map(realm -> toRealmRep(realm, briefRepresentation))
+                .map(realm -> toRealmRep(realm, briefRepresentation, realmsEvaluator))
                 .filter(Objects::nonNull);
         return throwIfEmpty(realms, new ForbiddenException());
     }
 
-    protected RealmRepresentation toRealmRep(RealmModel realm, boolean briefRep) {
-        if (AdminPermissions.realms(session, auth).canView(realm)) {
+    protected RealmRepresentation toRealmRep(RealmModel realm, boolean briefRep, RealmsPermissionEvaluator realmsEvaluator) {
+        if (realmsEvaluator.canView(realm)) {
             if (briefRep) {
                 return ModelToRepresentation.toBriefRepresentation(realm);
             }
@@ -139,7 +141,7 @@ public class RealmsAdminResource {
                     .toList();
             rep.setDefaultGroups(filteredDefaultGroups.isEmpty() ? null : filteredDefaultGroups);
             return rep;
-        } else if (AdminPermissions.realms(session, auth).isAdmin(realm)) {
+        } else if (realmsEvaluator.isAdmin(realm)) {
             RealmRepresentation rep = new RealmRepresentation();
             rep.setRealm(realm.getName());
             return rep;


### PR DESCRIPTION
Closes #52009

## Problem

`RealmsAdminResource.getRealms()` streams every realm and evaluates
`AdminPermissions.realms(session, auth)` **per realm** (twice per realm:
once for `canView`, once for `isAdmin` in the else-branch). Each call
constructs a fresh `MgmtPermissions`/`MgmtPermissionsV2`, which in turn
builds a fresh `KeycloakIdentity` from the request token. Identity
construction serializes the whole access token (`JsonSerialization.createObjectNode`)
and does user/client lookups — so the total cost is
**O(realms × token-claims)**.

For a master-realm admin service-account token whose `admin` composite
expands to a role-claim block per realm, a `GET /admin/realms` with
hundreds of realms issues tens of thousands of role queries and exceeds
the client idle-timeout.

## Fix

Create the `RealmsPermissionEvaluator` **once per request** in
`getRealms()` and pass it into `toRealmRep()`:

```java
RealmsPermissionEvaluator realmsEvaluator = AdminPermissions.realms(session, auth);
```

All per-realm `canView`/`isAdmin` checks reuse the same evaluator and
the same `KeycloakIdentity`, so identity/role resolution happens exactly
once per request and `GET /admin/realms` latency scales roughly linearly
with realm count.

`AdminPermissions.evaluator(session, realm, auth)` (realm-scoped
permissions for default-group filtering) is intentionally left
per-realm — it is bound to a specific realm by design.

## Verification

- Existing `RealmsAdminResource` behavior preserved: same filtering
  semantics, same `ForbiddenException` on empty stream.
- `toRealmRep` has no other callers (verified via code search), so the
  signature change is contained.

No test changes: Keycloak has no dedicated unit test harness for this
resource; behavior is covered by the admin API integration test suite.
