### PR TITLE
fix: update protocol mapper name and protocol on update

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
@@ -463,6 +463,8 @@ public class ClientAdapter implements ClientModel, JpaModel<ClientEntity> {
             throw new ModelException("mapping with id " + mapping.getId() + " does not exist");
         }
         entity.setProtocolMapper(mapping.getProtocolMapper());
+        entity.setName(mapping.getName());
+        entity.setProtocol(mapping.getProtocol());
         if (entity.getConfig() == null) {
             entity.setConfig(mapping.getConfig());
         } else {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientScopeAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientScopeAdapter.java
@@ -177,6 +177,8 @@ public class ClientScopeAdapter implements ClientScopeModel, JpaModel<ClientScop
             throw new ModelException("mapping with id " + mapping.getId() + " does not exist");
         }
         entity.setProtocolMapper(mapping.getProtocolMapper());
+        entity.setName(mapping.getName());
+        entity.setProtocol(mapping.getProtocol());
         if (entity.getConfig() == null) {
             entity.setConfig(mapping.getConfig());
         } else {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientProtocolMapperTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientProtocolMapperTest.java
@@ -147,6 +147,7 @@ public class ClientProtocolMapperTest extends AbstractProtocolMapperTest {
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.clientProtocolMapperPath(samlClient.getId(), createdId), rep, ResourceType.PROTOCOL_MAPPER);
 
         rep.getConfig().put("role", "account.manage-account");
+        rep.setName("saml-role-name-mapper2-updated");
         rep.setId(createdId);
         samlMappersRsc.update(createdId, rep);
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientProtocolMapperPath(samlClient.getId(), createdId), rep, ResourceType.PROTOCOL_MAPPER);
@@ -166,6 +167,7 @@ public class ClientProtocolMapperTest extends AbstractProtocolMapperTest {
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.clientProtocolMapperPath(oidcClient.getId(), createdId), rep, ResourceType.PROTOCOL_MAPPER);
 
         rep.getConfig().put("role", "myotherrole");
+        rep.setName("oidc-hardcoded-role-mapper2-updated");
         rep.setId(createdId);
         oidcMappersRsc.update(createdId, rep);
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientProtocolMapperPath(oidcClient.getId(), createdId), rep, ResourceType.PROTOCOL_MAPPER);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeProtocolMapperTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeProtocolMapperTest.java
@@ -157,6 +157,7 @@ public class ClientScopeProtocolMapperTest extends AbstractProtocolMapperTest {
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.clientScopeProtocolMapperPath(samlClientScopeId, createdId), rep, ResourceType.PROTOCOL_MAPPER);
 
         rep.getConfig().put("role", "account.manage-account");
+        rep.setName("saml-role-name-mapper2-updated");
         rep.setId(createdId);
         samlMappersRsc.update(createdId, rep);
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientScopeProtocolMapperPath(samlClientScopeId, createdId), rep, ResourceType.PROTOCOL_MAPPER);
@@ -176,6 +177,7 @@ public class ClientScopeProtocolMapperTest extends AbstractProtocolMapperTest {
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.clientScopeProtocolMapperPath(oidcClientScopeId, createdId), rep, ResourceType.PROTOCOL_MAPPER);
 
         rep.getConfig().put("role", "myotherrole");
+        rep.setName("oidc-hardcoded-role-mapper2-updated");
         rep.setId(createdId);
         oidcMappersRsc.update(createdId, rep);
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientScopeProtocolMapperPath(oidcClientScopeId, createdId), rep, ResourceType.PROTOCOL_MAPPER);


### PR DESCRIPTION
Fixes #52049

## Problem
`updateProtocolMapper` in `ClientAdapter` and `ClientScopeAdapter` only updated the `protocolMapper` and `config` fields, but never the mapper's `name` or `protocol`. So renaming a protocol mapper via the Admin REST API (e.g. through the Terraform provider) silently left the persisted name unchanged.

The create path (`addProtocolMapper`) sets all of `name`, `protocol` and `protocolMapper`; the update path was inconsistent.

## Fix
Align the update path with the create path by also persisting `name` and `protocol` in both `ClientAdapter.updateProtocolMapper` and `ClientScopeAdapter.updateProtocolMapper`.

## Tests
Extended `ClientProtocolMapperTest` and `ClientScopeProtocolMapperTest` update tests (`test06UpdateSamlMapper`, `test07UpdateOidcMapper`) to rename the mapper during the update and assert the new name is persisted via `assertEqualMappers`.
