### PR TITLE
fix: treat underscore as special character in client-side password validation

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
@@ -32,7 +32,7 @@ const policies = {
     }
   },
   specialChars: (policy, value) => {
-    let specialChars = value.split("").filter((char) => char.match(/[^\p{L}\p{N}]/u));
+    let specialChars = value.split("").filter((char) => char.match(/[^\p{L}\p{Nd}]/u));
     if (specialChars.length < policy.value) {
       return templateError(policy);
     }

--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/js/password-policy.js
@@ -32,7 +32,7 @@ const policies = {
     }
   },
   specialChars: (policy, value) => {
-    let specialChars = value.split("").filter((char) => char.match(/\W/));
+    let specialChars = value.split("").filter((char) => char.match(/[^\p{L}\p{N}]/u));
     if (specialChars.length < policy.value) {
       return templateError(policy);
     }


### PR DESCRIPTION
Fixes #52166

The client-side password validator used `\W` to detect special characters.
In JavaScript, `_` is part of `\w`, so `\W` does not match it — a password
like `Abcdefghij1_` was wrongly reported as missing a required special
character, while the server-side policy (`SpecialCharsPasswordPolicyProvider`
uses `Character.isLetterOrDigit`) treats `_` as a special character and
accepts the password.

Changed the client-side check to use the Unicode-aware `[^\p{L}\p{N}]`
pattern, which matches any character that is neither a letter nor a digit —
consistent with the server-side `Character.isLetterOrDigit` semantics. This
also avoids miscounting Unicode letters (e.g. `é`) as special characters.

Verified locally with Node: `Abcdefghij1_` now passes, `Abcdefghij1` still
fails, and combined cases (`ab_!`) count `_` and `!` both as special.
