### PR TITLE
feat(admin-ui): expose pass login_hint for social identity providers

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
@@ -22,6 +22,7 @@ import { toIdentityProvider } from "../routes/IdentityProvider";
 import type { IdentityProviderCreateParams } from "../routes/IdentityProviderCreate";
 import { toIdentityProviders } from "../routes/IdentityProviders";
 import { GeneralSettings } from "./GeneralSettings";
+import { SocialBrokerSettings } from "./SocialBrokerSettings";
 
 export default function AddIdentityProvider() {
   const { adminClient } = useAdminClient();
@@ -105,6 +106,7 @@ export default function AddIdentityProvider() {
                 properties={providerInfo.properties}
               />
             )}
+            <SocialBrokerSettings />
           </FormProvider>
           <ActionGroup>
             <Button

--- a/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddIdentityProvider.tsx
@@ -18,6 +18,7 @@ import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
 import { toUpperCase } from "../../util";
 import { useParams } from "../../utils/useParams";
+import { isSocialIdentityProvider } from "../socialIdentityProvider";
 import { toIdentityProvider } from "../routes/IdentityProvider";
 import type { IdentityProviderCreateParams } from "../routes/IdentityProviderCreate";
 import { toIdentityProviders } from "../routes/IdentityProviders";
@@ -106,7 +107,9 @@ export default function AddIdentityProvider() {
                 properties={providerInfo.properties}
               />
             )}
-            <SocialBrokerSettings />
+            {isSocialIdentityProvider(providerId, serverInfo) && (
+              <SocialBrokerSettings />
+            )}
           </FormProvider>
           <ActionGroup>
             <Button

--- a/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DetailSettings.tsx
@@ -69,6 +69,7 @@ import { OIDCAuthentication } from "./OIDCAuthentication";
 import { OIDCGeneralSettings } from "./OIDCGeneralSettings";
 import { ReqAuthnConstraints } from "./ReqAuthnConstraintsSettings";
 import { SamlGeneralSettings } from "./SamlGeneralSettings";
+import { SocialBrokerSettings } from "./SocialBrokerSettings";
 import { SpiffeSettings } from "./SpiffeSettings";
 import { AdminEvents } from "../../events/AdminEvents";
 import { UserProfileClaimsSettings } from "./OAuth2UserProfileClaimsSettings";
@@ -497,6 +498,7 @@ export default function DetailSettings() {
           {providerInfo && (
             <DynamicComponents stringify properties={providerInfo.properties} />
           )}
+          {isSocial && <SocialBrokerSettings />}
         </FormAccess>
       ),
     },

--- a/js/apps/admin-ui/src/identity-providers/add/SocialBrokerSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/SocialBrokerSettings.tsx
@@ -1,0 +1,5 @@
+import { SwitchField } from "../component/SwitchField";
+
+export const SocialBrokerSettings = () => (
+  <SwitchField label="passLoginHint" field="config.loginHint" />
+);

--- a/js/apps/admin-ui/src/identity-providers/socialIdentityProvider.test.ts
+++ b/js/apps/admin-ui/src/identity-providers/socialIdentityProvider.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { isSocialIdentityProvider } from "./socialIdentityProvider";
+
+describe("isSocialIdentityProvider", () => {
+  const serverInfo = {
+    componentTypes: {
+      "org.keycloak.broker.social.SocialIdentityProvider": [
+        { id: "google" },
+        { id: "microsoft" },
+      ],
+    },
+  };
+
+  it("detects social providers from server info", () => {
+    expect(isSocialIdentityProvider("google", serverInfo)).toBe(true);
+    expect(isSocialIdentityProvider("oidc", serverInfo)).toBe(false);
+    expect(isSocialIdentityProvider(undefined, serverInfo)).toBe(false);
+  });
+});

--- a/js/apps/admin-ui/src/identity-providers/socialIdentityProvider.ts
+++ b/js/apps/admin-ui/src/identity-providers/socialIdentityProvider.ts
@@ -1,0 +1,17 @@
+import type { ServerInfoRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/serverInfoRepresentation";
+
+const SOCIAL_IDENTITY_PROVIDER_SPI =
+  "org.keycloak.broker.social.SocialIdentityProvider";
+
+export function isSocialIdentityProvider(
+  providerId: string | undefined,
+  serverInfo: ServerInfoRepresentation | undefined,
+): boolean {
+  if (!providerId) {
+    return false;
+  }
+
+  return !!serverInfo?.componentTypes?.[SOCIAL_IDENTITY_PROVIDER_SPI]?.some(
+    ({ id }) => id === providerId,
+  );
+}

--- a/js/apps/admin-ui/test/identity-providers/social.spec.ts
+++ b/js/apps/admin-ui/test/identity-providers/social.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import adminClient from "../utils/AdminClient.ts";
+import { switchOff, switchOn } from "../utils/form.ts";
+import { login } from "../utils/login.ts";
+import { assertNotificationMessage } from "../utils/masthead.ts";
+import { goToIdentityProviders } from "../utils/sidebar.ts";
+import { clickSaveButton } from "./main.ts";
+
+const alias = "google-login-hint";
+
+test.describe.serial("Social identity provider pass login_hint", () => {
+  test.beforeEach(async ({ page }) => {
+    try {
+      await adminClient.deleteIdentityProvider(alias);
+    } catch {
+      // The provider may not exist before the test starts.
+    }
+
+    await login(page);
+    await goToIdentityProviders(page);
+  });
+
+  test.afterEach(async () => {
+    try {
+      await adminClient.deleteIdentityProvider(alias);
+    } catch {
+      // The provider may already have been deleted.
+    }
+  });
+
+  test("should expose and persist pass login_hint for Google", async ({
+    page,
+  }) => {
+    await page.getByTestId("google-card").click();
+    await expect(page.locator("#passLoginHint")).toBeVisible();
+
+    await page.getByTestId("alias").fill(alias);
+    await page.getByTestId("config.clientId").fill("client");
+    await page.getByTestId("config.clientSecret").fill("secret");
+    await switchOn(page, "#passLoginHint");
+    await page.getByTestId("createProvider").click();
+
+    await assertNotificationMessage(
+      page,
+      "Identity provider successfully created",
+    );
+    await expect(page.locator("#passLoginHint")).toBeChecked();
+
+    await switchOff(page, "#passLoginHint");
+    await clickSaveButton(page);
+    await assertNotificationMessage(page, "Provider successfully updated");
+    await expect(page.locator("#passLoginHint")).not.toBeChecked();
+
+    await switchOn(page, "#passLoginHint");
+    await clickSaveButton(page);
+    await assertNotificationMessage(page, "Provider successfully updated");
+    await expect(page.locator("#passLoginHint")).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary

Social OAuth2/OIDC identity providers (Google, Microsoft, GitLab, etc.) already support forwarding `login_hint` to the upstream IdP when `config.loginHint=true`, via `AbstractOAuth2IdentityProvider.createAuthorizationUrl()`.

However, the admin console only exposed the "Pass login_hint" toggle for user-defined OIDC/OAuth2 providers, not for built-in social providers where the OIDC settings tab is hidden (`isSocial=true`).

This PR adds the existing `passLoginHint` switch to social provider create and edit screens.

Fixes #11707