### PR TITLE
Read the user managed access flag from the updated realm delegate

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -187,7 +187,7 @@ public class RealmAdapter implements CachedRealmModel {
 
     @Override
     public boolean isUserManagedAccessAllowed() {
-        if (isUpdated()) return updated.isEnabled();
+        if (isUpdated()) return updated.isUserManagedAccessAllowed();
         return cached.isAllowUserManagedAccess();
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/model/CacheTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/CacheTest.java
@@ -91,6 +91,26 @@ public class CacheTest {
     }
 
     @Test
+    public void testUserManagedAccessAllowedReadAfterRealmUpdated() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            assertTrue(realm instanceof RealmAdapter);
+            assertTrue(realm.isEnabled());
+            Assertions.assertFalse(realm.isUserManagedAccessAllowed());
+
+            // any update to the realm makes the following reads go through the updated delegate
+            realm.setDisplayName("cache-test");
+            Assertions.assertFalse(realm.isUserManagedAccessAllowed());
+
+            realm.setUserManagedAccessAllowed(true);
+            assertTrue(realm.isUserManagedAccessAllowed());
+
+            realm.setUserManagedAccessAllowed(false);
+            realm.setDisplayName(null);
+        });
+    }
+
+    @Test
     public void testAddUserNotAddedToCache() {
 
     	runOnServer.run(session -> {


### PR DESCRIPTION
Closes #52172

`RealmAdapter.isUserManagedAccessAllowed()` returned `updated.isEnabled()` where it should return
`updated.isUserManagedAccessAllowed()`. The cached branch is correct, so the flag only misreports
once something in the same transaction has written to the realm — from that point until the
transaction ends, reads return the realm's `enabled` state instead of its own.

Nothing is persisted incorrectly: the write goes through `RealmEntity.setAllowUserManagedAccess`
as it should, and a later request re-reads the correct value from the cache. Only the
in-transaction read is wrong, which is why ordinary admin traffic never sees it — it shows up in
code that writes a realm and then verifies what it wrote.

I checked the other 87 delegating getters in `RealmAdapter` for the same copy/paste and this was
the only one.

### Testing

`CacheTest.testUserManagedAccessAllowedReadAfterRealmUpdated` reproduces the report: on an enabled
realm with user-managed access off, it writes the display name and reads the flag back in the same
session. Verified both ways: with the fix reverted it fails at `CacheTest.java:103` with
`expected: <false> but was: <true>`, and it passes with the fix.

> Drafted with AI assistance; I've reviewed and verified the change