### PR TITLE
Deprecate volatile sessions and disable caching of persistent sessions

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -222,7 +222,7 @@ To avoid the deprecation warning at startup, set those SPI options to `false`.
 [#disabling-persistent-user-sessions-volatile-sessions-is-deprecated]
 === Disabling persistent user sessions (volatile sessions) is deprecated
 
-Disabling the `persistent-user-sessions` feature (volatile sessions) is deprecated and will be removed in a future release.Persistent user sessions will become the only supported mode.If you have explicitly disabled persistent user sessions with `--features-disabled=persistent-user-sessions`, remove this option before upgrading to a future release.
+Disabling the `persistent-user-sessions` feature (volatile sessions) is deprecated and will be removed in a future release. Persistent user sessions will become the only supported mode. If you have explicitly disabled persistent user sessions with `--features-disabled=persistent-user-sessions`, remove this option before upgrading to a future release.
 
 === Organization invitation link no longer exposed in API responses
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -135,6 +135,16 @@ On PostgreSQL, if an invalid index exists from a previously failed `CREATE INDEX
 
 On databases that do not support non-blocking index creation, or when the migration strategy is set to `manual` or `validate`, {project_name} continues to log the SQL statement for manual execution without creating the index automatically.
 
+=== Caching of persistent user sessions disabled by default
+
+Caching of persistent user sessions in the embedded Infinispan cache is now disabled by default. Recent optimizations to the database layer, including async commits, improved indexes, and cheaper refresh-date updates, make persistent sessions without caching a viable default. Disabling the cache reduces memory usage and network traffic between nodes, enabling smoother rolling updates.
+
+Users may observe increased database connection usage and higher CPU usage on the database. For users already using persistent sessions, the database's own caching layer should prevent any additional IOPS.
+
+To re-enable caching, set `+--spi-user-sessions--infinispan--use-caches=true+`. This option is provided as a temporary workaround. It is now deprecated and will be removed in a future release.
+
+See also the <<disabling-persistent-user-sessions-volatile-sessions-is-deprecated>> section below for related changes.
+
 === Certificate Common Name truncated to 64 characters
 
 When {project_name} generates self-signed certificates (for example, during SAML client creation), the Common Name (CN) is now truncated to 64 characters to comply with the https://datatracker.ietf.org/doc/html/rfc5280[RFC 5280] `ub-common-name` upper bound. Previously, values longer than 64 characters, such as long client IDs, were used as-is. With the BouncyCastle 1.85 update, this caused certificate generation to fail.
@@ -209,11 +219,16 @@ The options `+spi-sticky-session-encoder--infinispan--should-attach-route+` and 
 The setting is still enabled by default to avoid breaking existing setups.
 To avoid the deprecation warning at startup, set those SPI options to `false`.
 
+[#disabling-persistent-user-sessions-volatile-sessions-is-deprecated]
+=== Disabling persistent user sessions (volatile sessions) is deprecated
+
+Disabling the `persistent-user-sessions` feature (volatile sessions) is deprecated and will be removed in a future release.Persistent user sessions will become the only supported mode.If you have explicitly disabled persistent user sessions with `--features-disabled=persistent-user-sessions`, remove this option before upgrading to a future release.
+
 === Organization invitation link no longer exposed in API responses
 
 The `inviteLink` field in `OrganizationInvitationRepresentation` is deprecated and is no longer returned in Admin REST API responses from the organization invitation endpoints.
 
-Previously, the invitation link containing the signed registration token was stored and returned in the representation. The invitation link is still sent via email to the intended recipient.
+Previously, the invitation link containing the signed registration token was stored and returned in the representation.The invitation link is still sent via email to the intended recipient.
 
 The `getInviteLink()` and `setInviteLink()` methods on `OrganizationInvitationRepresentation` are deprecated and will be removed in a future major version. If your code reads `inviteLink` from invitation API responses, it will now receive `null`.
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -228,7 +228,7 @@ Disabling the `persistent-user-sessions` feature (volatile sessions) is deprecat
 
 The `inviteLink` field in `OrganizationInvitationRepresentation` is deprecated and is no longer returned in Admin REST API responses from the organization invitation endpoints.
 
-Previously, the invitation link containing the signed registration token was stored and returned in the representation.The invitation link is still sent via email to the intended recipient.
+Previously, the invitation link containing the signed registration token was stored and returned in the representation. The invitation link is still sent via email to the intended recipient.
 
 The `getInviteLink()` and `setInviteLink()` methods on `OrganizationInvitationRepresentation` are deprecated and will be removed in a future major version. If your code reads `inviteLink` from invitation API responses, it will now receive `null`.
 

--- a/docs/documentation/upgrading/topics/prep_migration.adoc
+++ b/docs/documentation/upgrading/topics/prep_migration.adoc
@@ -23,6 +23,7 @@ The database schema will no longer be compatible with the old server after the u
 If the `persistent-user-sessions` feature is disabled in your current setup and the server is upgraded, all user sessions will be lost except for offline user sessions.
 Users with these sessions will have to log in again.
 Note that the `persistent-user-sessions` feature is disabled by default in {project_name} server releases prior to 26.0.0.
+Disabling `persistent-user-sessions` is deprecated since {project_name} 26.8 and will not be supported in a future release.
 ====
 
 [WARNING]

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -89,35 +89,6 @@ to any node without losing their authentication state. However, production-ready
 to the node where their sessions were initially created. By doing that, you are going to avoid unnecessary state transfer between nodes and improve
 CPU, memory, and network utilization.
 
-.User sessions
-Once the user is authenticated, a user session is created. The user session tracks your active users and their state so that they can seamlessly
-authenticate to any application without being asked for their credentials again. For each application, the user authenticates with a client session, so that the server can track the applications the user is authenticated with and their state on a per-application basis.
-
-User and client sessions are automatically destroyed whenever the user performs a logout, the client performs a token revocation, or due to reaching their expiration time.
-
-The session data are stored in the database by default and loaded on-demand to the following caches:
-
-* `sessions`
-* `clientSessions`
-
-By relying on a distributable cache, cached user and client sessions are available to any node in the cluster so that users can be redirected
-to any node without the need to load session data from the database. However, production-ready deployments should always consider session affinity and favor redirecting users
-to the node where their sessions were initially created. By doing that, you are going to avoid unnecessary state transfer between nodes and improve
-CPU, memory, and network utilization.
-
-These in-memory caches for user sessions and client sessions are limited to, by default, 10000 entries per node which reduces the overall memory usage of {project_name} for larger installations.
-The internal caches will run with only a single owner for each cache entry.
-
-.Offline user sessions
-As an OpenID Connect Provider, the server is capable of authenticating users and issuing offline tokens. When issuing an offline token after successful authentication, the server creates an offline user session and offline client session.
-
-The following caches are used to store offline sessions:
-
-* offlineSessions
-* offlineClientSessions
-
-Like the user and client sessions caches, the offline user and client session caches are limited to 10000 entries per node by default. Items which are evicted from the memory will be loaded on-demand from the database when needed.
-
 .Password brute force detection
 The `loginFailures` distributed cache is used to track data about failed login attempts.
 This cache is needed for the Brute Force Protection feature to work in a multi-node {project_name} setup.
@@ -127,6 +98,29 @@ Action tokens are used for scenarios when a user needs to confirm an action asyn
 The `actionTokens` distributed cache is used to track metadata about action tokens.
 
 TIP: You can see the applied Infinispan configuration in the logs by configuring `--log-level=info,org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory:debug`.
+
+=== User session caching (deprecated)
+
+WARNING: Caching of persistent user and offline sessions is deprecated since {project_name} 26.8 and will be removed in a future release.
+
+A user session tracks an authenticated user across one or more applications (client sessions). Offline sessions are long-lived sessions backed by offline tokens.
+User sessions, client sessions, offline user sessions, and offline client sessions are stored in the database. The embedded Infinispan caches (`sessions`, `clientSessions`, `offlineSessions`, `offlineClientSessions`) exist but are not populated by default.
+
+To temporarily re-enable session caching (for example, to reduce database load at the cost of increased memory usage and the risk of data loss on restart), set:
+
+[source]
+----
+spi-user-sessions--infinispan--use-caches=true
+----
+
+When enabled:
+
+* Sessions are loaded on-demand from the database into the embedded caches.
+* Cached sessions are available to any node in the cluster without a database round-trip.
+* In-memory caches are limited to 10000 entries per node by default (configurable via `--cache-embedded-sessions-max-count` etc.).
+* Cache entries use a single owner per entry.
+
+This option will be removed in a future release. Remove it from your configuration before upgrading to that release.
 
 === Volatile user sessions (deprecated)
 

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -128,31 +128,14 @@ The `actionTokens` distributed cache is used to track metadata about action toke
 
 TIP: You can see the applied Infinispan configuration in the logs by configuring `--log-level=info,org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory:debug`.
 
-=== Volatile user sessions
+=== Volatile user sessions (deprecated)
 
-By default, regular user sessions are stored in the database and loaded on-demand to the cache.
-It is possible to configure {project_name} to store regular user sessions in the cache only and minimize calls to the database.
+WARNING: Volatile user sessions are deprecated since {project_name} 26.8 and will be removed in a future release. Persistent user sessions will become the only supported mode.
+If you have `--features-disabled=persistent-user-sessions` in your configuration, remove it to use the default persistent sessions mode.
 
-Since all the sessions in this setup are stored in-memory, there are two side effects related to this:
-
-* Losing sessions when all {project_name} nodes restart.
-* Increased memory consumption.
-
-When using volatile user sessions, the cache is the source of truth for user and client sessions.
-{project_name} automatically adjusts the number of entries that can be stored in memory, and increases the number of copies to prevent data loss.
-
-Follow these steps to enable this setup:
-
-1. Disable `persistent-user-sessions` feature using the following command:
-+
-----
-bin/kc.sh start --features-disabled=persistent-user-sessions ...
-----
-
-[NOTE]
-====
-Disabling `persistent-user-sessions` is not possible when `multi-site` feature is enabled.
-====
+By default, regular user sessions are stored in the database.
+It is possible to configure {project_name} to store regular user sessions in-memory only by disabling the `persistent-user-sessions` feature.
+This means all user sessions are lost when all {project_name} nodes are restarted, and memory consumption increases as the number of active sessions grows.
 
 === Stateless instances
 
@@ -173,7 +156,7 @@ apply the upper bound to. For example, to apply an upper-bound of `1000` to the 
 `--cache-embedded-offline-sessions-max-count=1000`. An upper bound can not be defined on the following caches:
 `actionToken`, `authenticationSessions`, `loginFailures`, `work`.
 
-Setting a maximum cache size for `sessions`, `clientSessions` is not supported when volatile sessions are enabled.
+Setting a maximum cache size for `sessions`, `clientSessions` is not supported when the deprecated volatile sessions mode is used.
 
 === Specify your own cache configuration file
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -146,7 +146,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             log.warn("Disabling the persistent-user-sessions feature is deprecated since Keycloak 26.8 and will not be supported in a future release. Persistent user sessions will become the only supported mode.");
         }
         // Deprecated since 26.8: caching of persistent user sessions is disabled by default and will be removed in a future release.
-        useCaches = config.getBoolean(CONFIG_USE_CACHES) && InfinispanUtils.isEmbeddedInfinispan() && !Profile.isFeatureEnabled(Profile.Feature.STATELESS);
+        useCaches = config.getBoolean(CONFIG_USE_CACHES, false) && InfinispanUtils.isEmbeddedInfinispan() && !Profile.isFeatureEnabled(Profile.Feature.STATELESS);
         if (useCaches && MultiSiteUtils.isPersistentSessionsEnabled()) {
             log.warn("Caching of persistent user sessions is deprecated since Keycloak 26.8 and will be removed in a future release. Remove the spi-user-sessions--infinispan--use-caches option to disable caching.");
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -141,8 +141,16 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             // to be removed in KC 27
             log.warn("The option spi-user-sessions--infinispan--offline-client-session-cache-entry-lifespan-override is deprecated and will be removed in a future release");
         }
-        // Do not use caches for sessions if explicitly disabled or if embedded caches are not used
-        useCaches = config.getBoolean(CONFIG_USE_CACHES, !Profile.isFeatureEnabled(Profile.Feature.STATELESS)) && InfinispanUtils.isEmbeddedInfinispan();
+        // Deprecated since 26.8: disabling persistent user sessions (volatile sessions) is deprecated.
+        if (!MultiSiteUtils.isPersistentSessionsEnabled()) {
+            log.warn("Disabling the persistent-user-sessions feature is deprecated since Keycloak 26.8 and will not be supported in a future release. Persistent user sessions will become the only supported mode.");
+        }
+        // Deprecated since 26.8: caching of persistent user sessions is disabled by default and will be removed in a future release.
+        boolean defaultUseCaches = !Profile.isFeatureEnabled(Profile.Feature.STATELESS) && !MultiSiteUtils.isPersistentSessionsEnabled();
+        useCaches = config.getBoolean(CONFIG_USE_CACHES, defaultUseCaches) && InfinispanUtils.isEmbeddedInfinispan();
+        if (useCaches && MultiSiteUtils.isPersistentSessionsEnabled()) {
+            log.warn("Caching of persistent user sessions is deprecated since Keycloak 26.8 and will be removed in a future release. Remove the spi-user-sessions--infinispan--use-caches option to disable caching.");
+        }
         expirationPeriodSeconds = getExpirationPeriodSeconds(config);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -146,8 +146,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             log.warn("Disabling the persistent-user-sessions feature is deprecated since Keycloak 26.8 and will not be supported in a future release. Persistent user sessions will become the only supported mode.");
         }
         // Deprecated since 26.8: caching of persistent user sessions is disabled by default and will be removed in a future release.
-        boolean defaultUseCaches = !Profile.isFeatureEnabled(Profile.Feature.STATELESS) && !MultiSiteUtils.isPersistentSessionsEnabled();
-        useCaches = config.getBoolean(CONFIG_USE_CACHES, defaultUseCaches) && InfinispanUtils.isEmbeddedInfinispan();
+        useCaches = config.getBoolean(CONFIG_USE_CACHES) && InfinispanUtils.isEmbeddedInfinispan() && !Profile.isFeatureEnabled(Profile.Feature.STATELESS);
         if (useCaches && MultiSiteUtils.isPersistentSessionsEnabled()) {
             log.warn("Caching of persistent user sessions is deprecated since Keycloak 26.8 and will be removed in a future release. Remove the spi-user-sessions--infinispan--use-caches option to disable caching.");
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -146,7 +146,8 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             log.warn("Disabling the persistent-user-sessions feature is deprecated since Keycloak 26.8 and will not be supported in a future release. Persistent user sessions will become the only supported mode.");
         }
         // Deprecated since 26.8: caching of persistent user sessions is disabled by default and will be removed in a future release.
-        useCaches = config.getBoolean(CONFIG_USE_CACHES, false) && InfinispanUtils.isEmbeddedInfinispan() && !Profile.isFeatureEnabled(Profile.Feature.STATELESS);
+        boolean defaultUseCaches = !MultiSiteUtils.isPersistentSessionsEnabled();
+        useCaches = config.getBoolean(CONFIG_USE_CACHES, defaultUseCaches) && InfinispanUtils.isEmbeddedInfinispan() && !Profile.isFeatureEnabled(Profile.Feature.STATELESS);
         if (useCaches && MultiSiteUtils.isPersistentSessionsEnabled()) {
             log.warn("Caching of persistent user sessions is deprecated since Keycloak 26.8 and will be removed in a future release. Remove the spi-user-sessions--infinispan--use-caches option to disable caching.");
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -374,7 +374,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
         builder.property()
                 .name(CONFIG_USE_CACHES)
                 .type("boolean")
-                .helpText("Enable or disable caches. Enabled by default unless the external feature to use only external remote caches is used or " + Profile.Feature.STATELESS.getUnversionedKey() + " is enabled")
+                .helpText("Enable or disable caching of persistent user sessions. Disabled by default since Keycloak 26.8. When enabled, sessions are cached in the embedded Infinispan to reduce database load, but this is deprecated and will be removed in a future release. Caching is always disabled when the " + Profile.Feature.STATELESS.getUnversionedKey() + " feature is enabled or when using remote Infinispan.")
                 .add();
 
         builder.property()

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/RefreshTokenTest.java
@@ -43,6 +43,8 @@ import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.Constants;
+import org.keycloak.models.UserSessionProvider;
+import org.keycloak.models.sessions.infinispan.InfinispanUserSessionProviderFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -489,6 +491,10 @@ public class RefreshTokenTest {
     @Test
     public void refreshingTokenLoadsSessionIntoCache() {
         Assumptions.assumeTrue(isPersistentSessionsFeatureEnabled(adminClient), "Skip as persistent_user_sessions feature is disabled");
+        Assumptions.assumeTrue(runOnServer.fetch(session -> {
+            var factory = (InfinispanUserSessionProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(UserSessionProvider.class);
+            return factory.useCaches();
+        }, Boolean.class), "Skip as session caching is disabled");
 
         oauth.doLogin("test-user@localhost", "password");
 

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionInitializerTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionInitializerTest.java
@@ -17,16 +17,8 @@
 
 package org.keycloak.testsuite.model.session;
 
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
-import org.keycloak.common.Profile;
-import org.keycloak.common.util.MultiSiteUtils;
-import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
-import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -38,21 +30,14 @@ import org.keycloak.models.UserProvider;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.UserSessionProvider;
 import org.keycloak.models.session.UserSessionPersisterProvider;
-import org.keycloak.testsuite.model.HotRodServerRule;
 import org.keycloak.testsuite.model.KeycloakModelTest;
 import org.keycloak.testsuite.model.RequireProvider;
 
-import org.infinispan.Cache;
-import org.infinispan.client.hotrod.RemoteCache;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.USER_SESSION_CACHE_NAME;
-
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Every.everyItem;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -160,52 +145,6 @@ public class UserSessionInitializerTest extends KeycloakModelTest {
             realm.addClient("test-app");
         });
 
-    }
-
-    @Test
-    public void testUserSessionPropagationBetweenSites() throws InterruptedException {
-        assumeFalse("Run only if Infinispan caches are used for storing/caching sessions", MultiSiteUtils.isMultiSiteEnabled() && MultiSiteUtils.isPersistentSessionsEnabled());
-        assumeFalse("The Sessions caches are disabled", Profile.isFeatureEnabled(Profile.Feature.STATELESS));
-        AtomicInteger index = new AtomicInteger();
-        AtomicReference<String> userSessionId = new AtomicReference<>();
-        AtomicReference<List<Boolean>> containsSession = new AtomicReference<>(new LinkedList<>());
-
-        Object lock = new Object();
-
-        Optional<HotRodServerRule> hotRodServer = getParameters(HotRodServerRule.class).findFirst();
-
-        inIndependentFactories(4, 60, () -> {
-            synchronized (lock) {
-                if (index.incrementAndGet() == 1) {
-                    // create a user session in the first node
-                    UserSessionModel userSessionModel = withRealm(realmId, (session, realm) -> {
-                        final UserModel user = session.users().getUserByUsername(realm, "user1");
-                        return session.sessions().createUserSession(null, realm, user, "un1", "ip1", "auth", false, null, null, UserSessionModel.SessionPersistenceState.PERSISTENT);
-                    });
-                    userSessionId.set(userSessionModel.getId());
-                } else {
-                    // try to get the user session at other nodes and also at different sites
-                    inComittedTransaction(session -> {
-                        InfinispanConnectionProvider provider = session.getProvider(InfinispanConnectionProvider.class);
-                        if (InfinispanUtils.isEmbeddedInfinispan()) {
-                            Cache<String, Object> localSessions = provider.getCache(USER_SESSION_CACHE_NAME);
-                            containsSession.get().add(localSessions.containsKey(userSessionId.get()));
-                        }
-
-                        if (hotRodServer.isPresent()) {
-                            RemoteCache<String, Object> remoteSessions = provider.getRemoteCache(USER_SESSION_CACHE_NAME);
-                            containsSession.get().add(remoteSessions.containsKey(userSessionId.get()));
-                        }
-                    });
-                }
-            }
-        });
-
-        assertThat(containsSession.get(), everyItem(is(true)));
-
-        // 3 nodes (first node just creates the session), with Hot Rod server we have local + remote cache, without just local cache
-        int size = hotRodServer.isPresent() && InfinispanUtils.isEmbeddedInfinispan() ? 6 : 3;
-        assertThat(containsSession.get().size(), is(size));
     }
 
     // Create sessions in persister + infinispan, but then delete them from infinispan cache by reinitializing keycloak session factory


### PR DESCRIPTION
Closes #52121

### What changed

**Code (`InfinispanUserSessionProviderFactory`):**
- When `persistent-user-sessions` is disabled, a deprecation warning is logged at startup.
- The `useCaches` default is now `false` when persistent sessions are enabled, so session data is read directly from the database instead of being cached in the embedded Infinispan distributed cache.
- When a user explicitly re-enables caching via `--spi-user-sessions--infinispan--use-caches=true`, a deprecation warning is logged.

**Migration guide (`changes-26_8_0.adoc`):**
- Notable change: caching disabled by default, with the SPI option documented for re-enabling.
- Deprecated feature: disabling `persistent-user-sessions` is deprecated.

**Server guide (`caching.adoc`):**
- The "Volatile user sessions" section is marked deprecated with a warning, caveats made explicit, and actionable guidance added.

**Upgrade guide (`prep_migration.adoc`):**
- Deprecation note added to the existing `persistent-user-sessions` paragraph.

### Context and tradeoffs

### Assumptions

- The existing `useCaches` SPI option (`CONFIG_USE_CACHES`) is the right lever to disable session caching. When `false`, the provider uses `createWithoutCache()` — session data is still stored in the database and the Infinispan cache infrastructure remains but is not populated.
- The deprecation warnings are placed in `InfinispanUserSessionProviderFactory.init()` rather than `Profile.logUnsupportedFeatures()` to keep them close to the session provider logic.
- The caching option is documented as a "temporary workaround" to set expectations that it will be removed.