### PR TITLE
fix: persist self-signed certificate of ec-generated key providers

### DIFF
--- a/services/src/main/java/org/keycloak/keys/AbstractGeneratedEcKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/AbstractGeneratedEcKeyProviderFactory.java
@@ -18,10 +18,12 @@ package org.keycloak.keys;
 
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
+import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
@@ -89,18 +91,18 @@ public abstract class AbstractGeneratedEcKeyProviderFactory<T extends KeyProvide
         if (ecInNistRep == null) ecInNistRep = getDefaultEcEllipticCurve();
 
         if (!(model.contains(getEcPrivateKeyKey()) && model.contains(getEcPublicKeyKey()))) {
-            generateKeys(model, ecInNistRep);
+            generateKeys(realm, model, ecInNistRep);
             getLogger().debugv("Generated keys for {0}", realm.getName());
         } else {
             String currentEc = getCurveFromPublicKey(model.getConfig().getFirst(getEcPublicKeyKey()));
             if (!ecInNistRep.equals(currentEc)) {
-                generateKeys(model, ecInNistRep);
+                generateKeys(realm, model, ecInNistRep);
                 getLogger().debugv("Elliptic Curve changed, generating new keys for {0}", realm.getName());
             }
         }
     }
 
-    protected void generateKeys(ComponentModel model, String ecInNistRep) {
+    protected void generateKeys(RealmModel realm, ComponentModel model, String ecInNistRep) {
         KeyPair keyPair;
         try {
             keyPair = KeyUtils.generateEcKeyPair(convertECDomainParmNistRepToSecRep(ecInNistRep));
@@ -109,6 +111,25 @@ public abstract class AbstractGeneratedEcKeyProviderFactory<T extends KeyProvide
             model.put(getEcEllipticCurveKey(), ecInNistRep);
         } catch (Throwable t) {
             throw new ComponentValidationException("Failed to generate EC keys", t);
+        }
+
+        String generateCertificate = model.get(Attributes.EC_GENERATE_CERTIFICATE_KEY);
+        if (generateCertificate != null && Boolean.parseBoolean(generateCertificate)) {
+            generateCertificate(realm, model, keyPair);
+        }
+    }
+
+    private void generateCertificate(RealmModel realm, ComponentModel model, KeyPair keyPair) {
+        try {
+            X509Certificate certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, realm.getName());
+            model.put(Attributes.CERTIFICATE_KEY, Base64.getEncoder().encodeToString(certificate.getEncoded()));
+        } catch (Throwable t) {
+            getLogger().warnf("Failed to generate certificate for key provider '%s' in realm '%s'. Details: %s",
+                    model.getName(), realm.getName(), t.getMessage());
+            if (getLogger().isDebugEnabled()) {
+                getLogger().debug(t.getMessage(), t);
+            }
+            throw new ComponentValidationException("Failed to generate certificate", t);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/keys/GeneratedEcdsaKeyProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/keys/GeneratedEcdsaKeyProviderTest.java
@@ -125,11 +125,14 @@ public class GeneratedEcdsaKeyProviderTest {
         ComponentRepresentation createdRep = realm.admin().components().component(id).toRepresentation();
 
         // stands for the number of properties in the key provider config
-        assertEquals(withCertificate ? 3 : 2, createdRep.getConfig().size());
+        assertEquals(withCertificate ? 4 : 2, createdRep.getConfig().size());
         assertEquals(Long.toString(priority), createdRep.getConfig().getFirst(Attributes.PRIORITY_KEY));
         assertEquals(ecInNistRep, createdRep.getConfig().getFirst(ECDSA_ELLIPTIC_CURVE_KEY));
         if (withCertificate) {
             assertNotNull(createdRep.getConfig().getFirst(Attributes.EC_GENERATE_CERTIFICATE_KEY));
+            // The self-signed certificate must be persisted in the component config so that it stays
+            // stable across restarts and across cluster nodes sharing the same database
+            assertNotNull(createdRep.getConfig().getFirst(Attributes.CERTIFICATE_KEY));
         }
 
         KeysMetadataRepresentation keys = realm.admin().keys().getKeyMetadata();


### PR DESCRIPTION
## What

Persist the self-signed X.509 certificate for `ecdsa-generated` (and `ecdh-generated`) key providers at creation time instead of generating a fresh one on every instantiation.

## Why

Closes #52093

For a key provider with `ecGenerateCertificate=true`, `GeneratedEcdsaKeyProvider.loadKey()` generates the self-signed certificate on demand and only ever writes it into the in-memory `ComponentModel` (`model.getConfig().put(...)`). The component is never persisted afterwards, so:

- every restart produces a new certificate (new serial number / validity) for the same, unchanged EC key pair;
- in a cluster, each node independently generates its own certificate, so the `x5c` claim served via the JWKS endpoint depends on which node answers;
- `COMPONENT_CONFIG` never contains a `certificate` entry.

The `rsa-generated` provider does not have this problem: key pair and certificate are generated together in `validateConfiguration()` and persisted in the same transaction.

## How

- `AbstractGeneratedEcKeyProviderFactory.generateKeys()` now also generates and stores the self-signed certificate (`certificate` config attribute) when `ecGenerateCertificate=true`, mirroring `AbstractGeneratedRsaKeyProviderFactory.generateKeys()/generateCertificate()`.
- `loadKey()` keeps its lazy fallback so existing components created before this fix (key pair present, certificate absent) keep working.
- `GeneratedEcdsaKeyProviderTest` now asserts the certificate is persisted in the component config.

## Tests

- `GeneratedEcdsaKeyProviderTest` (config size 3 -> 4 when `ecGenerateCertificate=true`, plus `CERTIFICATE_KEY` persistence assertion).
