### PR TITLE
fix: remove obsolete persistedClientUUID null check in OAuth2CodeParser

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2CodeParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2CodeParser.java
@@ -113,9 +113,7 @@ public class OAuth2CodeParser {
         }
 
         String persistedClientUUID = result.codeData.getClientUUID();
-        // We allow "persistedClientUUID" to be null just because zero-downtime upgrade between micro versions (as older KC versions might not have clientUUID stored).
-        // This might be removed in the future version
-        if (persistedClientUUID != null && !clientUUID.equals(persistedClientUUID)) {
+        if (!clientUUID.equals(persistedClientUUID)) {
             logger.warnf("Code is bound to a different client '%s'", clientUUID);
             return result.illegalCode();
         }


### PR DESCRIPTION
Closes #52092

Removes the `persistedClientUUID != null` check in `OAuth2CodeParser` as suggested by the maintainer.

Keycloak 27 has no zero-downtime upgrade path from versions older than the `#51003` fix, so `persistedClientUUID` can no longer be null when a code is validated. Removing the obsolete check simplifies the condition.

```java
- if (persistedClientUUID != null && !clientUUID.equals(persistedClientUUID)) {
+ if (!clientUUID.equals(persistedClientUUID)) {
```