### PR TITLE
Persist client session note removals with persistent user sessions

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/UserSessionAdapter.java
@@ -270,9 +270,7 @@ public class UserSessionAdapter<T extends SessionRefreshStore & UserSessionProvi
             @Override
             public void runUpdate(UserSessionEntity entity) {
                 if (value == null) {
-                    if (entity.getNotes().containsKey(name)) {
-                        removeNote(name);
-                    }
+                    entity.getNotes().remove(name);
                     return;
                 }
                 entity.getNotes().put(name, value);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
@@ -20,12 +20,9 @@ package org.keycloak.models.sessions.infinispan.changes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
@@ -139,14 +136,10 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
         };
         PersistentAuthenticatedClientSessionAdapter clientSessionModel = (PersistentAuthenticatedClientSessionAdapter) userSessionPersister.loadClientSession(realm, client, userSession, entity.isOffline());
         if (clientSessionModel != null) {
-            // The update tasks run against a mutable snapshot of the persisted notes, so that every Map operation
-            // (put, remove, clear, containsKey, iteration, ...) behaves as it does on the cached entity. The result is
-            // written back to the persisted model once all tasks have been applied, see writeBackNotes().
-            Map<String, String> notes = copyNotes(clientSessionModel.getNotes());
             AuthenticatedClientSessionEntity authenticatedClientSessionEntity = new AuthenticatedClientSessionEntity() {
                 @Override
                 public Map<String, String> getNotes() {
-                    return notes;
+                    return clientSessionModel.getNotes();
                 }
 
                 @Override
@@ -216,8 +209,8 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
 
                 @Override
                 public void setNotes(Map<String, String> newNotes) {
-                    notes.clear();
-                    notes.putAll(newNotes);
+                    clientSessionModel.getNotes().clear();
+                    clientSessionModel.getNotes().putAll(newNotes);
                 }
 
                 @Override
@@ -241,7 +234,6 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
                     userSessionPersister.removeClientSession(entity.getUserSessionId(), entity.getClientId(), entity.isOffline());
                 }
             });
-            writeBackNotes(notes, clientSessionModel.getNotes(), clientSessionModel::removeNote, clientSessionModel::setNote);
             clientSessionModel.getUpdatedModel();
         } else {
             LOG.debugf("No client session found for %s/%s", entity.getUserSessionId(), entity.getClientId());
@@ -534,12 +526,10 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
     }
 
     private static <K, V extends SessionEntity> void mergeUserSession(KeycloakSession innerSession, Map.Entry<K, SessionUpdatesList<V>> entry, PersistentUserSessionAdapter userSessionModel, RealmModel realm, SessionUpdatesList<V> sessionUpdates, UserSessionPersisterProvider userSessionPersister, UserSessionEntity entity) {
-        // See mergeClientSession() for the rationale of the notes snapshot.
-        Map<String, String> notes = copyNotes(userSessionModel.getNotes());
         UserSessionEntity userSessionEntity = new UserSessionEntity(userSessionModel.getId()) {
             @Override
             public Map<String, String> getNotes() {
-                return notes;
+                return userSessionModel.getNotes();
             }
 
             @Override
@@ -629,8 +619,8 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
 
             @Override
             public void setNotes(Map<String, String> newNotes) {
-                notes.clear();
-                notes.putAll(newNotes);
+                userSessionModel.getNotes().clear();
+                userSessionModel.getNotes().putAll(newNotes);
             }
 
             @Override
@@ -669,27 +659,7 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
                 userSessionPersister.removeUserSession(entry.getKey().toString(), entity.isOffline());
             }
         });
-        writeBackNotes(notes, userSessionModel.getNotes(), userSessionModel::removeNote, userSessionModel::setNote);
         userSessionModel.getUpdatedModel();
     }
 
-    private static Map<String, String> copyNotes(Map<String, String> persistedNotes) {
-        return persistedNotes == null ? new HashMap<>() : new HashMap<>(persistedNotes);
-    }
-
-    /**
-     * Applies the notes as modified by the update tasks to the persisted model: notes that are no longer present are
-     * removed, all remaining notes are set. The persisted key set is copied before iterating because the persisted
-     * model may expose its live notes map.
-     */
-    private static void writeBackNotes(Map<String, String> updatedNotes,
-                                       Map<String, String> persistedNotes, Consumer<String> removeNote,
-                                       BiConsumer<String, String> setNote) {
-        if (persistedNotes != null) {
-            new ArrayList<>(persistedNotes.keySet()).stream()
-                    .filter(key -> !updatedNotes.containsKey(key))
-                    .forEach(removeNote);
-        }
-        updatedNotes.forEach(setNote);
-    }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/JpaChangesPerformer.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
@@ -137,22 +139,14 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
         };
         PersistentAuthenticatedClientSessionAdapter clientSessionModel = (PersistentAuthenticatedClientSessionAdapter) userSessionPersister.loadClientSession(realm, client, userSession, entity.isOffline());
         if (clientSessionModel != null) {
+            // The update tasks run against a mutable snapshot of the persisted notes, so that every Map operation
+            // (put, remove, clear, containsKey, iteration, ...) behaves as it does on the cached entity. The result is
+            // written back to the persisted model once all tasks have been applied, see writeBackNotes().
+            Map<String, String> notes = copyNotes(clientSessionModel.getNotes());
             AuthenticatedClientSessionEntity authenticatedClientSessionEntity = new AuthenticatedClientSessionEntity() {
                 @Override
                 public Map<String, String> getNotes() {
-                    return new HashMap<>() {
-                        @Override
-                        public String get(Object key) {
-                            return clientSessionModel.getNotes().get(key);
-                        }
-
-                        @Override
-                        public String put(String key, String value) {
-                            String oldValue = clientSessionModel.getNotes().get(key);
-                            clientSessionModel.setNote(key, value);
-                            return oldValue;
-                        }
-                    };
+                    return notes;
                 }
 
                 @Override
@@ -221,9 +215,9 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
                 }
 
                 @Override
-                public void setNotes(Map<String, String> notes) {
-                    clientSessionModel.getNotes().keySet().forEach(clientSessionModel::removeNote);
-                    notes.forEach(clientSessionModel::setNote);
+                public void setNotes(Map<String, String> newNotes) {
+                    notes.clear();
+                    notes.putAll(newNotes);
                 }
 
                 @Override
@@ -247,6 +241,7 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
                     userSessionPersister.removeClientSession(entity.getUserSessionId(), entity.getClientId(), entity.isOffline());
                 }
             });
+            writeBackNotes(notes, clientSessionModel.getNotes(), clientSessionModel::removeNote, clientSessionModel::setNote);
             clientSessionModel.getUpdatedModel();
         } else {
             LOG.debugf("No client session found for %s/%s", entity.getUserSessionId(), entity.getClientId());
@@ -539,35 +534,12 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
     }
 
     private static <K, V extends SessionEntity> void mergeUserSession(KeycloakSession innerSession, Map.Entry<K, SessionUpdatesList<V>> entry, PersistentUserSessionAdapter userSessionModel, RealmModel realm, SessionUpdatesList<V> sessionUpdates, UserSessionPersisterProvider userSessionPersister, UserSessionEntity entity) {
+        // See mergeClientSession() for the rationale of the notes snapshot.
+        Map<String, String> notes = copyNotes(userSessionModel.getNotes());
         UserSessionEntity userSessionEntity = new UserSessionEntity(userSessionModel.getId()) {
             @Override
             public Map<String, String> getNotes() {
-                return new HashMap<>() {
-
-                    @Override
-                    public String get(Object key) {
-                        return userSessionModel.getNotes().get(key);
-                    }
-
-                    @Override
-                    public String put(String key, String value) {
-                        String oldValue = userSessionModel.getNotes().get(key);
-                        userSessionModel.setNote(key, value);
-                        return oldValue;
-                    }
-
-                    @Override
-                    public String remove(Object key) {
-                        String oldValue = userSessionModel.getNotes().get(key);
-                        userSessionModel.removeNote(key.toString());
-                        return oldValue;
-                    }
-
-                    @Override
-                    public void clear() {
-                        userSessionModel.getNotes().clear();
-                    }
-                };
+                return notes;
             }
 
             @Override
@@ -656,9 +628,9 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
             }
 
             @Override
-            public void setNotes(Map<String, String> notes) {
-                userSessionModel.getNotes().keySet().forEach(userSessionModel::removeNote);
-                notes.forEach(userSessionModel::setNote);
+            public void setNotes(Map<String, String> newNotes) {
+                notes.clear();
+                notes.putAll(newNotes);
             }
 
             @Override
@@ -697,6 +669,27 @@ public class JpaChangesPerformer<K, V extends SessionEntity> {
                 userSessionPersister.removeUserSession(entry.getKey().toString(), entity.isOffline());
             }
         });
+        writeBackNotes(notes, userSessionModel.getNotes(), userSessionModel::removeNote, userSessionModel::setNote);
         userSessionModel.getUpdatedModel();
+    }
+
+    private static Map<String, String> copyNotes(Map<String, String> persistedNotes) {
+        return persistedNotes == null ? new HashMap<>() : new HashMap<>(persistedNotes);
+    }
+
+    /**
+     * Applies the notes as modified by the update tasks to the persisted model: notes that are no longer present are
+     * removed, all remaining notes are set. The persisted key set is copied before iterating because the persisted
+     * model may expose its live notes map.
+     */
+    private static void writeBackNotes(Map<String, String> updatedNotes,
+                                       Map<String, String> persistedNotes, Consumer<String> removeNote,
+                                       BiConsumer<String, String> setNote) {
+        if (persistedNotes != null) {
+            new ArrayList<>(persistedNotes.keySet()).stream()
+                    .filter(key -> !updatedNotes.containsKey(key))
+                    .forEach(removeNote);
+        }
+        updatedNotes.forEach(setNote);
     }
 }

--- a/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/PersistentAuthenticatedClientSessionAdapter.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.session;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -240,7 +239,9 @@ public class PersistentAuthenticatedClientSessionAdapter implements Authenticate
     @Override
     public Map<String, String> getNotes() {
         PersistentClientSessionData entity = getData();
-        if (entity.getNotes() == null || entity.getNotes().isEmpty()) return Collections.emptyMap();
+        if (entity.getNotes() == null) {
+            entity.setNotes(new HashMap<>());
+        }
         return entity.getNotes();
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/session/SessionNotePersistenceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/session/SessionNotePersistenceTest.java
@@ -143,11 +143,8 @@ public class SessionNotePersistenceTest {
 
     @Test
     public void testUserSessionNoteSetToNullIsRemovedFromDatabase() {
-        // Regression guard for the user session counterpart. UserSessionAdapter#setNote(name, null) gates the removal on
-        // entity.getNotes().containsKey(name), which is always false on the synthetic entity used by
-        // JpaChangesPerformer#mergeUserSession. It still works today only because the task runs first against the cached
-        // entity (SessionUpdatesList#addAndExecute), where the check succeeds and removeNote(name) registers a second task
-        // whose Map#remove call the user session map does implement.
+        // Regression guard: UserSessionAdapter#setNote(name, null) must remove directly from the replay entity so the
+        // removal is applied both to the cached session and to the persisted session during task replay.
         final String realmName = managedRealm.getName();
         final String noteName = "note-to-null";
         final String userSessionId = createUserSessionWithNote(realmName, noteName, "value");

--- a/tests/base/src/test/java/org/keycloak/tests/session/SessionNotePersistenceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/session/SessionNotePersistenceTest.java
@@ -1,0 +1,233 @@
+package org.keycloak.tests.session;
+
+import java.util.Map;
+
+import org.keycloak.common.util.MultiSiteUtils;
+import org.keycloak.infinispan.util.InfinispanUtils;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.session.UserSessionPersisterProvider;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that note removals on persistent user/client sessions reach the database and not only the cached entity.
+ * <p>
+ * Each step runs in its own server request (and therefore its own transaction), so that removals are replayed by
+ * {@code JpaChangesPerformer} as an update of an already persisted session. The persisted state is read back through
+ * {@link UserSessionPersisterProvider}, bypassing the session cache.
+ */
+@KeycloakIntegrationTest
+public class SessionNotePersistenceTest {
+
+    private static final String USERNAME = "user1";
+    private static final String CLIENT_ID = "test-app";
+
+    @InjectRealm(config = SessionNotePersistenceRealmConfig.class)
+    ManagedRealm managedRealm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @BeforeEach
+    public void assumePersistentUserSessionsWithEmbeddedCaches() {
+        boolean supported = runOnServer.fetch(session -> MultiSiteUtils.isPersistentSessionsEnabled() && InfinispanUtils.isEmbeddedInfinispan(), Boolean.class);
+        Assumptions.assumeTrue(supported, "Requires persistent user sessions with embedded Infinispan caches");
+    }
+
+    @Test
+    public void testClientSessionNoteRemovalIsPersisted() {
+        final String realmName = managedRealm.getName();
+        final String noteName = "note-to-remove";
+        final String userSessionId = createUserSessionWithClientSessionNote(realmName, noteName, "value");
+
+        // sanity check: setting the note is persisted
+        runOnServer.run(session -> assertEquals("value", loadClientSessionFromDatabase(session, realmName, userSessionId).getNote(noteName)));
+
+        runOnServer.run(session -> {
+            AuthenticatedClientSessionModel clientSession = loadClientSessionFromProvider(session, realmName, userSessionId);
+            clientSession.removeNote(noteName);
+            assertNull(clientSession.getNote(noteName), "note must be gone from the in-memory session");
+        });
+
+        runOnServer.run(session -> assertNull(loadClientSessionFromDatabase(session, realmName, userSessionId).getNote(noteName),
+                "removed client session note must not survive in the database"));
+    }
+
+    @Test
+    public void testClientSessionRestartClearsPersistedNotes() {
+        final String realmName = managedRealm.getName();
+        final String noteName = "note-before-restart";
+        final String userSessionId = createUserSessionWithClientSessionNote(realmName, noteName, "value");
+
+        runOnServer.run(session -> assertEquals("value", loadClientSessionFromDatabase(session, realmName, userSessionId).getNote(noteName)));
+
+        runOnServer.run(session -> {
+            AuthenticatedClientSessionModel clientSession = loadClientSessionFromProvider(session, realmName, userSessionId);
+            clientSession.restartClientSession();
+            assertNull(clientSession.getNote(noteName), "note must be gone from the in-memory session");
+            assertNotNull(clientSession.getNote(AuthenticatedClientSessionModel.STARTED_AT_NOTE));
+        });
+
+        runOnServer.run(session -> {
+            AuthenticatedClientSessionModel persisted = loadClientSessionFromDatabase(session, realmName, userSessionId);
+            assertNotNull(persisted.getNote(AuthenticatedClientSessionModel.STARTED_AT_NOTE), "restart writes the started-at note");
+            assertNull(persisted.getNote(noteName), "notes of the previous authentication must not survive restartClientSession() in the database");
+        });
+    }
+
+    @Test
+    public void testUserSessionNoteRemovalIsPersisted() {
+        final String realmName = managedRealm.getName();
+        final String noteName = "note-to-remove";
+        final String userSessionId = createUserSessionWithNote(realmName, noteName, "value");
+
+        runOnServer.run(session -> assertEquals("value", loadUserSessionFromDatabase(session, realmName, userSessionId).getNote(noteName)));
+
+        runOnServer.run(session -> {
+            RealmModel realm = setRealmContext(session, realmName);
+            UserSessionModel userSession = session.sessions().getUserSession(realm, userSessionId);
+            userSession.removeNote(noteName);
+            assertNull(userSession.getNote(noteName), "note must be gone from the in-memory session");
+        });
+
+        runOnServer.run(session -> assertNull(loadUserSessionFromDatabase(session, realmName, userSessionId).getNote(noteName),
+                "removed user session note must not survive in the database"));
+    }
+
+    @Test
+    public void testUserSessionRestartClearsPersistedNotes() {
+        // Regression guard: UserSessionAdapter#restartSession clears the notes via Map#clear on the synthetic entity used by
+        // JpaChangesPerformer#mergeUserSession, which delegates to the live notes map of PersistentUserSessionAdapter.
+        final String realmName = managedRealm.getName();
+        final String noteName = "note-before-restart";
+        final String userSessionId = createUserSessionWithNote(realmName, noteName, "value");
+
+        runOnServer.run(session -> assertEquals("value", loadUserSessionFromDatabase(session, realmName, userSessionId).getNote(noteName)));
+
+        runOnServer.run(session -> {
+            RealmModel realm = setRealmContext(session, realmName);
+            UserSessionModel userSession = session.sessions().getUserSession(realm, userSessionId);
+            UserModel user = session.users().getUserByUsername(realm, USERNAME);
+            userSession.restartSession(realm, user, USERNAME, "127.0.0.2", "form", false, null, null);
+            assertNull(userSession.getNote(noteName), "note must be gone from the in-memory session");
+        });
+
+        runOnServer.run(session -> {
+            UserSessionModel persisted = loadUserSessionFromDatabase(session, realmName, userSessionId);
+            assertEquals("127.0.0.2", persisted.getIpAddress(), "restart is persisted");
+            Map<String, String> notes = persisted.getNotes();
+            assertTrue(notes == null || notes.isEmpty(), "notes of the previous authentication must not survive restartSession() in the database, but got: " + notes);
+        });
+    }
+
+    @Test
+    public void testUserSessionNoteSetToNullIsRemovedFromDatabase() {
+        // Regression guard for the user session counterpart. UserSessionAdapter#setNote(name, null) gates the removal on
+        // entity.getNotes().containsKey(name), which is always false on the synthetic entity used by
+        // JpaChangesPerformer#mergeUserSession. It still works today only because the task runs first against the cached
+        // entity (SessionUpdatesList#addAndExecute), where the check succeeds and removeNote(name) registers a second task
+        // whose Map#remove call the user session map does implement.
+        final String realmName = managedRealm.getName();
+        final String noteName = "note-to-null";
+        final String userSessionId = createUserSessionWithNote(realmName, noteName, "value");
+
+        runOnServer.run(session -> assertEquals("value", loadUserSessionFromDatabase(session, realmName, userSessionId).getNote(noteName)));
+
+        runOnServer.run(session -> {
+            RealmModel realm = setRealmContext(session, realmName);
+            UserSessionModel userSession = session.sessions().getUserSession(realm, userSessionId);
+            userSession.setNote(noteName, null);
+            assertNull(userSession.getNote(noteName), "note must be gone from the in-memory session");
+        });
+
+        runOnServer.run(session -> assertNull(loadUserSessionFromDatabase(session, realmName, userSessionId).getNote(noteName),
+                "user session note set to null must be removed from the database"));
+    }
+
+    private String createUserSessionWithNote(String realmName, String noteName, String noteValue) {
+        return runOnServer.fetch(session -> {
+            RealmModel realm = setRealmContext(session, realmName);
+            UserSessionModel userSession = createUserSession(session, realm);
+            userSession.setNote(noteName, noteValue);
+            return userSession.getId();
+        }, String.class);
+    }
+
+    private String createUserSessionWithClientSessionNote(String realmName, String noteName, String noteValue) {
+        return runOnServer.fetch(session -> {
+            RealmModel realm = setRealmContext(session, realmName);
+            UserSessionModel userSession = createUserSession(session, realm);
+            AuthenticatedClientSessionModel clientSession = session.sessions().createClientSession(realm, realm.getClientByClientId(CLIENT_ID), userSession);
+            clientSession.setRedirectUri("http://redirect");
+            clientSession.setNote(noteName, noteValue);
+            return userSession.getId();
+        }, String.class);
+    }
+
+    private static RealmModel setRealmContext(KeycloakSession session, String realmName) {
+        RealmModel realm = session.realms().getRealmByName(realmName);
+        session.getContext().setRealm(realm);
+        return realm;
+    }
+
+    private static UserSessionModel createUserSession(KeycloakSession session, RealmModel realm) {
+        UserModel user = session.users().getUserByUsername(realm, USERNAME);
+        return session.sessions().createUserSession(null, realm, user, USERNAME, "127.0.0.1", "form", false, null, null, UserSessionModel.SessionPersistenceState.PERSISTENT);
+    }
+
+    private static AuthenticatedClientSessionModel loadClientSessionFromProvider(KeycloakSession session, String realmName, String userSessionId) {
+        RealmModel realm = setRealmContext(session, realmName);
+        UserSessionModel userSession = session.sessions().getUserSession(realm, userSessionId);
+        return session.sessions().getClientSession(userSession, realm.getClientByClientId(CLIENT_ID), false);
+    }
+
+    /**
+     * Bypasses the session cache and reads the client session as stored by the {@link UserSessionPersisterProvider}.
+     */
+    private static AuthenticatedClientSessionModel loadClientSessionFromDatabase(KeycloakSession session, String realmName, String userSessionId) {
+        RealmModel realm = setRealmContext(session, realmName);
+        ClientModel client = realm.getClientByClientId(CLIENT_ID);
+        UserSessionModel userSession = session.sessions().getUserSession(realm, userSessionId);
+        return session.getProvider(UserSessionPersisterProvider.class).loadClientSession(realm, client, userSession, false);
+    }
+
+    /**
+     * Bypasses the session cache and reads the user session as stored by the {@link UserSessionPersisterProvider}.
+     */
+    private static UserSessionModel loadUserSessionFromDatabase(KeycloakSession session, String realmName, String userSessionId) {
+        RealmModel realm = setRealmContext(session, realmName);
+        return session.getProvider(UserSessionPersisterProvider.class).loadUserSession(realm, userSessionId, false);
+    }
+
+    private static class SessionNotePersistenceRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.name("client-session-notes");
+            realm.users(UserBuilder.create(USERNAME));
+            realm.clients(ClientBuilder.create(CLIENT_ID));
+            return realm;
+        }
+    }
+}


### PR DESCRIPTION
With persistent user sessions, JpaChangesPerformer replayed the recorded update tasks against a synthetic entity whose getNotes() returned a fresh anonymous HashMap forwarding only get/put (client sessions) or get/put/remove/clear (user sessions) to the persisted model. Every other Map operation ran against the throwaway map, so AuthenticatedClientSessionModel#removeNote and restartClientSession() (which clears all notes) never reached the database. 

The synthetic entities now expose the persisted model's notes map directly, so all Map operations of the update tasks are applied to the persisted state.
PersistentAuthenticatedClientSessionAdapter#getNotes() lazily initializes the map instead of returning an immutable empty map, so that the tasks can mutate it.
UserSessionAdapter#setNote(name, null) removes the note from the task's entity instead of registering a  nested update task from within the task, which would modify the task list while it is being replayed.

Fixes #52038

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
