### PR TITLE
Pass userSessionId as a debugf argument when locking a client session

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -504,7 +504,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
                 .getSingleResultOrNull();
 
         boolean locked = currentVersion != null && knownVersion == currentVersion;
-        logger.debugf("User session %s/%s/%s lock status: %b"+ userSessionId, clientId, offline, locked);
+        logger.debugf("User session %s/%s/%s lock status: %b", userSessionId, clientId, offline, locked);
         return locked;
     }
 


### PR DESCRIPTION
`lockClientSession` logged lock status with JBoss Logging `debugf`, but the first argument was concatenated onto the format string:

```java
logger.debugf("User session %s/%s/%s lock status: %b"+ userSessionId, clientId, offline, locked);
```

That leaves four placeholders and three arguments. With DEBUG enabled, `String.format` throws `MissingFormatArgumentException` and aborts the client-session lock or delete.

The neighboring `lockUserSession` call already passes every value as an argument. This does the same for the client-session path.

Closes #52153