### PR TITLE
Avoid orphaned offline client sessions for V1 token exchange

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
@@ -62,6 +62,7 @@ import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
+import org.keycloak.services.util.DefaultClientSessionContext;
 import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -321,26 +322,45 @@ public class V1TokenExchangeProvider extends AbstractTokenExchangeProvider {
         AuthenticationManager.setClientScopesInSession(session, authSession);
 
         // For offline sessions, attachAuthenticationSession must not call createClientSession directly
-        // on the offline user session: createClientSession only writes to the Infinispan cache and
-        // skips the UserSessionPersisterProvider call that createOfflineClientSession makes. Use a
-        // transient wrapper so the client session is built in memory first, then import it into
-        // offline storage (Infinispan offline cache + JPA) via createOfflineClientSession.
+        // on the offline user session: createClientSession writes to the online Infinispan cache and
+        // skips UserSessionPersisterProvider, resulting in an offline=0 row. The correct path is
+        // createOfflineClientSession, but it requires a source client session to copy data from.
+        // Strategy: use a transient wrapper only when no existing client session is present
+        // (so createClientSession runs safely on the transient session). When a session already
+        // exists, attach directly so restartClientSession() or update logic applies correctly.
         final boolean isOfflineSession = targetUserSession.isOffline();
-        final UserSessionModel sessionForAttach = isOfflineSession
-                ? UserSessionUtil.createTransientUserSession(session, targetUserSession)
-                : targetUserSession;
 
-        ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, sessionForAttach, authSession);
-        if (isOfflineSession) {
-            session.sessions().createOfflineClientSession(clientSessionCtx.getClientSession(), targetUserSession);
+        ClientSessionContext clientSessionCtx;
+        AuthenticatedClientSessionModel existingTargetSession =
+                targetUserSession.getAuthenticatedClientSessionByClient(targetClient.getId());
+        if (isOfflineSession && existingTargetSession == null) {
+            UserSessionModel transientSession = UserSessionUtil.createTransientUserSession(session, targetUserSession);
+            AuthenticatedClientSessionModel transientClientSession =
+                    TokenManager.attachAuthenticationSession(this.session, transientSession, authSession).getClientSession();
+            AuthenticatedClientSessionModel offlineClientSession =
+                    session.sessions().createOfflineClientSession(transientClientSession, targetUserSession);
+            // Rebuild around the persisted offline session so the encoder marks the token OFFLINE,
+            // not OFFLINE_TRANSIENT_CLIENT (which would bypass revocation checks).
+            clientSessionCtx = DefaultClientSessionContext.fromClientSessionScopeParameter(offlineClientSession, session);
+        } else {
+            clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, targetUserSession, authSession);
         }
 
-        if (!AuthenticationManager.isClientSessionValid(realm, client, targetUserSession, targetUserSession.getAuthenticatedClientSessionByClient(client.getId()))) {
+        // Re-read after the target attach so that when target == requester the block below is
+        // correctly skipped (the session was just created/updated by the first attach).
+        AuthenticatedClientSessionModel existingRequesterSession =
+                targetUserSession.getAuthenticatedClientSessionByClient(client.getId());
+        if (!AuthenticationManager.isClientSessionValid(realm, client, targetUserSession, existingRequesterSession)) {
             // create the requester client session if needed
             AuthenticationSessionModel clientAuthSession = createSessionModel(targetUserSession, rootAuthSession, targetUser, client, scope);
-            AuthenticatedClientSessionModel requesterClientSession = TokenManager.attachAuthenticationSession(this.session, sessionForAttach, clientAuthSession).getClientSession();
-            if (isOfflineSession) {
-                session.sessions().createOfflineClientSession(requesterClientSession, targetUserSession);
+            if (isOfflineSession && existingRequesterSession == null) {
+                UserSessionModel transientSession = UserSessionUtil.createTransientUserSession(session, targetUserSession);
+                AuthenticatedClientSessionModel transientClientSession =
+                        TokenManager.attachAuthenticationSession(this.session, transientSession, clientAuthSession).getClientSession();
+                session.sessions().createOfflineClientSession(transientClientSession, targetUserSession);
+            } else {
+                // Session exists but is invalid: restartClientSession() is called internally.
+                TokenManager.attachAuthenticationSession(this.session, targetUserSession, clientAuthSession);
             }
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
@@ -36,6 +36,7 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
@@ -61,6 +62,7 @@ import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.UserSessionManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
@@ -317,12 +319,29 @@ public class V1TokenExchangeProvider extends AbstractTokenExchangeProvider {
         AuthenticationSessionModel authSession = createSessionModel(targetUserSession, rootAuthSession, targetUser, targetClient, scope);
 
         AuthenticationManager.setClientScopesInSession(session, authSession);
-        ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, targetUserSession, authSession);
+
+        // For offline sessions, attachAuthenticationSession must not call createClientSession directly
+        // on the offline user session: createClientSession only writes to the Infinispan cache and
+        // skips the UserSessionPersisterProvider call that createOfflineClientSession makes. Use a
+        // transient wrapper so the client session is built in memory first, then import it into
+        // offline storage (Infinispan offline cache + JPA) via createOfflineClientSession.
+        final boolean isOfflineSession = targetUserSession.isOffline();
+        final UserSessionModel sessionForAttach = isOfflineSession
+                ? UserSessionUtil.createTransientUserSession(session, targetUserSession)
+                : targetUserSession;
+
+        ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, sessionForAttach, authSession);
+        if (isOfflineSession) {
+            session.sessions().createOfflineClientSession(clientSessionCtx.getClientSession(), targetUserSession);
+        }
 
         if (!AuthenticationManager.isClientSessionValid(realm, client, targetUserSession, targetUserSession.getAuthenticatedClientSessionByClient(client.getId()))) {
             // create the requester client session if needed
             AuthenticationSessionModel clientAuthSession = createSessionModel(targetUserSession, rootAuthSession, targetUser, client, scope);
-            TokenManager.attachAuthenticationSession(this.session, targetUserSession, clientAuthSession);
+            AuthenticatedClientSessionModel requesterClientSession = TokenManager.attachAuthenticationSession(this.session, sessionForAttach, clientAuthSession).getClientSession();
+            if (isOfflineSession) {
+                session.sessions().createOfflineClientSession(requesterClientSession, targetUserSession);
+            }
         }
 
         updateUserSessionFromClientAuth(targetUserSession);

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
@@ -1,29 +1,23 @@
 package org.keycloak.tests.oauth;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.persistence.EntityManager;
-import jakarta.ws.rs.NotFoundException;
 
 import org.keycloak.OAuth2Constants;
-import org.keycloak.admin.client.Keycloak;
 import org.keycloak.common.Profile;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.jpa.session.JpaSessionUtil;
 import org.keycloak.models.jpa.session.PersistentClientSessionEntity;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
-import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ClientBuilder;
-import org.keycloak.testframework.realm.ClientConfig;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
@@ -37,7 +31,6 @@ import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.TokenUtil;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,37 +51,20 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class OfflineTokenExchangeTest {
 
     private static final String OFFLINE_CLIENT_ID = "offline-client";
-    private static final String REQUESTER_CLIENT_ID = "test-app";
+    private static final String TEST_APP_CLIENT_ID = "test-app";
     private static final String OFFLINE_CLIENT_APP_URI = "http://localhost:8080/offline-client";
 
     @InjectRealm(config = OfflineTokenExchangeTest.OfflineTokenExchangeRealmConfig.class)
     ManagedRealm realm;
 
-    @InjectOAuthClient(config = OfflineTokenExchangeTest.OfflineAuthClientConfig.class)
+    @InjectOAuthClient
     OAuthClient oauth;
-
-    @InjectAdminClient
-    Keycloak adminClient;
 
     @InjectWebDriver
     ManagedWebDriver driver;
 
     @InjectRunOnServer
     RunOnServerClient runOnServer;
-
-    @BeforeEach
-    public void setup() {
-        oauth.realm("test");
-        oauth.client(OFFLINE_CLIENT_ID, "secret1");
-        oauth.redirectUri(OFFLINE_CLIENT_APP_URI);
-        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
-
-        try {
-            adminClient.realm("test").logoutAll();
-        } catch (NotFoundException e) {
-            // expected on first run
-        }
-    }
 
     /**
      * V1 token exchange with an offline source session triggers {@code createClientSession} with the
@@ -97,6 +73,9 @@ public class OfflineTokenExchangeTest {
      */
     @Test
     public void testClientSessionStoredAsOfflineDuringTokenExchange() {
+        oauth.client(OFFLINE_CLIENT_ID, "secret1");
+        oauth.redirectUri(OFFLINE_CLIENT_APP_URI);
+        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
         oauth.doLogin("test-user@localhost", "password");
 
         String code = oauth.parseLoginResponse().getCode();
@@ -112,8 +91,8 @@ public class OfflineTokenExchangeTest {
         // the access token targeting itself. This calls attachAuthenticationSession with the offline
         // user session, which in turn calls createClientSession(realm, test-app, offlineUserSession).
         AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(accessToken)
-                .client(REQUESTER_CLIENT_ID, "password")
-                .audience(REQUESTER_CLIENT_ID)
+                .client(TEST_APP_CLIENT_ID, "test-secret")
+                .audience(TEST_APP_CLIENT_ID)
                 .send();
         assertEquals(200, exchangeResponse.getStatusCode());
         // V1 defaults requested_token_type to REFRESH_TOKEN_TYPE and the offline session is persistent,
@@ -124,20 +103,19 @@ public class OfflineTokenExchangeTest {
         // Before the fix, createClientSession wrote offline="0", orphaning the client session.
         runOnServer.run(session -> {
             RealmModel realm = session.realms().getRealmByName("test");
-            UserSessionModel offlineSession = session.sessions().getOfflineUserSession(realm, sessionId);
-            assertNotNull(offlineSession, "Offline user session not found");
+            assertNotNull(session.sessions().getOfflineUserSession(realm, sessionId), "Offline user session not found");
 
-            ClientModel requesterClient = realm.getClientByClientId(REQUESTER_CLIENT_ID);
+            ClientModel testAppClient = realm.getClientByClientId(TEST_APP_CLIENT_ID);
             EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
 
             PersistentClientSessionEntity onlineEntry = em.find(PersistentClientSessionEntity.class,
-                    new PersistentClientSessionEntity.Key(sessionId, requesterClient.getId(),
+                    new PersistentClientSessionEntity.Key(sessionId, testAppClient.getId(),
                             PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
                             JpaSessionUtil.offlineToString(false)));
             assertNull(onlineEntry, "createClientSession must not write an online (offline=0) DB entry for an offline session");
 
             PersistentClientSessionEntity offlineEntry = em.find(PersistentClientSessionEntity.class,
-                    new PersistentClientSessionEntity.Key(sessionId, requesterClient.getId(),
+                    new PersistentClientSessionEntity.Key(sessionId, testAppClient.getId(),
                             PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
                             JpaSessionUtil.offlineToString(true)));
             assertNotNull(offlineEntry, "createClientSession must write an offline (offline=1) DB entry for an offline session");
@@ -145,7 +123,8 @@ public class OfflineTokenExchangeTest {
 
         // Use the refresh token returned by the exchange to refresh: the client session must be
         // reachable from the offline session, otherwise this refresh will fail with INVALID_GRANT.
-        oauth.client(REQUESTER_CLIENT_ID, "password");
+        oauth.scope(null);
+        oauth.client(TEST_APP_CLIENT_ID, "test-secret");
         AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(exchangeResponse.getRefreshToken());
         assertEquals(200, refreshResponse.getStatusCode());
     }
@@ -161,18 +140,14 @@ public class OfflineTokenExchangeTest {
     public static class OfflineTokenExchangeRealmConfig implements RealmConfig {
         @Override
         public RealmBuilder configure(RealmBuilder builder) {
-            builder.name("test")
-                    .ssoSessionIdleTimeout(30)
-                    .update(r -> r.setAccessTokenLifespan(10));
+            builder.name("test");
 
             // offline-client is the subject client; it includes test-app in the access token audience
             // so that test-app can perform a V1 self-exchange without needing fine-grained permissions.
-            // test-app is created by @InjectOAuthClient, so only offline-client is declared here.
             builder.clients(ClientBuilder.create(OFFLINE_CLIENT_ID)
                     .secret("secret1")
                     .redirectUris(OFFLINE_CLIENT_APP_URI)
-                    .directAccessGrantsEnabled(true)
-                    .protocolMappers(createAudienceMapper("test-app-audience", REQUESTER_CLIENT_ID)));
+                    .protocolMappers(createAudienceMapper("test-app-audience", TEST_APP_CLIENT_ID)));
 
             builder.users(UserBuilder.create("test-user@localhost")
                     .name("Test", "User")
@@ -189,24 +164,8 @@ public class OfflineTokenExchangeTest {
             mapper.setName(name);
             mapper.setProtocol("openid-connect");
             mapper.setProtocolMapper("oidc-audience-mapper");
-            Map<String, String> config = new HashMap<>();
-            config.put("included.client.audience", audience);
-            config.put("id.token.claim", "false");
-            config.put("lightweight.claim", "false");
-            config.put("access.token.claim", "true");
-            config.put("introspection.token.claim", "true");
-            mapper.setConfig(config);
+            mapper.setConfig(Map.of("included.client.audience", audience, "access.token.claim", "true"));
             return mapper;
-        }
-    }
-
-    public static class OfflineAuthClientConfig implements ClientConfig {
-        @Override
-        public ClientBuilder configure(ClientBuilder client) {
-            // This creates test-app (the requester in the exchange). offline-client is created by the realm config.
-            return client.clientId(REQUESTER_CLIENT_ID)
-                    .secret("password")
-                    .directAccessGrantsEnabled(true);
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
@@ -26,8 +26,6 @@ import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
-import org.keycloak.testframework.ui.annotations.InjectWebDriver;
-import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.TokenUtil;
 
@@ -59,9 +57,6 @@ public class OfflineTokenExchangeTest {
 
     @InjectOAuthClient
     OAuthClient oauth;
-
-    @InjectWebDriver
-    ManagedWebDriver driver;
 
     @InjectRunOnServer
     RunOnServerClient runOnServer;

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import jakarta.persistence.EntityManager;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.ResourceServer;
 import org.keycloak.common.Profile;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.ClientModel;
@@ -13,6 +15,9 @@ import org.keycloak.models.jpa.session.JpaSessionUtil;
 import org.keycloak.models.jpa.session.PersistentClientSessionEntity;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.authorization.ClientPolicyRepresentation;
+import org.keycloak.services.resources.admin.fgap.AdminPermissionManagement;
+import org.keycloak.services.resources.admin.fgap.AdminPermissions;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.oauth.OAuthClient;
@@ -50,6 +55,7 @@ public class OfflineTokenExchangeTest {
 
     private static final String OFFLINE_CLIENT_ID = "offline-client";
     private static final String TEST_APP_CLIENT_ID = "test-app";
+    private static final String TARGET_CLIENT_ID = "target-client";
     private static final String OFFLINE_CLIENT_APP_URI = "http://localhost:8080/offline-client";
 
     @InjectRealm(config = OfflineTokenExchangeTest.OfflineTokenExchangeRealmConfig.class)
@@ -124,10 +130,91 @@ public class OfflineTokenExchangeTest {
         assertEquals(200, refreshResponse.getStatusCode());
     }
 
+    /**
+     * Exercises the requester-client path (lines 341–343 in V1TokenExchangeProvider): when the
+     * requester and target clients differ, the V1 exchange creates a client session for both.
+     * Verifies that both sessions are stored as offline (offline=1) in the database.
+     */
+    @Test
+    public void testRequesterClientSessionStoredAsOfflineDuringTokenExchange() {
+        oauth.client(OFFLINE_CLIENT_ID, "secret1");
+        oauth.redirectUri(OFFLINE_CLIENT_APP_URI);
+        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+        oauth.doLogin("test-user@localhost", "password");
+
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
+
+        assertEquals(200, tokenResponse.getStatusCode());
+        String sessionId = oauth.parseRefreshToken(tokenResponse.getRefreshToken()).getSessionState();
+        String accessToken = tokenResponse.getAccessToken();
+
+        // Grant test-app permission to exchange tokens to target-client via fine-grained admin permissions.
+        runOnServer.run(session -> {
+            RealmModel r = session.realms().getRealmByName("test");
+            ClientModel requesterClient = r.getClientByClientId(TEST_APP_CLIENT_ID);
+            ClientModel targetClient = r.getClientByClientId(TARGET_CLIENT_ID);
+
+            ClientPolicyRepresentation policyRep = new ClientPolicyRepresentation();
+            policyRep.setName("allow-test-app-to-target-client");
+            policyRep.addClient(requesterClient.getId());
+
+            AdminPermissionManagement management = AdminPermissions.management(session, r);
+            management.clients().setPermissionsEnabled(targetClient, true);
+            ResourceServer server = management.realmResourceServer();
+            Policy policy = management.authz().getStoreFactory().getPolicyStore().create(server, policyRep);
+            management.clients().exchangeToPermission(targetClient).addAssociatedPolicy(policy);
+        });
+
+        // V1 token exchange: test-app (requester) exchanges to target-client (target).
+        // Since requester != target, attachAuthenticationSession is called once for target-client
+        // and once for test-app (requester path). Both must be stored as offline.
+        AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(accessToken)
+                .client(TEST_APP_CLIENT_ID, "test-secret")
+                .audience(TARGET_CLIENT_ID)
+                .send();
+        assertEquals(200, exchangeResponse.getStatusCode());
+        assertNotNull(exchangeResponse.getRefreshToken(), "V1 token exchange must return a refresh token");
+
+        runOnServer.run(session -> {
+            RealmModel r = session.realms().getRealmByName("test");
+            EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+
+            ClientModel targetClient = r.getClientByClientId(TARGET_CLIENT_ID);
+            PersistentClientSessionEntity targetOnline = em.find(PersistentClientSessionEntity.class,
+                    new PersistentClientSessionEntity.Key(sessionId, targetClient.getId(),
+                            PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
+                            JpaSessionUtil.offlineToString(false)));
+            assertNull(targetOnline, "target-client must not have an online (offline=0) DB entry");
+            PersistentClientSessionEntity targetOffline = em.find(PersistentClientSessionEntity.class,
+                    new PersistentClientSessionEntity.Key(sessionId, targetClient.getId(),
+                            PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
+                            JpaSessionUtil.offlineToString(true)));
+            assertNotNull(targetOffline, "target-client must have an offline (offline=1) DB entry");
+
+            ClientModel requesterClient = r.getClientByClientId(TEST_APP_CLIENT_ID);
+            PersistentClientSessionEntity requesterOnline = em.find(PersistentClientSessionEntity.class,
+                    new PersistentClientSessionEntity.Key(sessionId, requesterClient.getId(),
+                            PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
+                            JpaSessionUtil.offlineToString(false)));
+            assertNull(requesterOnline, "test-app (requester) must not have an online (offline=0) DB entry");
+            PersistentClientSessionEntity requesterOffline = em.find(PersistentClientSessionEntity.class,
+                    new PersistentClientSessionEntity.Key(sessionId, requesterClient.getId(),
+                            PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
+                            JpaSessionUtil.offlineToString(true)));
+            assertNotNull(requesterOffline, "test-app (requester) must have an offline (offline=1) DB entry");
+        });
+
+        oauth.scope(null);
+        oauth.client(TEST_APP_CLIENT_ID, "test-secret");
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(exchangeResponse.getRefreshToken());
+        assertEquals(200, refreshResponse.getStatusCode());
+    }
+
     public static class TokenExchangeServerConfig implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            config.features(Profile.Feature.TOKEN_EXCHANGE);
+            config.features(Profile.Feature.TOKEN_EXCHANGE, Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ);
             return config;
         }
     }
@@ -143,6 +230,13 @@ public class OfflineTokenExchangeTest {
                     .secret("secret1")
                     .redirectUris(OFFLINE_CLIENT_APP_URI)
                     .protocolMappers(createAudienceMapper("test-app-audience", TEST_APP_CLIENT_ID)));
+
+            // target-client is used as the exchange target when testing the requester path
+            // (requester = test-app, target = target-client). Fine-grained exchange permissions
+            // gate this path; no audience mapper is needed.
+            builder.clients(ClientBuilder.create(TARGET_CLIENT_ID)
+                    .secret("target-secret")
+                    .redirectUris("http://localhost:8080/target-client"));
 
             builder.users(UserBuilder.create("test-user@localhost")
                     .name("Test", "User")

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OfflineTokenExchangeTest.java
@@ -1,0 +1,212 @@
+package org.keycloak.tests.oauth;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.NotFoundException;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.common.Profile;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.jpa.session.JpaSessionUtil;
+import org.keycloak.models.jpa.session.PersistentClientSessionEntity;
+import org.keycloak.representations.RefreshToken;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.util.TokenUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Reproducer for https://github.com/keycloak/keycloak/issues/52139 via the V1 token-exchange path.
+ * <p>
+ * V1 token exchange calls {@code TokenManager.attachAuthenticationSession} directly with the offline
+ * user session (unlike V2 which wraps it in a transient session first). When the requester client
+ * has no existing session on the offline user session, {@code createClientSession} is invoked with
+ * the offline session as the user session. Before the fix, the resulting
+ * {@code PersistentClientSessionEntity} was stored with {@code offline="0"} (online), making it
+ * invisible to the offline session and orphaning it once the online session expired.
+ */
+@KeycloakIntegrationTest(config = OfflineTokenExchangeTest.TokenExchangeServerConfig.class)
+public class OfflineTokenExchangeTest {
+
+    private static final String OFFLINE_CLIENT_ID = "offline-client";
+    private static final String REQUESTER_CLIENT_ID = "test-app";
+    private static final String OFFLINE_CLIENT_APP_URI = "http://localhost:8080/offline-client";
+
+    @InjectRealm(config = OfflineTokenExchangeTest.OfflineTokenExchangeRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectOAuthClient(config = OfflineTokenExchangeTest.OfflineAuthClientConfig.class)
+    OAuthClient oauth;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectWebDriver
+    ManagedWebDriver driver;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @BeforeEach
+    public void setup() {
+        oauth.realm("test");
+        oauth.client(OFFLINE_CLIENT_ID, "secret1");
+        oauth.redirectUri(OFFLINE_CLIENT_APP_URI);
+        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+
+        try {
+            adminClient.realm("test").logoutAll();
+        } catch (NotFoundException e) {
+            // expected on first run
+        }
+    }
+
+    /**
+     * V1 token exchange with an offline source session triggers {@code createClientSession} with the
+     * offline user session directly. Verifies the resulting client session is stored as offline
+     * ({@code offline="1"}) and not as online ({@code offline="0"}) in the database.
+     */
+    @Test
+    public void testClientSessionStoredAsOfflineDuringTokenExchange() {
+        oauth.doLogin("test-user@localhost", "password");
+
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
+
+        assertEquals(200, tokenResponse.getStatusCode());
+        RefreshToken offlineToken = oauth.parseRefreshToken(tokenResponse.getRefreshToken());
+        assertEquals(TokenUtil.TOKEN_TYPE_OFFLINE, offlineToken.getType());
+        String sessionId = offlineToken.getSessionState();
+        String accessToken = tokenResponse.getAccessToken();
+
+        // V1 token exchange: test-app (which is in the audience of offline-client's token) exchanges
+        // the access token targeting itself. This calls attachAuthenticationSession with the offline
+        // user session, which in turn calls createClientSession(realm, test-app, offlineUserSession).
+        AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(accessToken)
+                .client(REQUESTER_CLIENT_ID, "password")
+                .audience(REQUESTER_CLIENT_ID)
+                .send();
+        assertEquals(200, exchangeResponse.getStatusCode());
+        // V1 defaults requested_token_type to REFRESH_TOKEN_TYPE and the offline session is persistent,
+        // so a refresh token must be returned. Any fix must preserve this behaviour.
+        assertNotNull(exchangeResponse.getRefreshToken(), "V1 token exchange must return a refresh token");
+
+        // Verify: the test-app client session on the offline user session must be stored as offline="1".
+        // Before the fix, createClientSession wrote offline="0", orphaning the client session.
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            UserSessionModel offlineSession = session.sessions().getOfflineUserSession(realm, sessionId);
+            assertNotNull(offlineSession, "Offline user session not found");
+
+            ClientModel requesterClient = realm.getClientByClientId(REQUESTER_CLIENT_ID);
+            EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+
+            PersistentClientSessionEntity onlineEntry = em.find(PersistentClientSessionEntity.class,
+                    new PersistentClientSessionEntity.Key(sessionId, requesterClient.getId(),
+                            PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
+                            JpaSessionUtil.offlineToString(false)));
+            assertNull(onlineEntry, "createClientSession must not write an online (offline=0) DB entry for an offline session");
+
+            PersistentClientSessionEntity offlineEntry = em.find(PersistentClientSessionEntity.class,
+                    new PersistentClientSessionEntity.Key(sessionId, requesterClient.getId(),
+                            PersistentClientSessionEntity.LOCAL, PersistentClientSessionEntity.LOCAL,
+                            JpaSessionUtil.offlineToString(true)));
+            assertNotNull(offlineEntry, "createClientSession must write an offline (offline=1) DB entry for an offline session");
+        });
+
+        // Use the refresh token returned by the exchange to refresh: the client session must be
+        // reachable from the offline session, otherwise this refresh will fail with INVALID_GRANT.
+        oauth.client(REQUESTER_CLIENT_ID, "password");
+        AccessTokenResponse refreshResponse = oauth.doRefreshTokenRequest(exchangeResponse.getRefreshToken());
+        assertEquals(200, refreshResponse.getStatusCode());
+    }
+
+    public static class TokenExchangeServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            config.features(Profile.Feature.TOKEN_EXCHANGE);
+            return config;
+        }
+    }
+
+    public static class OfflineTokenExchangeRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder builder) {
+            builder.name("test")
+                    .ssoSessionIdleTimeout(30)
+                    .update(r -> r.setAccessTokenLifespan(10));
+
+            // offline-client is the subject client; it includes test-app in the access token audience
+            // so that test-app can perform a V1 self-exchange without needing fine-grained permissions.
+            // test-app is created by @InjectOAuthClient, so only offline-client is declared here.
+            builder.clients(ClientBuilder.create(OFFLINE_CLIENT_ID)
+                    .secret("secret1")
+                    .redirectUris(OFFLINE_CLIENT_APP_URI)
+                    .directAccessGrantsEnabled(true)
+                    .protocolMappers(createAudienceMapper("test-app-audience", REQUESTER_CLIENT_ID)));
+
+            builder.users(UserBuilder.create("test-user@localhost")
+                    .name("Test", "User")
+                    .email("test-user@localhost")
+                    .emailVerified(true)
+                    .password("password")
+                    .realmRoles("user", "offline_access"));
+
+            return builder;
+        }
+
+        private ProtocolMapperRepresentation createAudienceMapper(String name, String audience) {
+            ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+            mapper.setName(name);
+            mapper.setProtocol("openid-connect");
+            mapper.setProtocolMapper("oidc-audience-mapper");
+            Map<String, String> config = new HashMap<>();
+            config.put("included.client.audience", audience);
+            config.put("id.token.claim", "false");
+            config.put("lightweight.claim", "false");
+            config.put("access.token.claim", "true");
+            config.put("introspection.token.claim", "true");
+            mapper.setConfig(config);
+            return mapper;
+        }
+    }
+
+    public static class OfflineAuthClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            // This creates test-app (the requester in the exchange). offline-client is created by the realm config.
+            return client.clientId(REQUESTER_CLIENT_ID)
+                    .secret("password")
+                    .directAccessGrantsEnabled(true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #52139

## Summary

V1 token exchange calls `TokenManager.attachAuthenticationSession` directly with the offline user session. If the requester client has no existing session on it, `attachAuthenticationSession` falls through to `UserSessionProvider.createClientSession` — the wrong path for offline sessions. The correct path is `createOfflineClientSession`, which also calls `UserSessionPersisterProvider.createClientSession` for JPA persistence.

## Design decisions

**Fix location — V1TokenExchangeProvider, not the providers themselves.**  
The instinctive fix would be to change the hardcoded `offline=false` inside each `UserSessionProvider.createClientSession` implementation. This is insufficient: for `InfinispanUserSessionProvider`, switching the Infinispan cache target to the offline cache would still skip the `UserSessionPersisterProvider` call that `createOfflineClientSession` makes. To reach `createOfflineClientSession` properly, the caller needs an existing `AuthenticatedClientSessionModel` to use as a data source. The right fix is therefore at the V1 call site.

**Using a transient session as an intermediary.**  
`createOfflineClientSession(sourceClientSession, offlineUserSession)` requires a source `AuthenticatedClientSessionModel` to copy data from. Rather than duplicating the scope/redirect-URI/notes logic that `attachAuthenticationSession` already performs, we let `attachAuthenticationSession` do its work on a transient wrapper of the offline session. The resulting transient client session carries all the correct data and is then imported into proper offline storage via `createOfflineClientSession`. The transient user session is discarded afterwards.

**V2 standard exchange already handles this correctly.**  
`StandardTokenExchangeProvider` wraps offline sessions in a transient session before calling `attachAuthenticationSession`, ensuring `createClientSession` is never called with a live offline session. This PR applies the same principle to V1, but diverges in one key way: V2 leaves the client session transient (no persistence), whereas V1 follows through with `createOfflineClientSession` to produce a persistent offline client session. This is intentional — V1 defaults `requested_token_type` to `REFRESH_TOKEN_TYPE` and issues a refresh token when `persistenceState != TRANSIENT`, so making the session transient would silently suppress the refresh token.

**Both `attachAuthenticationSession` call sites in V1 are fixed.**  
The method is called twice: once for the target client and once for the requester client when its session is missing or invalid. Both calls now use the transient session wrapper, and both resulting client sessions are imported into offline storage.

**Assumptions.**  
- The source session passed to `createOfflineClientSession` is the transient client session produced by `attachAuthenticationSession`. `createOfflineClientSession` uses it only as a data source (copies notes, redirect URI, etc.) and does not retain a reference to it, so discarding the transient session afterwards is safe.
- `createOfflineClientSession` resets `timestamp` and `STARTED_AT_NOTE` to the current time. This is consistent with the existing `createOrUpdateOfflineSession` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)