### PR TITLE
fix: scope OID4VC issued credential revocation to the path user

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/resources/admin/UserVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/resources/admin/UserVerifiableCredentialResource.java
@@ -254,7 +254,7 @@ public class UserVerifiableCredentialResource {
         auth.users().requireManage(user);
         checkOid4VCIEnabled();
 
-        boolean removed = session.users().removeIssuedVerifiableCredential(credentialId);
+        boolean removed = session.users().removeIssuedVerifiableCredential(user.getId(), credentialId);
         if (!removed) {
             logger.warn(String.format("Issued verifiable credential with ID '%s' not found for user '%s' in realm '%s'.",
                     credentialId, user.getUsername(), realm.getName()));


### PR DESCRIPTION
Fixes #52105

The \`DELETE /admin/realms/{realm}/users/{user-id}/vc/issued-credentials/{id}\` endpoint authorized the caller against the path \`{user-id}\` but removed the issued verifiable credential by primary key only, with no check that it belongs to that user or realm. This allowed an admin with \`manage-users\` on at least one user to delete any other user's issued credential in the same realm (cross-user), and — because no realm predicate was applied — credentials of users in other realms (cross-realm).

The JPA provider already exposes a user-scoped overload \`removeIssuedVerifiableCredential(userId, credentialId)\` that verifies the credential belongs to the path user before removing it (used by the account console's \`AccountIssuedVerifiableCredentialResource\`). This PR switches the admin endpoint to that overload, consistent with the sibling \`revokeCredential()\` and \`getIssuedCredentials()\` methods in the same class.

- **Before:** \`session.users().removeIssuedVerifiableCredential(credentialId)\`
- **After:** \`session.users().removeIssuedVerifiableCredential(user.getId(), credentialId)\`

A \`404\` is returned when the credential does not belong to the path user or does not exist (previously a \`204\` was returned for any existing id, also acting as an existence oracle over the issued-credential table).
