### PR TITLE
fix: use client UUID for SAML metadata public key cache key

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlProtocolUtils.java
@@ -183,7 +183,7 @@ public class SamlProtocolUtils {
     public static KeyLocator createKeyLocatorForClient(KeycloakSession session, SamlClient samlClient, KeyUse use) throws VerificationException {
         if (StringUtil.isNotBlank(samlClient.getMetadataDescriptorUrl()) && samlClient.isUseMetadataDescriptorUrl()) {
             // configured to use the metadata
-            String modelKey = PublicKeyStorageUtils.getClientModelCacheKey(samlClient.getClient().getRealm().getId(), samlClient.getClient().getClientId());
+            String modelKey = PublicKeyStorageUtils.getClientModelCacheKey(samlClient.getClient().getRealm().getId(), samlClient.getClient().getId());
             PublicKeyStorageProvider keyStorage = session.getProvider(PublicKeyStorageProvider.class);
             PublicKeyLoader keyLoader = new SamlMetadataPublicKeyLoader(session, samlClient.getMetadataDescriptorUrl(), false);
             return new SamlMetadataKeyLocator(modelKey, keyLoader, use, keyStorage);


### PR DESCRIPTION
Fixes #52106

## Problem

`SamlProtocolUtils.createKeyLocatorForClient()` builds the public-key storage cache key with `client.getClientId()` (the human-readable SAML client ID string), while `InfinispanPublicKeyStorageProviderFactory` invalidates cache entries built from `client.getId()` (the internal client UUID) on `ClientUpdatedEvent`/`ClientRemovedEvent`.

Because these two keys never match, a client update (e.g. rotating the SAML metadata URL or key material) does **not** evict the stale SAML metadata public-key entry. The retired signing certificate remains cached and trusted indefinitely (no `validUntil`/`cacheDuration` means no expiration), until cache eviction or manual reload.

## Fix

Use `client.getId()` in the lookup so it uses the same UUID-based cache key that invalidation targets.

## Verification

- The lookup key now equals the invalidation key for the same client:
  - OLD lookup key: `realm::client::<clientId-string>::keyuse::SIG` (≠ invalidation)
  - NEW lookup key: `realm::client::<client-uuid>::keyuse::SIG` (== invalidation for SIG; ENC variant also covered)

No DCO / Apache-2.0 licensed repo contribution.
