### PR TITLE
Chunk parent role ids in JpaRealmProvider#getCompositeRolesStream (#51510)

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
@@ -93,7 +93,9 @@ public class CollectionUtil {
             return Collections.emptyList();
         }
         int chunkCapacity = Math.min(chunkSize, items.size());
-        List<List<T>> chunks = new ArrayList<>((items.size() + chunkSize - 1) / chunkSize);
+        // ceil(size / chunkSize) without overflowing for large chunkSize values; items is non-empty here
+        int chunkCount = 1 + (items.size() - 1) / chunkSize;
+        List<List<T>> chunks = new ArrayList<>(chunkCount);
         List<T> chunk = new ArrayList<>(chunkCapacity);
         for (T item : items) {
             chunk.add(item);

--- a/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
+++ b/common/src/main/java/org/keycloak/common/util/CollectionUtil.java
@@ -17,9 +17,12 @@
 
 package org.keycloak.common.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -70,5 +73,38 @@ public class CollectionUtil {
 
     public static <T> Set<T> collectionToSet(Collection<T> collection) {
         return collection == null ? null : new HashSet<>(collection);
+    }
+
+    /**
+     * Splits the given collection into consecutive chunks of at most {@code chunkSize} elements,
+     * preserving iteration order. Every chunk except possibly the last has exactly {@code chunkSize}
+     * elements. The returned chunks are independent copies and do not reference the source collection.
+     *
+     * @param items the collection to split; may be {@code null}
+     * @param chunkSize the maximum number of elements per chunk; must be greater than 0
+     * @return list of chunks; an empty list if {@code items} is {@code null} or empty
+     * @throws IllegalArgumentException if {@code chunkSize} is not positive
+     */
+    public static <T> List<List<T>> partition(Collection<T> items, int chunkSize) {
+        if (chunkSize <= 0) {
+            throw new IllegalArgumentException("chunkSize must be greater than 0");
+        }
+        if (isEmpty(items)) {
+            return Collections.emptyList();
+        }
+        int chunkCapacity = Math.min(chunkSize, items.size());
+        List<List<T>> chunks = new ArrayList<>((items.size() + chunkSize - 1) / chunkSize);
+        List<T> chunk = new ArrayList<>(chunkCapacity);
+        for (T item : items) {
+            chunk.add(item);
+            if (chunk.size() == chunkSize) {
+                chunks.add(chunk);
+                chunk = new ArrayList<>(chunkCapacity);
+            }
+        }
+        if (!chunk.isEmpty()) {
+            chunks.add(chunk);
+        }
+        return chunks;
     }
 }

--- a/common/src/test/java/org/keycloak/common/util/CollectionUtilTest.java
+++ b/common/src/test/java/org/keycloak/common/util/CollectionUtilTest.java
@@ -156,6 +156,12 @@ public class CollectionUtilTest {
         }
 
         @Test
+        void maxChunkSizeDoesNotOverflow() {
+            List<List<String>> chunks = CollectionUtil.partition(ids(3), Integer.MAX_VALUE);
+            Assertions.assertEquals(Collections.singletonList(ids(3)), chunks);
+        }
+
+        @Test
         void emptyOrNullInputYieldsNoChunks() {
             Assertions.assertTrue(CollectionUtil.partition(Collections.emptyList(), 3).isEmpty());
             Assertions.assertTrue(CollectionUtil.partition(null, 3).isEmpty());

--- a/common/src/test/java/org/keycloak/common/util/CollectionUtilTest.java
+++ b/common/src/test/java/org/keycloak/common/util/CollectionUtilTest.java
@@ -2,11 +2,16 @@ package org.keycloak.common.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -76,5 +81,91 @@ public class CollectionUtilTest {
         Assertions.assertFalse(CollectionUtil.collectionEquals(Arrays.asList("A", "C"), Arrays.asList("A", "C", "B")));
         Assertions.assertFalse(CollectionUtil.collectionEquals(Arrays.asList(1, 3, 2, 3), Arrays.asList(1, 2, 3, 2)));
         Assertions.assertTrue(CollectionUtil.collectionEquals(Arrays.asList(1, 3, 3), Arrays.asList(3, 1, 3)));
+    }
+
+    @Nested
+    class PartitionTest {
+
+        // Note: the common module is compiled at Java 8 level, hence no Stream.toList() / List.of() here.
+        private List<String> ids(int n) {
+            return IntStream.range(0, n).mapToObj(i -> "id-" + i).collect(Collectors.toList());
+        }
+
+        @Test
+        void splitsIntoConsecutiveChunksWithPartialTail() {
+            List<List<Integer>> chunks = CollectionUtil.partition(Arrays.asList(1, 2, 3, 4, 5), 2);
+            Assertions.assertEquals(Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3, 4), Arrays.asList(5)), chunks);
+        }
+
+        // Exhaustive sweep with small chunk sizes: catches boundary interactions
+        // (n == cs, n == cs +/- 1, n == k*cs, n == k*cs +/- 1) that single examples can mask.
+        @Test
+        void exhaustiveSweepForSmallChunkSizes() {
+            for (int cs = 1; cs <= 7; cs++) {
+                for (int n = 0; n <= 200; n++) {
+                    List<String> original = ids(n);
+                    List<List<String>> chunks = CollectionUtil.partition(original, cs);
+
+                    // count
+                    Assertions.assertEquals((n + cs - 1) / cs, chunks.size(), "count: n=" + n + " cs=" + cs);
+                    // reconstruction: nothing lost, nothing duplicated, order preserved
+                    List<String> rebuilt = new ArrayList<>(n);
+                    chunks.forEach(rebuilt::addAll);
+                    Assertions.assertEquals(original, rebuilt, "reconstruction: n=" + n + " cs=" + cs);
+                    // sizes: every chunk non-empty, only the last may be partial
+                    for (int i = 0; i < chunks.size(); i++) {
+                        int size = chunks.get(i).size();
+                        Assertions.assertTrue(size > 0 && size <= cs, "size: n=" + n + " cs=" + cs + " chunk=" + i);
+                        if (i < chunks.size() - 1) {
+                            Assertions.assertEquals(cs, size, "fullness: n=" + n + " cs=" + cs + " chunk=" + i);
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        void acceptsAnyCollectionAndPreservesIterationOrder() {
+            Set<String> source = new LinkedHashSet<>(Arrays.asList("c", "a", "b"));
+            List<List<String>> chunks = CollectionUtil.partition(source, 2);
+            Assertions.assertEquals(Arrays.asList(Arrays.asList("c", "a"), Arrays.asList("b")), chunks);
+        }
+
+        @Test
+        void chunksAreIndependentCopiesNotSubListViews() {
+            // subList views become invalid if the backing list is structurally modified;
+            // the chunks must not be affected by that.
+            List<String> source = new ArrayList<>(ids(5));
+            List<List<String>> chunks = CollectionUtil.partition(source, 2);
+
+            source.clear(); // structural modification of the original
+
+            List<String> rebuilt = new ArrayList<>();
+            Assertions.assertDoesNotThrow(() -> chunks.forEach(rebuilt::addAll),
+                    "chunks must not be live views of the source list");
+            Assertions.assertEquals(ids(5), rebuilt);
+        }
+
+        @Test
+        void duplicateInputElementsArePreserved() {
+            // partition must not deduplicate; that is the caller's concern
+            List<String> withDupes = Arrays.asList("a", "b", "a", "c", "b");
+            List<String> rebuilt = new ArrayList<>();
+            CollectionUtil.partition(withDupes, 2).forEach(rebuilt::addAll);
+            Assertions.assertEquals(withDupes, rebuilt);
+        }
+
+        @Test
+        void emptyOrNullInputYieldsNoChunks() {
+            Assertions.assertTrue(CollectionUtil.partition(Collections.emptyList(), 3).isEmpty());
+            Assertions.assertTrue(CollectionUtil.partition(null, 3).isEmpty());
+        }
+
+        @Test
+        void rejectsNonPositiveChunkSize() {
+            Assertions.assertThrows(IllegalArgumentException.class, () -> CollectionUtil.partition(Arrays.asList(1, 2), 0));
+            Assertions.assertThrows(IllegalArgumentException.class, () -> CollectionUtil.partition(Arrays.asList(1, 2), -1));
+            Assertions.assertThrows(IllegalArgumentException.class, () -> CollectionUtil.partition(Collections.emptyList(), 0));
+        }
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -45,6 +45,7 @@ import jakarta.persistence.criteria.Subquery;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.util.JpaUtils;
 import org.keycloak.migration.MigrationModel;
@@ -96,17 +97,27 @@ import static org.keycloak.utils.StreamsUtil.closing;
  * @version $Revision: 1 $
  */
 public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientScopeProvider, GroupProvider, RoleProvider, DeploymentStateProvider {
+
+    public static final int JPA_IN_PARAMETERS_LIMIT_THRESHOLD = 1000;
+
     protected static final Logger logger = Logger.getLogger(JpaRealmProvider.class);
+
     private final KeycloakSession session;
     protected EntityManager em;
+    protected int jpaInParametersLimitThreshold;
     private Set<String> clientSearchableAttributes;
     private Set<String> groupSearchableAttributes;
 
     public JpaRealmProvider(KeycloakSession session, EntityManager em, Set<String> clientSearchableAttributes, Set<String> groupSearchableAttributes) {
+        this(session, em, clientSearchableAttributes, groupSearchableAttributes, JPA_IN_PARAMETERS_LIMIT_THRESHOLD);
+    }
+
+    public JpaRealmProvider(KeycloakSession session, EntityManager em, Set<String> clientSearchableAttributes, Set<String> groupSearchableAttributes, int jpaInParametersLimitThreshold) {
         this.session = session;
         this.em = em;
         this.clientSearchableAttributes = clientSearchableAttributes;
         this.groupSearchableAttributes = groupSearchableAttributes;
+        this.jpaInParametersLimitThreshold = jpaInParametersLimitThreshold;
     }
 
     @Override
@@ -516,10 +527,21 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         // tree expands with a single getChildRolesFromParentIds query per breadth-first level. The
         // query hydrates the child RoleEntity rows, so the getRoleById calls below are served from
         // the persistence context without extra round-trips.
-        TypedQuery<RoleEntity> query = em.createNamedQuery("getChildRolesFromParentIds", RoleEntity.class)
-                .setParameter("parentRoleIds", parentRoleIds);
-        return closing(query.getResultStream())
-                .map(roleEntity -> session.roles().getRoleById(realm, roleEntity.getId()))
+        //
+        // Databases cap the number of bind parameters per statement (e.g. MSSQL: 2100), so a large
+        // frontier is split into chunks of at most jpaInParametersLimitThreshold parent ids, each
+        // queried separately. The query is "select distinct", but a child shared by parents in
+        // different chunks would be returned once per chunk, hence the distinct() on the child ids.
+        List<List<String>> roleIdChunks = CollectionUtil.partition(parentRoleIds, jpaInParametersLimitThreshold);
+        return roleIdChunks.stream()
+                .flatMap(parentRoleIdsChunk -> {
+                    return closing(em.createNamedQuery("getChildRolesFromParentIds", RoleEntity.class)
+                            .setParameter("parentRoleIds", parentRoleIdsChunk)
+                            .getResultStream());
+                })
+                .map(RoleEntity::getId)
+                .distinct()
+                .map(roleId -> session.roles().getRoleById(realm, roleId))
                 .filter(Objects::nonNull);
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -523,15 +523,16 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         if (parentRoleIds == null || parentRoleIds.isEmpty()) {
             return Stream.empty();
         }
-        // One query fetches the child roles for every parent in the frontier, so a composite-role
-        // tree expands with a single getChildRolesFromParentIds query per breadth-first level. The
-        // query hydrates the child RoleEntity rows, so the getRoleById calls below are served from
-        // the persistence context without extra round-trips.
+        // getChildRolesFromParentIds fetches the child roles of many parents at once, so a
+        // composite-role tree expands with a bounded number of queries per breadth-first level
+        // instead of one per role. The query hydrates the child RoleEntity rows, so the getRoleById
+        // calls below are served from the persistence context without extra round-trips.
         //
-        // Databases cap the number of bind parameters per statement (e.g. MSSQL: 2100), so a large
-        // frontier is split into chunks of at most jpaInParametersLimitThreshold parent ids, each
-        // queried separately. The query is "select distinct", but a child shared by parents in
-        // different chunks would be returned once per chunk, hence the distinct() on the child ids.
+        // Databases cap the number of bind parameters per statement (e.g. MSSQL: 2100), so the
+        // frontier is split into chunks of at most jpaInParametersLimitThreshold parent ids and
+        // one query is issued per chunk (i.e. a single query for frontiers within the threshold).
+        // The query is "select distinct", but a child shared by parents in different chunks would
+        // be returned once per chunk, hence the distinct() on the child ids.
         List<List<String>> roleIdChunks = CollectionUtil.partition(parentRoleIds, jpaInParametersLimitThreshold);
         return roleIdChunks.stream()
                 .flatMap(parentRoleIdsChunk -> {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/role/RoleModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/role/RoleModelTest.java
@@ -1,14 +1,19 @@
 package org.keycloak.testsuite.model.role;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import jakarta.persistence.EntityManager;
+
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientProvider;
 import org.keycloak.models.Constants;
@@ -17,6 +22,8 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
+import org.keycloak.models.jpa.JpaRealmProvider;
+import org.keycloak.models.jpa.JpaRealmProviderFactory;
 import org.keycloak.testsuite.model.KeycloakModelTest;
 import org.keycloak.testsuite.model.RequireProvider;
 
@@ -291,6 +298,54 @@ public class RoleModelTest extends KeycloakModelTest {
             RoleModel parentClientRole = session.roles().getRoleById(realm, parentClientRoleId.get());
             assertThat(parentRealmRole.getCompositesStream().collect(Collectors.toSet()), empty());
             assertThat(parentClientRole.getCompositesStream().collect(Collectors.toSet()), empty());
+            return null;
+        });
+    }
+
+    /**
+     * Regression test for #51510: expanding a composite-role tree bound every parent id of a
+     * breadth-first level into a single IN clause, exceeding the parameter limit of some databases.
+     * Uses a tiny threshold so the frontier spans several chunks, and a child shared by parents
+     * in different chunks to verify that the chunked lookup still returns each child exactly once.
+     */
+    @Test
+    @RequireProvider(value = RealmProvider.class, only = JpaRealmProviderFactory.PROVIDER_ID)
+    public void testCompositeRolesStreamChunksParentIds() {
+        final int threshold = 2;
+        final int parentCount = 5; // spans 3 chunks with threshold 2
+
+        final Set<String> parentIds = new HashSet<>();
+        final Set<String> expectedChildIds = new HashSet<>();
+        final AtomicReference<String> sharedChildId = new AtomicReference<>();
+
+        withRealm(realmId, (session, realm) -> {
+            RoleModel sharedChild = session.roles().addRealmRole(realm, "chunked-shared-child");
+            sharedChildId.set(sharedChild.getId());
+            expectedChildIds.add(sharedChild.getId());
+
+            for (int i = 0; i < parentCount; i++) {
+                RoleModel parent = session.roles().addRealmRole(realm, "chunked-parent-" + i);
+                RoleModel ownChild = session.roles().addRealmRole(realm, "chunked-own-child-" + i);
+                parent.addCompositeRole(ownChild);
+                parent.addCompositeRole(sharedChild);
+                parentIds.add(parent.getId());
+                expectedChildIds.add(ownChild.getId());
+            }
+            return null;
+        });
+
+        withRealm(realmId, (session, realm) -> {
+            EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+            JpaRealmProvider provider = new JpaRealmProvider(session, em, null, null, threshold);
+
+            List<String> childIds = provider.getCompositeRolesStream(realm, parentIds)
+                    .map(RoleModel::getId)
+                    .collect(Collectors.toList());
+
+            // every child exactly once: the shared child must not be duplicated across chunks
+            assertThat(childIds, hasSize(expectedChildIds.size()));
+            assertThat(new HashSet<>(childIds), is(expectedChildIds));
+            assertThat(childIds.stream().filter(sharedChildId.get()::equals).count(), is(1L));
             return null;
         });
     }


### PR DESCRIPTION
Expanding a composite-role tree bound every parent id of a breadth-first level into a single IN clause, which exceeds the per-statement parameter limit on some databases (MSSQL: 2100) for large role sets.

Split the parent ids into chunks of at most jpaInParametersLimitThreshold (default 1000) via the new generic CollectionUtil#partition and run one getChildRolesFromParentIds query per chunk. Child ids are de-duplicated across chunks to preserve the "select distinct" semantics.

Fixes #51510

Claude Fable 5 was used to implement this PR

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
