### PR TITLE
Fix: JWE key-management algorithm not validated against provisioned key algorithm on request object decryption

### DIFF
--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -133,15 +133,19 @@ public class DefaultTokenManager implements TokenManager {
             try {
                 Optional<KeyWrapper> activeKey;
                 String kid = joseToken.getHeader().getKeyId();
+                String keyManagementAlgorithm = joseToken.getHeader().getRawAlgorithm();
                 Stream<KeyWrapper> keys = session.keys().getKeysStream(session.getContext().getRealm());
 
                 if (kid == null) {
-                    activeKey = keys.filter(k -> KeyUse.ENC.equals(k.getUse()) && k.getPublicKey() != null)
+                    activeKey = keys.filter(k -> KeyUse.ENC.equals(k.getUse()) && k.getPublicKey() != null
+                                    && matchesKeyManagementAlgorithm(k, keyManagementAlgorithm))
                             .sorted(Comparator.comparingLong(KeyWrapper::getProviderPriority).reversed())
                             .findFirst();
                 } else {
                     activeKey = keys
-                            .filter(k -> KeyUse.ENC.equals(k.getUse()) && k.getKid().equals(kid)).findAny();
+                            .filter(k -> KeyUse.ENC.equals(k.getUse()) && k.getKid().equals(kid)
+                                    && matchesKeyManagementAlgorithm(k, keyManagementAlgorithm))
+                            .findAny();
                 }
 
                 JWE jwe = JWE.class.cast(joseToken);
@@ -173,6 +177,20 @@ public class DefaultTokenManager implements TokenManager {
         }
 
         return verifyJWS(client, clazz, (JWSInput) joseToken, allowNoneAlgorithm);
+    }
+
+    /**
+     * Verifies that the JWE key-management algorithm declared in the JWE header matches the algorithm
+     * provisioned for the decryption key. This prevents an attacker from forcing the realm's encryption
+     * key into a weaker key-management algorithm (e.g. RSA1_5) than the operator configured for the key.
+     *
+     * @param key the candidate decryption key
+     * @param headerAlgorithm the key-management algorithm ("alg") from the JWE header
+     * @return {@code true} when the key carries no configured algorithm or the algorithms match
+     */
+    private boolean matchesKeyManagementAlgorithm(KeyWrapper key, String headerAlgorithm) {
+        String keyAlgorithm = key.getAlgorithm();
+        return keyAlgorithm == null || keyAlgorithm.equals(headerAlgorithm);
     }
 
     private <T> T verifyJWS(ClientModel client, Class<T> clazz, JWSInput jws, boolean allowNoneAlgorithm) {


### PR DESCRIPTION
## Description

When decrypting an encrypted OIDC request object (JWE), Keycloak selects the realm decryption key by key-use (`ENC`) and key ID only. It does not verify that the key-management algorithm (`alg`) in the JWE header matches the algorithm provisioned for that key. An unauthenticated caller can submit a request object encrypted with `RSA1_5` (RSAES-PKCS1-v1.5) instead of the provisioned `RSA-OAEP`, and Keycloak will decrypt it using the weaker algorithm. The attacker still needs the correct realm public key (available in the public JWKS), but can force the realm's private encryption key into performing a legacy key-management algorithm the operator never enabled.

## Fix

In `DefaultTokenManager.decodeClientJWT`, when selecting the decryption key for JWE tokens, additionally filter by the JWE header's key-management algorithm. Keys without a configured algorithm (e.g. some symmetric key types) are not restricted.

Closes #52104
