### PR TITLE
Deprecate in-memory login failures and make persistent login failures  the default

### DIFF
--- a/.github/actions/run-store-tests/action.yml
+++ b/.github/actions/run-store-tests/action.yml
@@ -59,19 +59,10 @@ runs:
           -pl testsuite/integration-arquillian/tests/base \
           2>&1 | misc/log/trimmer.sh
 
-    # The LoginTest should be enough to exercise the authentication sessions
-    - name: Run stateless smoke test
+    - name: Run stateless tests
       shell: bash
       run: |
-        ./mvnw test ${{ env.SUREFIRE_RETRY }} \
-          -Pauth-server-quarkus -Pdb-${{ inputs.db }} \
-          "-Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver" \
-          -Dtest=LoginTest \
-          -Dauth.server.feature=stateless \
-          -Ddocker.database.skip=true \
-          -Ddocker.database.port=$DATABASE_PORT \
-          -Ddocker.container.testdb.ip=localhost \
-          -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+        KC_TEST_DATABASE=${{ inputs.db }} KC_TEST_DATABASE_REUSE=true TESTCONTAINERS_REUSE_ENABLE=true ./mvnw package -f tests/pom.xml -Dtest=StatelessTestSuite -Dkc.test.server.start.timeout=360
 
     - uses: ./.github/actions/upload-flaky-tests
       name: Upload flaky tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,7 +846,7 @@ jobs:
     name: Store IT
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 85
     strategy:
       matrix:
         db: [postgres, mysql, oracle, mssql, mariadb]

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -130,8 +130,8 @@ public class Profile {
 
         TRANSIENT_USERS("Transient users for brokering", Type.EXPERIMENTAL),
 
-        LOGIN_FAILURES_V1("In-memory login failures", Type.DEPRECATED, 1, FeatureUpdatePolicy.ROLLING),
-        LOGIN_FAILURES_V2("Persistent login failures", Type.DEFAULT, 2, FeatureUpdatePolicy.ROLLING),
+        LOGIN_FAILURES_V1("In-memory login failures", Type.DEPRECATED, 1, FeatureUpdatePolicy.SHUTDOWN),
+        LOGIN_FAILURES_V2("Persistent login failures", Type.DEFAULT, 2, FeatureUpdatePolicy.SHUTDOWN),
 
         MULTI_SITE("Multi-site support", Type.DISABLED_BY_DEFAULT, FeatureUpdatePolicy.SHUTDOWN),
 

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -130,9 +130,12 @@ public class Profile {
 
         TRANSIENT_USERS("Transient users for brokering", Type.EXPERIMENTAL),
 
+        LOGIN_FAILURES_V1("In-memory login failures", Type.DEPRECATED, 1, FeatureUpdatePolicy.ROLLING),
+        LOGIN_FAILURES_V2("Persistent login failures", Type.DEFAULT, 2, FeatureUpdatePolicy.ROLLING),
+
         MULTI_SITE("Multi-site support", Type.DISABLED_BY_DEFAULT, FeatureUpdatePolicy.SHUTDOWN),
 
-        STATELESS("Stateless (stores authentication sessions, action tokens and login failure data in the database, allowing multiple clusters to be connected with just the database)", Type.PREVIEW, FeatureUpdatePolicy.SHUTDOWN),
+        STATELESS("Stateless (stores authentication sessions, action tokens and login failure data in the database, allowing multiple clusters to be connected with just the database)", Type.PREVIEW, FeatureUpdatePolicy.SHUTDOWN, Feature.LOGIN_FAILURES_V2),
 
         CLUSTERLESS("Store all session data, work cache and login failure data in an external Infinispan cluster.", Type.EXPERIMENTAL, FeatureUpdatePolicy.SHUTDOWN),
 

--- a/docs/documentation/release_notes/topics/26_8_0.adoc
+++ b/docs/documentation/release_notes/topics/26_8_0.adoc
@@ -23,6 +23,13 @@ In this release, Client Secret Rotation is promoted from preview to supported. F
 
 {project_name} now supports encrypted PKCS#8 private keys in PEM format for HTTPS configuration. Use the new `--https-certificate-key-file-password` option to provide the decryption password. The management interface also supports this via `--https-management-certificate-key-file-password`. For details, see <@links.server id="enabletls"/>.
 
+== Login failures now stored in the database
+
+Brute force detection data is now persisted in the database by default, so temporarily locked-out users remain locked out across cluster restarts.
+Deployments using the `multi-site` or `clusterless` features continue to store login failures in the external Infinispan cluster.
+The previous in-memory behavior is available as `login-failures:v1` but is deprecated.
+For details, see the link:{upgradingguide_link}[{upgradingguide_name}].
+
 == Automatic non-blocking index creation for large tables
 // https://github.com/keycloak/keycloak/issues/46555
 

--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -46,7 +46,7 @@ https://www.oasis-open.org/standard/saml/
 https://www.h2database.com/*
 # Blocks automated HTTP requests from CI runners (returns 403), but loads fine in a browser.
 https://www.iso.org/*
-# Remove after 26.7 release
-https://www.keycloak.org/securing-apps/ssf-support
-https://www.keycloak.org/securing-apps/authzen-authorization
-https://www.keycloak.org/high-availability/multi-cluster-v2/introduction
+
+# Remove after 26.8 release
+https://www.keycloak.org/server/db#mariadb-galera-cluster-considerations
+https://www.keycloak.org/server/db#mysql-mariadb-transaction-isolation-level-in-stateless-mode

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -177,7 +177,7 @@ If you have tooling that inspects the CN of {project_name}-generated certificate
 
 === Transaction isolation level changed to READ COMMITTED for MySQL and MariaDB in stateless mode
 
-When the `stateless` feature is enabled, {project_name} now sets the transaction isolation level to `READ COMMITTED` for MySQL, MariaDB, and TiDB.
+When the `stateless` feature is enabled, {project_name} now sets the transaction isolation level to `READ COMMITTED` for MySQL and MariaDB.
 This prevents deadlocks that occur under concurrent logins.
 `READ COMMITTED` is the default isolation level used by PostgreSQL, Oracle, and Microsoft SQL Server.
 
@@ -202,6 +202,25 @@ SET GLOBAL binlog_format = 'ROW';
 Alternatively, update the MySQL or MariaDB configuration file (`my.cnf` / `my.ini`) to make the change persistent across database restarts.
 
 Changing the default transaction isolation level for all modes is being considered for a future release.
+
+=== MariaDB Galera Cluster considerations
+
+WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}. The guidance in this section is provided on a best-effort basis. Before reporting bugs, reproduce them with a supported database configuration first.
+
+Galera Cluster uses certification-based replication, which means the `transaction_isolation` setting configured by {project_name} has no practical effect -- Galera internally operates under its own Snapshot Isolation model regardless of the configured isolation level.
+
+On a multi-writer Galera setup, concurrent write transactions on different nodes that modify the same row can trigger certification failures.
+{project_name} does not retry these operations, which causes the affected request to fail.
+In `stateless` mode, authentication sessions and login failure data are written directly to the database, increasing the likelihood of such conflicts under concurrent logins.
+
+To avoid certification failures, route all {project_name} write traffic to a single Galera node, using the remaining nodes as read replicas or failover targets.
+
+Galera replication is asynchronous by default.
+A write committed on one node may not yet be visible on other nodes.
+This affects all modes of {project_name}: when data is written to one node and a subsequent request is routed to a different node that has not yet received the replication event, the read may return stale or missing data.
+In non-stateless mode, this can cause cache invalidation to race with replication, leading to stale data being served from the database after the cache has been cleared.
+If read traffic is distributed across multiple nodes, enable causal reads by setting `wsrep_sync_wait = 1` on the reader nodes.
+This ensures that read operations wait for all pending replication events to be applied before returning results.
 
 === Asynchronous commit on MS SQL Server and Oracle databases
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -179,48 +179,22 @@ If you have tooling that inspects the CN of {project_name}-generated certificate
 
 When the `stateless` feature is enabled, {project_name} now sets the transaction isolation level to `READ COMMITTED` for MySQL and MariaDB.
 This prevents deadlocks that occur under concurrent logins.
-`READ COMMITTED` is the default isolation level used by PostgreSQL, Oracle, and Microsoft SQL Server.
+If binary logging is enabled with `binlog_format = STATEMENT`, this change will cause write operations to fail.
+{project_name} logs an error at startup when it detects this incompatible setting.
 
-If binary logging is enabled on your MySQL or MariaDB instance with `binlog_format = STATEMENT`, this change will cause write operations to fail.
-MySQL 8.0 and later default to `binlog_format = ROW`, and MariaDB 10.6 and later defaults to `binlog_format = MIXED`, both of which are compatible.
-Only instances where `binlog_format` has been explicitly set to `STATEMENT` are affected.
-
-To verify your current setting before upgrading, run:
-
-[source,sql]
-----
-SHOW VARIABLES LIKE 'binlog_format';
-----
-
-If the result is `STATEMENT`, change it to `ROW` or `MIXED`:
-
-[source,sql]
-----
-SET GLOBAL binlog_format = 'ROW';
-----
-
-Alternatively, update the MySQL or MariaDB configuration file (`my.cnf` / `my.ini`) to make the change persistent across database restarts.
+See the link:https://www.keycloak.org/server/db#mysql-mariadb-transaction-isolation-level-in-stateless-mode[Transaction isolation level in stateless mode] section in the database configuration guide for details on `binlog_format` requirements.
 
 Changing the default transaction isolation level for all modes is being considered for a future release.
 
+[#mariadb-galera-cluster-considerations]
 === MariaDB Galera Cluster considerations
 
-WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}. The guidance in this section is provided on a best-effort basis. Before reporting bugs, reproduce them with a supported database configuration first.
+WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}.The guidance in this section is provided on a best-effort basis.Before reporting bugs, reproduce them with a supported database configuration first.
 
-Galera Cluster uses certification-based replication, which means the `transaction_isolation` setting configured by {project_name} has no practical effect -- Galera internally operates under its own Snapshot Isolation model regardless of the configured isolation level.
+On a multi-writer Galera setup, concurrent writes to the same row on different nodes can trigger certification failures, and asynchronous replication can cause stale reads.
+{project_name} logs an error at startup when it detects Galera with `wsrep_sync_wait = 0`.
 
-On a multi-writer Galera setup, concurrent write transactions on different nodes that modify the same row can trigger certification failures.
-{project_name} does not retry these operations, which causes the affected request to fail.
-In `stateless` mode, authentication sessions and login failure data are written directly to the database, increasing the likelihood of such conflicts under concurrent logins.
-
-To avoid certification failures, route all {project_name} write traffic to a single Galera node, using the remaining nodes as read replicas or failover targets.
-
-Galera replication is asynchronous by default.
-A write committed on one node may not yet be visible on other nodes.
-This affects all modes of {project_name}: when data is written to one node and a subsequent request is routed to a different node that has not yet received the replication event, the read may return stale or missing data.
-In non-stateless mode, this can cause cache invalidation to race with replication, leading to stale data being served from the database after the cache has been cleared.
-If read traffic is distributed across multiple nodes, enable causal reads by setting `wsrep_sync_wait = 1` on the reader nodes.
-This ensures that read operations wait for all pending replication events to be applied before returning results.
+See the link:https://www.keycloak.org/server/db#mariadb-galera-cluster-considerations[MariaDB Galera Cluster] section in the database configuration guide for recommended settings and limitations.
 
 === Asynchronous commit on MS SQL Server and Oracle databases
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -48,6 +48,9 @@ Deployments using the `multi-site` or `clusterless` features continue to store l
 
 As a trade-off, users may observe increased database connection usage and higher CPU usage on the database.
 
+The option `spi-brute-force-protector-default-brute-force-detector-allow-concurrent-requests` does no longer exist for `login-failures:v2`.
+Instead, concurrent logins for the same user are executed serially for each node.
+
 === Clusterless feature will be removed
 
 The experimental `clusterless` feature will be removed in a future release. The `stateless` feature is the successor for running {project_name} without depending on an external Infinispan cluster. While `clusterless` offloads all session data to an external Infinispan cluster, `stateless` stores session data in the database and uses the embedded Infinispan only as a cache.

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -178,8 +178,28 @@ If you have tooling that inspects the CN of {project_name}-generated certificate
 === Transaction isolation level changed to READ COMMITTED for MySQL and MariaDB in stateless mode
 
 When the `stateless` feature is enabled, {project_name} now sets the transaction isolation level to `READ COMMITTED` for MySQL, MariaDB, and TiDB.
-This prevents deadlocks in highly concurrent environments.
+This prevents deadlocks that occur under concurrent logins.
 `READ COMMITTED` is the default isolation level used by PostgreSQL, Oracle, and Microsoft SQL Server.
+
+If binary logging is enabled on your MySQL or MariaDB instance with `binlog_format = STATEMENT`, this change will cause write operations to fail.
+MySQL 8.0 and later default to `binlog_format = ROW`, and MariaDB 10.6 and later defaults to `binlog_format = MIXED`, both of which are compatible.
+Only instances where `binlog_format` has been explicitly set to `STATEMENT` are affected.
+
+To verify your current setting before upgrading, run:
+
+[source,sql]
+----
+SHOW VARIABLES LIKE 'binlog_format';
+----
+
+If the result is `STATEMENT`, change it to `ROW` or `MIXED`:
+
+[source,sql]
+----
+SET GLOBAL binlog_format = 'ROW';
+----
+
+Alternatively, update the MySQL or MariaDB configuration file (`my.cnf` / `my.ini`) to make the change persistent across database restarts.
 
 Changing the default transaction isolation level for all modes is being considered for a future release.
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -175,6 +175,14 @@ When {project_name} generates self-signed certificates (for example, during SAML
 
 If you have tooling that inspects the CN of {project_name}-generated certificates and expects it to match a value longer than 64 characters, be aware that the CN may now be shorter.
 
+=== Transaction isolation level changed to READ COMMITTED for MySQL and MariaDB in stateless mode
+
+When the `stateless` feature is enabled, {project_name} now sets the transaction isolation level to `READ COMMITTED` for MySQL, MariaDB, and TiDB.
+This prevents deadlocks in highly concurrent environments.
+`READ COMMITTED` is the default isolation level used by PostgreSQL, Oracle, and Microsoft SQL Server.
+
+Changing the default transaction isolation level for all modes is being considered for a future release.
+
 === Asynchronous commit on MS SQL Server and Oracle databases
 
 The asynchronous commit optimization, previously available only on PostgreSQL, now also supports MS SQL Server and Oracle databases.

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -48,7 +48,7 @@ Deployments using the `multi-site` or `clusterless` features continue to store l
 
 As a trade-off, users may observe increased database connection usage and higher CPU usage on the database.
 
-The option `spi-brute-force-protector-default-brute-force-detector-allow-concurrent-requests` does no longer exist for `login-failures:v2`.
+The option `spi-brute-force-protector-default-brute-force-detector-allow-concurrent-requests` is deprecated and has no effect with `login-failures:v2`.
 Instead, concurrent logins for the same user are executed serially for each node.
 
 === Clusterless feature will be removed

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -192,7 +192,7 @@ Changing the default transaction isolation level for all modes is being consider
 [#mariadb-galera-cluster-considerations]
 === MariaDB Galera Cluster considerations
 
-WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}.The guidance in this section is provided on a best-effort basis.Before reporting bugs, reproduce them with a supported database configuration first.
+WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}. The guidance in this section is provided on a best-effort basis. Before reporting bugs, reproduce them with a supported database configuration first.
 
 On a multi-writer Galera setup, concurrent writes to the same row on different nodes can trigger certification failures, and asynchronous replication can cause stale reads.
 {project_name} logs an error at startup when it detects Galera with `wsrep_sync_wait = 0`.

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -38,6 +38,16 @@ Revalidating certificates can be problematic in certain installations (for examp
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 
+=== Login failures now stored in the database by default
+
+Login failure data for brute force detection is now stored in the database by default, instead of only in the embedded Infinispan `loginFailures` cache. This ensures that temporarily locked-out users remain locked out across cluster restarts, and reduces memory consumption from accumulated login failure entries.
+
+This change is controlled by the new `login-failures` versioned feature. The previous in-memory behavior (`login-failures:v1`) is deprecated. To restore it, set `--features=login-failures:v1`. Note that `login-failures:v1` is incompatible with the `stateless` feature.
+
+Deployments using the `multi-site` or `clusterless` features continue to store login failure data in the external Infinispan cluster, regardless of the `login-failures` feature version.
+
+As a trade-off, users may observe increased database connection usage and higher CPU usage on the database.
+
 === Clusterless feature will be removed
 
 The experimental `clusterless` feature will be removed in a future release. The `stateless` feature is the successor for running {project_name} without depending on an external Infinispan cluster. While `clusterless` offloads all session data to an external Infinispan cluster, `stateless` stores session data in the database and uses the embedded Infinispan only as a cache.
@@ -280,6 +290,10 @@ To avoid the deprecation warning at startup, set those SPI options to `false`.
 === Disabling persistent user sessions (volatile sessions) is deprecated
 
 Disabling the `persistent-user-sessions` feature (volatile sessions) is deprecated and will be removed in a future release. Persistent user sessions will become the only supported mode. If you have explicitly disabled persistent user sessions with `--features-disabled=persistent-user-sessions`, remove this option before upgrading to a future release.
+
+=== In-memory login failures (`login-failures:v1`) is deprecated
+
+The previous default of storing login failure data only in the in-memory Infinispan cache (`login-failures:v1`) is deprecated and will be removed in a future release. Login failures are now stored in the database by default (`login-failures:v2`). If you have explicitly enabled `login-failures:v1`, plan to remove this option before upgrading to a future release.
 
 === Organization invitation link no longer exposed in API responses
 

--- a/docs/documentation/upgrading/topics/prep_migration.adoc
+++ b/docs/documentation/upgrading/topics/prep_migration.adoc
@@ -28,6 +28,7 @@ Disabling `persistent-user-sessions` is deprecated since {project_name} 26.8 and
 
 [WARNING]
 ====
-Information about failed logins for brute force detection and currently ongoing authentication flows is only stored in the internal caches that are cleared when {project_name} is shut down.
+Information about failed logins for brute force detection is now stored in the database by default since {project_name} 26.8 and survives cluster restarts.
+Currently ongoing authentication flows are only stored in the internal caches that are cleared when {project_name} is shut down.
 Users currently authenticating, changing their passwords, or resetting their passwords will need to restart the authentication flow once {project_name} is up and running again.
 ====

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -90,8 +90,8 @@ to the node where their sessions were initially created. By doing that, you are 
 CPU, memory, and network utilization.
 
 .Password brute force detection
-The `loginFailures` distributed cache is used to track data about failed login attempts.
-This cache is needed for the Brute Force Protection feature to work in a multi-node {project_name} setup.
+Login failure data for brute force detection is stored in the database by default.
+The `loginFailures` distributed cache is available as a fallback when the deprecated `login-failures:v1` feature is explicitly enabled, but this mode will be removed in a future release.
 
 .Action tokens
 Action tokens are used for scenarios when a user needs to confirm an action asynchronously, for example in the emails sent by the forgot password flow.

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -91,7 +91,8 @@ CPU, memory, and network utilization.
 
 .Password brute force detection
 Login failure data for brute force detection is stored in the database by default.
-The `loginFailures` distributed cache is available as a fallback when the deprecated `login-failures:v1` feature is explicitly enabled, but this mode will be removed in a future release.
+Deployments using the `multi-site` or `clusterless` features continue to store login failures in the external Infinispan `loginFailures` cache.
+The embedded `loginFailures` distributed cache is available as a fallback when the deprecated `login-failures:v1` feature is explicitly enabled, but this mode will be removed in a future release.
 
 .Action tokens
 Action tokens are used for scenarios when a user needs to confirm an action asynchronously, for example in the emails sent by the forgot password flow.

--- a/docs/guides/server/caching.adoc
+++ b/docs/guides/server/caching.adoc
@@ -93,6 +93,9 @@ CPU, memory, and network utilization.
 Login failure data for brute force detection is stored in the database by default.
 Deployments using the `multi-site` or `clusterless` features continue to store login failures in the external Infinispan `loginFailures` cache.
 The embedded `loginFailures` distributed cache is available as a fallback when the deprecated `login-failures:v1` feature is explicitly enabled, but this mode will be removed in a future release.
+When switching between storage modes (for example, from database to external Infinispan or vice versa), stale login failure entries may remain in the previous store.
+These entries are not cleaned up automatically and can resurface if the deployment reverts to the previous storage mode.
+Administrators should manually remove stale login failure data from the previous store after switching.
 
 .Action tokens
 Action tokens are used for scenarios when a user needs to confirm an action asynchronously, for example in the emails sent by the forgot password flow.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -390,11 +390,58 @@ Secure the connection by adding the options:
 * `db-tls-trust-store-file=/path/to/certificate`: The path to the server's public certificate file on the client machine.
 ====
 
-== Preparing for MySQL server
+== Preparing for MySQL and MariaDB
+
+=== Generated invisible primary keys (MySQL)
 
 Beginning with MySQL 8.0.30, MySQL supports generated invisible primary keys for any InnoDB table that is created without an explicit primary key (more information https://dev.mysql.com/doc/refman/8.0/en/create-table-gipks.html[here]).
 If this feature is enabled, the database schema initialization and also migrations will fail with the error message `Multiple primary key defined (1068)`.
 You then need to disable it by setting the parameter `sql_generate_invisible_primary_key` to `OFF` in your MySQL server configuration before installing or upgrading {project_name}.
+
+=== Transaction isolation level in stateless mode
+
+When the `stateless` feature is enabled, {project_name} automatically sets the transaction isolation level to `READ COMMITTED` for MySQL and MariaDB.
+The default `REPEATABLE READ` isolation level acquires gap locks on upsert statements, which causes deadlocks under concurrent logins.
+`READ COMMITTED` is the default isolation level used by PostgreSQL, Oracle, and Microsoft SQL Server.
+
+This requires that binary logging is not configured with `binlog_format = STATEMENT`.
+MySQL 8.0 and later default to `binlog_format = ROW`, and MariaDB 10.6 and later defaults to `binlog_format = MIXED`, both of which are compatible.
+
+To verify your current setting, run:
+
+[source,sql]
+----
+SHOW VARIABLES LIKE 'binlog_format';
+----
+
+If the result is `STATEMENT`, change it to `ROW` or `MIXED`:
+
+[source,sql]
+----
+SET GLOBAL binlog_format = 'ROW';
+----
+
+Alternatively, update the MySQL or MariaDB configuration file (`my.cnf` / `my.ini`) to make the change persistent across database restarts.
+
+=== MariaDB Galera Cluster
+
+WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}. The guidance in this section is provided on a best-effort basis. Before reporting bugs, reproduce them with a supported database configuration first.
+
+MariaDB Galera Cluster uses certification-based replication.
+The `transaction_isolation` setting configured by {project_name} has no practical effect on Galera, as Galera internally operates under its own Snapshot Isolation model regardless of the configured isolation level.
+
+On a multi-writer Galera setup, concurrent write transactions on different nodes that modify the same row can trigger certification failures.
+{project_name} does not retry these operations, which causes the affected request to fail.
+In `stateless` mode, authentication sessions and login failure data are written directly to the database, increasing the likelihood of such conflicts under concurrent logins.
+
+To avoid certification failures, route all {project_name} write traffic to a single Galera node, using the remaining nodes as read replicas or failover targets.
+
+Galera replication is asynchronous by default.
+A write committed on one node may not yet be visible on other nodes.
+This affects all modes of {project_name}: when data is written to one node and a subsequent request is routed to a different node that has not yet received the replication event, the read may return stale or missing data.
+This can cause cache invalidation to race with replication, leading to stale data being served from the database after the cache has been cleared.
+If read traffic is distributed across multiple nodes, set `wsrep_sync_wait = 1` on the reader nodes to enable causal reads.
+This ensures that read operations wait for all pending replication events to be applied before returning results.
 
 == Preparing for MS SQL server
 

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -398,6 +398,7 @@ Beginning with MySQL 8.0.30, MySQL supports generated invisible primary keys for
 If this feature is enabled, the database schema initialization and also migrations will fail with the error message `Multiple primary key defined (1068)`.
 You then need to disable it by setting the parameter `sql_generate_invisible_primary_key` to `OFF` in your MySQL server configuration before installing or upgrading {project_name}.
 
+[#mysql-mariadb-transaction-isolation-level-in-stateless-mode]
 === Transaction isolation level in stateless mode
 
 When the `stateless` feature is enabled, {project_name} automatically sets the transaction isolation level to `READ COMMITTED` for MySQL and MariaDB.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -424,6 +424,7 @@ SET GLOBAL binlog_format = 'ROW';
 
 Alternatively, update the MySQL or MariaDB configuration file (`my.cnf` / `my.ini`) to make the change persistent across database restarts.
 
+[#mariadb-galera-cluster-considerations]
 === MariaDB Galera Cluster
 
 WARNING: MariaDB Galera Cluster is not a supported database configuration for {project_name}. The guidance in this section is provided on a best-effort basis. Before reporting bugs, reproduce them with a supported database configuration first.

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -258,6 +258,13 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                     .forEach(holder.getNamedConfigurationBuilders()::remove);
         }
 
+        // remove login-failure cache if V2 is active
+        if (Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V2)) {
+            Arrays.stream(CLUSTERED_CACHE_NAMES)
+                    .filter(LOGIN_FAILURE_CACHE_NAME::equals)
+                    .forEach(holder.getNamedConfigurationBuilders()::remove);
+        }
+
         StringBuilderWriter sw = new StringBuilderWriter();
         ParserRegistry parser = new ParserRegistry();
         try (ConfigurationWriter w = ConfigurationWriter.to(sw).prettyPrint(true).build()) {

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -260,9 +260,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
 
         // remove login-failure cache if V2 is active
         if (Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V2)) {
-            Arrays.stream(CLUSTERED_CACHE_NAMES)
-                    .filter(LOGIN_FAILURE_CACHE_NAME::equals)
-                    .forEach(holder.getNamedConfigurationBuilders()::remove);
+            holder.getNamedConfigurationBuilders().remove(LOGIN_FAILURE_CACHE_NAME);
         }
 
         StringBuilderWriter sw = new StringBuilderWriter();

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserLoginFailureProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserLoginFailureProviderFactory.java
@@ -129,7 +129,7 @@ public class InfinispanUserLoginFailureProviderFactory implements UserLoginFailu
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return !Profile.isFeatureEnabled(Profile.Feature.STATELESS) && InfinispanUtils.isEmbeddedInfinispan();
+        return Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V1) && InfinispanUtils.isEmbeddedInfinispan();
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
@@ -64,7 +64,7 @@ import org.hibernate.annotations.DynamicUpdate;
         @NamedQuery(
                 name = "insertRootAuthSessionIfAbsent",
                 query = "insert into RootAuthenticationSessionEntity (id, realmId, timestamp, version) values (:id, :realmId, :timestamp, 0)" +
-                        " on conflict do nothing"
+                        " on conflict (id) do nothing"
         )
 })
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/DefaultJpaConnectionProviderFactory.java
@@ -212,9 +212,13 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
                             prepareOperationalInfo(connection);
 
                             String driverDialect = config.get("driverDialect");
-                            // use configured dialect, else rely on Hibernate detection
                             if (driverDialect != null && !driverDialect.isBlank()) {
                                 properties.put("hibernate.dialect", driverDialect);
+                            } else {
+                                String keycloakDialect = resolveKeycloakDialect(connection);
+                                if (keycloakDialect != null) {
+                                    properties.put("hibernate.dialect", keycloakDialect);
+                                }
                             }
 
                             migration(migrationStrategy, initializeEmpty, schema, databaseUpdateFile, connection, session);
@@ -378,6 +382,20 @@ public class DefaultJpaConnectionProviderFactory implements JpaConnectionProvide
             }
         } catch (Exception e) {
             throw new RuntimeException("Failed to connect to database", e);
+        }
+    }
+
+    private static String resolveKeycloakDialect(Connection connection) {
+        try {
+            String dbKind = getDatabaseType(connection.getMetaData().getDatabaseProductName());
+            return switch (dbKind) {
+                case "h2" -> "org.keycloak.connections.jpa.dialect.KeycloakH2Dialect";
+                case "mssql" -> "org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect";
+                case "oracle" -> "org.keycloak.connections.jpa.dialect.KeycloakOracleDialect";
+                default -> null;
+            };
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
         }
     }
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakH2Dialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakH2Dialect.java
@@ -42,10 +42,11 @@ public class KeycloakH2Dialect extends H2Dialect {
                 return new H2SqlAstTranslator<>(sessionFactory, statement) {
                     @Override
                     protected void visitInsertStatementOnly(InsertSelectStatement statement) {
-                        if (statement.getConflictClause() == null) {
-                            super.visitInsertStatementOnly(statement);
-                        } else {
+                        if (statement.getConflictClause() != null
+                                && !statement.getConflictClause().getConstraintColumnNames().isEmpty()) {
                             visitInsertStatementEmulateMerge(statement);
+                        } else {
+                            super.visitInsertStatementOnly(statement);
                         }
                     }
                 };

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakH2Dialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakH2Dialect.java
@@ -30,6 +30,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 /**
  * Fixes Hibernate's H2 dialect to correctly handle HQL {@code insert ... on conflict ... do nothing}
  * by emitting a MERGE statement instead of a plain INSERT that silently drops the conflict clause.
+ * <p>
+ * See <a href="https://hibernate.atlassian.net/browse/HHH-20826">HHH-20826</a> for the upstream tracker.
  */
 public class KeycloakH2Dialect extends H2Dialect {
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakH2Dialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakH2Dialect.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.jpa.dialect;
+
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.dialect.sql.ast.H2SqlAstTranslator;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
+import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
+import org.hibernate.sql.exec.spi.JdbcOperation;
+
+/**
+ * Fixes Hibernate's H2 dialect to correctly handle HQL {@code insert ... on conflict ... do nothing}
+ * by emitting a MERGE statement instead of a plain INSERT that silently drops the conflict clause.
+ */
+public class KeycloakH2Dialect extends H2Dialect {
+
+    @Override
+    public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
+        return new StandardSqlAstTranslatorFactory() {
+            @Override
+            protected <T extends JdbcOperation> SqlAstTranslator<T> buildTranslator(
+                    SessionFactoryImplementor sessionFactory, Statement statement) {
+                return new H2SqlAstTranslator<>(sessionFactory, statement) {
+                    @Override
+                    protected void visitInsertStatementOnly(InsertSelectStatement statement) {
+                        if (statement.getConflictClause() == null) {
+                            super.visitInsertStatementOnly(statement);
+                        } else {
+                            visitInsertStatementEmulateMerge(statement);
+                        }
+                    }
+                };
+            }
+        };
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakOracleDialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakOracleDialect.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.jpa.dialect;
+
+import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.sql.ast.OracleSqlAstTranslator;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
+import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
+import org.hibernate.sql.exec.spi.JdbcOperation;
+
+/**
+ * Fixes Hibernate's Oracle dialect to correctly handle HQL {@code insert ... on conflict ... do nothing}
+ * by emitting a MERGE statement instead of a plain INSERT that silently drops the conflict clause.
+ */
+public class KeycloakOracleDialect extends OracleDialect {
+
+    @Override
+    public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
+        return new StandardSqlAstTranslatorFactory() {
+            @Override
+            protected <T extends JdbcOperation> SqlAstTranslator<T> buildTranslator(
+                    SessionFactoryImplementor sessionFactory, Statement statement) {
+                return new OracleSqlAstTranslator<>(sessionFactory, statement) {
+                    @Override
+                    protected void visitInsertStatementOnly(InsertSelectStatement statement) {
+                        if (statement.getConflictClause() == null) {
+                            super.visitInsertStatementOnly(statement);
+                        } else {
+                            visitInsertStatementEmulateMerge(statement);
+                        }
+                    }
+                };
+            }
+        };
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakOracleDialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakOracleDialect.java
@@ -42,10 +42,11 @@ public class KeycloakOracleDialect extends OracleDialect {
                 return new OracleSqlAstTranslator<>(sessionFactory, statement) {
                     @Override
                     protected void visitInsertStatementOnly(InsertSelectStatement statement) {
-                        if (statement.getConflictClause() == null) {
-                            super.visitInsertStatementOnly(statement);
-                        } else {
+                        if (statement.getConflictClause() != null
+                                && !statement.getConflictClause().getConstraintColumnNames().isEmpty()) {
                             visitInsertStatementEmulateMerge(statement);
+                        } else {
+                            super.visitInsertStatementOnly(statement);
                         }
                     }
                 };

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakOracleDialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakOracleDialect.java
@@ -30,6 +30,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 /**
  * Fixes Hibernate's Oracle dialect to correctly handle HQL {@code insert ... on conflict ... do nothing}
  * by emitting a MERGE statement instead of a plain INSERT that silently drops the conflict clause.
+ * <p>
+ * See <a href="https://hibernate.atlassian.net/browse/HHH-20826">HHH-20826</a> for the upstream tracker.
  */
 public class KeycloakOracleDialect extends OracleDialect {
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakSQLServerDialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakSQLServerDialect.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.jpa.dialect;
+
+import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.dialect.sql.ast.SQLServerSqlAstTranslator;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.StandardSqlAstTranslatorFactory;
+import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
+import org.hibernate.sql.exec.spi.JdbcOperation;
+
+/**
+ * Fixes Hibernate's SQL Server dialect to correctly handle HQL {@code insert ... on conflict ... do nothing}
+ * by emitting a MERGE statement instead of a plain INSERT that silently drops the conflict clause.
+ */
+public class KeycloakSQLServerDialect extends SQLServerDialect {
+
+    @Override
+    public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
+        return new StandardSqlAstTranslatorFactory() {
+            @Override
+            protected <T extends JdbcOperation> SqlAstTranslator<T> buildTranslator(
+                    SessionFactoryImplementor sessionFactory, Statement statement) {
+                return new SQLServerSqlAstTranslator<>(sessionFactory, statement) {
+                    @Override
+                    protected void visitInsertStatementOnly(InsertSelectStatement statement) {
+                        if (statement.getConflictClause() == null) {
+                            super.visitInsertStatementOnly(statement);
+                        } else {
+                            visitInsertStatementEmulateMerge(statement);
+                            appendSql(';');
+                        }
+                    }
+                };
+            }
+        };
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakSQLServerDialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakSQLServerDialect.java
@@ -30,6 +30,8 @@ import org.hibernate.sql.exec.spi.JdbcOperation;
 /**
  * Fixes Hibernate's SQL Server dialect to correctly handle HQL {@code insert ... on conflict ... do nothing}
  * by emitting a MERGE statement instead of a plain INSERT that silently drops the conflict clause.
+ * <p>
+ * See <a href="https://hibernate.atlassian.net/browse/HHH-20826">HHH-20826</a> for the upstream tracker.
  */
 public class KeycloakSQLServerDialect extends SQLServerDialect {
 

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakSQLServerDialect.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/dialect/KeycloakSQLServerDialect.java
@@ -42,11 +42,12 @@ public class KeycloakSQLServerDialect extends SQLServerDialect {
                 return new SQLServerSqlAstTranslator<>(sessionFactory, statement) {
                     @Override
                     protected void visitInsertStatementOnly(InsertSelectStatement statement) {
-                        if (statement.getConflictClause() == null) {
-                            super.visitInsertStatementOnly(statement);
-                        } else {
+                        if (statement.getConflictClause() != null
+                                && !statement.getConflictClause().getConstraintColumnNames().isEmpty()) {
                             visitInsertStatementEmulateMerge(statement);
                             appendSql(';');
+                        } else {
+                            super.visitInsertStatementOnly(statement);
                         }
                     }
                 };

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
@@ -32,12 +31,13 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.UserLoginFailureProvider;
+import org.keycloak.models.utils.LoginFailureUtils;
 
 public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
 
     private final KeycloakSession session;
     private final Set<LoginFailureKey> notInDatabaseCache = new HashSet<>();
-    private final Map<LoginFailureKey, UserLoginFailureModel> entityInSession = new HashMap();
+    private final Map<LoginFailureKey, UserLoginFailureModel> entityInSession = new HashMap<>();
 
     public JpaUserLoginFailureProvider(KeycloakSession session) {
         this.session = session;
@@ -78,13 +78,9 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
             // Entry was cleared after a successful login — treat as expired, matching Infinispan TTL=0 behavior.
             return true;
         }
-        if (realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) {
-            // Permanent lockout only: entries never expire.
-            return false;
-        }
-        // Expired if last failure is older than maxDeltaTimeSeconds (same threshold used by LoginFailureExpirationAction).
-        long expireMs = TimeUnit.SECONDS.toMillis((long) Time.currentTime() - realm.getMaxDeltaTimeSeconds());
-        return entity.getLastFailure() < expireMs;
+
+        long expireMs = LoginFailureUtils.computeExpirationCutOffTimestamp(realm, Time.currentTimeSeconds());
+        return expireMs != -1 && entity.getLastFailure() < expireMs;
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
@@ -99,7 +99,9 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
                 .executeUpdate();
         var key = new LoginFailureKey(realm.getId(), userId);
         notInDatabaseCache.remove(key);
-        var entity = em.find(LoginFailureEntity.class, key);
+        var entity = inserted == 0
+                ? em.find(LoginFailureEntity.class, key, LockModeType.PESSIMISTIC_WRITE)
+                : em.find(LoginFailureEntity.class, key);
         UserLoginFailureModel model = new UserLoginFailureAdapter(em, entity);
         if (inserted == 0 && isExpired(realm, entity)) {
             // The entity already existed but is expired — clear its stale data so new failure counting starts fresh.

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
@@ -96,7 +96,7 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
         UserLoginFailureModel model = new UserLoginFailureAdapter(em, entity);
         if (inserted == 0 && isExpired(realm, entity)) {
             // The entity already existed but is expired — clear its stale data so new failure counting starts fresh.
-            model.clearFailures();
+            model.clearPrimaryAndSecondaryAuthFailures();
         }
         entityInSession.put(key, model);
         return model;

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
@@ -21,10 +21,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 
+import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -61,15 +63,34 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
             notInDatabaseCache.add(key);
             return null;
         }
+        if (isExpired(realm, entity)) {
+            // leave the clean-up to the background task to avoid concurrent updates to the database
+            notInDatabaseCache.add(key);
+            return null;
+        }
         model = new UserLoginFailureAdapter(em, entity);
         entityInSession.put(key, model);
         return model;
     }
 
+    private boolean isExpired(RealmModel realm, LoginFailureEntity entity) {
+        if (entity.getLastFailure() == 0) {
+            // Entry was cleared after a successful login — treat as expired, matching Infinispan TTL=0 behavior.
+            return true;
+        }
+        if (realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) {
+            // Permanent lockout only: entries never expire.
+            return false;
+        }
+        // Expired if last failure is older than maxDeltaTimeSeconds (same threshold used by LoginFailureExpirationAction).
+        long expireMs = TimeUnit.SECONDS.toMillis((long) Time.currentTime() - realm.getMaxDeltaTimeSeconds());
+        return entity.getLastFailure() < expireMs;
+    }
+
     @Override
     public UserLoginFailureModel addUserLoginFailure(RealmModel realm, String userId) {
         var em = getEntityManager();
-        em.createNamedQuery("insertLoginFailure")
+        int inserted = em.createNamedQuery("insertLoginFailure")
                 .setParameter("realmId", realm.getId())
                 .setParameter("userId", userId)
                 .executeUpdate();
@@ -77,6 +98,10 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
         notInDatabaseCache.remove(key);
         var entity = em.find(LoginFailureEntity.class, key);
         UserLoginFailureModel model = new UserLoginFailureAdapter(em, entity);
+        if (inserted == 0 && isExpired(realm, entity)) {
+            // The entity already existed but is expired — clear its stale data so new failure counting starts fresh.
+            model.clearFailures();
+        }
         entityInSession.put(key, model);
         return model;
     }

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
@@ -84,6 +84,13 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
     }
 
     @Override
+    public void updateWithLatestRealmSettings(RealmModel realm) {
+        if (!realm.isBruteForceProtected()) {
+            removeAllUserLoginFailures(realm);
+        }
+    }
+
+    @Override
     public UserLoginFailureModel addUserLoginFailure(RealmModel realm, String userId) {
         var em = getEntityManager();
         int inserted = em.createNamedQuery("insertLoginFailure")

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProviderFactory.java
@@ -33,16 +33,21 @@ import org.keycloak.expiration.jpa.ExpirationHelper;
 import org.keycloak.expiration.jpa.ExpirationTask;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserLoginFailureProvider;
 import org.keycloak.models.UserLoginFailureProviderFactory;
+import org.keycloak.models.UserModel;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.provider.ProviderEvent;
+import org.keycloak.provider.ProviderEventListener;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
 
 import org.jboss.logging.Logger;
 
-public class JpaUserLoginFailureProviderFactory implements UserLoginFailureProviderFactory<JpaUserLoginFailureProvider>, EnvironmentDependentProviderFactory, ServerInfoAwareProviderFactory {
+public class JpaUserLoginFailureProviderFactory implements UserLoginFailureProviderFactory<JpaUserLoginFailureProvider>, EnvironmentDependentProviderFactory, ServerInfoAwareProviderFactory, ProviderEventListener {
 
     private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
     private static final String PROVIDER_ID = "jpa";
@@ -68,6 +73,7 @@ public class JpaUserLoginFailureProviderFactory implements UserLoginFailureProvi
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
+        factory.register(this);
         ExpirationTask.builder()
                 .withEntityId("login-failure")
                 .withAction(LoginFailureExpirationAction.INSTANCE)
@@ -100,6 +106,19 @@ public class JpaUserLoginFailureProviderFactory implements UserLoginFailureProvi
         ExpirationHelper.addToOperationalInfo(expirationTaskIntervalSeconds, expirationTaskTimeoutSeconds, expirationTaskMaxRemoval, map);
         map.put(METRICS_KEY, Boolean.toString(metricsEnabled));
         return Map.copyOf(map);
+    }
+
+    @Override
+    public void onEvent(ProviderEvent event) {
+        if (event instanceof RealmModel.RealmRemovedEvent realmRemovedEvent) {
+            KeycloakSession session = realmRemovedEvent.getKeycloakSession();
+            UserLoginFailureProvider provider = session.getProvider(UserLoginFailureProvider.class);
+            provider.removeAllUserLoginFailures(realmRemovedEvent.getRealm());
+        } else if (event instanceof UserModel.UserRemovedEvent userRemovedEvent) {
+            KeycloakSession session = userRemovedEvent.getKeycloakSession();
+            UserLoginFailureProvider provider = session.getProvider(UserLoginFailureProvider.class);
+            provider.removeUserLoginFailure(userRemovedEvent.getRealm(), userRemovedEvent.getUser().getId());
+        }
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProviderFactory.java
@@ -121,6 +121,6 @@ public class JpaUserLoginFailureProviderFactory implements UserLoginFailureProvi
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return Profile.isFeatureEnabled(Profile.Feature.STATELESS);
+        return Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V2);
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/LoginFailureExpirationAction.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/LoginFailureExpirationAction.java
@@ -17,12 +17,12 @@
 
 package org.keycloak.loginfailures.jpa;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.IntConsumer;
 
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.expiration.jpa.ExpirationAction;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.utils.LoginFailureUtils;
 
 public enum LoginFailureExpirationAction implements ExpirationAction {
     INSTANCE;
@@ -33,12 +33,10 @@ public enum LoginFailureExpirationAction implements ExpirationAction {
         if (realm == null) {
             return false;
         }
-        if (realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) {
-            // If mode is permanent lockout only, the "failure reset time" cannot be configured and login failures should never expire.
+        var expired = LoginFailureUtils.computeExpirationCutOffTimestamp(realm, currentTime);
+        if (expired == -1) {
             return false;
         }
-        // expired if last-failure + max-delta-time < current time
-        var expired = TimeUnit.SECONDS.toMillis(currentTime - realm.getMaxDeltaTimeSeconds());
         var em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
         var userIds = em.createNamedQuery("findExpiredLoginFailureUserIdsByRealm", String.class)
                 .setParameter("realmId", realmId)

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/LoginFailureExpirationAction.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/LoginFailureExpirationAction.java
@@ -35,7 +35,8 @@ public enum LoginFailureExpirationAction implements ExpirationAction {
         }
         var expired = LoginFailureUtils.computeExpirationCutOffTimestamp(realm, currentTime);
         if (expired == -1) {
-            return false;
+            // Permanent-lockout realm: still purge cleared entries (lastFailure = 0)
+            expired = 1;
         }
         var em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
         var userIds = em.createNamedQuery("findExpiredLoginFailureUserIdsByRealm", String.class)

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/UserLoginFailureAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/UserLoginFailureAdapter.java
@@ -97,6 +97,10 @@ public class UserLoginFailureAdapter implements UserLoginFailureModel {
 
     @Override
     public void clearFailures() {
+        if (entity.getFailedLoginNotBefore() == 0 && entity.getNumFailures() == 0 && entity.getNumTemporaryLockouts() == 0 && entity.getLastFailure() == 0 && entity.getLastIPFailure() == null) {
+            // Fast exit to avoid locking the database entry on successful logins
+            return;
+        }
         ensureLocked();
         entity.setFailedLoginNotBefore(0);
         entity.setNumFailures(0);
@@ -141,6 +145,11 @@ public class UserLoginFailureAdapter implements UserLoginFailureModel {
     @Override
     public void clearPrimaryAndSecondaryAuthFailures() {
         clearFailures();
+        if (entity.getNumSecondaryAuthFailures() == 0) {
+            // Fast exit to avoid locking the database entry on successful logins
+            return;
+        }
+        ensureLocked();
         entity.setNumSecondaryAuthFailures(0);
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OutboxEntryEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OutboxEntryEntity.java
@@ -101,7 +101,7 @@ import org.hibernate.annotations.Nationalized;
                         + "  entryType, payload, metadata, status, attempts, nextAttemptAt, createdAt)"
                         + " VALUES (:id, :entryKind, :realmId, :ownerId, :containerId, :correlationId,"
                         + "         :entryType, :payload, :metadata, :status, :attempts, :nextAttemptAt, :createdAt)"
-                        + " ON CONFLICT DO NOTHING"),
+                        + " ON CONFLICT (entryKind, ownerId, correlationId) DO NOTHING"),
         @NamedQuery(
                 name = "OutboxEntryEntity.countByEntryKindRealmAndStatus",
                 query = "SELECT e.status, COUNT(e) FROM OutboxEntryEntity e"

--- a/model/jpa/src/main/resources/META-INF/queries-h2.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-h2.properties
@@ -1,0 +1,8 @@
+# H2 does not support the HQL 'insert ... on conflict ... do nothing' syntax.
+# Override with a native MERGE INTO statement.
+
+insertLoginFailure[native]=MERGE INTO LOGIN_FAILURE target \
+ USING (SELECT CAST(:realmId AS VARCHAR) AS REALM_ID, CAST(:userId AS VARCHAR) AS USER_ID) source \
+ ON target.REALM_ID = source.REALM_ID AND target.USER_ID = source.USER_ID \
+ WHEN NOT MATCHED THEN INSERT (REALM_ID, USER_ID, FAILED_LOGIN_NOT_BEFORE, NUM_FAILURES, NUM_TEMPORARY_LOCKOUTS, LAST_FAILURE, LAST_IP_FAILURE, NUM_SECONDARY_AUTH_FAILURES) \
+ VALUES (source.REALM_ID, source.USER_ID, 0, 0, 0, 0, NULL, 0)

--- a/model/jpa/src/main/resources/META-INF/queries-h2.properties
+++ b/model/jpa/src/main/resources/META-INF/queries-h2.properties
@@ -1,8 +1,0 @@
-# H2 does not support the HQL 'insert ... on conflict ... do nothing' syntax.
-# Override with a native MERGE INTO statement.
-
-insertLoginFailure[native]=MERGE INTO LOGIN_FAILURE target \
- USING (SELECT CAST(:realmId AS VARCHAR) AS REALM_ID, CAST(:userId AS VARCHAR) AS USER_ID) source \
- ON target.REALM_ID = source.REALM_ID AND target.USER_ID = source.USER_ID \
- WHEN NOT MATCHED THEN INSERT (REALM_ID, USER_ID, FAILED_LOGIN_NOT_BEFORE, NUM_FAILURES, NUM_TEMPORARY_LOCKOUTS, LAST_FAILURE, LAST_IP_FAILURE, NUM_SECONDARY_AUTH_FAILURES) \
- VALUES (source.REALM_ID, source.USER_ID, 0, 0, 0, 0, NULL, 0)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -101,7 +101,7 @@ public final class Database {
         H2("h2",
                 "org.h2.jdbcx.JdbcDataSource",
                 "org.h2.Driver",
-                "org.hibernate.dialect.H2Dialect",
+                "org.keycloak.connections.jpa.dialect.KeycloakH2Dialect",
                 new TriFunction<>() {
                     @Override
                     public String apply(Function<Option<?>, String> getter, String namedProperty, String alias) {
@@ -202,7 +202,7 @@ public final class Database {
         MSSQL("mssql",
                 "com.microsoft.sqlserver.jdbc.SQLServerXADataSource",
                 "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-                "org.hibernate.dialect.SQLServerDialect",
+                "org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect",
                 // default URL looks like this: "jdbc:sqlserver://${kc.db-url-host:localhost}:${kc.db-url-port:1433};databaseName=${kc.db-url-database:keycloak}${kc.db-url-properties:}"
                 (getter, namedProperty, alias) -> "jdbc:sqlserver://%s:%s;databaseName=%s%s".formatted(
                         getProperty(DatabaseOptions.DB_URL_HOST, getter, "localhost"),
@@ -215,7 +215,7 @@ public final class Database {
         ORACLE("oracle",
                 "oracle.jdbc.xa.client.OracleXADataSource",
                 "oracle.jdbc.driver.OracleDriver",
-                "org.hibernate.dialect.OracleDialect",
+                "org.keycloak.connections.jpa.dialect.KeycloakOracleDialect",
                 // default URL looks like this: "jdbc:oracle:thin:@//${kc.db-url-host:localhost}:${kc.db-url-port:1521}/${kc.db-url-database:keycloak}${kc.db-url-properties:}"
                 (getter, namedProperty, alias) -> "jdbc:oracle:thin:%s//%s:%s/%s%s".formatted(
                         DatabaseOptions.DatabaseTlsMode.fromCliValue(getProperty(DatabaseOptions.DB_TLS_MODE, getter,

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.DurationConverter;
 import org.keycloak.config.CachingOptions;
 import org.keycloak.config.CachingOptions.Stack;
@@ -284,6 +285,10 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 fromOption(SYNTHETIC_RUNTIME_DB_OPTION).mapFrom(DB, (name, value, context) -> "false")
                         .to(MSSQL_SEND_STRING_PARAMETER_AS_UNICODE)
                         .isEnabled(DatabasePropertyMappers::isMssqlSendStringParametersAsUnicode)
+                        .build(),
+                fromOption(SYNTHETIC_RUNTIME_DB_OPTION).mapFrom(DB, (name, value, context) -> "read-committed")
+                        .to("quarkus.datasource.jdbc.transaction-isolation-level")
+                        .isEnabled(DatabasePropertyMappers::isReadCommittedIsolationRequired)
                         .build()
         ));
         return result;
@@ -360,6 +365,22 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
 
         return !dbUrl.contains("sendStringParametersAsUnicode") &&
                 !dbUrlProperties.contains("sendStringParametersAsUnicode");
+    }
+
+    /**
+     * MySQL and MariaDB default to REPEATABLE READ transaction isolation, which acquires gap locks on
+     * {@code INSERT ... ON DUPLICATE KEY UPDATE} statements. When the stateless feature is enabled,
+     * concurrent login requests execute such upserts on authentication session and login failure tables,
+     * causing deadlocks under load. Switching to READ COMMITTED eliminates gap locks and resolves
+     * these deadlocks. This matches the isolation level PostgreSQL, Oracle, and SQL Server use by default.
+     */
+    public static boolean isReadCommittedIsolationRequired() {
+        String db = Configuration.getConfigValue(DB).getValue();
+        Database.Vendor vendor = Database.getVendor(db).orElse(null);
+        if (vendor != Database.Vendor.MYSQL && vendor != Database.Vendor.MARIADB && vendor != Database.Vendor.TIDB) {
+            return false;
+        }
+        return Profile.isFeatureEnabled(Profile.Feature.STATELESS);
     }
 
     private static ValueMapper getConnectTimeout(Collection<Database.Vendor> validForVendors, String timeoutProperty) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -366,6 +366,8 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
 
     private void checkMySQLBinlogFormat() {
         if (!Profile.isFeatureEnabled(Profile.Feature.STATELESS)) {
+            // Only when we switch on stateless, the transaction isolation level for MySQL is set to READ COMMITTED,
+            // and only then we need to check the binlog format.
             return;
         }
         String db = Configuration.getConfigValue(DatabaseOptions.DB).getValue();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -33,6 +33,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
 import org.keycloak.ServerStartupError;
+import org.keycloak.common.Profile;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Environment;
 import org.keycloak.config.DatabaseOptions;
@@ -109,6 +110,8 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
         }
 
         checkMySQLWaitTimeout();
+        checkMySQLBinlogFormat();
+        checkGaleraSyncWait();
         checkMSSQLIsolationLevel();
         checkUtf8Encoding();
 
@@ -358,6 +361,58 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
             }
         } catch (SQLException e) {
             logger.warnf(e, "Unable to validate %s 'wait_timeout' due to database exception", vendor);
+        }
+    }
+
+    private void checkMySQLBinlogFormat() {
+        if (!Profile.isFeatureEnabled(Profile.Feature.STATELESS)) {
+            return;
+        }
+        String db = Configuration.getConfigValue(DatabaseOptions.DB).getValue();
+        Database.Vendor vendor = Database.getVendor(db).orElseThrow();
+        if (!(Database.Vendor.MYSQL == vendor || Database.Vendor.MARIADB == vendor)) {
+            return;
+        }
+
+        try (Connection connection = getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'binlog_format'")) {
+            if (rs.next() && "STATEMENT".equalsIgnoreCase(rs.getString(2))) {
+                logger.errorf("%s 'binlog_format' is set to 'STATEMENT', which is incompatible with the READ COMMITTED transaction isolation level used by the stateless feature. "
+                        + "Change it to 'ROW' or 'MIXED' by running: SET GLOBAL binlog_format = 'ROW'", vendor);
+            }
+        } catch (SQLException e) {
+            logger.warnf(e, "Unable to validate %s 'binlog_format' due to database exception", vendor);
+        }
+    }
+
+    private void checkGaleraSyncWait() {
+        String db = Configuration.getConfigValue(DatabaseOptions.DB).getValue();
+        Database.Vendor vendor = Database.getVendor(db).orElseThrow();
+        if (!(Database.Vendor.MYSQL == vendor || Database.Vendor.MARIADB == vendor)) {
+            return;
+        }
+
+        try (Connection connection = getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'wsrep_on'")) {
+            if (!rs.next() || !"ON".equalsIgnoreCase(rs.getString(2))) {
+                return;
+            }
+        } catch (SQLException e) {
+            return;
+        }
+
+        try (Connection connection = getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'wsrep_sync_wait'")) {
+            if (rs.next() && "0".equals(rs.getString(2))) {
+                logger.errorf("Galera Cluster detected with 'wsrep_sync_wait = 0'. "
+                        + "This will cause stale reads when requests are routed to different nodes. "
+                        + "Set 'wsrep_sync_wait = 1' on all Galera nodes to enable causal reads.");
+            }
+        } catch (SQLException e) {
+            logger.warnf(e, "Unable to validate Galera 'wsrep_sync_wait' due to database exception");
         }
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -396,22 +396,19 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
         }
 
         try (Connection connection = getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'wsrep_on'")) {
-            if (!rs.next() || !"ON".equalsIgnoreCase(rs.getString(2))) {
-                return;
+             Statement statement = connection.createStatement()) {
+            try (ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'wsrep_on'")) {
+                if (!rs.next() || !"ON".equalsIgnoreCase(rs.getString(2))) {
+                    // not a Galera node, no further checks needed
+                    return;
+                }
             }
-        } catch (SQLException e) {
-            return;
-        }
-
-        try (Connection connection = getConnection();
-             Statement statement = connection.createStatement();
-             ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'wsrep_sync_wait'")) {
-            if (rs.next() && "0".equals(rs.getString(2))) {
-                logger.errorf("Galera Cluster detected with 'wsrep_sync_wait = 0'. "
-                        + "This will cause stale reads when requests are routed to different nodes. "
-                        + "Set 'wsrep_sync_wait = 1' on all Galera nodes to enable causal reads.");
+            try (ResultSet rs = statement.executeQuery("SHOW VARIABLES LIKE 'wsrep_sync_wait'")) {
+                if (rs.next() && "0".equals(rs.getString(2))) {
+                    logger.errorf("Galera Cluster detected with 'wsrep_sync_wait = 0'. "
+                            + "This will cause stale reads when requests are routed to different nodes. "
+                            + "Set 'wsrep_sync_wait = 1' on all Galera nodes to enable causal reads.");
+                }
             }
         } catch (SQLException e) {
             logger.warnf(e, "Unable to validate Galera 'wsrep_sync_wait' due to database exception");

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -30,6 +30,8 @@ import java.util.stream.StreamSupport;
 
 import org.keycloak.Config;
 import org.keycloak.config.CachingOptions;
+import org.keycloak.connections.jpa.dialect.KeycloakH2Dialect;
+import org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
@@ -46,7 +48,6 @@ import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfig;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.h2.Driver;
-import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.junit.Assert;
@@ -295,14 +296,14 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     public void testDatabaseDefaults() {
         ConfigArgsConfigSource.setCliArgs("--db=dev-file");
         SmallRyeConfig config = createConfig();
-        assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
         assertEquals(Driver.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
 
         assertEquals("jdbc:h2:file:" + Environment.getHomeDir().orElseThrow() + "/data/h2/keycloakdb;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=dev-mem");
         config = createConfig();
-        assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:h2:mem:keycloakdb;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("h2", config.getConfigValue("quarkus.datasource.db-kind").getValue());
 
@@ -358,7 +359,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     public void testDefaultDbPortGetApplied() {
         ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url-host=myhost", "--db-url-database=kcdb", "--db-url-port=1234", "--db-url-properties=?foo=bar");
         SmallRyeConfig config = createConfig();
-        assertEquals("org.hibernate.dialect.SQLServerDialect",
+        assertEquals(KeycloakSQLServerDialect.class.getName(),
                 config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:sqlserver://myhost:1234;databaseName=kcdb?foo=bar", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("mssql", config.getConfigValue("quarkus.datasource.db-kind").getValue());
@@ -380,12 +381,12 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         System.setProperty("kc.db-url-path", "test-dir");
         System.setProperty("kc.transaction-xa-enabled", "true");
         SmallRyeConfig config = createConfigFromCliArguments("--db=dev-file");
-        assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:h2:file:test-dir/data/h2/keycloakdb;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("xa", config.getConfigValue("quarkus.datasource.jdbc.transactions").getValue());
 
         config = createConfigFromCliArguments("");
-        assertEquals(H2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:h2:file:test-dir/data/h2/keycloakdb;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty("kc.db-url-properties", "?test=test&test1=test1");

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -30,8 +30,6 @@ import java.util.stream.StreamSupport;
 
 import org.keycloak.Config;
 import org.keycloak.config.CachingOptions;
-import org.keycloak.connections.jpa.dialect.KeycloakH2Dialect;
-import org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
@@ -296,14 +294,14 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     public void testDatabaseDefaults() {
         ConfigArgsConfigSource.setCliArgs("--db=dev-file");
         SmallRyeConfig config = createConfig();
-        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals("org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", config.getConfigValue("kc.db-dialect").getValue());
         assertEquals(Driver.class.getName(), config.getConfigValue("quarkus.datasource.jdbc.driver").getValue());
 
         assertEquals("jdbc:h2:file:" + Environment.getHomeDir().orElseThrow() + "/data/h2/keycloakdb;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=dev-mem");
         config = createConfig();
-        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals("org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:h2:mem:keycloakdb;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("h2", config.getConfigValue("quarkus.datasource.db-kind").getValue());
 
@@ -359,7 +357,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     public void testDefaultDbPortGetApplied() {
         ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url-host=myhost", "--db-url-database=kcdb", "--db-url-port=1234", "--db-url-properties=?foo=bar");
         SmallRyeConfig config = createConfig();
-        assertEquals(KeycloakSQLServerDialect.class.getName(),
+        assertEquals("org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect",
                 config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:sqlserver://myhost:1234;databaseName=kcdb?foo=bar", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("mssql", config.getConfigValue("quarkus.datasource.db-kind").getValue());
@@ -381,12 +379,12 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         System.setProperty("kc.db-url-path", "test-dir");
         System.setProperty("kc.transaction-xa-enabled", "true");
         SmallRyeConfig config = createConfigFromCliArguments("--db=dev-file");
-        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals("org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:h2:file:test-dir/data/h2/keycloakdb;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("xa", config.getConfigValue("quarkus.datasource.jdbc.transactions").getValue());
 
         config = createConfigFromCliArguments("");
-        assertEquals(KeycloakH2Dialect.class.getName(), config.getConfigValue("kc.db-dialect").getValue());
+        assertEquals("org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:h2:file:test-dir/data/h2/keycloakdb;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
 
         System.setProperty("kc.db-url-properties", "?test=test&test1=test1");

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -6,8 +6,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.keycloak.connections.jpa.dialect.KeycloakH2Dialect;
-import org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 
@@ -103,14 +101,14 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
     public void defaults() {
         ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-file");
         initConfig();
-        assertConfig("db-dialect-store", KeycloakH2Dialect.class.getName());
+        assertConfig("db-dialect-store", "org.keycloak.connections.jpa.dialect.KeycloakH2Dialect");
         // XA datasource is the default
         assertExternalConfig("quarkus.datasource.\"store\".jdbc.driver", JdbcDataSource.class.getName());
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-mem");
         initConfig();
-        assertConfig("db-dialect-store", KeycloakH2Dialect.class.getName());
+        assertConfig("db-dialect-store", "org.keycloak.connections.jpa.dialect.KeycloakH2Dialect");
         assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:mem:keycloakdb-store;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
         assertExternalConfig("quarkus.datasource.\"store\".db-kind", "h2");
         onAfter();
@@ -215,7 +213,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db-kind-realms=mssql", "--db-url-host-realms=myhost", "--db-url-database-realms=kcdb", "--db-url-port-realms=1234", "--db-url-properties-realms=?foo=bar");
         initConfig();
 
-        assertConfig("db-dialect-realms", KeycloakSQLServerDialect.class.getName());
+        assertConfig("db-dialect-realms", "org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect");
         assertExternalConfig(Map.of(
                 "quarkus.datasource.\"realms\".jdbc.url", "jdbc:sqlserver://myhost:1234;databaseName=kcdb?foo=bar",
                 "quarkus.datasource.\"realms\".db-kind", "mssql"
@@ -243,7 +241,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
 
         initConfig();
 
-        assertConfig("db-dialect-clients", KeycloakH2Dialect.class.getName());
+        assertConfig("db-dialect-clients", "org.keycloak.connections.jpa.dialect.KeycloakH2Dialect");
         assertExternalConfig(Map.of(
                 "quarkus.datasource.\"clients\".jdbc.url", "jdbc:h2:file:test-dir/data/h2-clients/keycloakdb-clients;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0",
                 "quarkus.datasource.\"clients\".jdbc.transactions", "xa"

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -6,13 +6,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.keycloak.connections.jpa.dialect.KeycloakH2Dialect;
+import org.keycloak.connections.jpa.dialect.KeycloakSQLServerDialect;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 
 import io.smallrye.config.Expressions;
 import io.smallrye.config.SmallRyeConfig;
 import org.h2.jdbcx.JdbcDataSource;
-import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.junit.Test;
@@ -102,14 +103,14 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
     public void defaults() {
         ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-file");
         initConfig();
-        assertConfig("db-dialect-store", H2Dialect.class.getName());
+        assertConfig("db-dialect-store", KeycloakH2Dialect.class.getName());
         // XA datasource is the default
         assertExternalConfig("quarkus.datasource.\"store\".jdbc.driver", JdbcDataSource.class.getName());
         onAfter();
 
         ConfigArgsConfigSource.setCliArgs("--db-kind-store=dev-mem");
         initConfig();
-        assertConfig("db-dialect-store", H2Dialect.class.getName());
+        assertConfig("db-dialect-store", KeycloakH2Dialect.class.getName());
         assertExternalConfig("quarkus.datasource.\"store\".jdbc.url", "jdbc:h2:mem:keycloakdb-store;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0");
         assertExternalConfig("quarkus.datasource.\"store\".db-kind", "h2");
         onAfter();
@@ -214,7 +215,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db-kind-realms=mssql", "--db-url-host-realms=myhost", "--db-url-database-realms=kcdb", "--db-url-port-realms=1234", "--db-url-properties-realms=?foo=bar");
         initConfig();
 
-        assertConfig("db-dialect-realms", "org.hibernate.dialect.SQLServerDialect");
+        assertConfig("db-dialect-realms", KeycloakSQLServerDialect.class.getName());
         assertExternalConfig(Map.of(
                 "quarkus.datasource.\"realms\".jdbc.url", "jdbc:sqlserver://myhost:1234;databaseName=kcdb?foo=bar",
                 "quarkus.datasource.\"realms\".db-kind", "mssql"
@@ -242,7 +243,7 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
 
         initConfig();
 
-        assertConfig("db-dialect-clients", H2Dialect.class.getName());
+        assertConfig("db-dialect-clients", KeycloakH2Dialect.class.getName());
         assertExternalConfig(Map.of(
                 "quarkus.datasource.\"clients\".jdbc.url", "jdbc:h2:file:test-dir/data/h2-clients/keycloakdb-clients;;test=test;test1=test1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=0",
                 "quarkus.datasource.\"clients\".jdbc.transactions", "xa"

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigKeepAliveDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigKeepAliveDistTest.java
@@ -38,11 +38,13 @@ import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHORIZATION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NUM_OWNERS;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.REALM_CACHE_NAME;
@@ -186,14 +188,20 @@ public class ClusterConfigKeepAliveDistTest {
         args.add("--cache=ispn");
         args.add("--features-disabled=persistent-user-sessions");
 
-        Arrays.stream(CLUSTERED_CACHE_NUM_OWNERS)
+        streamOfCacheNames()
                 .map(cache -> CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, cache))
                 .map("--spi-cache-embedded--default--%s-owners=1"::formatted)
                 .forEach(args::add);
         runner.run(args);
 
         // forces the numOwner to 2 to prevent data loss.
-        assertNumOwner(Arrays.stream(CLUSTERED_CACHE_NUM_OWNERS), 2);
+        assertNumOwner(streamOfCacheNames(), 2);
+    }
+
+    private static @NonNull Stream<String> streamOfCacheNames() {
+        return Arrays.stream(CLUSTERED_CACHE_NUM_OWNERS)
+                // The login failure cache is disabled by default since login-failures:v2
+                .filter(Predicate.not(LOGIN_FAILURE_CACHE_NAME::equals));
     }
 
     private void doNumOwnerTest(KeycloakRunner runner, boolean volatileSessions) {
@@ -205,13 +213,13 @@ public class ClusterConfigKeepAliveDistTest {
             args.add("--features-disabled=persistent-user-sessions");
         }
 
-        Arrays.stream(CLUSTERED_CACHE_NUM_OWNERS)
+        streamOfCacheNames()
                 .map(cache -> CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, cache))
                 .map(cache -> "--spi-cache-embedded--default--%s-owners=%s".formatted(cache, owners))
                 .forEach(args::add);
         runner.run(args);
 
-        Stream<String> caches = Arrays.stream(CLUSTERED_CACHE_NUM_OWNERS);
+        Stream<String> caches = streamOfCacheNames();
         if (!volatileSessions) {
             Set<String> sessionCaches = Set.of(
                     CLIENT_SESSION_CACHE_NAME,

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
@@ -80,7 +80,8 @@ public class CustomJpaEntityProviderDistTest {
         cliResult.assertMessage("jakarta.persistence.jtaDataSource: client-store");
         cliResult.assertMessage("jakarta.persistence.jtaDataSource: new-user-store");
         cliResult.assertMessage("jakarta.persistence.jtaDataSource: pu-without-dialect-store");
-        cliResult.assertMessageWasShownExactlyNumberOfTimes("hibernate.dialect: org.hibernate.dialect.H2Dialect", 4);
+        cliResult.assertMessageWasShownExactlyNumberOfTimes("hibernate.dialect: org.hibernate.dialect.H2Dialect", 2);
+        cliResult.assertMessageWasShownExactlyNumberOfTimes("hibernate.dialect: org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", 2);
 
         cliResult.assertStartedDevMode();
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/CustomJpaEntityProviderDistTest.java
@@ -80,8 +80,7 @@ public class CustomJpaEntityProviderDistTest {
         cliResult.assertMessage("jakarta.persistence.jtaDataSource: client-store");
         cliResult.assertMessage("jakarta.persistence.jtaDataSource: new-user-store");
         cliResult.assertMessage("jakarta.persistence.jtaDataSource: pu-without-dialect-store");
-        cliResult.assertMessageWasShownExactlyNumberOfTimes("hibernate.dialect: org.hibernate.dialect.H2Dialect", 2);
-        cliResult.assertMessageWasShownExactlyNumberOfTimes("hibernate.dialect: org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", 2);
+        cliResult.assertMessageWasShownExactlyNumberOfTimes("hibernate.dialect: org.keycloak.connections.jpa.dialect.KeycloakH2Dialect", 4);
 
         cliResult.assertStartedDevMode();
     }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/LoginFailureUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/LoginFailureUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +21,7 @@ import java.util.concurrent.TimeUnit;
 import org.keycloak.models.RealmModel;
 
 /**
- * <p>Shared methods to calculate the session expiration and idle.</p>
- *
- * @author rmartinc
+ * <p>Shared methods to calculate login failure idle times.</p>
  */
 public class LoginFailureUtils {
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/LoginFailureUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/LoginFailureUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.models.utils;
+
+import java.util.concurrent.TimeUnit;
+
+import org.keycloak.models.RealmModel;
+
+/**
+ * <p>Shared methods to calculate the session expiration and idle.</p>
+ *
+ * @author rmartinc
+ */
+public class LoginFailureUtils {
+
+    /**
+     * Compute the expiration time cut-off in milliseconds for expiring login failure entries.
+     *
+     * @param realm current realm
+     * @param currentTime current timestamp in seconds since last epoc
+     * @return Timestamp in milliseconds, or -1L if the realm will never expire.
+     */
+    public static long computeExpirationCutOffTimestamp(RealmModel realm, long currentTime) {
+        if (realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) {
+            // If mode is permanent lockout only, the "failure reset time" cannot be configured and login failures should never expire.
+            return -1L;
+        }
+        // expired if last-failure + max-delta-time < current time
+        return TimeUnit.SECONDS.toMillis(currentTime - realm.getMaxDeltaTimeSeconds());
+    }
+
+}

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/LoginFailureUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/LoginFailureUtils.java
@@ -29,7 +29,7 @@ public class LoginFailureUtils {
      * Compute the expiration time cut-off in milliseconds for expiring login failure entries.
      *
      * @param realm current realm
-     * @param currentTime current timestamp in seconds since last epoc
+     * @param currentTime current timestamp in seconds since last epoch
      * @return Timestamp in milliseconds, or -1L if the realm will never expire.
      */
     public static long computeExpirationCutOffTimestamp(RealmModel realm, long currentTime) {

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -19,6 +19,8 @@ package org.keycloak.services.managers;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
@@ -33,12 +35,13 @@ import org.keycloak.provider.ProviderConfigurationBuilder;
  */
 public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFactory {
     DefaultBruteForceProtector protector;
+    private final ConcurrentMap<String, DefaultLockingBruteForceProtector.UserLock> userLocks = new ConcurrentHashMap<>();
 
     private boolean allowConcurrentRequests;
 
     @Override
     public BruteForceProtector create(KeycloakSession session) {
-        return protector != null ? protector : new DefaultLockingBruteForceProtector(session.getKeycloakSessionFactory(), session);
+        return protector != null ? protector : new DefaultLockingBruteForceProtector(session.getKeycloakSessionFactory(), session, userLocks);
     }
 
     @Override
@@ -49,7 +52,9 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        protector = Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V2) ? null : allowConcurrentRequests ? new DefaultBruteForceProtector(factory) : new DefaultBlockingBruteForceProtector(factory);
+        if (Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V1)) {
+            protector = allowConcurrentRequests ? new DefaultBruteForceProtector(factory) : new DefaultBlockingBruteForceProtector(factory);
+        }
     }
 
     @Override
@@ -68,7 +73,7 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
                 .property()
                 .name("allowConcurrentRequests")
                 .type("boolean")
-                .helpText("If concurrent logins are allowed by the brute force protection.")
+                .helpText("If concurrent logins are allowed by the brute force protection. This is deprecated and only active for login-failures:v1. login-failure:v2 will execute concurrent logins serially on each Keycloak instance instead of returning an error.")
                 .defaultValue(false)
                 .add()
                 .build();

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -73,7 +73,7 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
                 .property()
                 .name("allowConcurrentRequests")
                 .type("boolean")
-                .helpText("If concurrent logins are allowed by the brute force protection. This is deprecated and only active for login-failures:v1. login-failure:v2 will execute concurrent logins serially on each Keycloak instance instead of returning an error.")
+                .helpText("If concurrent logins are allowed by the brute force protection. This is deprecated and only active for login-failures:v1. login-failures:v2 will execute concurrent logins serially on each Keycloak instance instead of returning an error.")
                 .defaultValue(false)
                 .add()
                 .build();

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtectorFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -37,7 +38,7 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
 
     @Override
     public BruteForceProtector create(KeycloakSession session) {
-        return protector;
+        return protector != null ? protector : new DefaultLockingBruteForceProtector(session.getKeycloakSessionFactory(), session);
     }
 
     @Override
@@ -48,7 +49,7 @@ public class DefaultBruteForceProtectorFactory implements BruteForceProtectorFac
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        protector = allowConcurrentRequests ? new DefaultBruteForceProtector(factory) : new DefaultBlockingBruteForceProtector(factory);
+        protector = Profile.isFeatureEnabled(Profile.Feature.LOGIN_FAILURES_V2) ? null : allowConcurrentRequests ? new DefaultBruteForceProtector(factory) : new DefaultBlockingBruteForceProtector(factory);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
@@ -27,7 +27,7 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
-public class DefaultLockingBruteForceProtector extends DefaultBlockingBruteForceProtector {
+public class DefaultLockingBruteForceProtector extends DefaultBruteForceProtector {
 
     private final KeycloakSession session;
 

--- a/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
@@ -32,6 +32,28 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.UserModel;
 
+/**
+ * Brute force protector that serializes login attempts per user within a JVM using a {@link Semaphore}.
+ *
+ * <p>The database row for login failures is only locked with {@code PESSIMISTIC_WRITE} when a write occurs
+ * (see {@link org.keycloak.loginfailures.jpa.UserLoginFailureAdapter#ensureLocked()}), not on reads.
+ * Without additional coordination, parallel login attempts could all read the same (stale) failure count,
+ * allowing more attempts than the configured limit. The JVM-level lock prevents this by ensuring only one
+ * thread per user per node reads and updates the failure state at a time.
+ *
+ * <p>This is a performance trade-off: acquiring a database lock on every read (including
+ * {@link #isTemporarilyDisabled} checks on every login) would be expensive. The JVM-level lock avoids that
+ * cost while still providing correctness within a single node. In a cluster, the upper bound for concurrent
+ * attempts that may bypass the check equals the number of nodes, as each node maintains its own lock map.
+ * The database pessimistic write lock still guarantees that no failure count update is lost.
+ *
+ * <p>A database-only locking approach would also require inserting a login failure row on the first login
+ * of every user (before knowing if it is a success or failure) in order to have a row to lock. This would
+ * significantly increase the number of rows and the IOPS on the login failure table.
+ *
+ * <p>This improves on the base {@link DefaultBruteForceProtector}, which processes failures asynchronously
+ * and would reject concurrent login attempts entirely during that window.
+ */
 public class DefaultLockingBruteForceProtector extends DefaultBruteForceProtector {
 
     static class UserLock {

--- a/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
@@ -16,31 +16,42 @@
  */
 package org.keycloak.services.managers;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Semaphore;
 
 import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.util.Time;
+import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.models.UserModel;
 
 public class DefaultLockingBruteForceProtector extends DefaultBruteForceProtector {
 
-    private final KeycloakSession session;
+    static class UserLock {
+        final Semaphore semaphore = new Semaphore(1);
+        int refCount;
+    }
 
-    public DefaultLockingBruteForceProtector(KeycloakSessionFactory factory, KeycloakSession session) {
+    private final KeycloakSession session;
+    private final ConcurrentMap<String, UserLock> userLocks;
+    private final Set<String> lockedUserIds = new HashSet<>();
+    private boolean transactionEnlisted;
+
+    public DefaultLockingBruteForceProtector(KeycloakSessionFactory factory, KeycloakSession session, ConcurrentMap<String, UserLock> userLocks) {
         super(factory);
         this.session = session;
+        this.userLocks = userLocks;
     }
 
     @Override
     protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success, Set<String> categories) {
-        // This is used with the JPA implementation which will lock the database entry to prevent concurrent updates.
-        // Not spawning a new thread ensures that once the login returns, the data is written to the database, and no concurrent execution is happening,
-        // making the next attempt fail due to the logic in DefaultBlockingBruteForceProtector.
         if (success) {
             success(session, realm, user.getId(), categories);
         } else {
@@ -48,4 +59,53 @@ public class DefaultLockingBruteForceProtector extends DefaultBruteForceProtecto
         }
     }
 
+    @Override
+    protected UserLoginFailureModel getUserFailureModel(KeycloakSession session, RealmModel realm, String userId) {
+        if (realm == null) return null;
+        acquireLock(session, userId);
+        return super.getUserFailureModel(session, realm, userId);
+    }
+
+    private void acquireLock(KeycloakSession session, String userId) {
+        if (lockedUserIds.contains(userId)) {
+            return;
+        }
+
+        UserLock lock = userLocks.compute(userId, (k, existing) -> {
+            if (existing == null) {
+                existing = new UserLock();
+            }
+            existing.refCount++;
+            return existing;
+        });
+
+        lock.semaphore.acquireUninterruptibly();
+        lockedUserIds.add(userId);
+
+        if (!transactionEnlisted) {
+            transactionEnlisted = true;
+            session.getTransactionManager().enlistAfterCompletion(new AbstractKeycloakTransaction() {
+                @Override
+                protected void commitImpl() {
+                    releaseAllLocks();
+                }
+
+                @Override
+                protected void rollbackImpl() {
+                    releaseAllLocks();
+                }
+            });
+        }
+    }
+
+    private void releaseAllLocks() {
+        for (String userId : lockedUserIds) {
+            userLocks.compute(userId, (k, lock) -> {
+                if (lock == null) return null;
+                lock.semaphore.release();
+                lock.refCount--;
+                return lock.refCount == 0 ? null : lock;
+            });
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultLockingBruteForceProtector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.managers;
+
+import java.util.Set;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import org.keycloak.common.ClientConnection;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+public class DefaultLockingBruteForceProtector extends DefaultBlockingBruteForceProtector {
+
+    private final KeycloakSession session;
+
+    public DefaultLockingBruteForceProtector(KeycloakSessionFactory factory, KeycloakSession session) {
+        super(factory);
+        this.session = session;
+    }
+
+    @Override
+    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success, Set<String> categories) {
+        // This is used with the JPA implementation which will lock the database entry to prevent concurrent updates.
+        // Not spawning a new thread ensures that once the login returns, the data is written to the database, and no concurrent execution is happening,
+        // making the next attempt fail due to the logic in DefaultBlockingBruteForceProtector.
+        if (success) {
+            success(session, realm, user.getId(), categories);
+        } else {
+            failure(session, realm, user.getId(), clientConnection.getRemoteHost(), Time.currentTimeMillis(), categories);
+        }
+    }
+
+}

--- a/tests/base/src/test/java/org/keycloak/tests/loginfailures/LoginFailureExpirationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/loginfailures/LoginFailureExpirationTest.java
@@ -108,9 +108,9 @@ public class LoginFailureExpirationTest {
             failure0.setLastFailure(Time.currentTimeMillis() - 10_000); // 10 seconds ago
             failure0.incrementFailures();
 
-            // User 1: Failure just at the edge (should NOT be expired)
+            // User 1: Failure within the safe window (should NOT be expired)
             var failure1 = session.loginFailures().addUserLoginFailure(realmModel, state.user1);
-            failure1.setLastFailure(Time.currentTimeMillis() - (MAX_DELTA_TIME_SECONDS * 1000)); // exactly at max delta
+            failure1.setLastFailure(Time.currentTimeMillis() - ((MAX_DELTA_TIME_SECONDS - 10) * 1000)); // 10 seconds before max delta
             failure1.incrementFailures();
 
             // User 2: Old failure (should be expired)

--- a/tests/base/src/test/java/org/keycloak/tests/loginfailures/LoginFailureExpirationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/loginfailures/LoginFailureExpirationTest.java
@@ -19,11 +19,11 @@ package org.keycloak.tests.loginfailures;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.common.Profile;
+import org.keycloak.common.util.Time;
 import org.keycloak.loginfailures.jpa.LoginFailureExpirationAction;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -57,10 +57,6 @@ public class LoginFailureExpirationTest {
 
     private static final int MAX_DELTA_TIME_SECONDS = 60; // 1 minute
 
-    // Not important, just large enough to keep test timestamps positive. All APIs take the current time as a parameter,
-    // so we avoid calling Time.currentTimeSeconds() in this test.
-    private static final int CURRENT_TIME_SECONDS = 60 * 60 * 5;
-    private static final long CURRENT_TIME_MILLIS = (long) CURRENT_TIME_SECONDS * 1000L;
     @InjectRealm(config = ConfigureMaxDeltaTimeout.class)
     ManagedRealm realm;
 
@@ -109,43 +105,28 @@ public class LoginFailureExpirationTest {
 
             // User 0: Recent failure (should NOT be expired)
             var failure0 = session.loginFailures().addUserLoginFailure(realmModel, state.user0);
-            failure0.setLastFailure(CURRENT_TIME_MILLIS - 10_000); // 10 seconds ago
+            failure0.setLastFailure(Time.currentTimeMillis() - 10_000); // 10 seconds ago
             failure0.incrementFailures();
 
             // User 1: Failure just at the edge (should NOT be expired)
             var failure1 = session.loginFailures().addUserLoginFailure(realmModel, state.user1);
-            failure1.setLastFailure(CURRENT_TIME_MILLIS - (MAX_DELTA_TIME_SECONDS * 1000)); // exactly at max delta
+            failure1.setLastFailure(Time.currentTimeMillis() - (MAX_DELTA_TIME_SECONDS * 1000)); // exactly at max delta
             failure1.incrementFailures();
 
             // User 2: Old failure (should be expired)
             var failure2 = session.loginFailures().addUserLoginFailure(realmModel, state.user2);
-            failure2.setLastFailure(CURRENT_TIME_MILLIS - ((MAX_DELTA_TIME_SECONDS + 10) * 1000)); // 10 seconds past max delta
+            failure2.setLastFailure(Time.currentTimeMillis() - ((MAX_DELTA_TIME_SECONDS + 10) * 1000)); // 10 seconds past max delta
             failure2.incrementFailures();
 
             // User 3: Very old failure (should be expired)
             var failure3 = session.loginFailures().addUserLoginFailure(realmModel, state.user3);
-            failure3.setLastFailure(CURRENT_TIME_MILLIS - ((MAX_DELTA_TIME_SECONDS + 120) * 1000)); // 2 minutes past max delta
+            failure3.setLastFailure(Time.currentTimeMillis() - ((MAX_DELTA_TIME_SECONDS + 120) * 1000)); // 2 minutes past max delta
             failure3.incrementFailures();
 
             // User 4: Ancient failure (should be expired)
             var failure4 = session.loginFailures().addUserLoginFailure(realmModel, state.user4);
-            failure4.setLastFailure(CURRENT_TIME_MILLIS - ((MAX_DELTA_TIME_SECONDS + 300) * 1000)); // 5 minutes past max delta
+            failure4.setLastFailure(Time.currentTimeMillis() - ((MAX_DELTA_TIME_SECONDS + 300) * 1000)); // 5 minutes past max delta
             failure4.incrementFailures();
-        });
-
-        // Verify all login failures exist before expiration
-        runOnServer.run(session -> {
-            var realmModel = session.realms().getRealm(state.realmId);
-
-            for (var userId : state.allUsers()) {
-                var failure = session.loginFailures().getUserLoginFailure(realmModel, userId);
-                if (Objects.equals(state.user0, userId)) {
-                    assertNotNull(failure, "Login failure should exist for user " + userId);
-                    assertEquals(1, failure.getNumFailures(), "Login failure should have 1 failure");
-                } else {
-                    assertNull(failure, "Login failure should not be returned");
-                }
-            }
         });
 
         // Run the expiration action manually
@@ -157,7 +138,7 @@ public class LoginFailureExpirationTest {
             var hasMore = LoginFailureExpirationAction.INSTANCE.removeExpired(
                     session,
                     realmModel.getId(),
-                    CURRENT_TIME_SECONDS,
+                    Time.currentTime(),
                     100, // maxRemoval
                     removedCount::addAndGet
             );
@@ -206,7 +187,7 @@ public class LoginFailureExpirationTest {
         runOnServer.run(session -> {
             var realmModel = session.realms().getRealm(state.realmId);
             var failure = session.loginFailures().addUserLoginFailure(realmModel, state.user0);
-            failure.setLastFailure(CURRENT_TIME_MILLIS - ((MAX_DELTA_TIME_SECONDS + 60) * 1000));
+            failure.setLastFailure(Time.currentTimeMillis() - ((MAX_DELTA_TIME_SECONDS + 60) * 1000));
             failure.incrementFailures();
         });
 
@@ -217,7 +198,7 @@ public class LoginFailureExpirationTest {
             LoginFailureExpirationAction.INSTANCE.removeExpired(
                     session,
                     realmModel.getId(),
-                    CURRENT_TIME_SECONDS,
+                    Time.currentTime(),
                     100,
                     removedCount::addAndGet
             );
@@ -245,7 +226,7 @@ public class LoginFailureExpirationTest {
             var realmModel = session.realms().getRealm(state.realmId);
             for (var userId : state.allUsers()) {
                 var failure = session.loginFailures().addUserLoginFailure(realmModel, userId);
-                failure.setLastFailure(CURRENT_TIME_MILLIS - ((MAX_DELTA_TIME_SECONDS + 60) * 1000));
+                failure.setLastFailure(Time.currentTimeMillis() - ((MAX_DELTA_TIME_SECONDS + 60) * 1000));
                 failure.incrementFailures();
             }
         });
@@ -257,7 +238,7 @@ public class LoginFailureExpirationTest {
             var hasMore = LoginFailureExpirationAction.INSTANCE.removeExpired(
                     session,
                     realmModel.getId(),
-                    CURRENT_TIME_SECONDS,
+                    Time.currentTime(),
                     2, // maxRemoval - limit to 2
                     removedCount::addAndGet
             );
@@ -273,7 +254,7 @@ public class LoginFailureExpirationTest {
             var hasMore = LoginFailureExpirationAction.INSTANCE.removeExpired(
                     session,
                     realmModel.getId(),
-                    CURRENT_TIME_SECONDS,
+                    Time.currentTime(),
                     100,
                     removedCount::addAndGet
             );

--- a/tests/base/src/test/java/org/keycloak/tests/loginfailures/LoginFailureExpirationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/loginfailures/LoginFailureExpirationTest.java
@@ -19,6 +19,7 @@ package org.keycloak.tests.loginfailures;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.keycloak.admin.client.Keycloak;
@@ -138,8 +139,12 @@ public class LoginFailureExpirationTest {
 
             for (var userId : state.allUsers()) {
                 var failure = session.loginFailures().getUserLoginFailure(realmModel, userId);
-                assertNotNull(failure, "Login failure should exist for user " + userId);
-                assertEquals(1, failure.getNumFailures(), "Login failure should have 1 failure");
+                if (Objects.equals(state.user0, userId)) {
+                    assertNotNull(failure, "Login failure should exist for user " + userId);
+                    assertEquals(1, failure.getNumFailures(), "Login failure should have 1 failure");
+                } else {
+                    assertNull(failure, "Login failure should not be returned");
+                }
             }
         });
 

--- a/tests/base/src/test/java/org/keycloak/tests/suites/StatelessTestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/StatelessTestSuite.java
@@ -7,6 +7,7 @@ import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.tests.admin.client.SessionTest;
 import org.keycloak.tests.admin.concurrency.ConcurrentLoginTest;
 import org.keycloak.tests.cli.admin.KcAdmSessionTest;
+import org.keycloak.tests.forms.RecoveryAuthnCodesAuthenticatorTest;
 import org.keycloak.tests.loginfailures.LoginFailureExpirationTest;
 import org.keycloak.tests.model.UserSessionProviderOfflineTest;
 import org.keycloak.tests.model.UserSessionProviderTest;
@@ -31,7 +32,9 @@ import org.junit.platform.suite.api.Suite;
         SessionTimeoutValidationTest.class,
         LoginFailureExpirationTest.class,
         OrganizationMemberTest.class,
-        KcAdmSessionTest.class
+        KcAdmSessionTest.class,
+        OrganizationMemberTest.class,
+        RecoveryAuthnCodesAuthenticatorTest.class
 })
 public class StatelessTestSuite {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/META-INF/keycloak-server.json
@@ -72,7 +72,7 @@
     },
 
     "loginFailure": {
-        "provider": "${keycloak.loginFailure.provider:infinispan}"
+        "provider": "${keycloak.loginFailure.provider:jpa}"
     },
 
     "singleUseObject": {

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Infinispan.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Infinispan.java
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.keycloak.cluster.infinispan.DatabaseAwareClusterProviderFactory;
 import org.keycloak.cluster.infinispan.InfinispanClusterProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.common.profile.PropertiesProfileConfigResolver;
 import org.keycloak.connections.infinispan.InfinispanConnectionProviderFactory;
 import org.keycloak.connections.infinispan.InfinispanConnectionSpi;
 import org.keycloak.infinispan.util.InfinispanUtils;
@@ -135,5 +137,6 @@ public class Infinispan extends KeycloakModelParameters {
 
     public Infinispan() {
         super(ALLOWED_SPIS, ALLOWED_FACTORIES);
+        System.getProperties().put(PropertiesProfileConfigResolver.getPropertyKey(Profile.Feature.LOGIN_FAILURES_V1), "enabled");
     }
 }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
@@ -59,6 +59,7 @@ import org.keycloak.revoketokens.jpa.JpaRevokedTokenProviderFactory;
 import org.keycloak.sessions.AuthenticationSessionSpi;
 import org.keycloak.singleobject.jpa.JpaSingleUseObjectProviderFactory;
 import org.keycloak.storage.DatastoreSpi;
+import org.keycloak.storage.configuration.jpa.JpaServerConfigStorageProviderFactory;
 import org.keycloak.storage.datastore.DefaultDatastoreProviderFactory;
 import org.keycloak.testsuite.model.Config;
 import org.keycloak.testsuite.model.KeycloakModelParameters;
@@ -122,6 +123,7 @@ public class Jpa extends KeycloakModelParameters {
       .add(JpaRevokedTokenProviderFactory.class)
       .add(JpaSingleUseObjectProviderFactory.class)
       .add(JpaUserLoginFailureProviderFactory.class)
+      .add(JpaServerConfigStorageProviderFactory.class)
 
       //required for migrateModel
       .add(MigrationProviderFactory.class)

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
@@ -59,6 +59,7 @@ import org.keycloak.revoketokens.jpa.JpaRevokedTokenProviderFactory;
 import org.keycloak.sessions.AuthenticationSessionSpi;
 import org.keycloak.singleobject.jpa.JpaSingleUseObjectProviderFactory;
 import org.keycloak.storage.DatastoreSpi;
+import org.keycloak.storage.configuration.ServerConfigurationStorageProviderSpi;
 import org.keycloak.storage.configuration.jpa.JpaServerConfigStorageProviderFactory;
 import org.keycloak.storage.datastore.DefaultDatastoreProviderFactory;
 import org.keycloak.testsuite.model.Config;
@@ -83,7 +84,7 @@ public class Jpa extends KeycloakModelParameters {
       .add(RevokedTokenSpi.class)
       .add(SingleUseObjectSpi.class)
       .add(UserLoginFailureSpi.class)
-
+      .add(ServerConfigurationStorageProviderSpi.class)
       .add(DatastoreSpi.class)
 
       //required for migrateModel

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Jpa.java
@@ -30,6 +30,8 @@ import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionPr
 import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionSpi;
 import org.keycloak.connections.jpa.updater.liquibase.lock.LiquibaseDBLockProviderFactory;
 import org.keycloak.events.jpa.JpaEventStoreProviderFactory;
+import org.keycloak.executors.DefaultExecutorsProviderFactory;
+import org.keycloak.executors.ExecutorsSpi;
 import org.keycloak.loginfailures.jpa.JpaUserLoginFailureProviderFactory;
 import org.keycloak.migration.MigrationProviderFactory;
 import org.keycloak.migration.MigrationSpi;
@@ -64,6 +66,8 @@ import org.keycloak.storage.configuration.jpa.JpaServerConfigStorageProviderFact
 import org.keycloak.storage.datastore.DefaultDatastoreProviderFactory;
 import org.keycloak.testsuite.model.Config;
 import org.keycloak.testsuite.model.KeycloakModelParameters;
+import org.keycloak.timer.TimerSpi;
+import org.keycloak.timer.basic.BasicTimerProviderFactory;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -86,6 +90,8 @@ public class Jpa extends KeycloakModelParameters {
       .add(UserLoginFailureSpi.class)
       .add(ServerConfigurationStorageProviderSpi.class)
       .add(DatastoreSpi.class)
+      .add(TimerSpi.class)
+      .add(ExecutorsSpi.class)
 
       //required for migrateModel
       .add(MigrationSpi.class)
@@ -125,6 +131,8 @@ public class Jpa extends KeycloakModelParameters {
       .add(JpaSingleUseObjectProviderFactory.class)
       .add(JpaUserLoginFailureProviderFactory.class)
       .add(JpaServerConfigStorageProviderFactory.class)
+      .add(BasicTimerProviderFactory.class)
+      .add(DefaultExecutorsProviderFactory.class)
 
       //required for migrateModel
       .add(MigrationProviderFactory.class)

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Stateless.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/parameters/Stateless.java
@@ -32,5 +32,7 @@ public class Stateless extends KeycloakModelParameters {
     @Override
     public void updateConfig(Config cf) {
         System.getProperties().put(PropertiesProfileConfigResolver.getPropertyKey(Profile.Feature.STATELESS), "enabled");
+        // STATELESS depends on LOGIN_FAILURES_V2; remove any V1 override set by Infinispan parameters.
+        System.getProperties().remove(PropertiesProfileConfigResolver.getPropertyKey(Profile.Feature.LOGIN_FAILURES_V1));
     }
 }


### PR DESCRIPTION
Closes #52126

## Summary

- Introduces a new versioned feature `login-failures` with `v1` (in-memory, deprecated) and `v2` (persistent/database, default).
- The JPA login failure provider (already used by `stateless`) is now active by default via `LOGIN_FAILURES_V2`, making database-backed login failures the standard for single-site deployments.
- The embedded Infinispan provider activates only when `login-failures:v1` is explicitly enabled.
- Custom Hibernate dialects (`KeycloakH2Dialect`, `KeycloakOracleDialect`, `KeycloakSQLServerDialect`) fix `INSERT ... ON CONFLICT ... DO NOTHING` being silently dropped by Hibernate on H2, Oracle, and MS SQL Server.
- MySQL/MariaDB transaction isolation switched to READ COMMITTED when the `stateless` feature is enabled, preventing deadlocks from gap locks on upsert statements.
- Idempotent `clearFailures()` optimization: skips database locking on successful logins when no failure data exists.
- Login failure expiration: entries are treated as expired based on `maxDeltaTimeSeconds`, matching the Infinispan TTL behavior.
- Cleanup on realm/user removal via `ProviderEventListener`.
- Documentation updated across release notes, upgrading guide, migration prep, and caching guide.

## Decisions and assumptions

- **MULTI_SITE and CLUSTERLESS are unchanged:** These features continue to store login failures in the external Infinispan cluster via `RemoteUserLoginFailureProviderFactory`, regardless of the `login-failures` feature version. No dependency on `LOGIN_FAILURES_V2` was added to these features. The remote provider's `isSupported()` check (`!STATELESS && isRemoteInfinispan()`) is unchanged.
- **Only STATELESS depends on LOGIN_FAILURES_V2:** Since `stateless` already required JPA login failures, this dependency is a natural fit. The versioned feature conflict mechanism prevents `login-failures:v1` from being enabled alongside `stateless`.
- **Provider ordering handles multi-site/clusterless correctly:** The remote provider has `order()=1` vs JPA's default `order()=0`. When both are supported (e.g., `clusterless` + default `v2`), the remote provider wins automatically — no explicit exclusion needed in the JPA provider.
- **Custom Hibernate dialects for H2, Oracle, MS SQL Server:** Hibernate's default SQL AST translators for these databases silently drop `ON CONFLICT ... DO NOTHING` conflict clauses instead of emitting MERGE statements. The custom dialects override `visitInsertStatementOnly` to call `visitInsertStatementEmulateMerge` when conflict columns are present. MySQL/MariaDB and PostgreSQL handle this correctly out of the box. The Quarkus distribution sets the custom dialect on all persistence units; `DefaultJpaConnectionProviderFactory` (used in tests) auto-detects the database and applies the dialect.
- **Explicit conflict columns in HQL queries:** The MERGE emulation requires explicit conflict column names. `LoginFailureEntity`, `OutboxEntryEntity`, and `RootAuthenticationSessionEntity` specify `ON CONFLICT(id) DO NOTHING` (or composite keys) so the dialect can produce a correct MERGE ON clause.
- **MySQL/MariaDB READ COMMITTED isolation (stateless only):** The default REPEATABLE READ isolation acquires gap locks on `INSERT ... ON DUPLICATE KEY UPDATE`, causing deadlocks under concurrent logins. READ COMMITTED is set only when `stateless` is enabled to limit the blast radius. This matches PostgreSQL, Oracle, and SQL Server defaults. Requires `binlog_format = ROW` or `MIXED` (default since MySQL 8.0 / MariaDB 10.6). Changing isolation for all modes is being considered for a future release.
- **Idempotent `clearFailures()` avoids unnecessary locking:** On successful logins, `clearFailures()` checks whether any failure data exists before acquiring a database lock. This avoids contention on the login failure row during the common successful-login path.
- **Login failure expiration in JPA:** Entries are treated as expired when `lastFailure` is older than `maxDeltaTimeSeconds` (same threshold as `LoginFailureExpirationAction`). Expired entries are filtered out on read and re-initialized on upsert. A background `ExpirationTask` periodically purges old entries.
- **Test infrastructure fixes:** `Jpa.java` adds `TimerSpi`/`ExecutorsSpi` and their factories (required by the expiration task now loaded by default). `Stateless.java` removes the `LOGIN_FAILURES_V1` system property set by `Infinispan.java` to prevent the V1/STATELESS dependency conflict. `CustomJpaEntityProviderDistTest` updated because Quarkus overrides dialect for all persistence units (4x `KeycloakH2Dialect`).
- **Galera Cluster:** The default behavior of a MySQL or MariaDB Galera cluster is problematic for stateless, but also for any other mode: Replication is visible only asynchronous by default though they are replicated synchronously. This can be changed with `wsrep_sync_wait = 1`. Also the isolation level READ COMMITTED will only be effective within a node, but not across nodes. With that, all writes need to go to a single node. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)