### PR TITLE
fix: surface underlying LDAP error instead of misleading JSON parse error

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -82,8 +82,9 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
 
             error.setError(getErrorCode(throwable));
             if (throwable instanceof ModelValidationException || throwable.getCause() instanceof ModelException) {
-                error.setErrorDescription(throwable.getMessage());
-            } if (throwable instanceof ModelDuplicateException) {
+                Throwable cause = throwable.getCause();
+                error.setErrorDescription(cause instanceof ModelException ? cause.getMessage() : throwable.getMessage());
+            } else if (throwable instanceof ModelDuplicateException) {
                 error.setErrorDescription(throwable.getMessage());
             } else if (throwable instanceof JsonProcessingException || throwable.getCause() instanceof JsonProcessingException) {
                 error.setErrorDescription("Cannot parse the JSON");


### PR DESCRIPTION
### Problem

When an LDAP User Federation has an invalid/misconfigured setting and **Pagination is enabled**, `GET /admin/realms/{realm}/users` (and `?search=...`) returns a misleading HTTP 400:

```json
{
  "error": "unknown_error",
  "error_description": "Cannot parse the JSON"
}
```

The paginated LDAP search returns a **lazy stream** (`Stream.iterate(...).flatMap(...)` in `LDAPStorageProvider.paginatedSearchLDAP`), so the LDAP query only runs during response JSON serialization. When the query fails (e.g. an invalid custom LDAP filter `(test)`), the thrown `ModelException` is wrapped by Jackson into a `JsonMappingException` (a `JsonProcessingException` subtype).

In `KeycloakErrorHandler`, the error-description if/else chain was broken: the first `if` (which handles `ModelException` causes) was a standalone `if` instead of an `else if`, so the subsequent `else if (throwable instanceof JsonProcessingException ...)` branch **overrode** the meaningful description with the generic `"Cannot parse the JSON"`. With pagination disabled the same LDAP failure surfaces a meaningful error, so behavior was inconsistent.

### Fix

- Chain the `ModelDuplicateException` branch with `else if` so a matched `ModelException` cause is not overwritten by the generic JSON-parse message.
- When the cause is a `ModelException`, surface the underlying cause message (the actual LDAP failure) instead of the wrapped Jackson exception message.

### Expected behavior

```json
{
  "error": "unknown_error",
  "error_description": "Failed to fetch results from the LDAP [<provider>] provider: Querying of LDAP failed ..."
}
```

Consistent error handling regardless of whether LDAP Pagination is enabled.

Fixes #52113
