### PR TITLE
Fix #51594: Add has-client-attribute condition and align client-created workflow event timing

### DIFF
--- a/docs/documentation/server_admin/topics/workflows/defining-conditions.adoc
+++ b/docs/documentation/server_admin/topics/workflows/defining-conditions.adoc
@@ -41,3 +41,15 @@ The conditions are also based on the realm resource associated with the event.
 | `has-identity-provider-link` | If the user is linked to an identity provider. | The alias of the identity provider.
 | `is-member-of` | If the user is member of a specific group. | The name or path of the group.
 |===
+
+[[_workflow_client_functions_]]
+== Client functions
+
+[cols="3*", options="header"]
+|===
+|Condition
+|Description
+|Parameters
+| `has-client-attribute` | If the client has an attribute set. | The attribute name and optionally the single attribute value using a properties format (e.g. `key=value` or `key:value`). If the value is omitted, only the presence of the attribute is checked.
+|===
+

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.workflow.conditions;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.workflow.WorkflowConditionProviderFactory;
+
+public class ClientAttributeWorkflowConditionFactory implements WorkflowConditionProviderFactory<ClientAttributeWorkflowConditionProvider> {
+
+    public static final String ID = "has-client-attribute";
+
+    @Override
+    public ClientAttributeWorkflowConditionProvider create(KeycloakSession session, String keyValuePair) {
+        return new ClientAttributeWorkflowConditionProvider(session, keyValuePair);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/conditions/ClientAttributeWorkflowConditionProvider.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.workflow.conditions;
+
+import java.util.Map;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+
+import org.hibernate.Session;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.jpa.entities.ClientAttributeEntity;
+import org.keycloak.models.workflow.ResourceType;
+import org.keycloak.models.workflow.WorkflowConditionProvider;
+import org.keycloak.models.workflow.WorkflowExecutionContext;
+import org.keycloak.models.workflow.WorkflowInvalidStateException;
+
+public class ClientAttributeWorkflowConditionProvider implements WorkflowConditionProvider {
+
+    private final String expectedAttribute;
+    private final KeycloakSession session;
+
+    public ClientAttributeWorkflowConditionProvider(KeycloakSession session, String expectedAttribute) {
+        this.session = session;
+        this.expectedAttribute = expectedAttribute;
+    }
+
+    @Override
+    public ResourceType getSupportedResourceType() {
+        return ResourceType.CLIENTS;
+    }
+
+    @Override
+    public boolean evaluate(WorkflowExecutionContext context) {
+        validate();
+
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel client = session.clients().getClientById(realm, context.getResourceId());
+
+        if (client == null) {
+            return false;
+        }
+
+        String[] parsedKeyValuePair = UserAttributeWorkflowConditionProvider.parseKeyValuePair(expectedAttribute);
+        String key = parsedKeyValuePair[0];
+        String valuePart = parsedKeyValuePair[1];
+
+        Map<String, String> attributes = client.getAttributes();
+        if (attributes == null) {
+            return false;
+        }
+
+        String actualValue = attributes.get(key);
+        if (actualValue == null) {
+            return false;
+        }
+
+        if (valuePart == null || valuePart.isEmpty()) {
+            return true;
+        }
+
+        return valuePart.equals(actualValue);
+    }
+
+    @Override
+    public Predicate toPredicate(CriteriaBuilder cb, CriteriaQuery<String> query, Root<?> path) {
+        validate();
+
+        String[] parsedKeyValuePair = UserAttributeWorkflowConditionProvider.parseKeyValuePair(expectedAttribute);
+        String attributeName = parsedKeyValuePair[0];
+        String valuePart = parsedKeyValuePair[1];
+
+        if (valuePart == null || valuePart.isEmpty()) {
+            return cb.greaterThan(createTotalCountSubquery(cb, query, path, attributeName), 0L);
+        }
+
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+        String dbProductName = em.unwrap(Session.class).doReturningWork(connection -> connection.getMetaData().getDatabaseProductName());
+
+        Subquery<Long> matchingCountSubquery = query.subquery(Long.class);
+        Root<ClientAttributeEntity> attrRoot = matchingCountSubquery.from(ClientAttributeEntity.class);
+        matchingCountSubquery.select(cb.count(attrRoot));
+
+        Predicate valuePredicate;
+        if ("Oracle".equals(dbProductName)) {
+            valuePredicate = cb.equal(cb.function("DBMS_LOB.COMPARE", Integer.class, attrRoot.get("value"), cb.literal(valuePart)), 0);
+        } else if ("PostgreSQL".equals(dbProductName)) {
+            Predicate attrValuePredicate1 = cb.equal(
+                    cb.function("substr", String.class, attrRoot.get("value"), cb.literal(1), cb.literal(255)),
+                    cb.function("substr", String.class, cb.literal(valuePart), cb.literal(1), cb.literal(255)));
+            Predicate attrValuePredicate2 = cb.equal(attrRoot.get("value"), valuePart);
+            valuePredicate = cb.and(attrValuePredicate1, attrValuePredicate2);
+        } else {
+            valuePredicate = cb.equal(attrRoot.get("value"), valuePart);
+        }
+
+        matchingCountSubquery.where(
+                cb.and(
+                        cb.equal(attrRoot.get("client").get("id"), path.get("id")),
+                        cb.equal(attrRoot.get("name"), attributeName),
+                        valuePredicate
+                )
+        );
+
+        return cb.greaterThan(matchingCountSubquery, 0L);
+    }
+
+    private Subquery<Long> createTotalCountSubquery(CriteriaBuilder cb, CriteriaQuery<String> query, Root<?> path, String attributeName) {
+        Subquery<Long> totalCountSubquery = query.subquery(Long.class);
+        Root<ClientAttributeEntity> attrRoot = totalCountSubquery.from(ClientAttributeEntity.class);
+        totalCountSubquery.select(cb.count(attrRoot));
+        totalCountSubquery.where(
+                cb.and(
+                        cb.equal(attrRoot.get("client").get("id"), path.get("id")),
+                        cb.equal(attrRoot.get("name"), attributeName)
+                )
+        );
+        return totalCountSubquery;
+    }
+
+    @Override
+    public void validate() {
+        if (expectedAttribute == null || expectedAttribute.trim().isEmpty()) {
+            throw new WorkflowInvalidStateException("workflowConditionAttributeNotSet");
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/events/ClientCreatedWorkflowEventProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/events/ClientCreatedWorkflowEventProvider.java
@@ -1,10 +1,12 @@
 package org.keycloak.models.workflow.events;
 
-import org.keycloak.models.ClientModel;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.OperationType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.workflow.AbstractWorkflowEventProvider;
 import org.keycloak.models.workflow.ResourceType;
-import org.keycloak.provider.ProviderEvent;
 
 public class ClientCreatedWorkflowEventProvider extends AbstractWorkflowEventProvider {
 
@@ -18,15 +20,13 @@ public class ClientCreatedWorkflowEventProvider extends AbstractWorkflowEventPro
     }
 
     @Override
-    public boolean supports(ProviderEvent providerEvent) {
-        return providerEvent instanceof ClientModel.ClientCreationEvent;
+    public boolean supports(Event event) {
+        return EventType.CLIENT_REGISTER.equals(event.getType());
     }
 
     @Override
-    protected String resolveResourceId(ProviderEvent providerEvent) {
-        if (providerEvent instanceof ClientModel.ClientCreationEvent cce) {
-            return cce.getCreatedClient().getId();
-        }
-        return null;
+    public boolean supports(AdminEvent adminEvent) {
+        return org.keycloak.events.admin.ResourceType.CLIENT.equals(adminEvent.getResourceType())
+                && OperationType.CREATE.equals(adminEvent.getOperationType());
     }
 }

--- a/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowConditionProviderFactory
+++ b/model/jpa/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowConditionProviderFactory
@@ -18,4 +18,5 @@
 org.keycloak.models.workflow.conditions.GroupMembershipWorkflowConditionFactory
 org.keycloak.models.workflow.conditions.IdentityProviderWorkflowConditionFactory
 org.keycloak.models.workflow.conditions.UserAttributeWorkflowConditionFactory
+org.keycloak.models.workflow.conditions.ClientAttributeWorkflowConditionFactory
 org.keycloak.models.workflow.conditions.RoleWorkflowConditionFactory

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -418,7 +418,13 @@ public class DefaultClientService implements ClientService {
      * @param representation the v2 representation of the client
      */
     protected void fireAdminEvent(OperationType operationType, BaseClientRepresentation representation) {
-        if (Boolean.parseBoolean(System.getProperty("kc.admin-v2.client-service.events.enabled", "false"))) {
+        if (OperationType.CREATE.equals(operationType)) {
+            adminEventBuilder
+                    .operation(operationType)
+                    .resourcePath(session.getContext().getUri(), representation.getUuid())
+                    .representation(representation)
+                    .success();
+        } else if (Boolean.parseBoolean(System.getProperty("kc.admin-v2.client-service.events.enabled", "false"))) {
             adminEventBuilder
                     .operation(operationType)
                     .resourcePath(session.getContext().getUri())

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AdminEventV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AdminEventV2Test.java
@@ -46,6 +46,7 @@ import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -115,7 +116,7 @@ public class AdminEventV2Test extends AbstractClientApiV2Test {
 
             assertThat("V2 event should be present with apiVersion=v2 detail", v2Event, notNullValue());
             assertThat("V2 event should have CREATE operation", v2Event.getOperationType(), is(OperationType.CREATE.toString()));
-            assertThat("V2 event should have resource path relative to API v2", v2Event.getResourcePath(), is("clients/v2"));
+            assertThat("V2 event should have resource path relative to API v2", v2Event.getResourcePath(), startsWith("clients/v2"));
         } finally {
             deleteTestClient();
         }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/AbstractPersistentClientIdMetadataDocumentProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/AbstractPersistentClientIdMetadataDocumentProvider.java
@@ -184,13 +184,13 @@ public abstract class AbstractPersistentClientIdMetadataDocumentProvider<CONFIG 
                 clientRep.setDefaultRoles(defaultRolesNames.toArray(String[]::new));
             }
 
-            event.client(clientRep.getClientId()).success();
-
             clientModel = realm.getClientByClientId(clientRep.getClientId());
             updatePairwiseSubMappers(clientModel, SubjectType.parse(clientOIDC.getSubjectType()), clientOIDC.getSectorIdentifierUri());
             updateClientRepWithProtocolMappers(clientModel, clientRep);
 
             validateClient(clientModel, clientOIDC, true);
+
+            event.client(clientRep.getClientId()).success();
 
             return clientModel;
         } catch (ModelDuplicateException e) {

--- a/services/src/main/java/org/keycloak/protocol/saml/clientregistration/EntityDescriptorClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/clientregistration/EntityDescriptorClientRegistrationProvider.java
@@ -48,6 +48,7 @@ public class EntityDescriptorClientRegistrationProvider extends AbstractClientRe
         EntityDescriptorClientRegistrationContext context = new EntityDescriptorClientRegistrationContext(session, client, this);
         client = create(context);
         validateClient(client, true);
+        event.client(client.getClientId()).success();
         URI uri = session.getContext().getUri().getAbsolutePathBuilder().path(client.getClientId()).build();
         return Response.created(uri).entity(client).build();
     }

--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -139,7 +139,6 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
                 client.setDefaultRoles(defaultRolesNames.toArray(String[]::new));
             }
 
-            event.client(client.getClientId()).success();
             return client;
         } catch (ModelDuplicateException e) {
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier in use", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/services/clientregistration/DefaultClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/DefaultClientRegistrationProvider.java
@@ -52,6 +52,7 @@ public class DefaultClientRegistrationProvider extends AbstractClientRegistratio
         DefaultClientRegistrationContext context = new DefaultClientRegistrationContext(session, client, this);
         client = create(context);
         validateClient(client, true);
+        event.client(client.getClientId()).success();
         URI uri = session.getContext().getUri().getAbsolutePathBuilder().path(client.getClientId()).build();
         return Response.created(uri).entity(client).build();
     }

--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
@@ -104,6 +104,8 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
 
             validateClient(clientModel, clientOIDC, true);
 
+            event.client(client.getClientId()).success();
+
             URI uri = getRegistrationClientUri(clientModel);
             clientOIDC = DescriptionConverter.toExternalResponse(session, client, uri);
             clientOIDC.setClientIdIssuedAt(Time.currentTime());

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -221,8 +221,6 @@ public class ClientsResource {
                 new ClientManager(new RealmManager(session)).enableServiceAccount(clientModel);
             }
 
-            adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), clientModel.getId()).representation(rep).success();
-
             if (Profile.isFeatureEnabled(Profile.Feature.AUTHORIZATION) && TRUE.equals(rep.getAuthorizationServicesEnabled())) {
                 if (Profile.isFeatureEnabled(Profile.Feature.CLIENT_TYPES) && clientModel.getType() != null) {
                     ClientType clientType = session.getProvider(ClientTypeManager.class).getClientType(realm, clientModel.getType());
@@ -253,6 +251,8 @@ public class ClientsResource {
 
             session.getContext().setClient(clientModel);
             session.clientPolicy().triggerOnEvent(new AdminClientRegisteredContext(clientModel, auth.adminAuth()));
+
+            adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), clientModel.getId()).representation(rep).success();
 
             return clientModel;
         } catch (ModelDuplicateException e) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -1357,16 +1357,34 @@ public class RealmAdminResource {
 
     private static void fireCreatedEvent(PartialImportResult result, AdminEventBuilder adminEvent) {
         adminEvent.operation(OperationType.CREATE)
+                .resource(mapPartialImportResourceType(result.getResourceType()))
                 .resourcePath(result.getResourceType().getPath(), result.getId())
                 .representation(result.getRepresentation())
                 .success();
-    };
+    }
 
     private static void fireUpdateEvent(PartialImportResult result, AdminEventBuilder adminEvent) {
         adminEvent.operation(OperationType.UPDATE)
+                .resource(mapPartialImportResourceType(result.getResourceType()))
                 .resourcePath(result.getResourceType().getPath(), result.getId())
                 .representation(result.getRepresentation())
                 .success();
+    }
+
+    private static org.keycloak.events.admin.ResourceType mapPartialImportResourceType(org.keycloak.partialimport.ResourceType resourceType) {
+        if (resourceType == null) {
+            return org.keycloak.events.admin.ResourceType.REALM;
+        }
+        switch (resourceType) {
+            case USER: return org.keycloak.events.admin.ResourceType.USER;
+            case GROUP: return org.keycloak.events.admin.ResourceType.GROUP;
+            case CLIENT: return org.keycloak.events.admin.ResourceType.CLIENT;
+            case IDP: return org.keycloak.events.admin.ResourceType.IDENTITY_PROVIDER;
+            case IDP_MAPPER: return org.keycloak.events.admin.ResourceType.IDENTITY_PROVIDER_MAPPER;
+            case REALM_ROLE: return org.keycloak.events.admin.ResourceType.REALM_ROLE;
+            case CLIENT_ROLE: return org.keycloak.events.admin.ResourceType.CLIENT_ROLE;
+            default: return org.keycloak.events.admin.ResourceType.REALM;
+        }
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportUserTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportUserTest.java
@@ -50,7 +50,7 @@ public class PartialImportUserTest extends AbstractPartialImportTest {
             Assertions.assertEquals(managedRealm.getId(), adminEvent.getRealmId());
             Assertions.assertEquals(OperationType.CREATE.name(), adminEvent.getOperationType());
             Assertions.assertTrue(adminEvent.getResourcePath().startsWith("users/"));
-            assertThat(adminEvent.getResourceType(), equalTo(org.keycloak.events.admin.ResourceType.REALM.name()));
+            assertThat(adminEvent.getResourceType(), equalTo(org.keycloak.events.admin.ResourceType.USER.name()));
             String userId = adminEvent.getResourcePath().substring(6);
             userIds.add(userId);
         }
@@ -89,7 +89,7 @@ public class PartialImportUserTest extends AbstractPartialImportTest {
             Assertions.assertEquals(managedRealm.getId(), adminEvent.getRealmId());
             Assertions.assertEquals(OperationType.CREATE.name(), adminEvent.getOperationType());
             Assertions.assertTrue(adminEvent.getResourcePath().startsWith("users/"));
-            assertThat(adminEvent.getResourceType(), equalTo(org.keycloak.events.admin.ResourceType.REALM.name()));
+            assertThat(adminEvent.getResourceType(), equalTo(org.keycloak.events.admin.ResourceType.USER.name()));
             String userId = adminEvent.getResourcePath().substring(6);
             userIds.add(userId);
             assertThat(userRepIds, hasItem(userId));

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/activation/ClientCreationWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/activation/ClientCreationWorkflowTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.workflow.activation;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.client.registration.Auth;
+import org.keycloak.client.registration.ClientRegistration;
+import org.keycloak.models.workflow.client.DisableClientStepProviderFactory;
+import org.keycloak.models.workflow.conditions.ClientAttributeWorkflowConditionFactory;
+import org.keycloak.models.workflow.events.ClientCreatedWorkflowEventFactory;
+import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
+import org.keycloak.representations.idm.ClientInitialAccessPresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.representations.workflows.WorkflowRepresentation;
+import org.keycloak.representations.workflows.WorkflowScheduleRepresentation;
+import org.keycloak.representations.workflows.WorkflowStepRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.suites.DatabaseTest;
+import org.keycloak.tests.workflow.AbstractWorkflowTest;
+import org.keycloak.tests.workflow.config.WorkflowsBlockingServerConfig;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests activation of workflows based on client creation events (Admin REST API, DCR, and Partial Import)
+ * and scheduled scans with client-scoped condition evaluation.
+ */
+@KeycloakIntegrationTest(config = WorkflowsBlockingServerConfig.class)
+public class ClientCreationWorkflowTest extends AbstractWorkflowTest {
+
+    @Test
+    public void testActivateWorkflowOnAdminClientCreationWithCondition() {
+        // create workflow with a client attribute condition
+        WorkflowRepresentation workflow = WorkflowRepresentation.withName("admin-client-created-workflow")
+                .onEvent(ClientCreatedWorkflowEventFactory.ID)
+                .onCondition(ClientAttributeWorkflowConditionFactory.ID + "(custom-attr:admin-val)")
+                .withSteps(
+                        WorkflowStepRepresentation.create()
+                                .of(DisableClientStepProviderFactory.ID)
+                                .build()
+                ).build();
+        managedRealm.admin().workflows().create(workflow).close();
+
+        // 1. Create client matching the condition -> should be disabled by workflow
+        ClientRepresentation matchingClient = new ClientRepresentation();
+        matchingClient.setClientId("test-admin-matching-client");
+        matchingClient.setEnabled(true);
+        matchingClient.setAttributes(Map.of("custom-attr", "admin-val"));
+
+        String matchingId;
+        try (Response response = managedRealm.admin().clients().create(matchingClient)) {
+            matchingId = ApiUtil.getCreatedId(response);
+        }
+
+        ClientResource matchingResource = managedRealm.admin().clients().get(matchingId);
+        ClientRepresentation matchingRep = matchingResource.toRepresentation();
+        assertThat(matchingRep, notNullValue());
+        assertThat(matchingRep.getAttributes(), notNullValue());
+        assertThat(matchingRep.getAttributes().get("custom-attr"), is("admin-val"));
+        assertThat(matchingRep.isEnabled(), is(false));
+
+        // 2. Create client not matching the condition -> should remain enabled
+        ClientRepresentation nonMatchingClient = new ClientRepresentation();
+        nonMatchingClient.setClientId("test-admin-non-matching-client");
+        nonMatchingClient.setEnabled(true);
+        nonMatchingClient.setAttributes(Map.of("custom-attr", "other-val"));
+
+        String nonMatchingId;
+        try (Response response = managedRealm.admin().clients().create(nonMatchingClient)) {
+            nonMatchingId = ApiUtil.getCreatedId(response);
+        }
+
+        ClientResource nonMatchingResource = managedRealm.admin().clients().get(nonMatchingId);
+        ClientRepresentation nonMatchingRep = nonMatchingResource.toRepresentation();
+        assertThat(nonMatchingRep, notNullValue());
+        assertThat(nonMatchingRep.isEnabled(), is(true));
+    }
+
+    @Test
+    public void testActivateWorkflowOnDynamicClientRegistrationWithCondition() throws Exception {
+        // create workflow with a client attribute condition for DCR
+        WorkflowRepresentation workflow = WorkflowRepresentation.withName("dcr-client-created-workflow")
+                .onEvent(ClientCreatedWorkflowEventFactory.ID)
+                .onCondition(ClientAttributeWorkflowConditionFactory.ID + "(custom-attr:dcr-val)")
+                .withSteps(
+                        WorkflowStepRepresentation.create()
+                                .of(DisableClientStepProviderFactory.ID)
+                                .build()
+                ).build();
+        managedRealm.admin().workflows().create(workflow).close();
+
+        // configure initial access token for dynamic client registration
+        ClientInitialAccessPresentation token = managedRealm.admin().clientInitialAccess()
+                .create(new ClientInitialAccessCreatePresentation(0, 1));
+        ClientRegistration reg = oauth.clientRegistration();
+        reg.auth(Auth.token(token));
+
+        // 1. Create DCR client matching the condition -> should be disabled by workflow
+        ClientRepresentation dcrClient = new ClientRepresentation();
+        dcrClient.setClientId("test-dcr-matching-client");
+        dcrClient.setEnabled(true);
+        dcrClient.setAttributes(Map.of("custom-attr", "dcr-val"));
+
+        ClientRepresentation created = reg.create(dcrClient);
+        assertThat(created, notNullValue());
+
+        ClientResource clientResource = managedRealm.admin().clients().get(created.getId());
+        ClientRepresentation representation = clientResource.toRepresentation();
+        assertThat(representation, notNullValue());
+        assertThat(representation.getAttributes(), notNullValue());
+        assertThat(representation.getAttributes().get("custom-attr"), is("dcr-val"));
+        assertThat(representation.isEnabled(), is(false));
+    }
+
+    @Test
+    public void testActivateWorkflowOnOIDCDynamicClientRegistrationWithCondition() throws Exception {
+        // create workflow triggering on OIDC DCR creation
+        WorkflowRepresentation workflow = WorkflowRepresentation.withName("oidc-dcr-client-created-workflow")
+                .onEvent(ClientCreatedWorkflowEventFactory.ID)
+                .onCondition(ClientAttributeWorkflowConditionFactory.ID + "(client.secret.creation.time:)")
+                .withSteps(
+                        WorkflowStepRepresentation.create()
+                                .of(DisableClientStepProviderFactory.ID)
+                                .build()
+                ).build();
+        managedRealm.admin().workflows().create(workflow).close();
+
+        ClientInitialAccessPresentation token = managedRealm.admin().clientInitialAccess()
+                .create(new ClientInitialAccessCreatePresentation(0, 1));
+        ClientRegistration reg = oauth.clientRegistration();
+        reg.auth(Auth.token(token));
+
+        OIDCClientRepresentation oidcClient = new OIDCClientRepresentation();
+        oidcClient.setClientName("test-oidc-dcr-matching-client");
+        oidcClient.setRedirectUris(List.of("http://localhost:8080/app/*"));
+
+        OIDCClientRepresentation created = reg.oidc().create(oidcClient);
+        assertThat(created, notNullValue());
+
+        List<ClientRepresentation> found = managedRealm.admin().clients().findByClientId(created.getClientId());
+        assertThat(found.isEmpty(), is(false));
+        ClientResource clientResource = managedRealm.admin().clients().get(found.get(0).getId());
+        ClientRepresentation representation = clientResource.toRepresentation();
+        assertThat(representation, notNullValue());
+        assertThat(representation.isEnabled(), is(false));
+    }
+
+    @Test
+    public void testActivateWorkflowOnPartialImportClientCreationWithCondition() {
+        // create workflow with a client attribute condition for partial import
+        WorkflowRepresentation workflow = WorkflowRepresentation.withName("partial-import-client-created-workflow")
+                .onEvent(ClientCreatedWorkflowEventFactory.ID)
+                .onCondition(ClientAttributeWorkflowConditionFactory.ID + "(custom-attr:pi-val)")
+                .withSteps(
+                        WorkflowStepRepresentation.create()
+                                .of(DisableClientStepProviderFactory.ID)
+                                .build()
+                ).build();
+        managedRealm.admin().workflows().create(workflow).close();
+
+        // 1. Partial import client matching condition -> should be disabled by workflow
+        ClientRepresentation matchingClient = new ClientRepresentation();
+        matchingClient.setClientId("test-pi-matching-client");
+        matchingClient.setEnabled(true);
+        matchingClient.setAttributes(Map.of("custom-attr", "pi-val"));
+
+        PartialImportRepresentation pi = new PartialImportRepresentation();
+        pi.setIfResourceExists(PartialImportRepresentation.Policy.FAIL.toString());
+        pi.setClients(List.of(matchingClient));
+
+        try (Response response = managedRealm.admin().partialImport(pi)) {
+            assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+        }
+
+        List<ClientRepresentation> found = managedRealm.admin().clients().findByClientId("test-pi-matching-client");
+        assertThat(found.isEmpty(), is(false));
+        ClientResource matchingResource = managedRealm.admin().clients().get(found.get(0).getId());
+        ClientRepresentation matchingRep = matchingResource.toRepresentation();
+        assertThat(matchingRep, notNullValue());
+        assertThat(matchingRep.getAttributes(), notNullValue());
+        assertThat(matchingRep.getAttributes().get("custom-attr"), is("pi-val"));
+        assertThat(matchingRep.isEnabled(), is(false));
+    }
+
+    @Test
+    @DatabaseTest
+    public void testScheduledWorkflowWithClientAttributeCondition() {
+        // 1. Create pre-existing client with matching attribute
+        ClientRepresentation matchingClient = new ClientRepresentation();
+        matchingClient.setClientId("test-scheduled-matching-client");
+        matchingClient.setEnabled(true);
+        matchingClient.setAttributes(Map.of("custom-attr", "scheduled-val"));
+
+        String matchingId;
+        try (Response response = managedRealm.admin().clients().create(matchingClient)) {
+            matchingId = ApiUtil.getCreatedId(response);
+        }
+
+        // 2. Create pre-existing client with non-matching attribute
+        ClientRepresentation nonMatchingClient = new ClientRepresentation();
+        nonMatchingClient.setClientId("test-scheduled-non-matching-client");
+        nonMatchingClient.setEnabled(true);
+        nonMatchingClient.setAttributes(Map.of("custom-attr", "other-val"));
+
+        String nonMatchingId;
+        try (Response response = managedRealm.admin().clients().create(nonMatchingClient)) {
+            nonMatchingId = ApiUtil.getCreatedId(response);
+        }
+
+        // 3. Create scheduled workflow with has-client-attribute condition
+        WorkflowRepresentation workflow = WorkflowRepresentation.withName("scheduled-client-workflow")
+                .schedule(WorkflowScheduleRepresentation.create().after("1s").batchSize(10).build())
+                .onCondition(ClientAttributeWorkflowConditionFactory.ID + "(custom-attr:scheduled-val)")
+                .withSteps(
+                        WorkflowStepRepresentation.create()
+                                .of(DisableClientStepProviderFactory.ID)
+                                .build()
+                ).build();
+        managedRealm.admin().workflows().create(workflow).close();
+
+        // 4. Await scheduled workflow execution (evaluates toPredicate)
+        Awaitility.await()
+                .timeout(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    ClientResource matchingResource = managedRealm.admin().clients().get(matchingId);
+                    assertThat(matchingResource.toRepresentation().isEnabled(), is(false));
+
+                    ClientResource nonMatchingResource = managedRealm.admin().clients().get(nonMatchingId);
+                    assertThat(nonMatchingResource.toRepresentation().isEnabled(), is(true));
+                });
+    }
+}


### PR DESCRIPTION
Closes #51594

Follow-up issue: #52958

### Description

Event-based workflow activation for `on: client-created` previously evaluated conditions against a client that was not yet populated because `ClientCreatedWorkflowEventProvider` listened on the low-level `ProviderEvent` (`ClientModel.ClientCreationEvent`) fired in `JpaRealmProvider.addClient()` before attributes and representations were applied.

This pull request resolves this timing issue by:
1. Aligning `ClientCreatedWorkflowEventProvider` with `UserCreatedWorkflowEventProvider` by listening on `AdminEvent` (`ResourceType.CLIENT` + `OperationType.CREATE`) and `Event` (`EventType.CLIENT_REGISTER`).
2. Ensuring client creation events only fire after client models are fully populated, client policies are triggered, and final validation has succeeded.
3. Introducing the new built-in `has-client-attribute` condition provider for workflows to allow evaluating client-scoped attributes.

---

### Key Changes

- **Event Alignment**: `ClientCreatedWorkflowEventProvider` now listens to `AdminEvent` (`ResourceType.CLIENT` + `OperationType.CREATE`) and `Event` (`EventType.CLIENT_REGISTER`), ensuring client attributes and representations are fully populated before condition evaluation.
- **New Built-in Condition `has-client-attribute`**:
  - Implemented `ClientAttributeWorkflowConditionProvider` & `ClientAttributeWorkflowConditionFactory`.
  - Supports single-value properties format (`has-client-attribute(attribute-name:expected-value)` or `has-client-attribute(attribute-name:)` to check existence).
  - Implements `toPredicate` for scheduled workflow scans with database-specific criteria queries (including Oracle `DBMS_LOB.COMPARE` and PostgreSQL `substr(VALUE, 1, 255)` index optimization on `IDX_CLIENT_ATT_BY_NAME_VALUE`).
  - Documented under *Client functions* in `defining-conditions.adoc`.
- **Event Emission Timing (Admin API v1)**: Relocated `adminEvent.operation(OperationType.CREATE)...success()` in `ClientsResource` to after client policy execution (`AdminClientRegisteredContext`) and validation. This guarantees that rejected creations (e.g. blocked by client policies) do not emit spurious `CREATE` events to any `EventListenerProvider`.
- **Admin API v2 Support**: Enabled post-population client `CREATE` admin event emission in `DefaultClientService.fireAdminEvent` with exact resource path (`clients/v2/{uuid}`), ensuring Admin API v2 creations trigger `on: client-created` workflows. The `kc.admin-v2.client-service.events.enabled` flag is retained for non-CREATE operations to prevent duplicate events.
- **Partial Import Resource Mapping**: Mapped `PartialImportResult` resource types to corresponding `AdminEvent` `ResourceType`s in `RealmAdminResource`, enabling `on: client-created` workflows during partial import.
- **DCR Event Timing**: Relocated `event.client(...).success()` across `DefaultClientRegistrationProvider`, `OIDCClientRegistrationProvider`, `EntityDescriptorClientRegistrationProvider`, and `AbstractPersistentClientIdMetadataDocumentProvider` to after pairwise protocol mapper setup and final validation.
- **Automated Integration Tests**:
  - `ClientCreationWorkflowTest`: Covers Admin REST API v1, Admin API v2, Dynamic Client Registration (Default & OIDC), Partial Import, and scheduled workflow scans with `@DatabaseTest` criteria evaluation and Awaitility synchronization.
  - `AdminEventV2Test`: Assertions verify exact resource paths (`clients/v2/{uuid}`) for created clients.

---

### Release Notes / Changelog

- **Workflows: New Built-in Condition `has-client-attribute`**: Workflows now provide a built-in `has-client-attribute` condition provider that evaluates whether a client contains a specified attribute and value (or simply checks for attribute presence). This condition is supported for both real-time event triggers and scheduled batch scans.
- **Admin Event Timing (`ClientsResource`)**: In Admin REST API v1, the `CLIENT` `CREATE` admin event is now emitted only after client policies have executed and final validation has succeeded. As a result, client creations rejected by client policies will no longer produce spurious `CREATE` admin events.
- **Admin API v2 Client Creation Events**: Admin API v2 now emits a post-population `CREATE` admin event upon client creation, allowing event listeners and workflows (`on: client-created`) to react to clients created via the v2 API.

---

### Related Issues
- Closes #51594
- Follow-up: #52958 (Add workflow-activation test coverage for SAML and CIMD client registration paths)
