### PR TITLE
Preserve realm overrides when deleting user attributes

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
@@ -62,41 +62,46 @@ export const AttributesTab = ({ setTableData }: AttributesTabProps) => {
         (attribute) => attribute.name === attributeToDelete,
       )?.displayName;
 
-      // Remove the the `${}` from translationsToDelete string
-      const formattedTranslationsToDelete = translationsToDelete?.substring(
-        2,
-        translationsToDelete.length - 1,
-      );
+      // Only a `${...}` display name refers to a translation key. Without one
+      // there is nothing to delete, and passing an empty key would target the
+      // endpoint that removes every message of the locale.
+      const formattedTranslationsToDelete =
+        translationsToDelete?.startsWith("${") &&
+        translationsToDelete.endsWith("}")
+          ? translationsToDelete.slice(2, -1)
+          : undefined;
 
       try {
-        await Promise.all(
-          combinedLocales.map(async (locale) => {
-            try {
-              const response =
-                (await adminClient.realms.getRealmLocalizationTexts({
-                  realm,
-                  selectedLocale: locale,
-                })) as Record<string, string> | undefined;
-
-              if (response) {
-                await adminClient.realms.deleteRealmLocalizationTexts({
-                  realm,
-                  selectedLocale: locale,
-                  key: formattedTranslationsToDelete,
-                });
-
-                const updatedData =
-                  await adminClient.realms.getRealmLocalizationTexts({
+        if (formattedTranslationsToDelete) {
+          await Promise.all(
+            combinedLocales.map(async (locale) => {
+              try {
+                const response =
+                  (await adminClient.realms.getRealmLocalizationTexts({
                     realm,
                     selectedLocale: locale,
+                  })) as Record<string, string> | undefined;
+
+                if (response) {
+                  await adminClient.realms.deleteRealmLocalizationTexts({
+                    realm,
+                    selectedLocale: locale,
+                    key: formattedTranslationsToDelete,
                   });
-                setTableData([updatedData]);
+
+                  const updatedData =
+                    await adminClient.realms.getRealmLocalizationTexts({
+                      realm,
+                      selectedLocale: locale,
+                    });
+                  setTableData([updatedData]);
+                }
+              } catch {
+                console.error(`Error removing translations for ${locale}`);
               }
-            } catch {
-              console.error(`Error removing translations for ${locale}`);
-            }
-          }),
-        );
+            }),
+          );
+        }
 
         const updatedAttributes = config.attributes.filter(
           (attribute) => attribute.name !== attributeToDelete,

--- a/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
@@ -126,6 +126,34 @@ test.describe.serial("User profile tabs", () => {
         "No validators.",
       );
     });
+
+    test("Keeps realm overrides when deleting an attribute without a translation key", async ({
+      page,
+    }) => {
+      const attributeWithoutDisplayName = "NoTranslationKey";
+      await adminClient.addLocalizationText(
+        "en",
+        "loginAccountTitle",
+        "My Custom Login",
+        realmName,
+      );
+
+      await clickCreateAttribute(page);
+      await fillAttributeForm(page, { name: attributeWithoutDisplayName });
+      await clickSaveAttribute(page);
+      await assertNotificationMessage(
+        page,
+        "Success! User Profile configuration has been saved.",
+      );
+
+      await clickRowKebabItem(page, attributeWithoutDisplayName, "Delete");
+      await confirmModal(page);
+      await assertNotificationMessage(page, "Attribute deleted");
+
+      expect(await adminClient.getLocalizationTexts("en", realmName)).toEqual({
+        loginAccountTitle: "My Custom Login",
+      });
+    });
   });
 
   test("Deletes an attributes group", async ({ page }) => {

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -388,6 +388,17 @@ class AdminClient {
     );
   }
 
+  async getLocalizationTexts(
+    locale: string,
+    realm: string = this.#client.realmName,
+  ) {
+    await this.#login();
+    return await this.#client.realms.getRealmLocalizationTexts({
+      realm,
+      selectedLocale: locale,
+    });
+  }
+
   async removeAllLocalizationTexts() {
     await this.#login();
     const localesWithTexts = await this.#client.realms.getRealmSpecificLocales({


### PR DESCRIPTION
When deleting a user profile attribute without a translation key, the Admin
Console could unintentionally delete existing realm localization overrides.

The deletion logic was attempting to derive a translation key from the
attribute display name even when no translation key was configured. This could
result in the localization delete operation affecting existing realm
overrides.

This change ensures localization text is only removed when the attribute has
a valid `${...}` translation key. Attributes without a translation key are
deleted without modifying the realm's existing localization overrides.

Closes #51496