### PR TITLE
Address cache policy fields by the shape held in the form

### DIFF
--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.test.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { Help } from "@keycloak/keycloak-ui-shared";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { FormProvider, get, useForm } from "react-hook-form";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cacheFieldName, SettingsCache } from "./SettingsCache";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const Harness = ({
+  config,
+  onSave,
+}: {
+  config: Record<string, unknown>;
+  onSave: (values: any) => void;
+}) => {
+  const form = useForm({ defaultValues: { config } });
+  return (
+    <Help>
+      <FormProvider {...form}>
+        <form onSubmit={form.handleSubmit(onSave)}>
+          <SettingsCache form={form} unWrap />
+          <button type="submit">save</button>
+        </form>
+      </FormProvider>
+    </Help>
+  );
+};
+
+// The LDAP and Kerberos screens keep the raw ComponentRepresentation, so a config
+// entry is an array. The custom provider screen loads through convertToFormValues,
+// which unwraps a single-element array, so the same entry is a plain string.
+const SHAPES: [string, Record<string, unknown>][] = [
+  [
+    "array (LDAP, Kerberos)",
+    { cachePolicy: ["MAX_LIFESPAN"], maxLifespan: ["50"] },
+  ],
+  [
+    "scalar (custom provider)",
+    { cachePolicy: "MAX_LIFESPAN", maxLifespan: "50" },
+  ],
+];
+
+describe("SettingsCache", () => {
+  afterEach(cleanup);
+
+  it.each(SHAPES)(
+    "shows the stored maxLifespan for a %s config",
+    async (_l, config) => {
+      render(<Harness config={config} onSave={vi.fn()} />);
+
+      const input = await screen.findByRole("spinbutton");
+
+      expect((input as HTMLInputElement).value).toBe("50");
+    },
+  );
+
+  it.each(SHAPES)(
+    "saves an edited maxLifespan for a %s config",
+    async (_l, config) => {
+      const onSave = vi.fn();
+      render(<Harness config={config} onSave={onSave} />);
+      const input = await screen.findByRole("spinbutton");
+
+      fireEvent.change(input, { target: { value: "120" } });
+      fireEvent.click(screen.getByRole("button", { name: "save" }));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled());
+      const saved = onSave.mock.calls[0][0].config.maxLifespan;
+      expect(Array.isArray(saved) ? saved[0] : saved).toBe(120);
+    },
+  );
+
+  it.each(SHAPES)(
+    "saves the stored maxLifespan untouched for a %s config",
+    async (_l, config) => {
+      const onSave = vi.fn();
+      render(<Harness config={config} onSave={onSave} />);
+      await screen.findByRole("spinbutton");
+
+      fireEvent.click(screen.getByRole("button", { name: "save" }));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled());
+      const saved = onSave.mock.calls[0][0].config.maxLifespan;
+      expect(Array.isArray(saved) ? saved[0] : saved).toBe("50");
+    },
+  );
+});
+
+describe("cacheFieldName", () => {
+  it("indexes into the array the LDAP and Kerberos screens keep", () => {
+    expect(cacheFieldName("config.maxLifespan", ["50"])).toBe(
+      "config.maxLifespan[0]",
+    );
+  });
+
+  it("addresses the scalar the custom provider screen keeps", () => {
+    expect(cacheFieldName("config.maxLifespan", "50")).toBe(
+      "config.maxLifespan",
+    );
+  });
+
+  it("keeps the scalar path once a number control has written a number", () => {
+    expect(cacheFieldName("config.maxLifespan", 120)).toBe(
+      "config.maxLifespan",
+    );
+  });
+
+  it("keeps the array path while the value is still unset", () => {
+    expect(cacheFieldName("config.maxLifespan", undefined)).toBe(
+      "config.maxLifespan[0]",
+    );
+  });
+
+  it("resolves to the stored value in both form shapes", () => {
+    const shapes = [
+      { maxLifespan: ["50"], evictionHour: ["12"], evictionMinute: ["30"] },
+      { maxLifespan: "50", evictionHour: "12", evictionMinute: "30" },
+    ];
+    const expected = {
+      maxLifespan: "50",
+      evictionHour: "12",
+      evictionMinute: "30",
+    };
+
+    for (const config of shapes) {
+      for (const [key, want] of Object.entries(expected)) {
+        const value = config[key as keyof typeof expected];
+        const name = cacheFieldName(`config.${key}`, value);
+        expect(get({ config }, name)).toBe(want);
+      }
+    }
+  });
+});

--- a/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
+++ b/js/apps/admin-ui/src/user-federation/shared/SettingsCache.tsx
@@ -22,6 +22,14 @@ const getValue = (value: string | string[] | undefined) => {
   return value;
 };
 
+// The LDAP and Kerberos screens load with `form.reset(component)` and keep the raw
+// ComponentRepresentation, so a config entry is an array. The custom provider screen loads with
+// `convertToFormValues`, which unwraps a single-element array, so the same entry is a plain
+// string. A field has to be addressed by the shape that is actually in the form: react-hook-form
+// resolves `config.maxLifespan[0]` against the string "50" as "5".
+export const cacheFieldName = (key: string, value: unknown) =>
+  Array.isArray(value) || value === undefined ? `${key}[0]` : key;
+
 const CacheFields = ({ form }: { form: UseFormReturn }) => {
   const { t } = useTranslation();
 
@@ -31,6 +39,23 @@ const CacheFields = ({ form }: { form: UseFormReturn }) => {
   });
 
   const cachePolicy = getValue(cachePolicyType);
+
+  const evictionDayName = cacheFieldName(
+    "config.evictionDay",
+    useWatch({ control: form.control, name: "config.evictionDay" }),
+  );
+  const evictionHourName = cacheFieldName(
+    "config.evictionHour",
+    useWatch({ control: form.control, name: "config.evictionHour" }),
+  );
+  const evictionMinuteName = cacheFieldName(
+    "config.evictionMinute",
+    useWatch({ control: form.control, name: "config.evictionMinute" }),
+  );
+  const maxLifespanName = cacheFieldName(
+    "config.maxLifespan",
+    useWatch({ control: form.control, name: "config.maxLifespan" }),
+  );
 
   const hourOptions: SelectControlOption[] = [];
   let hourDisplay = "";
@@ -76,7 +101,7 @@ const CacheFields = ({ form }: { form: UseFormReturn }) => {
       {cachePolicy === "EVICT_WEEKLY" ? (
         <SelectControl
           id="kc-eviction-day"
-          name="config.evictionDay[0]"
+          name={evictionDayName}
           label={t("evictionDay")}
           labelIcon={t("evictionDayHelp")}
           controller={{
@@ -98,7 +123,7 @@ const CacheFields = ({ form }: { form: UseFormReturn }) => {
         <>
           <SelectControl
             id="kc-eviction-hour"
-            name="config.evictionHour[0]"
+            name={evictionHourName}
             label={t("evictionHour")}
             labelIcon={t("evictionHourHelp")}
             controller={{
@@ -109,7 +134,7 @@ const CacheFields = ({ form }: { form: UseFormReturn }) => {
           />
           <SelectControl
             id="kc-eviction-minute"
-            name="config.evictionMinute[0]"
+            name={evictionMinuteName}
             label={t("evictionMinute")}
             labelIcon={t("evictionMinuteHelp")}
             controller={{
@@ -123,7 +148,7 @@ const CacheFields = ({ form }: { form: UseFormReturn }) => {
       {cachePolicy === "MAX_LIFESPAN" ? (
         <NumberControl
           data-testid="kerberos-cache-lifespan"
-          name="config.maxLifespan[0]"
+          name={maxLifespanName}
           label={t("maxLifespan")}
           labelIcon={t("maxLifespanHelp")}
           unit={t("ms")}


### PR DESCRIPTION
Closes #52029

`SettingsCache` renders the four cache policy detail fields with a fixed array index in
the react-hook-form field name — `config.maxLifespan[0]` and the three eviction fields.

That is correct on the LDAP and Kerberos screens, which load with `form.reset(component)`
and keep the raw `ComponentRepresentation`, so the entry really is an array. The custom
provider screen loads with `convertToFormValues`, which unwraps a single-element array, so
the same entry is the plain string `"50"`. react-hook-form resolves `config.maxLifespan[0]`
against that string as `"5"`.

The truncation is not only cosmetic. Registering a `Controller` on an index path writes the
truncated value back into form state, so it is what the next save sends whether or not the
user ever touched the field:

| stored | displayed | saved |
| --- | --- | --- |
| `maxLifespan: 50` | `5` | `["5"]` |
| eviction `12:30` | `1` / `3` | `["1"]` / `["3"]` |

`Header.tsx` calls `save()` from the enable/disable toggle with no dirty check, so toggling a
custom provider off and on is enough to persist the truncated value.

### The change

Each field is addressed by the shape actually present in the form, the same way
`config.cachePolicy` already tolerated both through the existing `getValue`. Only an array or
a still-unset value takes the index, so LDAP, Kerberos and newly created providers are
unchanged — and the path stays put when `NumberControl` replaces the string with a number,
which is what makes editing work rather than writing `null`.

### Verification

- Full `admin-ui` suite: 10 files, 69 tests passing; `eslint`, `prettier --check`, `tsc --noEmit`
  and `vite build` all clean.
- New tests in `SettingsCache.test.tsx` cover both form shapes for display, untouched save and
  edited save. Against the unmodified component 5 of 11 fail; against a variant that keys the
  path on `typeof value === "string"` 2 of 11 fail, which is the case where an edit is lost.
- Behaviour on the LDAP settings, LDAP wizard, Kerberos settings and Kerberos wizard screens was
  compared against `main` across display, untouched save, edited save and remount, and is
  identical in every case.

One pre-existing defect is deliberately left alone: `NumberControl` does `value + 1` on a string,
so stepping a stored `50` produces `501` on every screen, LDAP included. Fixing that means
changing a shared control used across the admin UI and belongs in its own PR.

### A note to the reporter

@dasniko — you offered to contribute the fix and asked which direction was preferred. I had this
working before I saw that and did not want to sit on a config-corrupting bug, but the find and the
diagnosis are yours, and this is close to the option you leaned towards. Happy to close this in
favour of your PR if you would rather take it.

### Disclosure

Per CONTRIBUTING's *Use of Generative AI*: I used AI assistance while preparing this change. I
understand the change and can explain it, I will engage with review feedback in my own words, and
I can revise the code myself.
