### PR TITLE
Fix authorization resource search beyond the initial page

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -81,6 +81,8 @@ export type AttributeForm = Omit<
 
 type Props = ClientSettingsProps & EvaluationResultRepresentation;
 
+const RESOURCE_SEARCH_MAX = 10;
+
 export const AuthorizationEvaluate = (props: Props) => {
   const { hasAccess } = useAccess();
 
@@ -105,7 +107,14 @@ const AuthorizationEvaluateContent = ({ client }: Props) => {
   const realm = useRealm();
   const [isExpanded, setIsExpanded] = useState(false);
   const [applyToResourceType, setApplyToResourceType] = useState(false);
+  // Everything ever fetched, because the scope select and the evaluation both
+  // resolve a selected resource by name after its search has been cleared.
   const [resources, setResources] = useState<ResourceRepresentation[]>([]);
+  // Only what the current search returned, which is what the key select offers.
+  const [resourceOptions, setResourceOptions] = useState<
+    ResourceRepresentation[]
+  >([]);
+  const [resourceSearch, setResourceSearch] = useState("");
   const [scopes, setScopes] = useState<ScopeRepresentation[]>([]);
   const [evaluateResult, setEvaluateResult] =
     useState<PolicyEvaluationResponse>();
@@ -121,16 +130,36 @@ const AuthorizationEvaluateContent = ({ client }: Props) => {
 
   useFetch(
     () =>
-      Promise.all([
-        adminClient.clients.listResources({
-          id: client.id!,
-        }),
-        adminClient.clients.listAllScopes({
-          id: client.id!,
-        }),
-      ]),
-    ([resources, scopes]) => {
-      setResources(resources);
+      adminClient.clients.listResources({
+        id: client.id!,
+        // Without a search the server lists its default page, as before. A
+        // search has to go to the server because the resource being looked for
+        // may not be on that page.
+        ...(resourceSearch
+          ? { first: 0, max: RESOURCE_SEARCH_MAX, name: resourceSearch }
+          : {}),
+      }),
+    (fetchedResources) => {
+      setResourceOptions(fetchedResources);
+      setResources((currentResources) => {
+        const resourcesById = new Map(
+          currentResources.map((resource) => [resource._id!, resource]),
+        );
+        fetchedResources.forEach((resource) =>
+          resourcesById.set(resource._id!, resource),
+        );
+        return Array.from(resourcesById.values());
+      });
+    },
+    [resourceSearch],
+  );
+
+  useFetch(
+    () =>
+      adminClient.clients.listAllScopes({
+        id: client.id!,
+      }),
+    (scopes) => {
       setScopes(scopes);
     },
     [],
@@ -263,12 +292,15 @@ const AuthorizationEvaluateContent = ({ client }: Props) => {
                   fieldId="resourcesAndScopes"
                 >
                   <KeyBasedAttributeInput
-                    selectableValues={resources.map<AttributeType>((item) => ({
-                      name: item.name!,
-                      key: item._id!,
-                    }))}
+                    selectableValues={resourceOptions.map<AttributeType>(
+                      (item) => ({
+                        name: item.name!,
+                        key: item._id!,
+                      }),
+                    )}
                     resources={resources}
                     name="resources"
+                    onFilter={setResourceSearch}
                   />
                 </FormGroup>
               ) : (

--- a/js/apps/admin-ui/src/clients/authorization/KeyBasedAttributeInput.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/KeyBasedAttributeInput.tsx
@@ -24,6 +24,7 @@ type AttributeInputProps = {
   name: string;
   selectableValues?: AttributeType[];
   resources?: ResourceRepresentation[];
+  onFilter?: (value: string) => void;
 };
 
 type ValueInputProps = {
@@ -136,6 +137,7 @@ export const KeyBasedAttributeInput = ({
   name,
   selectableValues,
   resources,
+  onFilter,
 }: AttributeInputProps) => {
   const { t } = useTranslation();
   const { control, watch } = useFormContext();
@@ -188,6 +190,7 @@ export const KeyBasedAttributeInput = ({
                     variant={SelectVariant.typeahead}
                     typeAheadAriaLabel={t("selectOrTypeAKey")}
                     placeholderText={t("selectOrTypeAKey")}
+                    onFilter={onFilter}
                     selections={field.value}
                     onSelect={(v) => {
                       field.onChange(v.toString());

--- a/js/apps/admin-ui/test/clients/authorization.spec.ts
+++ b/js/apps/admin-ui/test/clients/authorization.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import type ResourceEvaluation from "@keycloak/keycloak-admin-client/lib/defs/resourceEvaluation";
 import adminClient from "../utils/AdminClient.ts";
 import { clickSaveButton } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
@@ -472,5 +473,111 @@ test.describe.serial("Client authorization evaluate resource key", () => {
     await expect(
       page.getByText("Required field", { exact: true }),
     ).toBeVisible();
+  });
+});
+
+test.describe("Client authorization evaluate resource search", () => {
+  const clientId = `client-authz-evaluate-search-${crypto.randomUUID()}`;
+  const username = `authz-evaluate-user-${crypto.randomUUID()}`;
+  const scopeName = "test-scope-111";
+
+  test.beforeAll(async () => {
+    await adminClient.createClient({
+      protocol: "openid-connect",
+      clientId,
+      publicClient: false,
+      authorizationServicesEnabled: true,
+      serviceAccountsEnabled: true,
+      standardFlowEnabled: true,
+    });
+    await adminClient.createUser({ username, enabled: true });
+
+    await adminClient.createResources(
+      clientId,
+      Array.from({ length: 120 }, (_, index) => {
+        const resourceNumber = index + 1;
+        return {
+          name: `test-resource-${resourceNumber.toString().padStart(3, "0")}`,
+          ...(resourceNumber === 111 ? { scopes: [{ name: scopeName }] } : {}),
+        };
+      }),
+    );
+  });
+
+  test.afterAll(async () => {
+    await adminClient.deleteClient(clientId);
+    await adminClient.deleteUser(username);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToClients(page);
+    await searchItem(page, "Search for client", clientId);
+    await clickTableRowItem(page, clientId);
+    await goToAuthorizationTab(page);
+    await goToEvaluateSubTab(page);
+  });
+
+  test("Should search and evaluate a resource beyond the first 100", async ({
+    page,
+  }) => {
+    const key = getEvaluateResourceKeyInput(page);
+    const options = getEvaluateResourceKeyOptions(page);
+    const firstPageNames = Array.from(
+      { length: 100 },
+      (_, index) => `test-resource-${(index + 1).toString().padStart(3, "0")}`,
+    );
+
+    // The server still lists its default page of 100, so the first 100 names
+    // are offered without a search. Resource 111 is not on that page.
+    await key.click();
+    await expect(options).toHaveText(firstPageNames);
+
+    // test-resource-111 is outside that list, so it can only be found by
+    // searching the server for it by name.
+    const search = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return (
+        url.pathname.endsWith("/authz/resource-server/resource") &&
+        url.searchParams.get("name") === "test-resource-111"
+      );
+    });
+    await key.pressSequentially("test-resource-111");
+    await search;
+
+    await expect(options).toHaveText(["test-resource-111"]);
+    await key.press("Enter");
+    await expect(key).toHaveValue("test-resource-111");
+
+    // Selecting clears the search, so the searched resource has to be kept
+    // around for its scopes to still resolve. The scope select is the second
+    // combobox of the row: its menu class only exists once the menu is open.
+    const scope = page
+      .getByTestId("attribute-row")
+      .first()
+      .getByRole("combobox")
+      .nth(1);
+    await scope.click();
+    await page.getByRole("option", { name: scopeName, exact: true }).click();
+
+    const user = page.getByTestId("user").getByRole("combobox");
+    await user.fill(username);
+    await page.getByRole("option", { name: username, exact: true }).click();
+
+    const evaluationRequest = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        request.url().endsWith("/authz/resource-server/policy/evaluate"),
+    );
+    await page.getByTestId("authorization-eval").click();
+
+    const evaluation = (await evaluationRequest).postDataJSON() as
+      | ResourceEvaluation
+      | undefined;
+    expect(evaluation?.resources).toHaveLength(1);
+    expect(evaluation?.resources?.[0].name).toBe("test-resource-111");
+    expect(
+      evaluation?.resources?.[0].scopes?.map((scope) => scope.name),
+    ).toEqual([scopeName]);
   });
 });

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -650,6 +650,26 @@ class AdminClient {
     );
   }
 
+  async createResources(clientId: string, resources: ResourceRepresentation[]) {
+    await this.#login();
+    const realm = this.#client.realmName;
+    const client = (await this.#client.clients.find({ clientId, realm }))[0];
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- find()[0] is undefined when client does not exist
+    if (!client?.id) {
+      throw new Error(`Client ${clientId} not found in realm ${realm}`);
+    }
+
+    return await Promise.all(
+      resources.map((resource) =>
+        this.#client.clients.createResource(
+          { id: client.id!, realm },
+          resource,
+        ),
+      ),
+    );
+  }
+
   async deleteResource(
     clientId: string,
     resource: { name: string; realm?: string },


### PR DESCRIPTION
Closes #51585

### Summary

Fixes resource search in Client Authorization → Evaluate so resources
beyond the initial page can be found and selected.

### Changes

- Search resources from the server when filtering.
- Preserve previously fetched resources so selected resources remain available.
- Add an Admin UI E2E regression test covering a resource beyond the initial page.

### Testing

- Prettier checks pass.
- Added an Admin UI E2E regression test for searching and evaluating a resource beyond the initial page.