### PR TITLE
Fix-51286:Implemented param stripping for all OIDC response modes

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -726,7 +726,7 @@ public class KeycloakUriBuilder {
         }
 
         String replacedName = Encode.encodeQueryParam(name);
-        removeQueryParams(rawName -> rawName.equals(replacedName));
+        query = removeParams(query, rawName -> rawName.equals(replacedName));
 
         // don't set values if values is null
         if (values == null) return this;
@@ -840,21 +840,41 @@ public class KeycloakUriBuilder {
     public KeycloakUriBuilder removeQueryParamByDecodedName(String name) {
         if (name == null) throw new IllegalArgumentException("name parameter is null");
         if (query == null || query.isEmpty()) return this;
-        removeQueryParams(rawName -> name.equals(Encode.decode(rawName)));
+        query = removeParams(query, rawName -> name.equals(Encode.decode(rawName)));
         return this;
     }
 
-    private void removeQueryParams(Predicate<String> nameMatches) {
-        String[] params = query.split("&");
-        query = null;
-        for (String param : params) {
+    /**
+     * Removes all fragment parameters whose name, after percent-decoding, equals the given {@code name}.
+     * Fragment is treated as query-string-style key=value pairs separated by {@code &}.
+     *
+     * <pre>
+     * KeycloakUriBuilder.fromUri("http://example.com/path#st%61te=evil&amp;other=keep", false)
+     *     .removeFragmentParamByDecodedName("state")
+     *     // result: http://example.com/path#other=keep
+     * </pre>
+     *
+     * @param name the decoded parameter name to match against
+     * @return this builder
+     */
+    public KeycloakUriBuilder removeFragmentParamByDecodedName(String name) {
+        if (name == null) throw new IllegalArgumentException("name parameter is null");
+        if (fragment == null || fragment.isEmpty()) return this;
+        fragment = removeParams(fragment, rawName -> name.equals(Encode.decode(rawName)));
+        return this;
+    }
+
+    private static String removeParams(String paramString, Predicate<String> nameMatches) {
+        String result = null;
+        for (String param : paramString.split("&")) {
             int pos = param.indexOf('=');
             String rawName = pos >= 0 ? param.substring(0, pos) : param;
             if (nameMatches.test(rawName)) continue;
-            if (query == null) query = "";
-            else query += "&";
-            query += param;
+            if (result == null) result = "";
+            else result += "&";
+            result += param;
         }
+        return result;
     }
 
     public KeycloakUriBuilder resolveTemplate(String name, Object value, boolean encodeSlashInPath) throws IllegalArgumentException {

--- a/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
+++ b/common/src/main/java/org/keycloak/common/util/KeycloakUriBuilder.java
@@ -865,16 +865,17 @@ public class KeycloakUriBuilder {
     }
 
     private static String removeParams(String paramString, Predicate<String> nameMatches) {
-        String result = null;
+        StringBuilder result = null;
         for (String param : paramString.split("&")) {
+            if (param.isEmpty()) continue;
             int pos = param.indexOf('=');
             String rawName = pos >= 0 ? param.substring(0, pos) : param;
             if (nameMatches.test(rawName)) continue;
-            if (result == null) result = "";
-            else result += "&";
-            result += param;
+            if (result == null) result = new StringBuilder();
+            else result.append('&');
+            result.append(param);
         }
-        return result;
+        return result == null ? null : result.toString();
     }
 
     public KeycloakUriBuilder resolveTemplate(String name, Object value, boolean encodeSlashInPath) throws IllegalArgumentException {

--- a/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
+++ b/common/src/test/java/org/keycloak/common/util/KeycloakUriBuilderTest.java
@@ -122,4 +122,27 @@ public class KeycloakUriBuilderTest {
                 KeycloakUriBuilder.fromUri("http://localhost/path?state=val", false)
                         .removeQueryParamByDecodedName("other").buildAsString());
     }
+
+    @Test
+    public void testRemoveFragmentParamByDecodedName() {
+        Assertions.assertEquals("http://localhost/path#other=keep",
+                KeycloakUriBuilder.fromUri("http://localhost/path#state=val&other=keep", false)
+                        .removeFragmentParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path#other=keep",
+                KeycloakUriBuilder.fromUri("http://localhost/path#st%61te=val&other=keep", false)
+                        .removeFragmentParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path#other=keep",
+                KeycloakUriBuilder.fromUri("http://localhost/path#other=keep&%73%74%61%74%65=val", false)
+                        .removeFragmentParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path",
+                KeycloakUriBuilder.fromUri("http://localhost/path#state=val", false)
+                        .removeFragmentParamByDecodedName("state").buildAsString());
+
+        Assertions.assertEquals("http://localhost/path#state=val",
+                KeycloakUriBuilder.fromUri("http://localhost/path#state=val", false)
+                        .removeFragmentParamByDecodedName("other").buildAsString());
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
@@ -38,6 +38,8 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.AuthorizationResponseToken;
 import org.keycloak.services.Urls;
 
+import static org.keycloak.protocol.oidc.utils.RedirectUtils.FORBIDDEN_OIDC_PARAMS;
+
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
@@ -56,6 +58,12 @@ public abstract class OIDCRedirectUriBuilder {
 
     public static OIDCRedirectUriBuilder fromUri(String baseUri, OIDCResponseMode responseMode, KeycloakSession session, AuthenticatedClientSessionModel clientSession) {
         KeycloakUriBuilder uriBuilder = KeycloakUriBuilder.fromUri(baseUri);
+
+        //Strip forbidden OIDC params from both query and fragment
+        for (String param : FORBIDDEN_OIDC_PARAMS) {
+            uriBuilder.removeQueryParamByDecodedName(param);
+            uriBuilder.removeFragmentParamByDecodedName(param);
+        }
 
         switch (responseMode) {
             case QUERY: return new QueryRedirectUriBuilder(uriBuilder);
@@ -167,6 +175,8 @@ public abstract class OIDCRedirectUriBuilder {
         @Override
         public Response build() {
             StringBuilder builder = new StringBuilder();
+            uriBuilder.replaceQuery(null);
+            uriBuilder.fragment(null);
             URI redirectUri = uriBuilder.build();
 
             builder.append("<HTML>");
@@ -255,6 +265,7 @@ public abstract class OIDCRedirectUriBuilder {
         }
 
         private Response buildQueryResponse() {
+            uriBuilder.removeQueryParamByDecodedName(OAuth2Constants.RESPONSE);
             uriBuilder.queryParam(OAuth2Constants.RESPONSE, session.tokens().encodeAndEncrypt(responseJWT));
             URI redirectUri = uriBuilder.build();
             Response.ResponseBuilder location = Response.status(302).location(redirectUri);
@@ -270,6 +281,8 @@ public abstract class OIDCRedirectUriBuilder {
 
         private Response buildFormPostResponse() {
             StringBuilder builder = new StringBuilder();
+            uriBuilder.replaceQuery(null);
+            uriBuilder.fragment(null);
             URI redirectUri = uriBuilder.build();
 
             builder.append("<HTML>");

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
@@ -175,8 +175,6 @@ public abstract class OIDCRedirectUriBuilder {
         @Override
         public Response build() {
             StringBuilder builder = new StringBuilder();
-            uriBuilder.replaceQuery(null);
-            uriBuilder.fragment(null);
             URI redirectUri = uriBuilder.build();
 
             builder.append("<HTML>");
@@ -281,8 +279,6 @@ public abstract class OIDCRedirectUriBuilder {
 
         private Response buildFormPostResponse() {
             StringBuilder builder = new StringBuilder();
-            uriBuilder.replaceQuery(null);
-            uriBuilder.fragment(null);
             URI redirectUri = uriBuilder.build();
 
             builder.append("<HTML>");

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -49,7 +49,7 @@ public class RedirectUtils {
 
     public static final Set<String> LOOPBACK_INTERFACES = new HashSet<>(Arrays.asList("localhost", "127.0.0.1", "[::1]"));
 
-    private static final Set<String> FORBIDDEN_OIDC_PARAMS = Set.of(
+    static final Set<String> FORBIDDEN_OIDC_PARAMS = Set.of(
                                                                      OAuth2Constants.CODE,
                                                                      OAuth2Constants.ID_TOKEN,
                                                                      OAuth2Constants.ACCESS_TOKEN,

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilderTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilderTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.protocol.oidc.utils;
+
+import java.net.URI;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for stripping of forbidden OIDC parameters in OIDCRedirectUriBuilder.
+ */
+public class OIDCRedirectUriBuilderTest {
+
+    @Test
+    public void testQueryModeStripsForbiddenParamsFromQuery() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback?code=evil&legit=keep",
+                OIDCResponseMode.QUERY, null, null);
+        builder.addParam("code", "real_code");
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertFalse("Attacker's code param should be stripped", url.contains("code=evil"));
+        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
+        Assert.assertTrue("Non-forbidden param should survive", url.contains("legit=keep"));
+    }
+
+    @Test
+    public void testQueryModeStripsForbiddenParamsFromFragment() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback#state=evil",
+                OIDCResponseMode.QUERY, null, null);
+        builder.addParam("state", "real_state");
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertFalse("Attacker's state in fragment should be stripped", url.contains("state=evil"));
+        Assert.assertTrue("Legitimate state param should be present", url.contains("state=real_state"));
+    }
+
+    @Test
+    public void testQueryModeStripsEncodedForbiddenParams() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback?c%6Fde=evil&legit=keep",
+                OIDCResponseMode.QUERY, null, null);
+        builder.addParam("code", "real_code");
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertFalse("Percent-encoded forbidden param should be stripped", url.contains("evil"));
+        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
+        Assert.assertTrue("Non-forbidden param should survive", url.contains("legit=keep"));
+    }
+
+    @Test
+    public void testFragmentModeStripsForbiddenParamsFromFragment() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback#code=evil&custom=keep",
+                OIDCResponseMode.FRAGMENT, null, null);
+        builder.addParam("code", "real_code");
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertFalse("Attacker's code in fragment should be stripped", url.contains("code=evil"));
+        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
+        Assert.assertTrue("Non-forbidden fragment param should survive", url.contains("custom=keep"));
+    }
+
+    @Test
+    public void testFragmentModeStripsForbiddenParamsFromQuery() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback?code=evil",
+                OIDCResponseMode.FRAGMENT, null, null);
+        builder.addParam("code", "real_code");
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertFalse("Attacker's code in query should be stripped", url.contains("code=evil"));
+        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
+    }
+
+    @Test
+    public void testFormPostModeStripsQueryAndFragmentFromActionUrl() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback?code=evil#state=evil",
+                OIDCResponseMode.FORM_POST, null, null);
+        builder.addParam("code", "real_code");
+        builder.addParam("state", "real_state");
+        Response response = builder.build();
+        String html = (String) response.getEntity();
+
+        Assert.assertTrue("Form action should point to callback URL", html.contains("ACTION=\"https://client.com/callback\""));
+        Assert.assertFalse("Query params should not appear in form action", html.contains("code=evil"));
+        Assert.assertFalse("Fragment should not appear in form action", html.contains("state=evil"));
+        Assert.assertTrue("Legitimate code should be in hidden field", html.contains("VALUE=\"real_code\""));
+        Assert.assertTrue("Legitimate state should be in hidden field", html.contains("VALUE=\"real_state\""));
+    }
+
+    @Test
+    public void testFormPostModePreservesNonForbiddenQueryParams() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback?tab=profile&code=evil",
+                OIDCResponseMode.FORM_POST, null, null);
+        builder.addParam("code", "real_code");
+        Response response = builder.build();
+        String html = (String) response.getEntity();
+
+        Assert.assertFalse("Forbidden param should be stripped from action URL", html.contains("code=evil"));
+        Assert.assertFalse("Query should be fully stripped from form action", html.contains("tab=profile"));
+        Assert.assertTrue("Legitimate code should be in hidden field", html.contains("VALUE=\"real_code\""));
+    }
+
+    @Test
+    public void testAllForbiddenParamsStrippedFromQuery() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri(
+                "https://client.com/callback?code=a&state=b&iss=c&access_token=d&id_token=e&response=f&session_state=g&legit=keep",
+                OIDCResponseMode.QUERY, null, null);
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertFalse("code should be stripped", url.contains("code=a"));
+        Assert.assertFalse("state should be stripped", url.contains("state=b"));
+        Assert.assertFalse("iss should be stripped", url.contains("iss=c"));
+        Assert.assertFalse("access_token should be stripped", url.contains("access_token=d"));
+        Assert.assertFalse("id_token should be stripped", url.contains("id_token=e"));
+        Assert.assertFalse("response should be stripped", url.contains("response=f"));
+        Assert.assertFalse("session_state should be stripped", url.contains("session_state=g"));
+        Assert.assertTrue("Non-forbidden param should survive", url.contains("legit=keep"));
+    }
+
+    @Test
+    public void testCleanUriPassesThroughUnchanged() {
+        OIDCRedirectUriBuilder builder = OIDCRedirectUriBuilder.fromUri("https://client.com/callback?tab=profile",
+                OIDCResponseMode.QUERY, null, null);
+        builder.addParam("code", "real_code");
+        Response response = builder.build();
+        URI location = response.getLocation();
+
+        String url = location.toString();
+        Assert.assertTrue("Non-forbidden query param should survive", url.contains("tab=profile"));
+        Assert.assertTrue("Added param should be present", url.contains("code=real_code"));
+    }
+}

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilderTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilderTest.java
@@ -20,8 +20,8 @@ import java.net.URI;
 
 import jakarta.ws.rs.core.Response;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for stripping of forbidden OIDC parameters in OIDCRedirectUriBuilder.
@@ -37,9 +37,9 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertFalse("Attacker's code param should be stripped", url.contains("code=evil"));
-        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
-        Assert.assertTrue("Non-forbidden param should survive", url.contains("legit=keep"));
+        Assertions.assertFalse(url.contains("code=evil"), "Attacker's code param should be stripped");
+        Assertions.assertTrue(url.contains("code=real_code"), "Legitimate code param should be present");
+        Assertions.assertTrue(url.contains("legit=keep"), "Non-forbidden param should survive");
     }
 
     @Test
@@ -51,8 +51,8 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertFalse("Attacker's state in fragment should be stripped", url.contains("state=evil"));
-        Assert.assertTrue("Legitimate state param should be present", url.contains("state=real_state"));
+        Assertions.assertFalse(url.contains("state=evil"), "Attacker's state in fragment should be stripped");
+        Assertions.assertTrue(url.contains("state=real_state"), "Legitimate state param should be present");
     }
 
     @Test
@@ -64,9 +64,9 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertFalse("Percent-encoded forbidden param should be stripped", url.contains("evil"));
-        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
-        Assert.assertTrue("Non-forbidden param should survive", url.contains("legit=keep"));
+        Assertions.assertFalse(url.contains("c%6Fde=evil"), "Percent-encoded forbidden param should be stripped");
+        Assertions.assertTrue(url.contains("code=real_code"), "Legitimate code param should be present");
+        Assertions.assertTrue(url.contains("legit=keep"), "Non-forbidden param should survive");
     }
 
     @Test
@@ -78,9 +78,9 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertFalse("Attacker's code in fragment should be stripped", url.contains("code=evil"));
-        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
-        Assert.assertTrue("Non-forbidden fragment param should survive", url.contains("custom=keep"));
+        Assertions.assertFalse(url.contains("code=evil"), "Attacker's code in fragment should be stripped");
+        Assertions.assertTrue(url.contains("code=real_code"), "Legitimate code param should be present");
+        Assertions.assertTrue(url.contains("custom=keep"), "Non-forbidden fragment param should survive");
     }
 
     @Test
@@ -92,8 +92,8 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertFalse("Attacker's code in query should be stripped", url.contains("code=evil"));
-        Assert.assertTrue("Legitimate code param should be present", url.contains("code=real_code"));
+        Assertions.assertFalse(url.contains("code=evil"), "Attacker's code in query should be stripped");
+        Assertions.assertTrue(url.contains("code=real_code"), "Legitimate code param should be present");
     }
 
     @Test
@@ -105,11 +105,11 @@ public class OIDCRedirectUriBuilderTest {
         Response response = builder.build();
         String html = (String) response.getEntity();
 
-        Assert.assertTrue("Form action should point to callback URL", html.contains("ACTION=\"https://client.com/callback\""));
-        Assert.assertFalse("Query params should not appear in form action", html.contains("code=evil"));
-        Assert.assertFalse("Fragment should not appear in form action", html.contains("state=evil"));
-        Assert.assertTrue("Legitimate code should be in hidden field", html.contains("VALUE=\"real_code\""));
-        Assert.assertTrue("Legitimate state should be in hidden field", html.contains("VALUE=\"real_state\""));
+        Assertions.assertTrue(html.contains("ACTION=\"https://client.com/callback\""), "Form action should point to callback URL");
+        Assertions.assertFalse(html.contains("code=evil"), "Forbidden code param should be stripped by fromUri");
+        Assertions.assertFalse(html.contains("state=evil"), "Forbidden state param should be stripped by fromUri");
+        Assertions.assertTrue(html.contains("VALUE=\"real_code\""), "Legitimate code should be in hidden field");
+        Assertions.assertTrue(html.contains("VALUE=\"real_state\""), "Legitimate state should be in hidden field");
     }
 
     @Test
@@ -120,9 +120,9 @@ public class OIDCRedirectUriBuilderTest {
         Response response = builder.build();
         String html = (String) response.getEntity();
 
-        Assert.assertFalse("Forbidden param should be stripped from action URL", html.contains("code=evil"));
-        Assert.assertFalse("Query should be fully stripped from form action", html.contains("tab=profile"));
-        Assert.assertTrue("Legitimate code should be in hidden field", html.contains("VALUE=\"real_code\""));
+        Assertions.assertFalse(html.contains("code=evil"), "Forbidden param should be stripped from action URL");
+        Assertions.assertTrue(html.contains("tab=profile"), "Non-forbidden query param should survive in form action");
+        Assertions.assertTrue(html.contains("VALUE=\"real_code\""), "Legitimate code should be in hidden field");
     }
 
     @Test
@@ -134,14 +134,14 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertFalse("code should be stripped", url.contains("code=a"));
-        Assert.assertFalse("state should be stripped", url.contains("state=b"));
-        Assert.assertFalse("iss should be stripped", url.contains("iss=c"));
-        Assert.assertFalse("access_token should be stripped", url.contains("access_token=d"));
-        Assert.assertFalse("id_token should be stripped", url.contains("id_token=e"));
-        Assert.assertFalse("response should be stripped", url.contains("response=f"));
-        Assert.assertFalse("session_state should be stripped", url.contains("session_state=g"));
-        Assert.assertTrue("Non-forbidden param should survive", url.contains("legit=keep"));
+        Assertions.assertFalse(url.contains("code=a"), "code should be stripped");
+        Assertions.assertFalse(url.contains("state=b"), "state should be stripped");
+        Assertions.assertFalse(url.contains("iss=c"), "iss should be stripped");
+        Assertions.assertFalse(url.contains("access_token=d"), "access_token should be stripped");
+        Assertions.assertFalse(url.contains("id_token=e"), "id_token should be stripped");
+        Assertions.assertFalse(url.contains("response=f"), "response should be stripped");
+        Assertions.assertFalse(url.contains("session_state=g"), "session_state should be stripped");
+        Assertions.assertTrue(url.contains("legit=keep"), "Non-forbidden param should survive");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class OIDCRedirectUriBuilderTest {
         URI location = response.getLocation();
 
         String url = location.toString();
-        Assert.assertTrue("Non-forbidden query param should survive", url.contains("tab=profile"));
-        Assert.assertTrue("Added param should be present", url.contains("code=real_code"));
+        Assertions.assertTrue(url.contains("tab=profile"), "Non-forbidden query param should survive");
+        Assertions.assertTrue(url.contains("code=real_code"), "Added param should be present");
     }
 }


### PR DESCRIPTION
Extended HTTP Parameter Pollution fix to cover form_post and JWT response modes.

Refactored KeycloakUriBuilder by adding removeFragmentParamByDecodedName method and updating callers. Added tests

Closes #51286

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
