### PR TITLE
fix: include parent-group roles in group composite client role mappings

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/utils/RoleUtils.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/RoleUtils.java
@@ -219,13 +219,17 @@ public class RoleUtils {
      */
     public static Set<RoleModel> getDeepRoleMappings(RoleMapperModel roleMapper) {
         // RoleMapperModel has exactly two implementations: UserModel and GroupModel.
-        // UserModel.hasRole() considers group-inherited roles, so we must include them
-        // here too — otherwise the effective role set would be incomplete for users
-        // who receive roles through group membership.
-        // GroupModel has no parent-group role inheritance at this level, so a plain
-        // composite expansion of its direct mappings is sufficient.
+        // Both UserModel.hasRole() and GroupModel role inheritance consider
+        // parent-group roles, so we must include them here too — otherwise the
+        // effective role set would be incomplete for groups that receive roles
+        // through membership in a parent group.
         if (roleMapper instanceof UserModel) {
             return getDeepUserRoleMappings((UserModel) roleMapper);
+        }
+        if (roleMapper instanceof GroupModel group) {
+            Set<RoleModel> roleMappings = new HashSet<>();
+            addGroupRoles(group, roleMappings);
+            return expandCompositeRoles(roleMappings);
         }
         return expandCompositeRoles(roleMapper.getRoleMappingsStream().collect(Collectors.toSet()));
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/CompositeClientRoleMappingsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/CompositeClientRoleMappingsTest.java
@@ -25,11 +25,13 @@ import java.util.stream.Collectors;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.GroupBuilder;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RoleBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
@@ -76,6 +78,10 @@ public class CompositeClientRoleMappingsTest {
     private static String user1Id;
     private static String user2Id;
     private static String user3Id;
+
+    // Parent group holds A_LEAF_1; child group inherits it via parent-group traversal
+    private static String parentGroupId;
+    private static String childGroupId;
 
     @TestSetup
     public void setup() {
@@ -150,6 +156,19 @@ public class CompositeClientRoleMappingsTest {
                 realm.clients().get(clientBId).roles().get("B_COMPOSITE").toRepresentation()));
 
         // User 3 gets no roles
+
+        // --- Groups: parent gets A_LEAF_1, child inherits it via parent-group traversal ---
+        GroupRepresentation parent = GroupBuilder.create().name("PARENT_GROUP").build();
+        try (Response r = realm.groups().add(parent)) {
+            parentGroupId = ApiUtil.getCreatedId(r);
+        }
+        realm.groups().group(parentGroupId).roles().clientLevel(clientAId).add(Collections.singletonList(
+                realm.clients().get(clientAId).roles().get("A_LEAF_1").toRepresentation()));
+
+        GroupRepresentation child = GroupBuilder.create().name("CHILD_GROUP").build();
+        try (Response r = realm.groups().group(parentGroupId).subGroup(child)) {
+            childGroupId = ApiUtil.getCreatedId(r);
+        }
     }
 
     // --- User 1 + Client A: nested composite expands to all A roles ---
@@ -294,5 +313,28 @@ public class CompositeClientRoleMappingsTest {
                 .stream().map(RoleRepresentation::getName).collect(Collectors.toSet());
 
         assertThat("Brief and full representations should return the same roles", briefNames, is(fullNames));
+    }
+
+    // --- Group composite mappings include roles inherited from parent groups (GH #52046) ---
+
+    @Test
+    public void testGroupCompositeIncludesParentGroupRoles() {
+        List<RoleRepresentation> effective = managedRealm.admin().groups().group(childGroupId)
+                .roles().clientLevel(clientAId).listEffective();
+        Set<String> roleNames = effective.stream().map(RoleRepresentation::getName).collect(Collectors.toSet());
+
+        // A_LEAF_1 is assigned to PARENT_GROUP and must be inherited by CHILD_GROUP
+        assertThat(roleNames, containsInAnyOrder("A_LEAF_1"));
+        assertThat(effective, hasSize(1));
+    }
+
+    @Test
+    public void testGroupWithoutParentHasNoExtraRoles() {
+        List<RoleRepresentation> effective = managedRealm.admin().groups().group(parentGroupId)
+                .roles().clientLevel(clientAId).listEffective();
+        Set<String> roleNames = effective.stream().map(RoleRepresentation::getName).collect(Collectors.toSet());
+
+        assertThat(roleNames, containsInAnyOrder("A_LEAF_1"));
+        assertThat(effective, hasSize(1));
     }
 }


### PR DESCRIPTION
### Summary
Fixes #52046 — regression introduced in #47160.

`RoleUtils.getDeepRoleMappings()` was optimized to skip redundant composite
expansion, but the `GroupModel` branch only expands the group's **direct**
role mappings. The previous implementation used `roleMapper.hasRole()`,
which for groups delegates to `RoleUtils.hasRoleFromGroup()` — a method
that recursively walks parent groups. As a result,
`GET /{realm}/admin/groups/{groupId}/role-mappings/clients/{clientId}/composite`
silently drops client roles inherited from parent groups.

### Fix
Add a `GroupModel` branch in `RoleUtils.getDeepRoleMappings()` that collects
the group's direct role mappings **and** those of all parent groups using the
existing `addGroupRoles()` helper (same traversal the `UserModel` path uses),
then expands composites.

### Testing
- `testGroupCompositeIncludesParentGroupRoles` — child group inherits
  `A_LEAF_1` assigned to its parent via the composite endpoint.
- `testGroupWithoutParentHasNoExtraRoles` — top-level group still returns
  exactly its own role.

The `UserModel` path is unaffected (`getDeepUserRoleMappings` unchanged).