### PR TITLE
Bump woodstox-core to fix CVE-2022-40152 (DoS via DTD parsing)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <undertow.version>2.3.24.Final</undertow.version>
         <wildfly-elytron.version>2.9.2.Final</wildfly-elytron.version>
         <elytron.undertow-server.version>1.9.0.Final</elytron.undertow-server.version>
-        <woodstox.version>6.0.3</woodstox.version>
+        <woodstox.version>6.4.0</woodstox.version>
         <wildfly.common.quarkus.aligned.version>1.5.4.Final-format-001</wildfly.common.quarkus.aligned.version>
         <wildfly.common.wildfly.aligned.version>1.6.0.Final</wildfly.common.wildfly.aligned.version>
         <xmlsec.version>3.0.6</xmlsec.version>


### PR DESCRIPTION
## Summary
- `woodstox-core` 6.0.3 is vulnerable to a stack-overflow DoS when parsing untrusted XML containing DTDs (GHSA-3f7h-mf4q-vrm4 / CVE-2022-40152, fixed in 6.4.0)
- Bumps `woodstox.version` in the root `pom.xml` from 6.0.3 to 6.4.0 — the minimum patched release, chosen over a newer 6.x/7.x release to stay close to the version currently aligned with WildFly (per the comment next to the dependency declaration in `services/pom.xml`)

## Test plan
- [ ] CI build/test suite passes
- [ ] No Java/Maven environment was available locally to build/test this change before opening the PR — please verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)