### PR TITLE
fix: stop removing password fields from immutable form data on empty request

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPassword.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPassword.java
@@ -102,8 +102,6 @@ public class RegistrationPassword implements FormAction, FormActionFactory {
 
         if (errors.size() > 0) {
             context.error(Errors.INVALID_REGISTRATION);
-            formData.remove(RegistrationPage.FIELD_PASSWORD);
-            formData.remove(RegistrationPage.FIELD_PASSWORD_CONFIRM);
             context.validationError(formData, errors);
             return;
         } else {


### PR DESCRIPTION
## Fixes #52076

`RegistrationPassword.validate()` calls `formData.remove(...)` on the map returned by `context.getHttpRequest().getDecodedFormParameters()`. When the registration action URL is requested without any form data (a GET on the action URL, or an empty POST), `QuarkusHttpRequest.getDecodedFormParameters()` returns a shared **immutable** `EMPTY_FORM_PARAM` map, and the `remove` calls throw `UnsupportedOperationException`. The user then sees the generic HTTP 400 error page instead of the registration form with inline validation errors.

## Fix

Remove the two `formData.remove(...)` calls in `validate()`, mirroring the already-merged fix for the identical defect in the reCAPTCHA form action (#41148, fixed by #41781 — which deleted the same `formData.remove(G_RECAPTCHA_RESPONSE)` call).

The values removed here (password, password-confirm) are never re-rendered into the response form, so deleting the calls is safe and matches the accepted upstream pattern.

## Verification

- Normal browser submit that fails validation: unaffected (map is a mutable `QuarkusMultivaluedHashMap`).
- GET / empty POST on the registration action URL: now renders the registration form with the expected validation messages instead of throwing UOE.
