### PR TITLE
fix: do not leak SCIM resource existence to unauthorized callers

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/BaseResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/BaseResourceTypeProvider.java
@@ -53,6 +53,12 @@ public abstract class BaseResourceTypeProvider<M extends Model, R> implements Sc
         M model = getModel(id);
 
         if (model == null) {
+            // Do not leak the existence of a resource to callers without view permission:
+            // a missing resource must be reported as forbidden (403), not as not found (404),
+            // otherwise callers can probe which resource ids exist.
+            if (!canQuery()) {
+                throw new ForbiddenException();
+            }
             return null;
         }
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AuthorizationTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AuthorizationTest.java
@@ -98,6 +98,33 @@ public class AuthorizationTest extends AbstractScimTest {
     }
 
     @Test
+    public void testMissingResourceDoesNotLeakExistence() {
+        String missingId = KeycloakModelUtils.generateId();
+        User user = new User();
+        user.setId(missingId);
+        user.setUserName("missing");
+        // A caller without any access must receive 403 (not 404) even for a missing
+        // resource, so the response code cannot be used to probe whether a given
+        // resource id exists.
+        assertAccessDenied(() -> noAccessClient.users().get(missingId));
+        assertAccessDenied(() -> noAccessClient.users().update(missingId, user));
+        assertAccessDenied(() -> noAccessClient.users().patch(missingId, PatchRequest.create()
+                .add("name.displayName", "new display name")
+                .build()));
+        assertAccessDenied(() -> noAccessClient.users().delete(missingId));
+
+        assertAccessDenied(() -> noAccessClient.groups().get(missingId));
+        Group resource = new Group();
+        resource.setId(missingId);
+        resource.setDisplayName("display name");
+        assertAccessDenied(() -> noAccessClient.groups().update(missingId, resource));
+        assertAccessDenied(() -> noAccessClient.groups().patch(missingId, PatchRequest.create()
+                .add("displayName", "new display name")
+                .build()));
+        assertAccessDenied(() -> noAccessClient.groups().delete(missingId));
+    }
+
+    @Test
     public void testUsersCanQueryIfQueryRoleGranted() {
         grantAdminRole(AdminRoles.QUERY_USERS);
         ListResponse<User> response = noAccessClient.users().search("");


### PR DESCRIPTION
## Problem

SCIM mutative operations (patch, update, delete) and `GET` perform an existence check before the authorization check. A caller with no view permission sees a **404** when the resource does not exist, but a **403** when it does — leaking whether a given resource id exists. This lets callers enumerate resource ids they cannot access.

## Root cause

`BaseResourceTypeProvider.get(id, attributes, excludedAttributes)` returns `null` when the model is not found, before checking any permission. The resource layer (`ScimResourceTypeResource`) maps that `null` to a 404. Only when the model *does* exist does the code reach the `hasPermission(... VIEW)` check that produces a 403.

## Fix

When the model is null, first check realm-level view permission on the resource type (`hasPermission(getRealmResourceType(), VIEW)`). If the caller lacks it, throw `ForbiddenException` (→ 403) so the response is indistinguishable from an existing-but-forbidden resource. Callers who do hold view permission still receive the 404 for a truly missing resource.

## Test

Added `testMissingResourceDoesNotLeakExistence` to `AuthorizationTest`: an access-less client issuing `get`, `update`, `patch` and `delete` on a non-existent user id now receives 403 for all four, instead of 404.

Closes #52147
