### PR TITLE
Auto-create delegation client scopes as Optional for all realms

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -100,7 +100,7 @@ The parameterized client scope used by the experimental token exchange delegatio
 
 The full scope format in token requests changes from `delegation:<administrator>` to `delegation:user:<administrator>`. For example, a scope value that was previously `delegation:admin1` is now `delegation:user:admin1`.
 
-If you are upgrading an existing realm, rename its `delegation` client scope to `delegation:user`, change its parameterized scope type to `user-delegation`, and change its consent screen text to `${userDelegationScopeConsentText}`. Then update clients and automation to request `delegation:user:<administrator>`.
+During migration, the `delegation:user` and `delegation:client` client scopes are automatically created in existing realms as *Optional* client scopes. Delegation also requires configuring a delegation permission through FGAP V2. If you had a `delegation` client scope from a previous version, it can be safely removed after migration. Update clients and automation to request `delegation:user:<administrator>`.
 
 === Email is no longer marked as verified by other flows
 

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -354,7 +354,7 @@ bin/kc.[sh|bat] start --features=token-exchange-delegation,parameterized-scopes
 
 Admin delegation allows a user (subject) to delegate their token to an administrator (actor). The client requests the `delegation:user` scope with the administrator's identifier as a parameter using the https://datatracker.ietf.org/doc/html/rfc9396[parameterized scopes] syntax.
 
-When the feature is enabled, a `delegation:user` client scope is automatically created in new realms. Clients that want to use delegation must add the `delegation:user` scope to their optional client scopes in the Admin Console.
+When the feature is enabled, the `delegation:user` client scope is automatically created in all realms (new and existing) as an *Optional* client scope, making it available to all clients by default. Delegation also requires <<Granting delegation permission,granting delegation permission>>. Without a matching permission granting the `delegate` scope, the delegation scope is silently dropped from the token.
 
 ==== Granting delegation permission
 

--- a/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo26_8_0.java
+++ b/model/storage-private/src/main/java/org/keycloak/migration/migrators/MigrateTo26_8_0.java
@@ -1,7 +1,10 @@
 package org.keycloak.migration.migrators;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.common.Profile;
+import org.keycloak.migration.MigrationProvider;
 import org.keycloak.migration.ModelVersion;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 
@@ -18,5 +21,14 @@ public class MigrateTo26_8_0 extends RealmMigration {
     public void migrateRealm(KeycloakSession session, RealmModel realm) {
         AdminPermissionsSchema.SCHEMA.addResourceTypeScope(session, realm, AdminPermissionsSchema.USERS_RESOURCE_TYPE, AdminPermissionsSchema.DELEGATE);
         AdminPermissionsSchema.SCHEMA.addResourceTypeScope(session, realm, AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, AdminPermissionsSchema.DELEGATE_MEMBERS);
+
+        if (Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION)) {
+            MigrationProvider migrationProvider = session.getProvider(MigrationProvider.class);
+            // FGAP guards delegation permission evaluation, so scopes can safely be optional
+            ClientScopeModel userDelegation = migrationProvider.addOIDCUserDelegationClientScope(realm);
+            realm.addDefaultClientScope(userDelegation, false);
+            ClientScopeModel clientDelegation = migrationProvider.addOIDCClientDelegationClientScope(realm);
+            realm.addDefaultClientScope(clientDelegation, false);
+        }
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/migration/MigrationProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/migration/MigrationProvider.java
@@ -100,4 +100,20 @@ public interface MigrationProvider extends Provider {
      * @return created, already existing client scope or null if not step-up not enabled
      */
     ClientScopeModel addSamlAuthnContextClassRefClientScope(RealmModel realm);
+
+    /**
+     * Add 'delegation:user' client scope or return it if already exists
+     *
+     * @param realm
+     * @return created or already existing client scope 'delegation:user'
+     */
+    ClientScopeModel addOIDCUserDelegationClientScope(RealmModel realm);
+
+    /**
+     * Add 'delegation:client' client scope or return it if already exists
+     *
+     * @param realm
+     * @return created or already existing client scope 'delegation:client'
+     */
+    ClientScopeModel addOIDCClientDelegationClientScope(RealmModel realm);
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -435,29 +435,10 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         }
 
         if (Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION)) {
-            ClientScopeModel delegationScope = newRealm.addClientScope(USER_DELEGATION_SCOPE);
-            delegationScope.setDescription("OpenID Connect scope for token exchange delegation");
-            delegationScope.setIsParameterizedScope(true);
-            delegationScope.setDisplayOnConsentScreen(true);
-            delegationScope.setAttribute(ClientScopeModel.IS_ALWAYS_CONSENT, Boolean.TRUE.toString());
-            delegationScope.setAttribute(ClientScopeModel.PARAMETERIZED_SCOPE_TYPE, DelegationScopeType.TYPE);
-            delegationScope.setIncludeInTokenScope(true);
-            delegationScope.setProtocol(getId());
-            delegationScope.setConsentScreenText("${userDelegationScopeConsentText}");
-            delegationScope.addProtocolMapper(builtins.get(DELEGATION_MAY_ACT_SUB));
-
-            ClientScopeModel clientDelegationScope = newRealm.addClientScope(CLIENT_DELEGATION_SCOPE);
-            clientDelegationScope.setDescription("OpenID Connect scope for agent/client token exchange delegation");
-            clientDelegationScope.setIsParameterizedScope(true);
-            clientDelegationScope.setDisplayOnConsentScreen(true);
-            clientDelegationScope.setAttribute(ClientScopeModel.IS_ALWAYS_CONSENT, Boolean.TRUE.toString());
-            clientDelegationScope.setAttribute(ClientScopeModel.PARAMETERIZED_SCOPE_TYPE, ClientDelegationScopeType.TYPE);
-            clientDelegationScope.setIncludeInTokenScope(true);
-            clientDelegationScope.setProtocol(getId());
-            clientDelegationScope.setConsentScreenText("${clientDelegationScopeConsentText}");
-            clientDelegationScope.addProtocolMapper(builtins.get(CLIENT_DELEGATION_MAY_ACT_SUB));
-            clientDelegationScope.addProtocolMapper(builtins.get(CLIENT_DELEGATION_MAY_ACT_CLIENT_ID));
-            clientDelegationScope.addProtocolMapper(builtins.get(CLIENT_DELEGATION_AUDIENCE));
+            // FGAP guards delegation permission evaluation, so both scopes are optional by default for new realms
+            ClientScopeModel userDelegationScope = addUserDelegationClientScope(newRealm);
+            newRealm.addDefaultClientScope(userDelegationScope, false);
+            ClientScopeModel clientDelegationScope = addClientDelegationClientScope(newRealm);
             newRealm.addDefaultClientScope(clientDelegationScope, false);
         }
     }
@@ -606,6 +587,52 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
         return serviceAccountScope;
     }
 
+
+    public ClientScopeModel addUserDelegationClientScope(RealmModel newRealm) {
+        ClientScopeModel delegationScope = KeycloakModelUtils.getClientScopeByName(newRealm, USER_DELEGATION_SCOPE);
+        if (delegationScope == null) {
+            delegationScope = newRealm.addClientScope(USER_DELEGATION_SCOPE);
+            delegationScope.setDescription("OpenID Connect scope for token exchange delegation");
+            delegationScope.setIsParameterizedScope(true);
+            delegationScope.setDisplayOnConsentScreen(true);
+            delegationScope.setAttribute(ClientScopeModel.IS_ALWAYS_CONSENT, Boolean.TRUE.toString());
+            delegationScope.setAttribute(ClientScopeModel.PARAMETERIZED_SCOPE_TYPE, DelegationScopeType.TYPE);
+            delegationScope.setIncludeInTokenScope(true);
+            delegationScope.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+            delegationScope.setConsentScreenText("${userDelegationScopeConsentText}");
+            delegationScope.addProtocolMapper(builtins.get(DELEGATION_MAY_ACT_SUB));
+
+            logger.debugf("Client scope '%s' created in the realm '%s'.", USER_DELEGATION_SCOPE, newRealm.getName());
+        } else {
+            logger.debugf("Client scope '%s' already exists in realm '%s'. Skip creating it.", USER_DELEGATION_SCOPE, newRealm.getName());
+        }
+
+        return delegationScope;
+    }
+
+    public ClientScopeModel addClientDelegationClientScope(RealmModel newRealm) {
+        ClientScopeModel clientDelegationScope = KeycloakModelUtils.getClientScopeByName(newRealm, CLIENT_DELEGATION_SCOPE);
+        if (clientDelegationScope == null) {
+            clientDelegationScope = newRealm.addClientScope(CLIENT_DELEGATION_SCOPE);
+            clientDelegationScope.setDescription("OpenID Connect scope for agent/client token exchange delegation");
+            clientDelegationScope.setIsParameterizedScope(true);
+            clientDelegationScope.setDisplayOnConsentScreen(true);
+            clientDelegationScope.setAttribute(ClientScopeModel.IS_ALWAYS_CONSENT, Boolean.TRUE.toString());
+            clientDelegationScope.setAttribute(ClientScopeModel.PARAMETERIZED_SCOPE_TYPE, ClientDelegationScopeType.TYPE);
+            clientDelegationScope.setIncludeInTokenScope(true);
+            clientDelegationScope.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+            clientDelegationScope.setConsentScreenText("${clientDelegationScopeConsentText}");
+            clientDelegationScope.addProtocolMapper(builtins.get(CLIENT_DELEGATION_MAY_ACT_SUB));
+            clientDelegationScope.addProtocolMapper(builtins.get(CLIENT_DELEGATION_MAY_ACT_CLIENT_ID));
+            clientDelegationScope.addProtocolMapper(builtins.get(CLIENT_DELEGATION_AUDIENCE));
+
+            logger.debugf("Client scope '%s' created in the realm '%s'.", CLIENT_DELEGATION_SCOPE, newRealm.getName());
+        } else {
+            logger.debugf("Client scope '%s' already exists in realm '%s'. Skip creating it.", CLIENT_DELEGATION_SCOPE, newRealm.getName());
+        }
+
+        return clientDelegationScope;
+    }
 
     @Override
     protected void addDefaults(ClientModel client) {

--- a/services/src/main/java/org/keycloak/services/migration/DefaultMigrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/migration/DefaultMigrationProvider.java
@@ -129,6 +129,16 @@ public class DefaultMigrationProvider implements MigrationProvider {
     }
 
     @Override
+    public ClientScopeModel addOIDCUserDelegationClientScope(RealmModel realm) {
+        return getOIDCLoginProtocolFactory().addUserDelegationClientScope(realm);
+    }
+
+    @Override
+    public ClientScopeModel addOIDCClientDelegationClientScope(RealmModel realm) {
+        return getOIDCLoginProtocolFactory().addClientDelegationClientScope(realm);
+    }
+
+    @Override
     public void close() {
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/ClientAgentDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/ClientAgentDelegationTest.java
@@ -454,8 +454,6 @@ public class ClientAgentDelegationTest {
         public ClientBuilder configure(ClientBuilder client) {
             return super.configure(client)
                     .clientId(SUBJECT_CLIENT_ID).publicClient(true)
-                    .defaultClientScopes("acr", "basic", "email", "profile")
-                    .optionalClientScopes(OIDCLoginProtocolFactory.CLIENT_DELEGATION_SCOPE)
                     .consentRequired(true)
                     .fullScopeEnabled(false);
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/ClientDelegationCibaTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/ClientDelegationCibaTest.java
@@ -14,7 +14,6 @@ import org.keycloak.events.EventType;
 import org.keycloak.models.CibaConfig;
 import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
-import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
 import org.keycloak.representations.AccessToken;
@@ -282,8 +281,6 @@ public class ClientDelegationCibaTest {
         @Override
         public ClientBuilder configure(ClientBuilder client) {
             return super.configure(client)
-                    .defaultClientScopes("acr", "basic", "email", "profile")
-                    .optionalClientScopes(OIDCLoginProtocolFactory.CLIENT_DELEGATION_SCOPE)
                     .consentRequired(true)
                     .attribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
                     .attribute(CibaConfig.CIBA_BACKCHANNEL_TOKEN_DELIVERY_MODE_PER_CLIENT, "ping")

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/ClientDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/ClientDelegationTest.java
@@ -468,8 +468,6 @@ public class ClientDelegationTest {
         @Override
         public ClientBuilder configure(ClientBuilder client) {
             return super.configure(client)
-                    .defaultClientScopes("acr", "basic", "email", "profile")
-                    .optionalClientScopes(OIDCLoginProtocolFactory.CLIENT_DELEGATION_SCOPE)
                     .consentRequired(true)
                     .attribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString());
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/tokenexchange/TokenExchangeDelegationTest.java
@@ -800,8 +800,6 @@ public class TokenExchangeDelegationTest {
         @Override
         public ClientBuilder configure(ClientBuilder client) {
             return super.configure(client)
-                    .defaultClientScopes("acr", "basic", "email", "profile")
-                    .optionalClientScopes(OIDCLoginProtocolFactory.USER_DELEGATION_SCOPE)
                     .consentRequired(true)
                     .attribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
                     .attribute(CibaConfig.CIBA_BACKCHANNEL_TOKEN_DELIVERY_MODE_PER_CLIENT, "ping")


### PR DESCRIPTION
- Closes #52085
- When the feature is enabled, we should add the `delegation:user`, and the `delegation:client` scopes realm optional by default - the scope is only assigned when the FGAP is correctly set and the user/client comply with these policies
- So, we have already guards on the FGAP - no need to assign the scopes again for specific users
- It's also very fragile to create the scopes manually for existing realms - as was seen here: https://github.com/keycloak/keycloak/pull/51999
- IMHO, this is a better approach

cc: @keycloak/core-authn WDYT? 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
