### PR TITLE
Check CA Subject DN in X509 user authenticators too

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/x509.adoc
+++ b/docs/documentation/server_admin/topics/authentication/x509.adoc
@@ -172,8 +172,10 @@ When more than one policy is specified in the `Validate Certificate Policy` sett
 *Bypass identity confirmation*::
 If enabled, X.509 client certificate authentication does not prompt the user to confirm the certificate identity. {project_name} signs in the user upon successful authentication.
 
-*Revalidate client certificate*::
-If set, the client certificate trust chain will be always verified at the application level using the certificates present in the configured trust store. This can be useful if the underlying web server does not enforce client certificate chain validation, for example because it is behind a non-validating load balancer or reverse proxy, or when the number of allowed CAs is too large for the mutual SSL negotiation (most browsers cap the maximum SSL negotiation packet size at 32767 bytes, which corresponds to about 200 advertised CAs). By default this option is off.
+*Certificate Authority subject DN*::
+Subject DN of the root Certificate Authority (or Authorities) (CA) that issued the user certificates (trust anchor). The CA Subject DN can be in the RFC4514 or RFC1779 format. This option allows you to identify the valid trust anchor names for the user certificates, differentiating them for anchors used for other usages or realms. This option is required.
++
+NOTE: Now the client certificate trust chain is always revalidated by {project_name} using the server trust-store or mTLS store in order to obtain the associated root CA.
 
 ==== Adding X.509 Client Certificate Authentication to a Direct Grant Flow
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -27,6 +27,14 @@ After upgrading, {project_name} always performs the upstream identity provider l
 
 To temporarily restore the previous behavior, enable the `allow-initiating-idp-logout-param` server option for the OpenID Connect provider. This option is deprecated and will be removed in a future release.
 
+=== X509 user authentication requires CA Subject DN
+
+Following the changes made to the X509 client authenticator, in this release the user counterparts also require the **Certificate Authority subject DN** option. In this case the new configuration attribute is multi-valued and identifies the trusted anchor CA (or CAs) for user certificates. The new option is now compulsory in the admin console. Besides, the option **Revalidate Client Certificate** should always be enabled in order to get the root certificate for the chain and check its subject DN, therefore it is now deprecated and not presented in the console. Previous configurations still work to maintain backwards compatibility but the new behavior will be enforced in the next major version.
+
+Note that {project_name}'s trust store (or mTLS store) is shared for all the realms, the new configuration allows to specify the correct CAs for user certificates and avoids interference with other unrelated CAs.
+
+Revalidating certificates can be problematic in certain installations (for example if a proxy is configured for TLS termination and the certificates are passed to {project_name} using headers). The trust-store or mTLS store in {project_name} should always be configured correctly to validate the client certificate chain. Please see link:https://www.keycloak.org/server/reverseproxy[Using a reverse proxy] and link:https://www.keycloak.org/server/mutual-tls[Configuring trusted certificates for mTLS], for more information if you are using a TLS termination proxy and X509 client authentication.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 
@@ -170,6 +178,10 @@ Some of the switches were deprecated already in previous versions. In addition t
 * Use lower-case bearer type in token responses
 
 Please update your client applications if you still rely on these switches as they will be removed in the future version.
+
+=== Option Revalidate Client Certificate is deprecated for the X509 user authenticators
+
+As commented in the breaking change section, the option **Revalidate Client Certificate** is deprecated for the X509 user authenticators. This option was used to revalidate the certificate chain presented by the user against the server trust store. In the future, the revalidation will always be executed and the trust store should be configured accordingly.
 
 === `HttpResponse#getStatus()` and `setStatus(int)` in server SPI
 

--- a/js/apps/admin-ui/src/components/multi-line-input/MultiLineInput.tsx
+++ b/js/apps/admin-ui/src/components/multi-line-input/MultiLineInput.tsx
@@ -99,7 +99,9 @@ export const MultiLineInput = ({
     register(name, {
       validate: (value) =>
         isRequired &&
-        (stringify ? value : toStringValue(value || [])).length === 0
+        (stringify ? stringToMultiline(value) : value || []).filter(
+          (s: string) => s.trim(),
+        ).length === 0
           ? t("required")
           : undefined,
     });

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/X509ClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/X509ClientAuthenticator.java
@@ -4,14 +4,12 @@ import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.security.auth.x500.X500Principal;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -38,28 +36,6 @@ public class X509ClientAuthenticator extends AbstractClientAuthenticator {
     public static final String ATTR_CA_SUBJECT_DN = ATTR_PREFIX + ".casubjectdn";
 
     public static final String ATTR_ALLOW_REGEX_PATTERN_COMPARISON = ATTR_PREFIX + ".allow.regex.pattern.comparison";
-
-    // Custom OIDs defined in the OpenBanking Brasil - https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-certificate-standards-1_ID1.html#name-client-certificate
-    // These are not recognized by default in RFC1779 or RFC2253 and hence not read in the java by default
-    private static final Map<String, String> CUSTOM_OIDS = new HashMap<>();
-    private static final Map<String, String> CUSTOM_OIDS_REVERSED = new HashMap<>();
-
-    static {
-        CUSTOM_OIDS.put("2.5.4.5", "serialNumber".toUpperCase());
-        CUSTOM_OIDS.put("2.5.4.15", "businessCategory".toUpperCase());
-        CUSTOM_OIDS.put("1.3.6.1.4.1.311.60.2.1.3", "jurisdictionCountryName".toUpperCase());
-        CUSTOM_OIDS.put("1.2.840.113549.1.9.1", "emailAddress".toUpperCase());
-
-        // Reverse map
-        for (Map.Entry<String, String> entry : CUSTOM_OIDS.entrySet()) {
-            CUSTOM_OIDS_REVERSED.put(entry.getValue(), entry.getKey());
-        }
-        CUSTOM_OIDS_REVERSED.put("E", "1.2.840.113549.1.9.1"); // Another synonym for "EMAILADDRESS"
-    }
-
-    public static X500Principal constructX500Principal(String subjectDN) {
-        return new X500Principal(subjectDN, CUSTOM_OIDS_REVERSED);
-    }
 
     @Override
     public void authenticateClient(ClientAuthenticationFlowContext context) {
@@ -164,19 +140,8 @@ public class X509ClientAuthenticator extends AbstractClientAuthenticator {
         }
 
         // validate the certificate against the CA
-        X509Certificate ca = validateCertificateChain(context.getSession(), certs);
+        X509Certificate ca = validateCertificateChain(context.getSession(), caSubjectDN, certs);
         if (ca == null) {
-            logger.debugf("[X509ClientCertificateAuthenticator:authenticate] Cert '%s' is not trusted by keycloak.", certificate.getSubjectDN().getName());
-            context.attempted();
-            return;
-        }
-
-        // check the ca name matches one of the configured DNs
-        if (!checkSubjectDNExact(ca, caSubjectDN)) {
-            if (logger.isDebugEnabled()) {
-                logger.debugf("[X509ClientCertificateAuthenticator:authenticate] Couldn't match CA certificate for expected Subject DNx %s with allow regex pattern '%s'.", caSubjectDN, clientCfg.getAllowRegexPatternComparison());
-                logger.debugf("[X509ClientCertificateAuthenticator:authenticate] CA Subject DN: %s", ca.getSubjectDN().getName());
-            }
             context.attempted();
             return;
         }
@@ -189,7 +154,7 @@ public class X509ClientAuthenticator extends AbstractClientAuthenticator {
         if (isRegExp) {
             return checkSubjectDNRegex(context, certificate, subjectDN);
         } else {
-            return checkSubjectDNExact(certificate, subjectDN);
+            return CertificateValidator.checkSubjectDNExact(certificate, subjectDN);
         }
     }
 
@@ -204,29 +169,23 @@ public class X509ClientAuthenticator extends AbstractClientAuthenticator {
         return subjectDNPattern.matcher(subjectdn).matches();
     }
 
-    private boolean checkSubjectDNExact(X509Certificate certificate, String subjectDN) {
-        // OIDC/OAuth2 does not use regex comparison as it expects exact DN given in the format according to RFC4514. See RFC8705 for the details.
-        // We allow custom OIDs attributes to be "expanded" or not expanded in the given Subject DN
-        X500Principal expectedDNPrincipal = constructX500Principal(subjectDN);
-
-        return (expectedDNPrincipal.getName(X500Principal.RFC2253, CUSTOM_OIDS).equals(certificate.getSubjectX500Principal().getName(X500Principal.RFC2253, CUSTOM_OIDS)));
-    }
-
-    private X509Certificate validateCertificateChain(KeycloakSession session, X509Certificate[] certs) {
+    private X509Certificate validateCertificateChain(KeycloakSession session, String caSubjectDN, X509Certificate[] certs) {
         try {
             CertificateValidator validator = new CertificateValidator.CertificateValidatorBuilder()
                     .session(session)
                     .trustValidation()
+                        .caSubjectDN(Collections.singletonList(caSubjectDN))
                         .enabled(true)
                     .timestampValidation()
                         .enabled(true)
                     .build(certs);
             validator.checkRevocationStatus()
                     .validateTimestamps()
-                    .validateTrust();
+                    .validateTrust()
+                    .validateCASubjectDN();
             return validator.getCertPathBuilderResult().getTrustAnchor().getTrustedCert();
         } catch (GeneralSecurityException e) {
-            logger.warnf(e, "Invalid certificate %s", certs[0].getSubjectX500Principal().getName(X500Principal.RFC2253, CUSTOM_OIDS));
+            logger.warnf(e, "Invalid certificate %s", CertificateValidator.getSubjectName(certs[0]));
             return null;
         }
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticator.java
@@ -92,7 +92,10 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
     public static final String CERTIFICATE_POLICY_MODE_ANY = "Any";
     static final String DEFAULT_MATCH_ALL_EXPRESSION = "(.*?)(?:$)";
     public static final String CONFIRMATION_PAGE_DISALLOWED = "x509-cert-auth.confirmation-page-disallowed";
+    // revalidate is deprecated and will be always true in 27.0
+    @Deprecated(forRemoval = true, since = "26.8")
     public static final String REVALIDATE_CERTIFICATE = "x509-cert-auth.revalidate-certificate-enabled";
+    public static final String CERTIFICATE_CA_SUBJECT_DN = "x509-cert-auth.casubjectdn";
 
     private final static Logger logger = Logger.getLogger(AbstractX509ClientCertificateAuthenticator.class);;
 
@@ -125,6 +128,7 @@ public abstract class AbstractX509ClientCertificateAuthenticator implements Auth
                         .oCSPResponseCertificate(config.getOCSPResponderCertificate())
                         .oCSPResponderURI(config.getOCSPResponder())
                     .trustValidation()
+                        .caSubjectDN(config.getCASubjectDN())
                         .enabled(config.getRevalidateCertificateEnabled())
                     .timestampValidation()
                         .enabled(config.isCertValidationEnabled());

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/AbstractX509ClientCertificateAuthenticatorFactory.java
@@ -30,6 +30,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 import static java.util.Arrays.asList;
 
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CANONICAL_DN;
+import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_CA_SUBJECT_DN;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_EXTENDED_KEY_USAGE;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_KEY_USAGE;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_POLICY;
@@ -60,7 +61,6 @@ import static org.keycloak.authentication.authenticators.x509.AbstractX509Client
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.OCSPRESPONDER_URI;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.OCSP_FAIL_OPEN;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.REGULAR_EXPRESSION;
-import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.REVALIDATE_CERTIFICATE;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.SERIALNUMBER_HEX;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.TIMESTAMP_VALIDATION;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.USERNAME_EMAIL_MAPPER;
@@ -255,11 +255,13 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
         identityConfirmationPageDisallowed.setLabel("Bypass identity confirmation");
         identityConfirmationPageDisallowed.setHelpText("By default, the users are prompted to confirm their identity extracted from X509 client certificate. The identity confirmation prompt is skipped if the option is switched on.");
 
-        ProviderConfigProperty revalidateCertificateEnabled = new ProviderConfigProperty();
-        revalidateCertificateEnabled.setType(BOOLEAN_TYPE);
-        revalidateCertificateEnabled.setName(REVALIDATE_CERTIFICATE);
-        revalidateCertificateEnabled.setLabel("Revalidate Client Certificate");
-        revalidateCertificateEnabled.setHelpText("Forces revalidation of the client certificate according to the certificates defined in the truststore. This is useful when behind a non-validating proxy or when the number of allowed certificate chains would be too large for mutual SSL negotiation.");
+        // revalidate certificate is removed at configuration although accepted for backwards compatibility
+        ProviderConfigProperty caSubjectDn = new ProviderConfigProperty();
+        caSubjectDn.setType(MULTIVALUED_STRING_TYPE);
+        caSubjectDn.setName(CERTIFICATE_CA_SUBJECT_DN);
+        caSubjectDn.setRequired(true);
+        caSubjectDn.setLabel("Certificate Authority subject DN");
+        caSubjectDn.setHelpText("Subject DN of the root Certificate Authority (or Authorities) (CA) that issued the user certificates (trust anchor). The CA Subject DN can be in the RFC4514 or RFC1779 format.");
 
         configProperties = asList(mappingMethodList,
                 canonicalDn,
@@ -279,7 +281,7 @@ public abstract class AbstractX509ClientCertificateAuthenticatorFactory implemen
                 keyUsage,
                 extendedKeyUsage,
                 identityConfirmationPageDisallowed,
-                revalidateCertificateEnabled,
+                caSubjectDn,
                 certificatePolicy,
                 certificatePolicyMode);
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/CertificateValidator.java
@@ -50,9 +50,11 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
@@ -91,6 +93,52 @@ public class CertificateValidator {
     private final static Logger logger = Logger.getLogger(CertificateValidator.class);
 
     private PKIXCertPathBuilderResult certPathBuilderResult;
+
+    // Custom OIDs defined in the OpenBanking Brasil - https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-certificate-standards-1_ID1.html#name-client-certificate
+    // These are not recognized by default in RFC1779 or RFC2253 and hence not read in Java by default
+    private static final Map<String, String> CUSTOM_OIDS = Map.of(
+            "2.5.4.5", "serialNumber".toUpperCase(Locale.ROOT),
+            "2.5.4.15", "businessCategory".toUpperCase(Locale.ROOT),
+            "1.3.6.1.4.1.311.60.2.1.3", "jurisdictionCountryName".toUpperCase(Locale.ROOT),
+            "1.2.840.113549.1.9.1", "emailAddress".toUpperCase(Locale.ROOT));
+    private static final Map<String, String> CUSTOM_OIDS_REVERSED = Stream.concat(
+            CUSTOM_OIDS.entrySet().stream(),
+            Stream.of(Map.entry("1.2.840.113549.1.9.1", "E")))
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getValue, Map.Entry::getKey));
+
+    public static X500Principal constructX500Principal(String subjectDN) {
+        if (subjectDN == null) {
+            return null;
+        }
+
+        try {
+            return new X500Principal(subjectDN, CUSTOM_OIDS_REVERSED);
+        } catch (IllegalArgumentException e) {
+            logger.debugf("Invalid subjectDN '%s'", subjectDN);
+            return null;
+        }
+    }
+
+    public static String getSubjectName(X509Certificate cert) {
+        if (cert == null) {
+            return null;
+        }
+        return cert.getSubjectX500Principal().getName(X500Principal.RFC2253, CUSTOM_OIDS);
+    }
+
+    public static boolean checkSubjectDNExact(X509Certificate certificate, String subjectDN) {
+        if (certificate == null || subjectDN == null) {
+            return false;
+        }
+
+        X500Principal expectedDNPrincipal = constructX500Principal(subjectDN);
+        if (expectedDNPrincipal == null) {
+            return false;
+        }
+
+        return expectedDNPrincipal.getName(X500Principal.RFC2253, CUSTOM_OIDS)
+                .equals(certificate.getSubjectX500Principal().getName(X500Principal.RFC2253, CUSTOM_OIDS));
+    }
 
     enum KeyUsageBits {
         DIGITAL_SIGNATURE(0, "digitalSignature"),
@@ -428,10 +476,12 @@ public class CertificateValidator {
     OCSPChecker ocspChecker;
     boolean _timestampValidationEnabled;
     boolean _trustValidationEnabled;
+    List<String> _caSubjectDN;
 
     public CertificateValidator() {
 
     }
+
     protected CertificateValidator(X509Certificate[] certChain,
                          int keyUsageBits, List<String> extendedKeyUsage,
                                    List<String> certificatePolicy, String certificatePolicyMode,
@@ -444,7 +494,8 @@ public class CertificateValidator {
                                    OCSPChecker ocspChecker,
                                    KeycloakSession session,
                                    boolean timestampValidationEnabled,
-                                   boolean trustValidationEnabled) {
+                                   boolean trustValidationEnabled,
+                                   List<String> caSubjectDN) {
         _certChain = certChain;
         _keyUsageBits = keyUsageBits;
         _extendedKeyUsage = extendedKeyUsage;
@@ -460,6 +511,7 @@ public class CertificateValidator {
         this.session = session;
         _timestampValidationEnabled = timestampValidationEnabled;
         _trustValidationEnabled = trustValidationEnabled;
+        _caSubjectDN = caSubjectDN;
 
         if (ocspChecker == null)
             throw new IllegalArgumentException("ocspChecker");
@@ -622,6 +674,27 @@ public class CertificateValidator {
             logger.debugf("Found %d trusted root certs", truststoreProvider.getHttpsTruststore().size());
 
             this.certPathBuilderResult = verifyCertificateTrust(_certChain, trustedRootCerts, trustedIntermediateCerts);
+        }
+
+        return this;
+    }
+
+    public CertificateValidator validateCASubjectDN() throws GeneralSecurityException {
+        if (_caSubjectDN == null || _caSubjectDN.isEmpty()) {
+            return this;
+        }
+
+        if (this.certPathBuilderResult == null) {
+            throw new GeneralSecurityException("Trust is not validated yet");
+        }
+
+        X509Certificate ca = this.certPathBuilderResult.getTrustAnchor().getTrustedCert();
+
+        if (ca == null || _caSubjectDN.stream().noneMatch(dn -> checkSubjectDNExact(ca, dn))) {
+            if (logger.isDebugEnabled()) {
+                logger.debugf("Couldn't match trusted anchor subject DN '%s' with expected CA Subject DNs: %s", getSubjectName(ca), _caSubjectDN);
+            }
+            throw new GeneralSecurityException("Invalid trust anchor for the certificate");
         }
 
         return this;
@@ -840,6 +913,7 @@ public class CertificateValidator {
         X509Certificate _responderCert;
         boolean _timestampValidationEnabled;
         boolean _trustValidationEnabled;
+        List<String> _caSubjectDN;
 
         public CertificateValidatorBuilder() {
             _extendedKeyUsage = new LinkedList<>();
@@ -1063,6 +1137,11 @@ public class CertificateValidator {
                 _parent = parent;
             }
 
+            public TrustValidationBuilder caSubjectDN(List<String> value) {
+                _caSubjectDN = value == null ? List.of() : List.copyOf(value);
+                return this;
+            }
+
             public CertificateValidatorBuilder enabled(boolean value) {
                 _trustValidationEnabled = value;
                 return _parent;
@@ -1105,7 +1184,7 @@ public class CertificateValidator {
             return new CertificateValidator(certs, _keyUsageBits, _extendedKeyUsage,
                     _certificatePolicy, _certificatePolicyMode,
                     _crlCheckingEnabled, _crlAbortIfNonUpdated, _crldpEnabled, _crlLoader, _ocspEnabled, _ocspFailOpen,
-                    new BouncyCastleOCSPChecker(session, _responderUri, _responderCert), session, _timestampValidationEnabled, _trustValidationEnabled);
+                    new BouncyCastleOCSPChecker(session, _responderUri, _responderCert), session, _timestampValidationEnabled, _trustValidationEnabled, _caSubjectDN);
         }
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
@@ -71,11 +71,17 @@ public class ValidateX509CertificateUsername extends AbstractX509ClientCertifica
             context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return;
         }
+        if (config.getCASubjectDN().isEmpty()) {
+            logger.warnf("[ValidateX509CertificateUsername:authenticate] Option '%s' is empty, this configuration is deprecated, please configure it for the authenticator in realm '%s'",
+                    CERTIFICATE_CA_SUBJECT_DN, context.getRealm().getName());
+        }
+
         // Validate X509 client certificate
         try {
             CertificateValidator.CertificateValidatorBuilder builder = certificateValidationParameters(context.getSession(), config);
             CertificateValidator validator = builder.build(certs);
             validator.validateTrust()
+                    .validateCASubjectDN()
                     .validateTimestamps()
                     .validateKeyUsage()
                     .validateExtendedKeyUsage()

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509AuthenticatorConfigModel.java
@@ -18,9 +18,16 @@
 
 package org.keycloak.authentication.authenticators.x509;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.Constants;
+import org.keycloak.utils.StringUtil;
 
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CANONICAL_DN;
+import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_CA_SUBJECT_DN;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_EXTENDED_KEY_USAGE;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_KEY_USAGE;
 import static org.keycloak.authentication.authenticators.x509.AbstractX509ClientCertificateAuthenticator.CERTIFICATE_POLICY;
@@ -370,11 +377,32 @@ public class X509AuthenticatorConfigModel extends AuthenticatorConfigModel {
     }
 
     public boolean getRevalidateCertificateEnabled() {
-        return Boolean.parseBoolean(getConfig().get(REVALIDATE_CERTIFICATE));
+        // revalidate is compulsory when CA subject DN is set
+        // maintain previous value for backwards compatibility
+        return !getCASubjectDN().isEmpty() || Boolean.parseBoolean(getConfig().get(REVALIDATE_CERTIFICATE));
     }
 
     public X509AuthenticatorConfigModel setRevalidateCertificateEnabled(boolean value) {
         getConfig().put(REVALIDATE_CERTIFICATE, Boolean.toString(value));
+        return this;
+    }
+
+    public List<String> getCASubjectDN() {
+        String value = getConfig().get(CERTIFICATE_CA_SUBJECT_DN);
+        return value != null
+                ? Arrays.stream(Constants.CFG_DELIMITER_PATTERN.split(value)).filter(StringUtil::isNotBlank).toList()
+                : Collections.emptyList();
+    }
+
+    public X509AuthenticatorConfigModel setCASubjectDN(List<String> value) {
+        value = value != null
+                ? value.stream().filter(StringUtil::isNotBlank).toList()
+                : Collections.emptyList();
+        if (!value.isEmpty()) {
+            getConfig().put(CERTIFICATE_CA_SUBJECT_DN, String.join(Constants.CFG_DELIMITER, value));
+        } else {
+            getConfig().remove(CERTIFICATE_CA_SUBJECT_DN);
+        }
         return this;
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -85,12 +85,17 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
                 context.attempted();
                 return;
             }
+            if (config.getCASubjectDN().isEmpty()) {
+                logger.warnf("[authenticate] Option '%s' is empty, this configuration is deprecated, please configure it for the authenticator in realm '%s'",
+                        CERTIFICATE_CA_SUBJECT_DN, context.getRealm().getName());
+            }
 
             // Validate X509 client certificate
             try {
                 CertificateValidator.CertificateValidatorBuilder builder = certificateValidationParameters(context.getSession(), config);
                 CertificateValidator validator = builder.build(certs);
                 validator.validateTrust()
+                         .validateCASubjectDN()
                          .validateTimestamps()
                          .validateKeyUsage()
                          .validateExtendedKeyUsage()

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/TlsClientAuthCASubjectDNExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/TlsClientAuthCASubjectDNExecutor.java
@@ -20,6 +20,7 @@ import javax.security.auth.x500.X500Principal;
 
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.authenticators.client.X509ClientAuthenticator;
+import org.keycloak.authentication.authenticators.x509.CertificateValidator;
 import org.keycloak.models.ClientModel;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
@@ -90,13 +91,9 @@ public class TlsClientAuthCASubjectDNExecutor implements ClientPolicyExecutorPro
             if (oidcClient.getTlsClientAuthCASubjectDn() == null) {
                 oidcClient.setTlsClientAuthCASubjectDn(dn);
             } else if (Boolean.TRUE.equals(configuration.isEnforced())) {
-                try {
-                    X500Principal forcedDn = X509ClientAuthenticator.constructX500Principal(dn);
-                    X500Principal passedDn = X509ClientAuthenticator.constructX500Principal(oidcClient.getTlsClientAuthCASubjectDn());
-                    if (!forcedDn.equals(passedDn)) {
-                        throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Certificate Authority subject DN must be " + dn);
-                    }
-                } catch (IllegalArgumentException e) {
+                X500Principal forcedDn = CertificateValidator.constructX500Principal(dn);
+                X500Principal passedDn = CertificateValidator.constructX500Principal(oidcClient.getTlsClientAuthCASubjectDn());
+                if (passedDn == null || forcedDn == null || !forcedDn.equals(passedDn)) {
                     throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Certificate Authority subject DN must be " + dn);
                 }
             }

--- a/tests/base/src/test/java/org/keycloak/tests/client/AbstractMutualTLSClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/AbstractMutualTLSClientTest.java
@@ -99,8 +99,8 @@ public abstract class AbstractMutualTLSClientTest {
     @Test
     public void testFailedClientInvocationWithProperCertificateAndIncorrectCASubjectDN() throws Exception {
         //when
-        changeCASubjectDN(ISSUER_SUBJECT_DN_CLIENT_ID, "EMAILADDRESS=contact@other.org,CN=Keycloak CA,OU=Keycloak,O=Red Hat,L=Boston,ST=MA,C=US");
-        AccessTokenResponse token = loginAndGetAccessTokenResponse(ISSUER_SUBJECT_DN_CLIENT_ID, this::newCloseableHttpClient);
+        changeCASubjectDN(EXACT_SUBJECT_DN_CLIENT_ID, "EMAILADDRESS=contact@other.org,CN=Keycloak CA,OU=Keycloak,O=Red Hat,L=Boston,ST=MA,C=US");
+        AccessTokenResponse token = loginAndGetAccessTokenResponse(EXACT_SUBJECT_DN_CLIENT_ID, this::newCloseableHttpClient);
 
         //then
         assertTokenNotObtained(token);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/AbstractX509AuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/AbstractX509AuthenticationTest.java
@@ -472,9 +472,15 @@ public abstract class AbstractX509AuthenticationTest extends AbstractTestRealmKe
                 .setExtendedKeyUsage(extendedKeyUsage);
     }
 
-    protected static X509AuthenticatorConfigModel createLoginSubjectEmailWithRevalidateCert(boolean revalidateCertEnabled) {
+    protected static X509AuthenticatorConfigModel createLoginSubjectEmailWithRevalidateCert(boolean revalidateCertEnabled, String... caSubjectDN) {
         return createLoginSubjectEmail2UsernameOrEmailConfig()
+                .setCASubjectDN(caSubjectDN != null ? Arrays.asList(caSubjectDN) : null)
                 .setRevalidateCertificateEnabled(revalidateCertEnabled);
+    }
+
+    protected static X509AuthenticatorConfigModel createLoginSubjectEmailWithRevalidateCert(String... caSubjectDN) {
+        return createLoginSubjectEmail2UsernameOrEmailConfig()
+                .setCASubjectDN(caSubjectDN != null ? Arrays.asList(caSubjectDN) : null);
     }
 
     protected static X509AuthenticatorConfigModel createLoginSubjectCN2UsernameOrEmailConfig() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509BrowserLoginTest.java
@@ -28,6 +28,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testsuite.util.DroneUtils;
 import org.keycloak.testsuite.util.HtmlUnitBrowser;
+import org.keycloak.testsuite.util.MutualTLSUtils;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -116,6 +117,27 @@ public class X509BrowserLoginTest extends AbstractX509AuthenticationTest {
     @Test
     public void loginWithRevalidateCertEnabledCertIsTrusted() throws Exception {
         x509BrowserLogin(createLoginSubjectEmailWithRevalidateCert(true), userId, "test-user@localhost", "test-user@localhost");
+    }
+
+    @Test
+    public void loginWithRevalidateCertEnabledCertIsTrustedAndCASubjectDN() throws Exception {
+        x509BrowserLogin(createLoginSubjectEmailWithRevalidateCert("InvalidCN", "CN=Other", MutualTLSUtils.CA_CERTIFICATE_SUBJECT_DN), userId, "test-user@localhost", "test-user@localhost");
+    }
+
+    @Test
+    public void loginWithRevalidateCertEnabledAndInvalidCASubjectDN() throws Exception {
+        AuthenticatorConfigRepresentation cfg = newConfig("x509-browser-config", createLoginSubjectEmailWithRevalidateCert(
+                false, MutualTLSUtils.DEFAULT_KEYSTORE_SUBJECT_DN, "CN=Other").getConfig());
+        String cfgId = createConfig(browserExecution.getId(), cfg);
+        Assertions.assertNotNull(cfgId);
+
+        oauth.openLoginForm();
+        loginPage.assertCurrent();
+
+        // Verify there is an error message
+        Assertions.assertNotNull(loginPage.getError());
+
+        assertThat(loginPage.getError(), containsString("Certificate validation's failed."));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509DirectGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/x509/X509DirectGrantTest.java
@@ -33,6 +33,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.HtmlUnitBrowser;
+import org.keycloak.testsuite.util.MutualTLSUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.hamcrest.MatcherAssert;
@@ -166,6 +167,37 @@ public class X509DirectGrantTest extends AbstractX509AuthenticationTest {
         AccessTokenResponse response = oauth.doPasswordGrantRequest("", "");
 
         assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    public void loginWithRevalidateCertEnabledCertIsTrusted() throws Exception {
+        // Set the X509 authenticator configuration
+        AuthenticatorConfigRepresentation cfg = newConfig("x509-directgrant-config",
+                createLoginSubjectEmailWithRevalidateCert(MutualTLSUtils.CA_CERTIFICATE_SUBJECT_DN).getConfig());
+        String cfgId = createConfig(directGrantExecution.getId(), cfg);
+        Assertions.assertNotNull(cfgId);
+
+        oauth.client("resource-owner", "secret");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest("", "");
+
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    public void loginWithRevalidateCertEnabledAndInvalidCASubjectDN() throws Exception {
+        // Set the X509 authenticator configuration
+        AuthenticatorConfigRepresentation cfg = newConfig("x509-directgrant-config",
+                createLoginSubjectEmailWithRevalidateCert(MutualTLSUtils.DEFAULT_KEYSTORE_SUBJECT_DN).getConfig());
+        String cfgId = createConfig(directGrantExecution.getId(), cfg);
+        Assertions.assertNotNull(cfgId);
+
+        oauth.client("resource-owner", "secret");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest("", "");
+
+        assertEquals(401, response.getStatusCode());
+        assertEquals("invalid_request", response.getError());
+        assertThat(response.getErrorDescription(), containsString("Invalid trust anchor for the certificate"));
+        events.clear();
     }
 
     @Test


### PR DESCRIPTION
Closes #51850

PR to check the CA Subject DN for user certificates. Follows the same idea used before for the client authenticator. The PR deprecates the `Revalidate Client Certificate` option is deprecated and removed from the configuration (now we need to always revalidate the chain to get the root CA cert). It adds the new `Certificate Authority subject DN` as compulsory but only for the admin console configuration. You can configure as before and it continues working using API or imports. Warning displayed when the `Certificate Authority subject DN` is not used in the authentication. Some methods have moved from the client authenticator to the CertificateValidator for reusing them in both. Now the vaidator can also check the CA subject DN and can be used for all X509 authenticators. Tests added for form and client_credentials authenticators.
