### PR TITLE
fix: stop overwriting meaningful ModelException descriptions with Cannot parse the JSON

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -83,7 +83,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             error.setError(getErrorCode(throwable));
             if (throwable instanceof ModelValidationException || throwable.getCause() instanceof ModelException) {
                 error.setErrorDescription(throwable.getMessage());
-            } if (throwable instanceof ModelDuplicateException) {
+            } else if (throwable instanceof ModelDuplicateException) {
                 error.setErrorDescription(throwable.getMessage());
             } else if (throwable instanceof JsonProcessingException || throwable.getCause() instanceof JsonProcessingException) {
                 error.setErrorDescription("Cannot parse the JSON");


### PR DESCRIPTION
## Why

Fixes #52113. When an LDAP user search fails (e.g. invalid/misconfigured LDAP provider) with pagination enabled, the underlying ModelException is thrown from a lazily-evaluated result stream and wrapped by Jackson into a JsonMappingException. The admin REST API then responds with the generic:

```json
{"error": "unknown_error", "error_description": "Cannot parse the JSON"}
```

...instead of the meaningful LDAP failure message. The same issue was previously reported in #41789 and closed as duplicate of #34857; maintainers asked to propagate a meaningful error to the administrator but it was never implemented.

## Root cause

In KeycloakErrorHandler.getResponse, the branch chain is:

```java
if (throwable instanceof ModelValidationException || throwable.getCause() instanceof ModelException) {
    error.setErrorDescription(throwable.getMessage());
} if (throwable instanceof ModelDuplicateException) {   // <-- standalone if, not else if
    ...
} else if (throwable instanceof JsonProcessingException || ...) {
    error.setErrorDescription("Cannot parse the JSON");
}
```

The `} if {` makes the ModelException branch and the JsonProcessingException branch non-exclusive. A JsonMappingException whose cause is a ModelException (exactly the LDAP pagination failure) matches BOTH branches: the first sets the meaningful description, the second overwrites it with `Cannot parse the JSON`.

## Fix

Change `} if {` to `} else if {`. The chain becomes mutually exclusive: when a ModelException (or one as cause) is present, the meaningful message survives. All other error classes behave identically (verified below).

## Behavior verification

Minimal Java replica of the handler logic - results:

| Case | Before | After |
|---|---|---|
| JsonMappingException with ModelException cause (LDAP pagination failure) | Cannot parse the JSON | User returned from LDAP has null username! ... |
| ModelValidationException (400) | message | message (same) |
| ModelDuplicateException (409) | message | message (same) |
| plain JsonProcessingException (no ModelException cause) | Cannot parse the JSON | Cannot parse the JSON (same) |
| non-ModelException cause wrapped in JsonMappingException | Cannot parse the JSON | Cannot parse the JSON (same) |
| direct ModelException (500) | server-log message | server-log message (same) |

Only the LDAP/ModelException case changes behavior - exactly what #52113 and #41789 asked for.

## Testing

Change is a one-word structural fix (`} if {` to `} else if {`); no new tests added since the handler has no dedicated unit test today. CI runs the existing error-handler/http integration tests.