### PR TITLE
perf: do not load all groups on rename

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -148,9 +148,9 @@ public class GroupResource {
         }
 
         if (!Objects.equals(groupName, group.getName())) {
-            boolean exists = siblings().filter(s -> !Objects.equals(s.getId(), group.getId()))
-                    .anyMatch(s -> Objects.equals(s.getName(), groupName));
-            if (exists) {
+            var realm = session.getContext().getRealm();
+            var existingGroup = session.groups().getGroupByName(realm, group.getParent(), groupName);
+            if (existingGroup != null && !Objects.equals(existingGroup.getId(), group.getId())) {
                 throw ErrorResponse.exists("Sibling group named '" + groupName + "' already exists.");
             }
         }


### PR DESCRIPTION
Closes #20121

## Problem

We are seeing group renames take on the order of 5 seconds in a realm that has ~20,000 groups. This is because the update group endpoint is [loading all groups](https://github.com/keycloak/keycloak/blob/dc1bfc54bf1462f7e79822adb4c59aba7e25d50f/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java#L143) then comparing each by name.

## Solution

Switch the duplicate name check to use the existing `session.groups().getGroupByName` method.

## Steps to reproduce

Run the keycloak server using [docker-compose.yml](https://github.com/user-attachments/files/31575237/docker-compose.yml). Run the [renameGroupDemo.js](https://github.com/user-attachments/files/31575238/renameGroupDemo.js) script against each to see the performance difference.

I used Claude Opus 5 to create the renameGroupDemo.js script.

## Results

Running locally:

Before fix:

```
=================================================================
Rename took 3.077s with 20000 top-level groups present
=================================================================
```

After fix:

```
=================================================================
Rename took 0.027s with 20000 top-level groups present
=================================================================
```

Approximately 100x improvement against a test realm of 20,000 groups.
