### PR TITLE
Stabilize flaky test PasskeysUsernameFormTest

### DIFF
--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/LoginPage.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/LoginPage.java
@@ -55,7 +55,7 @@ public class LoginPage extends AbstractLoginPage {
     }
 
     public void submit() {
-        submitButton.click();
+        driver.waiting().waitForPageReload(() -> submitButton.click());
     }
 
     public void clickSocial(String alias) {

--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/LoginUsernamePage.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/LoginUsernamePage.java
@@ -47,7 +47,7 @@ public class LoginUsernamePage extends AbstractLoginPage {
     }
 
     public void submit() {
-        submitButton.click();
+        driver.waiting().waitForPageReload(() -> submitButton.click());
     }
 
     @Override

--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/PasswordPage.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/PasswordPage.java
@@ -41,7 +41,7 @@ public class PasswordPage extends AbstractLoginPage {
     }
 
     public void submit() {
-        submitButton.click();
+        driver.waiting().waitForPageReload(() -> submitButton.click());
     }
 
     public String getPassword() {

--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/webdriver/WaitUtils.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/webdriver/WaitUtils.java
@@ -7,9 +7,12 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.testframework.ui.page.AbstractPage;
 
 import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class WaitUtils {
@@ -55,6 +58,13 @@ public class WaitUtils {
 
     public WaitUtils waitForTitle(String title) {
         createDefaultWait().until(d -> d.getTitle().equals(title));
+        return this;
+    }
+
+    public WaitUtils waitForPageReload(Runnable action) {
+        WebElement body = managed.findElement(By.tagName("body"));
+        action.run();
+        createDefaultWait().until(ExpectedConditions.stalenessOf(body));
         return this;
     }
 


### PR DESCRIPTION
## Summary
- Add `WaitUtils.waitForPageReload()` that detects actual page navigation by waiting for the current `<body>` element to become stale before returning
- Update `submit()` in `LoginPage`, `LoginUsernamePage`, and `PasswordPage` to use `waitForPageReload()`, ensuring the browser has completed the page reload before the test proceeds

The root cause of the flaky `StaleElementReferenceException` is that `submit()` returned immediately after clicking, and the subsequent `assertCurrent()` could match the **old** page's `data-page-id` (since it's the same login page after an invalid login), allowing element access before the DOM was fully swapped.

Closes #52074

🤖 Generated with [Claude Code](https://claude.com/claude-code)