### PR TITLE
[CVE-2026-16089] Authorization codes can be retargeted to another cli…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -260,6 +260,7 @@ public class OIDCLoginProtocol implements LoginProtocol {
         String code = null;
         if (responseType.hasResponseType(OIDCResponseType.CODE)) {
             OAuth2Code codeData = new OAuth2Code(SecretGenerator.getInstance().generateSecureID(),
+                authSession.getClient().getId(),
                 Time.currentTime() + userSession.getRealm().getAccessCodeLifespan(),
                 nonce,
                 authSession.getClientNote(OAuth2Constants.SCOPE),

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2Code.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2Code.java
@@ -33,6 +33,7 @@ public class OAuth2Code {
 
     public static final String ID_NOTE = "id";
     public static final String EXPIRATION_NOTE = "exp";
+    private static final String CLIENT_UUID_NOTE = "client_uuid";
     private static final String NONCE_NOTE = "nonce";
     private static final String SCOPE_NOTE = "scope";
     private static final String RESOURCE_NOTE = "resource";
@@ -43,6 +44,8 @@ public class OAuth2Code {
     public static final String USER_SESSION_ID_NOTE = "user_session_id";
 
     private final String id;
+
+    private final String clientUUID;
 
     private final int expiration;
 
@@ -60,23 +63,10 @@ public class OAuth2Code {
 
     private final String userSessionId;
 
-
-    public OAuth2Code(String id, int expiration, String nonce, String scope, String userSessionId) {
-        this.id = id;
-        this.expiration = expiration;
-        this.nonce = nonce;
-        this.scope = scope;
-        this.resource = null;
-        this.redirectUriParam = null;
-        this.codeChallenge = null;
-        this.codeChallengeMethod = null;
-        this.dpopJkt = null;
-        this.userSessionId = userSessionId;
-    }
-
-    public OAuth2Code(String id, int expiration, String nonce, String scope, String resource, String redirectUriParam,
+    public OAuth2Code(String id, String clientUUID, int expiration, String nonce, String scope, String resource, String redirectUriParam,
                       String codeChallenge, String codeChallengeMethod, String dpopJkt, String userSessionId) {
         this.id = id;
+        this.clientUUID = clientUUID;
         this.expiration = expiration;
         this.nonce = nonce;
         this.scope = scope;
@@ -90,6 +80,7 @@ public class OAuth2Code {
 
     private OAuth2Code(Map<String, String> data) {
         id = data.get(ID_NOTE);
+        clientUUID = data.get(CLIENT_UUID_NOTE);
         expiration = Integer.parseInt(data.get(EXPIRATION_NOTE));
         nonce = data.get(NONCE_NOTE);
         scope = data.get(SCOPE_NOTE);
@@ -111,6 +102,7 @@ public class OAuth2Code {
         Map<String, String> result = new HashMap<>();
 
         result.put(ID_NOTE, id);
+        result.put(CLIENT_UUID_NOTE, clientUUID);
         result.put(EXPIRATION_NOTE, String.valueOf(expiration));
         result.put(NONCE_NOTE, nonce);
         result.put(SCOPE_NOTE, scope);
@@ -126,6 +118,10 @@ public class OAuth2Code {
 
     public String getId() {
         return id;
+    }
+
+    public String getClientUUID() {
+        return clientUUID;
     }
 
     public int getExpiration() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2CodeParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2CodeParser.java
@@ -112,6 +112,14 @@ public class OAuth2CodeParser {
             return result.illegalCode();
         }
 
+        String persistedClientUUID = result.codeData.getClientUUID();
+        // We allow "persistedClientUUID" to be null just because zero-downtime upgrade between micro versions (as older KC versions might not have clientUUID stored).
+        // This might be removed in the future version
+        if (persistedClientUUID != null && !clientUUID.equals(persistedClientUUID)) {
+            logger.warnf("Code is bound to a different client '%s'", clientUUID);
+            return result.illegalCode();
+        }
+
         // Finally doublecheck if code is not expired
         int currentTime = Time.currentTime();
         if (currentTime > result.codeData.getExpiration()) {

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/AuthorizationCodeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/AuthorizationCodeTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.oauth;
+
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventType;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientConfigBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
+import org.keycloak.testframework.realm.UserConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.ErrorPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.OAuthErrorException.INVALID_GRANT;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
+ */
+@KeycloakIntegrationTest
+public class AuthorizationCodeTest {
+
+    @InjectRealm(config =  AuthzCodeRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm managedRealm;
+
+    @InjectWebDriver
+    ManagedWebDriver driver;
+
+    @InjectOAuthClient(lifecycle = LifeCycle.METHOD)
+    OAuthClient oauth;
+
+    @InjectEvents
+    Events events;
+
+    @InjectPage
+    ErrorPage errorPage;
+
+    @InjectHttpClient(followRedirects = false)
+    CloseableHttpClient httpClient;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    // Issue 51003
+    @Test
+    public void authorizationCodeCanBeRedeemedAfterClientUuidRetargeting() {
+        String redirectUri = oauth.getRedirectUri();
+
+        ClientRepresentation clientRep = ClientConfigBuilder.create()
+                .clientId("retarget-client")
+                .secret("secret")
+                .redirectUris(redirectUri)
+                .build();
+        try (Response resp = managedRealm.admin().clients().create(clientRep)) {
+            String retargetClientUuid = ApiUtil.getCreatedId(resp);
+            managedRealm.cleanup().add(r -> r.clients().delete(retargetClientUuid));
+
+            AuthorizationEndpointResponse retargetClientLogin = oauth
+                    .client("retarget-client", "secret")
+                    .redirectUri(redirectUri)
+                    .loginForm()
+                    .doLogin("test-user@localhost", "password");
+            Assertions.assertNotNull(retargetClientLogin.getCode());
+
+            AuthorizationEndpointResponse testAppLogin = oauth
+                    .client("test-app", "test-secret")
+                    .redirectUri(redirectUri)
+                    .loginForm()
+                    .doLoginWithCookie();
+            String testAppCode = testAppLogin.getCode();
+            Assertions.assertNotNull(testAppCode);
+
+            String testAppUuid = managedRealm.admin()
+                    .clients()
+                    .findByClientId("test-app")
+                    .get(0)
+                    .getId();
+
+            String retargetedCode = testAppCode.replace(testAppUuid, retargetClientUuid);
+
+            events.clear();
+
+            // Attempt to use "code" created for different client should fail
+            oauth.client("retarget-client", "secret").redirectUri(redirectUri);
+            AccessTokenResponse tokenResponse = oauth
+                    .accessTokenRequest(retargetedCode)
+                    .redirectUri(redirectUri)
+                    .send();
+
+            Assertions.assertFalse(tokenResponse.isSuccess());
+            assertEquals(INVALID_GRANT, tokenResponse.getError());
+            EventAssertion.assertError(events.poll()).type(EventType.CODE_TO_TOKEN_ERROR).error(Errors.INVALID_CODE);
+        }
+    }
+
+    private static class AuthzCodeRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmConfigBuilder configure(RealmConfigBuilder realmBuilder) {
+            RealmConfigBuilder realmCfgBuilder = realmBuilder.name("test");
+            realmCfgBuilder.addUser(UserConfigBuilder.create().username("test-user@localhost")
+                            .name("test", "user")
+                            .email("test-user@localhost")
+                            .emailVerified(true)
+                            .password("password")
+                            .roles("user", "offline_access").build());
+            return realmCfgBuilder;
+        }
+    }
+
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerEndpointTest.java
@@ -40,15 +40,11 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ComponentsResource;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.MultivaluedHashMap;
-import org.keycloak.common.util.SecretGenerator;
-import org.keycloak.common.util.Time;
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
@@ -62,7 +58,6 @@ import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
-import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ComponentRepresentation;
@@ -71,7 +66,6 @@ import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPAttributePermissions;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.services.managers.AppAuthManager;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.testframework.remote.providers.runonserver.RunOnServerException;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialIssuerMetadataResponse;
@@ -86,7 +80,6 @@ import org.jboss.logging.Logger;
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_VC;
 import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP_256;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONFIGURATION_ID;
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_URI_CODE_SCOPE;
 import static org.keycloak.userprofile.DeclarativeUserProfileProvider.UP_COMPONENT_CONFIG_KEY;
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_ADMIN;
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_USER;
@@ -472,29 +465,5 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCIssuerTestBase {
                 TIME_PROVIDER,
                 30
         );
-    }
-
-    static OAuth2CodeEntry prepareSessionCode(
-            KeycloakSession session,
-            AppAuthManager.BearerTokenAuthenticator authenticator,
-            String note) {
-
-        AuthenticationManager.AuthResult authResult = authenticator.authenticate();
-        UserSessionModel userSessionModel = authResult.session();
-        AuthenticatedClientSessionModel authenticatedClientSessionModel =
-                userSessionModel.getAuthenticatedClientSessionByClient(authResult.client().getId());
-
-        OAuth2Code oauth2Code = new OAuth2Code(
-                SecretGenerator.getInstance().randomString(),
-                Time.currentTime() + 6000,
-                SecretGenerator.getInstance().randomString(),
-                CREDENTIAL_OFFER_URI_CODE_SCOPE,
-                authenticatedClientSessionModel.getUserSession().getId()
-        );
-
-        String nonce = OAuth2CodeParser.persistCode(session, authenticatedClientSessionModel, oauth2Code);
-        authenticatedClientSessionModel.setNote(nonce, note);
-
-        return new OID4VCIssuerEndpointTest.OAuth2CodeEntry(nonce, oauth2Code);
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -234,20 +234,6 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     }
 
     @Test
-    public void testGetCredentialOfferWithABrokenNote() {
-        String token = getBearerToken(oauth);
-        assertThrows(BadRequestException.class, () ->
-                withCausePropagation(() -> runOnServer.run(session -> {
-                    BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
-                    authenticator.setTokenString(token);
-                    String nonce = prepareSessionCode(session, authenticator, "invalidNote").key();
-                    OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
-                    issuerEndpoint.getCredentialOffer(nonce);
-                }))
-        );
-    }
-
-    @Test
     public void testGetCredentialOffer() {
         String token = getBearerToken(oauth);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -56,8 +56,6 @@ import org.keycloak.common.VerificationException;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MultivaluedHashMap;
-import org.keycloak.common.util.SecretGenerator;
-import org.keycloak.common.util.Time;
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwe.JWE;
@@ -66,11 +64,9 @@ import org.keycloak.jose.jwe.JWEHeader;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.RSAPublicJWK;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
@@ -86,7 +82,6 @@ import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
-import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
@@ -99,7 +94,6 @@ import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPAttributePermissions;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.services.managers.AppAuthManager;
-import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.runonserver.RunOnServerException;
@@ -132,7 +126,6 @@ import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP_256;
 import static org.keycloak.models.Constants.CREATE_DEFAULT_CLIENT_SCOPES;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONFIGURATION_ID;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_FORMAT;
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_URI_CODE_SCOPE;
 import static org.keycloak.protocol.oid4vc.model.ProofType.JWT;
 import static org.keycloak.userprofile.DeclarativeUserProfileProvider.UP_COMPONENT_CONFIG_KEY;
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_ADMIN;
@@ -304,23 +297,6 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         sdJwtTypeCredentialClientScope = requireExistingClientScope(sdJwtTypeCredentialScopeName);
         jwtTypeCredentialClientScope = requireExistingClientScope(jwtTypeCredentialScopeName);
         minimalJwtTypeCredentialClientScope = requireExistingClientScope(minimalJwtTypeCredentialScopeName);
-    }
-
-    protected static OAuth2CodeEntry prepareSessionCode(KeycloakSession session, AppAuthManager.BearerTokenAuthenticator authenticator, String note) {
-        AuthenticationManager.AuthResult authResult = authenticator.authenticate();
-        UserSessionModel userSessionModel = authResult.session();
-        AuthenticatedClientSessionModel authenticatedClientSessionModel = userSessionModel.getAuthenticatedClientSessionByClient(
-                authResult.client().getId());
-        OAuth2Code oauth2Code = new OAuth2Code(
-                SecretGenerator.getInstance().randomString(),
-                Time.currentTime() + 6000,
-                SecretGenerator.getInstance().randomString(),
-                CREDENTIAL_OFFER_URI_CODE_SCOPE,
-                authenticatedClientSessionModel.getUserSession().getId());
-
-        String nonce = OAuth2CodeParser.persistCode(session, authenticatedClientSessionModel, oauth2Code);
-        authenticatedClientSessionModel.setNote(nonce, note);
-        return new OAuth2CodeEntry(nonce, oauth2Code);
     }
 
     protected static OID4VCIssuerEndpoint prepareIssuerEndpoint(KeycloakSession session,


### PR DESCRIPTION
…ent session

closes #51003


(cherry picked from commit 6eb0a6c4621267387b002056f08900531113f353)

Additional notes related to this backport:

- PR adds `AuthorizationCodeTest` in the new testsuite as it was not yet migrated in the branch `release/26.6` . However added just that one new method needed for the test

- PR removes `OID4VCJWTIssuerEndpointTest.testGetCredentialOfferWithABrokenNote()` , which was needed to fix the conflicts. Removing this test is fine as OID4VCI is not going to be supported in the `release/26.6` branch
