### PR TITLE
SAML ECP SOAP fault client id disclosure fix. (26.4)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/SamlEcpProfileService.java
@@ -98,7 +98,7 @@ public class SamlEcpProfileService extends SamlService {
                     // Do not allow ECP login when client does not support it
                     if (!new SamlClient(client).allowECPFlow()) {
                         logger.errorf("Client %s is not allowed to execute ECP flow", client.getClientId());
-                        throw new RuntimeException("Client is not allowed to use ECP profile.");
+                        return Soap.createFault().code("error").reason(AUTHN_REQUEST_CANNOT_BE_PROCESSED).build();
                     }
 
                     // force passive authentication when executing this profile
@@ -108,14 +108,8 @@ public class SamlEcpProfileService extends SamlService {
                 }
             }.execute(Soap.toSamlHttpPostMessage(soapMessage), null, null, null);
         } catch (Exception e) {
-            String reason = "Some error occurred while processing the AuthnRequest.";
-            String detail = e.getMessage();
-
-            if (detail == null) {
-                detail = reason;
-            }
-
-            return Soap.createFault().reason(reason).detail(detail).build();
+            logger.error("Some error occurred while processing the AuthnRequest.", e);
+            return Soap.createFault().code("error").reason(AUTHN_REQUEST_CANNOT_BE_PROCESSED).build();
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SOAPBindingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SOAPBindingTest.java
@@ -24,6 +24,7 @@ import org.keycloak.dom.saml.v2.protocol.StatusResponseType;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.saml.SamlConfigAttributes;
+import org.keycloak.protocol.saml.profile.ecp.SamlEcpProfileService;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
@@ -252,8 +253,9 @@ public class SOAPBindingTest extends AbstractSamlTest {
                     try {
                         MessageFactory messageFactory = MessageFactory.newInstance();
                         SOAPMessage soapMessage = messageFactory.createMessage(null, response.getEntity().getContent());
-                        String faultDetail = soapMessage.getSOAPBody().getFault().getDetail().getValue();
-                        assertThat(faultDetail, is(equalTo("Client is not allowed to use ECP profile.")));
+                        String faultString = soapMessage.getSOAPPart().getEnvelope().getBody().getFault().getFaultString();
+                        assertThat(faultString, is(equalTo(SamlEcpProfileService.AUTHN_REQUEST_CANNOT_BE_PROCESSED)));
+                        assertThat(soapMessage.getSOAPPart().getEnvelope().getBody().getFault().getDetail(), is(nullValue()));
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Closes #52017


(cherry picked from commit 6d625e4a99f6b21461cf738e30e81c4a02ee91ae)

