### PR TITLE
fix: keep resource_access claim when no entry can be converted

### DIFF
--- a/core/src/main/java/org/keycloak/util/TokenUtil.java
+++ b/core/src/main/java/org/keycloak/util/TokenUtil.java
@@ -274,18 +274,27 @@ public class TokenUtil {
         }
 
         if (token.getOtherClaims().containsKey(RESOURCE_ACCESS)) {
-            token.setResourceAccess(new HashMap<>(token.getResourceAccess())); // Re-create as hashMap as it might be unmodifiable map
-
             if (token.getOtherClaims().get(RESOURCE_ACCESS) instanceof Map) {
+                Map<String, AccessToken.Access> mergedResourceAccess = null;
                 for (Map.Entry<String, Object> entry : ((Map<String, Object>) token.getOtherClaims().get(RESOURCE_ACCESS)).entrySet()) {
                     String clientId = entry.getKey();
                     AccessToken.Access otherClaimsClientAccess = convertToAccess(entry.getValue(), RESOURCE_ACCESS + "." + clientId);
-                    AccessToken.Access mergedAccess = mergeAccess(token.getResourceAccess(clientId), otherClaimsClientAccess);
-                    if (mergedAccess != null) {
-                        token.getResourceAccess().put(clientId, mergedAccess);
+                    if (otherClaimsClientAccess != null) {
+                        if (mergedResourceAccess == null) {
+                            // Re-create as hashMap as it might be unmodifiable map
+                            mergedResourceAccess = new HashMap<>(token.getResourceAccess());
+                        }
+                        AccessToken.Access mergedAccess = mergeAccess(token.getResourceAccess(clientId), otherClaimsClientAccess);
+                        mergedResourceAccess.put(clientId, mergedAccess);
                     }
                 }
-                token.getOtherClaims().remove(RESOURCE_ACCESS);
+                // Only consume the raw claim when at least one entry could be converted. If nothing
+                // was converted (e.g. a JSON string injected via a user attribute protocol mapper),
+                // keep the original claim so the token retains its content instead of an empty {}.
+                if (mergedResourceAccess != null) {
+                    token.setResourceAccess(mergedResourceAccess);
+                    token.getOtherClaims().remove(RESOURCE_ACCESS);
+                }
             } else {
                 logger.warnf("Claim resource_access in the incorrect format in the access token of user %s. Ignoring", token.getPreferredUsername());
             }

--- a/core/src/test/java/org/keycloak/jose/JsonWebTokenTest.java
+++ b/core/src/test/java/org/keycloak/jose/JsonWebTokenTest.java
@@ -240,4 +240,53 @@ public class JsonWebTokenTest {
         Assert.assertEquals(role1Set, at.getResourceAccess().get("client1").getRoles());
     }
 
+    @Test
+    public void testResourceAccessMergeWithUnconvertibleClaim() throws IOException {
+        // Regression test for GH issue #52087: a User Attribute protocol mapper can inject a
+        // JSON *string* value directly under "resource_access.<client-id>". That value cannot be
+        // converted to Access (writeValueAsString wraps it in quotes, readValue fails with
+        // IOException). Previously the raw claim was unconditionally removed, leaving an empty
+        // "resource_access": {} in the token. The raw claim must be preserved when nothing
+        // could be merged.
+
+        // All entries unconvertible -> original claim must be kept
+        AccessToken at = new AccessToken();
+        Map<String, Object> map = new HashMap<>();
+        map.put("client1", "{\"roles\":[\"role1\"]}");
+        at.getOtherClaims().put(RESOURCE_ACCESS, map);
+        TokenUtil.convertTokenRolesFromOtherClaims(at);
+        Assert.assertEquals(0, at.getResourceAccess().size());
+        Assert.assertNotNull(at.getOtherClaims().get(RESOURCE_ACCESS));
+        // The serialized token still carries the original content
+        String json = JsonSerialization.writeValueAsString(at);
+        assertTrue(json.contains("role1"));
+
+        // Mixed: one convertible entry, one unconvertible -> raw claim consumed, convertible entry merged
+        at = new AccessToken();
+        Map<String, Object> mixedMap = new HashMap<>();
+        Set<String> role1Set = new HashSet<>(Collections.singleton("role1"));
+        Map<String, Object> map1 = new HashMap<>();
+        map1.put(ROLES, role1Set);
+        mixedMap.put("client1", map1);
+        mixedMap.put("client2", "{\"roles\":[\"role2\"]}");
+        at.getOtherClaims().put(RESOURCE_ACCESS, mixedMap);
+        TokenUtil.convertTokenRolesFromOtherClaims(at);
+        Assert.assertEquals(1, at.getResourceAccess().size());
+        Assert.assertEquals(role1Set, at.getResourceAccess().get("client1").getRoles());
+        Assert.assertNull(at.getOtherClaims().get(RESOURCE_ACCESS));
+
+        // Unconvertible entry with an existing typed resourceAccess -> nothing lost, claim kept
+        at = new AccessToken();
+        Map<String, AccessToken.Access> accessMap = new HashMap<>();
+        AccessToken.Access access1 = new AccessToken.Access();
+        access1.roles(role1Set);
+        accessMap.put("client2", access1);
+        at.setResourceAccess(accessMap);
+        at.getOtherClaims().put(RESOURCE_ACCESS, map);
+        TokenUtil.convertTokenRolesFromOtherClaims(at);
+        Assert.assertEquals(1, at.getResourceAccess().size());
+        Assert.assertEquals(role1Set, at.getResourceAccess().get("client2").getRoles());
+        Assert.assertNotNull(at.getOtherClaims().get(RESOURCE_ACCESS));
+    }
+
 }


### PR DESCRIPTION
## What

Fixes #52087. `TokenUtil.convertTokenRolesFromOtherClaims()` unconditionally removed `resource_access` from `otherClaims` even when every per-client entry failed to convert, replacing a previously-working JSON string (injected via a User Attribute protocol mapper under `resource_access.<client-id>`) with an empty `{}`.

## Why

`convertToAccess()` runs `writeValueAsString(accessClaim)` then `readValue(..., Access.class)`. For a JSON **string** value (e.g. `"{\"roles\":[\"role1\"]}"`), the round-trip produces a quoted string that fails to deserialize into `Access`, throwing `IOException` and returning `null`. The old code still called `remove(RESOURCE_ACCESS)` afterwards, so the raw claim was dropped with nothing merged in its place — regression since 26.7.1 (CVE-2026-16102 fix).

## How

Mirror the `realm_access` branch: only consume (set + remove) the raw claim when **at least one** entry was successfully converted and merged. If nothing converts, keep the original `otherClaims.resource_access` so the token retains its content instead of an empty `{}`.

## Verification

Standalone simulation of the conversion logic confirms:
- JSON string value fails conversion (`MismatchedInputException`)
- OLD: `{"resourceAccess":{},"otherClaims":{}}` (content lost)
- NEW: `otherClaims.resource_access` preserved with original string
- Mixed convertible/unconvertible: convertible entry merged, raw claim consumed; string entry preserved
- Normal convertible-only path unchanged

Added regression test `testResourceAccessMergeWithUnconvertibleClaim` covering all-unconvertible, mixed, and pre-existing-typed-access cases.