### PR TITLE
Allow unsetting optional OID4VCI client scope attributes on edit

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -354,12 +354,14 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
     }
   }, [parameterType]);
 
-  /* Form-level validation handles correctness; here we only prune known optional
+  /* Form-level validation handles correctness; here we only normalize known optional
        OID4VC fields when empty. If new attributes are added, extend
        OID4VC_ATTRIBUTE_KEYS (and related validation) so they participate in cleanup. */
   const onSubmit = (values: ClientScopeDefaultOptionalType) => {
     const isOid4vc = values.protocol === OID4VC_PROTOCOL;
-    const cleaned = isOid4vc ? removeEmptyOid4vcAttributes(values) : values;
+    const cleaned = isOid4vc
+      ? removeEmptyOid4vcAttributes(values, clientScope !== undefined)
+      : values;
     save(cleaned);
   };
 

--- a/js/apps/admin-ui/src/client-scopes/details/oid4vciAttributes.ts
+++ b/js/apps/admin-ui/src/client-scopes/details/oid4vciAttributes.ts
@@ -28,9 +28,15 @@ const isEmptyValue = (value: unknown) =>
   value === undefined ||
   (typeof value === "string" && value.trim() === "");
 
-/** Prune known optional OID4VC attributes from the payload when they are empty. */
+/**
+ * Normalize known optional OID4VC attributes when they are empty.
+ *
+ * On create, empty values are omitted so backend defaults can be applied.
+ * On edit, empty values are sent as null so the backend receives an explicit clear signal.
+ */
 export const removeEmptyOid4vcAttributes = (
   values: ClientScopeDefaultOptionalType,
+  isEdit = false,
 ): ClientScopeDefaultOptionalType => {
   const fieldNames = OID4VC_ATTRIBUTE_KEYS.map((attr) =>
     convertAttributeNameToForm<ClientScopeDefaultOptionalType>(
@@ -40,16 +46,22 @@ export const removeEmptyOid4vcAttributes = (
 
   /* Shallow copies are sufficient while OID4VC attributes stay flat; if we add
      nested objects under attributes.vc.* we should switch to a deep clone here. */
-  const cleanedValues = { ...values } as Record<string, unknown>;
-  const hadAttributes = Boolean(cleanedValues.attributes);
-  const cleanedAttributes = {
-    ...(cleanedValues.attributes as Record<string, unknown> | undefined),
+  const cleanedValues: ClientScopeDefaultOptionalType = { ...values };
+  const hadAttributes = cleanedValues.attributes !== undefined;
+  const cleanedAttributes: NonNullable<
+    ClientScopeDefaultOptionalType["attributes"]
+  > = {
+    ...cleanedValues.attributes,
   };
 
   for (const fieldName of fieldNames) {
     const attrKey = fieldName.replace(/^attributes\./, "");
     if (isEmptyValue(cleanedAttributes[attrKey])) {
-      delete cleanedAttributes[attrKey];
+      if (isEdit) {
+        cleanedAttributes[attrKey] = null;
+      } else {
+        delete cleanedAttributes[attrKey];
+      }
     }
   }
 
@@ -61,5 +73,5 @@ export const removeEmptyOid4vcAttributes = (
     cleanedValues.attributes = cleanedAttributes;
   }
 
-  return cleanedValues as unknown as ClientScopeDefaultOptionalType;
+  return cleanedValues;
 };

--- a/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
@@ -526,6 +526,41 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     );
   });
 
+  test("should clear previously set optional OID4VCI fields on edit", async ({
+    page,
+  }) => {
+    await using testBed = await createTestBed({
+      verifiableCredentialsEnabled: true,
+    });
+    const testClientScopeName = `oid4vci-clear-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+    await createClientScopeAndSelectProtocolAndFormat(
+      page,
+      testBed,
+      "SD-JWT VC (dc+sd-jwt)",
+    );
+
+    await page.getByTestId("name").fill(testClientScopeName);
+    await page
+      .getByTestId(OID4VCI_FIELDS.ISSUER_DID)
+      .fill(TEST_VALUES.ISSUER_DID);
+
+    await clickSaveButton(page);
+    await expect(page.getByText("Client scope created")).toBeVisible();
+
+    await navigateBackAndVerifyClientScope(page, testBed, testClientScopeName);
+    await expect(page.getByTestId(OID4VCI_FIELDS.ISSUER_DID)).toHaveValue(
+      TEST_VALUES.ISSUER_DID,
+    );
+
+    await page.getByTestId(OID4VCI_FIELDS.ISSUER_DID).fill("");
+    await clickSaveButton(page);
+    await expect(page.getByText("Client scope updated")).toBeVisible();
+
+    await navigateBackAndVerifyClientScope(page, testBed, testClientScopeName);
+    await expect(page.getByTestId(OID4VCI_FIELDS.ISSUER_DID)).toHaveValue("");
+  });
+
   test("should omit optional OID4VCI fields when left blank", async ({
     page,
   }) => {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientScopeAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientScopeAdapter.java
@@ -250,11 +250,24 @@ public class ClientScopeAdapter implements ClientScopeModel, JpaModel<ClientScop
 
     @Override
     public void setAttribute(String name, String value) {
+        boolean valueUndefined = value == null || "".equals(value.trim());
+
         for (ClientScopeAttributeEntity attr : entity.getAttributes()) {
             if (attr.getName().equals(name)) {
-                attr.setValue(value);
+                // clean up, so that attributes previously set with either a empty or null value are removed
+                // we should remove this in future versions so that new client scopes never store empty/null attributes
+                if (valueUndefined) {
+                    removeAttribute(name);
+                } else {
+                    attr.setValue(value);
+                }
                 return;
             }
+        }
+
+        // do not create attributes if empty or null
+        if (valueUndefined) {
+            return;
         }
 
         ClientScopeAttributeEntity attr = new ClientScopeAttributeEntity();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -76,6 +76,7 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_EXPIRY_IN_SECO
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_FORMAT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_FORMAT_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_INCLUDE_IN_METADATA;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_ISSUER_DID;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SD_JWT_NUMBER_OF_DECOYS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SD_JWT_NUMBER_OF_DECOYS_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SUPPORTED_TYPES;
@@ -403,6 +404,36 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
             if (realms.findAll().stream().anyMatch(realm -> realmName.equals(realm.getRealm()))) {
                 realms.realm(realmName).remove();
             }
+        }
+    }
+
+    /**
+     * Test that optional OID4VCI attributes can be unset through the admin client-scope update path.
+     */
+    @Test
+    public void testUnsetOptionalOid4vciAttributeOnUpdate() {
+        ClientScopesResource clientScopes = testRealm.admin().clientScopes();
+        String issuerDid = "did:example:123";
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("test-unset-issuer-did");
+        scope.setIssuerDid(issuerDid);
+
+        String scopeId = null;
+        try (Response response = clientScopes.create(scope)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+            scopeId = ApiUtil.getCreatedId(response);
+        }
+
+        try {
+            ClientScopeResource scopeResource = clientScopes.get(scopeId);
+            assertEquals(issuerDid, scopeResource.toRepresentation().getAttributes().get(VC_ISSUER_DID));
+
+            CredentialScopeRepresentation update = new CredentialScopeRepresentation(scopeResource.toRepresentation());
+            update.getAttributes().put(VC_ISSUER_DID, "");
+            scopeResource.update(update);
+
+            assertNull(scopeResource.toRepresentation().getAttributes().get(VC_ISSUER_DID));
+        } finally {
+            clientScopes.get(scopeId).remove();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug in the admin console where optional OID4VCI client scope fields could be set and saved, but could not be cleared afterward.

Closes #52190

## Root cause

On edit, empty optional OID4VCI attributes were removed from the request payload. Since client scope updates merge only the attributes present in the request, omitting an attribute left its previous value unchanged.

Additionally, `ClientScopeAdapter.setAttribute()` did not remove attributes when receiving null or blank values, unlike `ClientAdapter`.

## What changed

- Preserve the existing create behavior where empty optional OID4VCI attributes are omitted so backend defaults continue to apply.
- On edit, send cleared optional OID4VCI attributes as `null` so the backend receives an explicit clear signal.
- Update `ClientScopeAdapter.setAttribute()` to remove null/blank attributes, matching `ClientAdapter`.
- Add frontend and backend regression tests.

## Test plan

- [x] `./mvnw test -pl tests/base -Dtest=OID4VCClientScopeTest#testUnsetOptionalOid4vciAttributeOnUpdate`
- [x] `should clear previously set optional OID4VCI fields on edit` — Chromium and Firefox
- [x] `should omit optional OID4VCI fields when left blank` — Chromium and Firefox
- [x] `./mvnw -Pdocs,distribution,operator spotless:check`
- [x] Full admin-ui Playwright suite: 203 passed, with 2 unrelated realm-settings i18n failures