### PR TITLE
fix: limit OCSP and CRL response sizes to prevent OOM

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/utils/OCSPProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/OCSPProvider.java
@@ -19,6 +19,7 @@
 package org.keycloak.utils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.security.cert.CRLReason;
 import java.security.cert.CertPathValidatorException;
@@ -30,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.connections.httpclient.SafeInputStream;
 import org.keycloak.models.KeycloakSession;
 
 import org.apache.http.HttpHeaders;
@@ -136,8 +138,10 @@ public abstract class OCSPProvider {
                     throw new IOException(errorMessage);
                 }
 
-                byte[] data = EntityUtils.toByteArray(response.getEntity());
-                return data;
+                long maxConsumedResponseSize = session.getProvider(HttpClientProvider.class).getMaxConsumedResponseSize();
+                try (InputStream is = new SafeInputStream(response.getEntity().getContent(), maxConsumedResponseSize)) {
+                    return is.readAllBytes();
+                }
             } finally {
                 EntityUtils.consumeQuietly(response.getEntity());
             }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -65,6 +65,7 @@ import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.connections.httpclient.SafeInputStream;
 import org.keycloak.crl.CrlStorageProvider;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -342,7 +343,8 @@ public class CertificateValidator {
                 get.setHeader("Pragma", "no-cache");
                 get.setHeader("Cache-Control", "no-cache, no-store");
                 try (CloseableHttpResponse response = httpClient.execute(get)) {
-                    try (InputStream content = response.getEntity().getContent()) {
+                    long maxConsumedResponseSize = session.getProvider(HttpClientProvider.class).getMaxConsumedResponseSize();
+                    try (InputStream content = new SafeInputStream(response.getEntity().getContent(), maxConsumedResponseSize)) {
                         return loadFromStream(cf, content);
                     } finally {
                         EntityUtils.consumeQuietly(response.getEntity());


### PR DESCRIPTION
Fixes #52063

This is a follow-up to the response size limit introduced in #27293 (PR #27656), which limited the size of consumed HTTP responses for common requests but did not cover the OCSP and CRL download paths.

An attacker controlling an OCSP responder URI or a CRL distribution point (from a client certificate) could serve an unbounded response, causing `OutOfMemoryError` in the Keycloak server.

This PR enforces the existing `max-consumed-response-size` limit (default 10 MB) on both download paths:

- **OCSPProvider.getEncodedOCSPResponse** now reads the OCSP responder response through a `SafeInputStream` bounded by `getMaxConsumedResponseSize()`.
- **CertificateValidator.loadFromURI** now wraps the CRL download in a `SafeInputStream` with the same limit.

Both files re-use the existing `SafeInputStream` helper introduced for the original fix, so no new configuration is needed and the behavior stays consistent with the rest of the HTTP client.