### PR TITLE
[OID4VCI] Use example mdoc namespace instead of mDL to fix conformance tests

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/CertificateUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/CertificateUtils.java
@@ -18,8 +18,11 @@
 package org.keycloak.common.util;
 
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.SignatureException;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 
@@ -79,6 +82,26 @@ public class CertificateUtils {
 
     public static X509Certificate generateV1SelfSignedCertificate(KeyPair caKeyPair, String subject, BigInteger serialNumber, Date validityEndDate) {
         return CryptoIntegration.getProvider().getCertificateUtils().generateV1SelfSignedCertificate(caKeyPair, truncateCN(subject), serialNumber, validityEndDate);
+    }
+
+    /**
+     * Checks whether the certificate is self signed, meaning it is self issued with matching subject and
+     * issuer names and its signature verifies with its own public key.
+     *
+     * @param certificate the certificate to check
+     * @return true if the certificate is self issued and signed by its own key
+     * @throws GeneralSecurityException if the signature cannot be verified at all
+     */
+    public static boolean isSelfSigned(X509Certificate certificate) throws GeneralSecurityException {
+        if (!certificate.getSubjectX500Principal().equals(certificate.getIssuerX500Principal())) {
+            return false;
+        }
+        try {
+            certificate.verify(certificate.getPublicKey());
+            return true;
+        } catch (SignatureException | InvalidKeyException e) {
+            return false;
+        }
     }
 
     private static String truncateCN(String cn) {

--- a/core/src/main/java/org/keycloak/mdoc/MdocCredential.java
+++ b/core/src/main/java/org/keycloak/mdoc/MdocCredential.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.mdoc;
 
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.jose.jwk.JWK;
@@ -216,7 +218,16 @@ public class MdocCredential {
         if (certificateChain == null || certificateChain.isEmpty()) {
             throw new MdocException("mDoc signing key is missing certificate chain");
         }
-        return certificateChain;
+        // ISO/IEC 18013 part 5 excludes the trust anchor from x5chain
+        List<X509Certificate> chain = new ArrayList<>(certificateChain);
+        try {
+            while (chain.size() > 1 && CertificateUtils.isSelfSigned(chain.get(chain.size() - 1))) {
+                chain.remove(chain.size() - 1);
+            }
+        } catch (GeneralSecurityException e) {
+            throw new MdocException("Could not verify whether the mDoc signing certificate is self signed", e);
+        }
+        return chain;
     }
 
     private static byte[] generateRandom() {

--- a/core/src/main/java/org/keycloak/mdoc/MdocCredential.java
+++ b/core/src/main/java/org/keycloak/mdoc/MdocCredential.java
@@ -218,10 +218,13 @@ public class MdocCredential {
         if (certificateChain == null || certificateChain.isEmpty()) {
             throw new MdocException("mDoc signing key is missing certificate chain");
         }
-        // ISO/IEC 18013 part 5 excludes the trust anchor from x5chain
+        // ISO/IEC 18013 part 5 requires a CA issued signing certificate and keeps the trust anchor out of x5chain
         List<X509Certificate> chain = new ArrayList<>(certificateChain);
         try {
-            while (chain.size() > 1 && CertificateUtils.isSelfSigned(chain.get(chain.size() - 1))) {
+            if (CertificateUtils.isSelfSigned(chain.get(0))) {
+                throw new MdocException("mDoc signing certificate must not be self signed");
+            }
+            while (CertificateUtils.isSelfSigned(chain.get(chain.size() - 1))) {
                 chain.remove(chain.size() - 1);
             }
         } catch (GeneralSecurityException e) {

--- a/core/src/test/java/org/keycloak/mdoc/MdocCredentialCreationAndSigningTest.java
+++ b/core/src/test/java/org/keycloak/mdoc/MdocCredentialCreationAndSigningTest.java
@@ -50,8 +50,8 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class MdocCredentialCreationAndSigningTest {
 
-    private static final String DOC_TYPE = "org.iso.18013.5.1.mDL";
-    private static final String NAMESPACE = "org.iso.18013.5.1";
+    private static final String DOC_TYPE = "org.example.credential.mdoc";
+    private static final String NAMESPACE = "org.example.credential";
     private static final String GIVEN_NAME = "given_name";
     private static final String FAMILY_NAME = "family_name";
 

--- a/core/src/test/java/org/keycloak/mdoc/MdocCredentialCreationAndSigningTest.java
+++ b/core/src/test/java/org/keycloak/mdoc/MdocCredentialCreationAndSigningTest.java
@@ -21,6 +21,7 @@ import java.security.PublicKey;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -46,6 +47,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public abstract class MdocCredentialCreationAndSigningTest {
@@ -61,15 +63,15 @@ public abstract class MdocCredentialCreationAndSigningTest {
     @Test
     public void shouldCreateSignedMdocCredentialWithHolderBinding() throws Exception {
         KeyPair issuerKeyPair = KeyUtils.generateEcKeyPair(EC_KEY_SECP256R1);
-        X509Certificate issuerCertificate = selfSignedCertificate(issuerKeyPair);
+        IssuerCertificates certificates = issuerCertificates(issuerKeyPair);
         MdocCredential credential = mdocCredential();
         credential.addKeyBinding(proofJwk());
 
         MdocIssuerSignedDocument document = credential.signAsIssuerSignedDocument(
-                new ECDSASignatureSignerContext(issuerKey(issuerKeyPair, issuerCertificate))
+                new ECDSASignatureSignerContext(issuerKey(issuerKeyPair, certificates))
         );
 
-        assertIssuedCredential(document, issuerCertificate);
+        assertIssuedCredential(document, certificates.leafCertificate);
         assertNotNull(document.getMobileSecurityObject().get("deviceKeyInfo"));
         assertIssuerAuthSignature(document, issuerKeyPair.getPublic());
     }
@@ -77,15 +79,27 @@ public abstract class MdocCredentialCreationAndSigningTest {
     @Test
     public void shouldCreateSignedMdocCredentialWithoutHolderBinding() throws Exception {
         KeyPair issuerKeyPair = KeyUtils.generateEcKeyPair(EC_KEY_SECP256R1);
-        X509Certificate issuerCertificate = selfSignedCertificate(issuerKeyPair);
+        IssuerCertificates certificates = issuerCertificates(issuerKeyPair);
 
         MdocIssuerSignedDocument document = mdocCredential().signAsIssuerSignedDocument(
-                new ECDSASignatureSignerContext(issuerKey(issuerKeyPair, issuerCertificate))
+                new ECDSASignatureSignerContext(issuerKey(issuerKeyPair, certificates))
         );
 
-        assertIssuedCredential(document, issuerCertificate);
+        assertIssuedCredential(document, certificates.leafCertificate);
         assertNull(document.getMobileSecurityObject().get("deviceKeyInfo"));
         assertIssuerAuthSignature(document, issuerKeyPair.getPublic());
+    }
+
+    @Test
+    public void shouldRejectSelfSignedSigningCertificate() throws Exception {
+        KeyPair issuerKeyPair = KeyUtils.generateEcKeyPair(EC_KEY_SECP256R1);
+        KeyWrapper issuerKey = issuerKey(issuerKeyPair, null);
+        issuerKey.setCertificate(
+                (X509Certificate) CertificateUtils.generateV1SelfSignedCertificate(issuerKeyPair, "issuer-key"));
+
+        assertThrows(MdocException.class, () -> mdocCredential().signAsIssuerSignedDocument(
+                new ECDSASignatureSignerContext(issuerKey)
+        ));
     }
 
     private static MdocCredential mdocCredential() {
@@ -114,7 +128,7 @@ public abstract class MdocCredentialCreationAndSigningTest {
                 .ec(proofKeyPair.getPublic(), KeyUse.SIG);
     }
 
-    private static KeyWrapper issuerKey(KeyPair issuerKeyPair, X509Certificate issuerCertificate) {
+    private static KeyWrapper issuerKey(KeyPair issuerKeyPair, IssuerCertificates certificates) {
         KeyWrapper issuerKey = new KeyWrapper();
         issuerKey.setAlgorithm(Algorithm.ES256);
         issuerKey.setUse(KeyUse.SIG);
@@ -122,12 +136,32 @@ public abstract class MdocCredentialCreationAndSigningTest {
         issuerKey.setKid("issuer-key");
         issuerKey.setPrivateKey(issuerKeyPair.getPrivate());
         issuerKey.setPublicKey(issuerKeyPair.getPublic());
-        issuerKey.setCertificate(issuerCertificate);
+        if (certificates != null) {
+            issuerKey.setCertificate(certificates.leafCertificate);
+            issuerKey.setCertificateChain(
+                    Arrays.asList(certificates.leafCertificate, certificates.caCertificate));
+        }
         return issuerKey;
     }
 
-    private static X509Certificate selfSignedCertificate(KeyPair keyPair) throws Exception {
-        return (X509Certificate) CertificateUtils.generateV1SelfSignedCertificate(keyPair, "issuer-key");
+    private static final class IssuerCertificates {
+
+        private final X509Certificate leafCertificate;
+        private final X509Certificate caCertificate;
+
+        private IssuerCertificates(X509Certificate leafCertificate, X509Certificate caCertificate) {
+            this.leafCertificate = leafCertificate;
+            this.caCertificate = caCertificate;
+        }
+    }
+
+    private static IssuerCertificates issuerCertificates(KeyPair issuerKeyPair) throws Exception {
+        KeyPair caKeyPair = KeyUtils.generateEcKeyPair(EC_KEY_SECP256R1);
+        X509Certificate caCertificate =
+                (X509Certificate) CertificateUtils.generateV1SelfSignedCertificate(caKeyPair, "issuer-ca");
+        X509Certificate leafCertificate = CertificateUtils.generateV3Certificate(
+                issuerKeyPair, caKeyPair.getPrivate(), caCertificate, "issuer-key");
+        return new IssuerCertificates(leafCertificate, caCertificate);
     }
 
     private static void assertIssuedCredential(MdocIssuerSignedDocument document, X509Certificate issuerCertificate)

--- a/core/src/test/java/org/keycloak/mdoc/MdocCredentialTest.java
+++ b/core/src/test/java/org/keycloak/mdoc/MdocCredentialTest.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.assertThrows;
 
 public class MdocCredentialTest {
 
-    private static final String DOC_TYPE = "org.iso.18013.5.1.mDL";
-    private static final String NAMESPACE = "org.iso.18013.5.1";
+    private static final String DOC_TYPE = "org.example.credential.mdoc";
+    private static final String NAMESPACE = "org.example.credential";
 
     @Test
     public void shouldExposeNamespacedClaimsFromMapInput() {

--- a/core/src/test/java/org/keycloak/mdoc/MdocIssuerSignedDocumentTest.java
+++ b/core/src/test/java/org/keycloak/mdoc/MdocIssuerSignedDocumentTest.java
@@ -30,8 +30,8 @@ import static org.junit.Assert.assertTrue;
 
 public class MdocIssuerSignedDocumentTest {
 
-    private static final String DOC_TYPE = "org.iso.18013.5.1.mDL";
-    private static final String NAMESPACE = "org.iso.18013.5.1";
+    private static final String DOC_TYPE = "org.example.credential.mdoc";
+    private static final String NAMESPACE = "org.example.credential";
 
     @Test
     public void shouldParseIssuerSignedRepresentation() {

--- a/pom.xml
+++ b/pom.xml
@@ -177,9 +177,9 @@
         <!-- OID4VCI + OID4VP Conformance Container Images -->
         <mongodb.version>6.0.13</mongodb.version>
         <mongodb.container>mongo:${mongodb.version}</mongodb.container>
-        <conformance.version>release-v5.2.2</conformance.version>
+        <conformance.version>release-v5.2.4</conformance.version>
         <conformance.container>registry.gitlab.com/openid/conformance-suite:${conformance.version}</conformance.container>
-        <nginx.version>release-v5.2.2</nginx.version>
+        <nginx.version>release-v5.2.4</nginx.version>
         <nginx.container>registry.gitlab.com/openid/conformance-suite/nginx:${nginx.version}</nginx.container>
 
         <!-- Test -->

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/SdJwtCredentialSigner.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/SdJwtCredentialSigner.java
@@ -17,12 +17,8 @@
 
 package org.keycloak.protocol.oid4vc.issuance.signing;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.SignatureException;
+import java.security.GeneralSecurityException;
 import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -30,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBody;
@@ -143,11 +140,8 @@ public class SdJwtCredentialSigner extends AbstractCredentialSigner<String> {
 
     private boolean isSelfSigned(X509Certificate cert) throws CredentialSignerException {
         try {
-            cert.verify(cert.getPublicKey());
-            return true;
-        } catch (SignatureException | InvalidKeyException e) {
-            return false;
-        } catch (CertificateException | NoSuchAlgorithmException | NoSuchProviderException e) {
+            return CertificateUtils.isSelfSigned(cert);
+        } catch (GeneralSecurityException e) {
             throw new CredentialSignerException("HAIP-6.1.1 violation: failed to verify whether certificate is self-signed.", e);
         }
     }

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessorTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessorTest.java
@@ -248,11 +248,11 @@ public class OID4VCAuthorizationDetailsProcessorTest {
         OID4VCAuthorizationDetail authDetail = createValidAuthorizationDetail();
 
         ClaimsDescription claim1 = new ClaimsDescription();
-        claim1.setPath(Arrays.asList("org.iso.18013.5.1", "given_name"));
+        claim1.setPath(Arrays.asList("org.example.credential", "given_name"));
         claim1.setMandatory(true);
 
         ClaimsDescription claim2 = new ClaimsDescription();
-        claim2.setPath(Arrays.asList("org.iso.18013.5.1", "address", "street"));
+        claim2.setPath(Arrays.asList("org.example.credential", "address", "street"));
         claim2.setMandatory(false);
 
         authDetail.setClaims(Arrays.asList(claim1, claim2));
@@ -263,11 +263,11 @@ public class OID4VCAuthorizationDetailsProcessorTest {
         assertEquals("Should have exactly two claims", 2, parsedAuthDetail.getClaims().size());
 
         ClaimsDescription firstClaim = parsedAuthDetail.getClaims().get(0);
-        assertEquals(Arrays.asList("org.iso.18013.5.1", "given_name"), firstClaim.getPath());
+        assertEquals(Arrays.asList("org.example.credential", "given_name"), firstClaim.getPath());
         assertTrue(firstClaim.isMandatory());
 
         ClaimsDescription secondClaim = parsedAuthDetail.getClaims().get(1);
-        assertEquals(Arrays.asList("org.iso.18013.5.1", "address", "street"), secondClaim.getPath());
+        assertEquals(Arrays.asList("org.example.credential", "address", "street"), secondClaim.getPath());
         assertFalse(secondClaim.isMandatory());
     }
 

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilderTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilderTest.java
@@ -2,6 +2,7 @@ package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -271,9 +272,26 @@ public class MdocCredentialBuilderTest {
         issuerKey.setPrivateKey(issuerKeyPair.getPrivate());
         issuerKey.setPublicKey(issuerKeyPair.getPublic());
         if (includeCertificate) {
-            issuerKey.setCertificate(CertificateUtils.generateV1SelfSignedCertificate(issuerKeyPair, "issuer-key"));
+            issuerKey.setCertificate(caIssuedCertificate(issuerKeyPair, type));
         }
         return issuerKey;
+    }
+
+    // The signer rejects self signed signing certificates, so the fixture issues the leaf from a CA
+    private static X509Certificate caIssuedCertificate(KeyPair issuerKeyPair, String type) throws Exception {
+        KeyPair caKeyPair = "RSA".equals(type)
+                ? KeyUtils.generateRsaKeyPair(2048)
+                : generateEcKeyPair();
+        X509Certificate caCertificate =
+                (X509Certificate) CertificateUtils.generateV1SelfSignedCertificate(caKeyPair, "issuer-ca");
+        return CertificateUtils.generateV3Certificate(
+                issuerKeyPair, caKeyPair.getPrivate(), caCertificate, "issuer-key");
+    }
+
+    private static KeyPair generateEcKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+        return keyPairGenerator.generateKeyPair();
     }
 
     private void assertSignedMdoc(MdocIssuerSignedDocument issuerSignedDocument) {

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilderTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilderTest.java
@@ -35,8 +35,8 @@ import static org.junit.Assert.assertTrue;
 
 public class MdocCredentialBuilderTest {
 
-    private static final String DOC_TYPE = "org.iso.18013.5.1.mDL";
-    private static final String NAMESPACE = "org.iso.18013.5.1";
+    private static final String DOC_TYPE = "org.example.credential.mdoc";
+    private static final String NAMESPACE = "org.example.credential";
 
     @BeforeClass
     public static void initCrypto() {

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapperTest.java
@@ -18,42 +18,42 @@ public class OID4VCMapperTest {
     @Test
     public void shouldUseNamespaceClaimPathForMdoc() {
         OID4VCStaticClaimMapper mapper = new OID4VCStaticClaimMapper();
-        mapper.setMapperModel(createStaticClaimMapperModel("given_name", "John", "org.iso.18013.5.1"), VCFormat.MSO_MDOC);
+        mapper.setMapperModel(createStaticClaimMapperModel("given_name", "John", "org.example.credential"), VCFormat.MSO_MDOC);
 
         Map<String, Object> claims = new HashMap<>();
         mapper.setClaim(claims, null);
 
-        assertEquals(List.of("org.iso.18013.5.1", "given_name"), mapper.getMetadataAttributePath());
+        assertEquals(List.of("org.example.credential", "given_name"), mapper.getMetadataAttributePath());
         assertEquals(Map.of("given_name", "John"), claims);
 
         Map<String, Object> prefixedClaims = new HashMap<>();
         mapper.setClaimWithMetadataPrefix(claims, prefixedClaims);
-        assertEquals(Map.of("org.iso.18013.5.1", Map.of("given_name", "John")), prefixedClaims);
+        assertEquals(Map.of("org.example.credential", Map.of("given_name", "John")), prefixedClaims);
     }
 
     @Test
     public void shouldCreateNestedMdocClaimPaths() {
         OID4VCStaticClaimMapper mapper = new OID4VCStaticClaimMapper();
-        mapper.setMapperModel(createStaticClaimMapperModel("address.street", "Main Street", "org.iso.18013.5.1"), VCFormat.MSO_MDOC);
+        mapper.setMapperModel(createStaticClaimMapperModel("address.street", "Main Street", "org.example.credential"), VCFormat.MSO_MDOC);
 
         Map<String, Object> claims = new HashMap<>();
         mapper.setClaim(claims, null);
 
-        assertEquals(List.of("org.iso.18013.5.1", "address", "street"), mapper.getMetadataAttributePath());
+        assertEquals(List.of("org.example.credential", "address", "street"), mapper.getMetadataAttributePath());
         assertEquals(Map.of("address.street", "Main Street"), claims);
 
         Map<String, Object> prefixedClaims = new HashMap<>();
         mapper.setClaimWithMetadataPrefix(claims, prefixedClaims);
-        assertEquals(Map.of("org.iso.18013.5.1", Map.of("address", Map.of("street", "Main Street"))), prefixedClaims);
+        assertEquals(Map.of("org.example.credential", Map.of("address", Map.of("street", "Main Street"))), prefixedClaims);
     }
 
     @Test
     public void shouldKeepMdocClaimPathsSeparateWhenLeafNamesMatch() {
         OID4VCStaticClaimMapper addressMapper = new OID4VCStaticClaimMapper();
-        addressMapper.setMapperModel(createStaticClaimMapperModel("address.street", "Main Street", "org.iso.18013.5.1"), VCFormat.MSO_MDOC);
+        addressMapper.setMapperModel(createStaticClaimMapperModel("address.street", "Main Street", "org.example.credential"), VCFormat.MSO_MDOC);
 
         OID4VCStaticClaimMapper employerMapper = new OID4VCStaticClaimMapper();
-        employerMapper.setMapperModel(createStaticClaimMapperModel("employer.street", "Work Street", "org.iso.18013.5.1"), VCFormat.MSO_MDOC);
+        employerMapper.setMapperModel(createStaticClaimMapperModel("employer.street", "Work Street", "org.example.credential"), VCFormat.MSO_MDOC);
 
         Map<String, Object> claims = new HashMap<>();
         addressMapper.setClaim(claims, null);
@@ -63,7 +63,7 @@ public class OID4VCMapperTest {
         addressMapper.setClaimWithMetadataPrefix(claims, prefixedClaims);
         employerMapper.setClaimWithMetadataPrefix(claims, prefixedClaims);
 
-        assertEquals(Map.of("org.iso.18013.5.1", Map.of(
+        assertEquals(Map.of("org.example.credential", Map.of(
                 "address", Map.of("street", "Main Street"),
                 "employer", Map.of("street", "Work Street")
         )), prefixedClaims);
@@ -140,7 +140,7 @@ public class OID4VCMapperTest {
     public void shouldAcceptMdocClaimMapperWithNamespace() throws ProtocolMapperConfigException {
         OID4VCStaticClaimMapper mapper = new OID4VCStaticClaimMapper();
 
-        mapper.validateMdocNamespace(VCFormat.MSO_MDOC, createStaticClaimMapperModel("given_name", "John", "org.iso.18013.5.1"));
+        mapper.validateMdocNamespace(VCFormat.MSO_MDOC, createStaticClaimMapperModel("given_name", "John", "org.example.credential"));
     }
 
     @Test

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfigurationTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfigurationTest.java
@@ -38,9 +38,9 @@ public class SupportedCredentialConfigurationTest {
     public void shouldDeriveDocTypeForMdoc() {
         SupportedCredentialConfiguration config = new SupportedCredentialConfiguration()
                 .setFormat(VCFormat.MSO_MDOC)
-                .setDocType("org.iso.18013.5.1.mDL");
+                .setDocType("org.example.credential.mdoc");
 
-        assertEquals("org.iso.18013.5.1.mDL", config.deriveType().getValue());
+        assertEquals("org.example.credential.mdoc", config.deriveType().getValue());
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/MdocTestSigningKey.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/MdocTestSigningKey.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc;
+
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+// ES256 mdoc signing needs a CA issued certificate, and only the java keystore key provider can supply
+// an EC key with one. Its keystore must live in a realm folder under the configured keystores path option.
+final class MdocTestSigningKey {
+
+    static final String KEY_ALIAS = "mdoc-test-signing";
+    static final String PASSWORD = "password";
+
+    private static final Path KEYSTORES_BASE_DIR;
+    private static final String KEY_STORE_PATH;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    static {
+        try {
+            KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("EC");
+            keyGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair caKeyPair = keyGenerator.generateKeyPair();
+            KeyPair leafKeyPair = keyGenerator.generateKeyPair();
+
+            X500Name caName = new X500Name("CN=Mdoc Test CA");
+            X509Certificate caCertificate = generateCaCertificate(caName, caKeyPair);
+            X509Certificate leafCertificate = generateLeafCertificate(caName, leafKeyPair, caKeyPair);
+
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            keyStore.load(null, null);
+            keyStore.setKeyEntry(KEY_ALIAS, leafKeyPair.getPrivate(), PASSWORD.toCharArray(),
+                    new Certificate[] { leafCertificate, caCertificate });
+
+            KEYSTORES_BASE_DIR = Files.createTempDirectory("keycloak-mdoc-keystores");
+            KEYSTORES_BASE_DIR.toFile().deleteOnExit();
+            Path realmDir = Files.createDirectory(
+                    KEYSTORES_BASE_DIR.resolve(OID4VCIssuerTestBase.VCTestRealmConfig.TEST_REALM_NAME));
+            realmDir.toFile().deleteOnExit();
+            Path keyStorePath = Files.createTempFile(realmDir, "keycloak-mdoc-test-signing", ".p12");
+            try (OutputStream output = Files.newOutputStream(keyStorePath)) {
+                keyStore.store(output, PASSWORD.toCharArray());
+            }
+            keyStorePath.toFile().deleteOnExit();
+            KEY_STORE_PATH = keyStorePath.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create mdoc test signing key", e);
+        }
+    }
+
+    private MdocTestSigningKey() {
+    }
+
+    static String keystoresBaseDir() {
+        return KEYSTORES_BASE_DIR.toString();
+    }
+
+    static String keyStorePath() {
+        return KEY_STORE_PATH;
+    }
+
+    private static X509Certificate generateCaCertificate(X500Name caName, KeyPair caKeyPair) throws Exception {
+        X509v3CertificateBuilder builder = certificateBuilder(caName, caName, caKeyPair.getPublic());
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(0));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        return sign(builder, caKeyPair);
+    }
+
+    private static X509Certificate generateLeafCertificate(X500Name caName, KeyPair leafKeyPair, KeyPair caKeyPair)
+            throws Exception {
+        X500Name leafName = new X500Name("CN=Mdoc Test Signer");
+        X509v3CertificateBuilder builder = certificateBuilder(caName, leafName, leafKeyPair.getPublic());
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+        return sign(builder, caKeyPair);
+    }
+
+    private static X509v3CertificateBuilder certificateBuilder(X500Name issuer, X500Name subject, PublicKey publicKey) {
+        Instant now = Instant.now();
+        return new JcaX509v3CertificateBuilder(
+                issuer,
+                new BigInteger(159, RANDOM),
+                Date.from(now.minus(1, ChronoUnit.DAYS)),
+                Date.from(now.plus(365, ChronoUnit.DAYS)),
+                subject,
+                publicKey);
+    }
+
+    private static X509Certificate sign(X509v3CertificateBuilder builder, KeyPair signingKeyPair) throws Exception {
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA").build(signingKeyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -312,6 +312,7 @@ public abstract class OID4VCIssuerTestBase {
         oauth.client(client.getClientId(), client.getSecret());
         enableVerifiableCredentialEvents();
         ensureHaipCompliantSdJwtSigningConfiguration();
+        ensureMdocCompliantSigningConfiguration();
 
         wallet = new OID4VCBasicWallet(keycloak, oauth);
     }
@@ -588,6 +589,40 @@ public abstract class OID4VCIssuerTestBase {
                 200
         );
         components.add(provider).close();
+    }
+
+    /**
+     * Persistently add an ES256 signing key with a CA issued certificate, as mdoc issuance rejects
+     * the self signed certificates of generated realm keys.
+     */
+    protected void ensureMdocCompliantSigningConfiguration() {
+        if (!runOnServer.fetch(session -> Profile.isFeatureEnabled(Profile.Feature.OID4VC_MDOC), Boolean.class)) {
+            return;
+        }
+        final String providerName = "mdoc-signing-key-provider";
+        var components = testRealm.admin().components();
+        if (!components.query(testRealm.getId(), KeyProvider.class.getName(), providerName).isEmpty()) {
+            return;
+        }
+
+        ComponentRepresentation component = new ComponentRepresentation();
+        component.setProviderType(KeyProvider.class.getName());
+        component.setName(providerName);
+        component.setId(UUID.randomUUID().toString());
+        component.setProviderId("java-keystore");
+        component.setConfig(new MultivaluedHashMap<>(Map.of(
+                "keystore", List.of(MdocTestSigningKey.keyStorePath()),
+                "keystorePassword", List.of(MdocTestSigningKey.PASSWORD),
+                "keystoreType", List.of("PKCS12"),
+                "keyAlias", List.of(MdocTestSigningKey.KEY_ALIAS),
+                "keyPassword", List.of(MdocTestSigningKey.PASSWORD),
+                "algorithm", List.of(Algorithm.ES256),
+                "keyUse", List.of(KeyUse.SIG.name()),
+                "priority", List.of("300"),
+                "enabled", List.of("true"),
+                "active", List.of("true")
+        )));
+        components.add(component).close();
     }
 
     protected ClientPolicyRepresentation getClientPolicy(String policyName) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -178,7 +178,7 @@ public abstract class OID4VCIssuerTestBase {
 
     public static final String mdocTypeCredentialScopeName = "mdoc-credential";
     public static final String mdocTypeCredentialConfigurationIdName = "mdoc-credential-config-id";
-    public static final String mdocTypeCredentialDocType = "org.iso.18013.5.1.mDL";
+    public static final String mdocTypeCredentialDocType = "org.example.credential.mdoc";
 
     public static final String CONTEXT_URL = "https://www.w3.org/2018/credentials/v1";
     public static final List<String> TEST_TYPES = List.of("VerifiableCredential");
@@ -1046,9 +1046,9 @@ public abstract class OID4VCIssuerTestBase {
                     .setBindingRequired(true)
                     .setCryptographicBindingMethods(List.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY));
             cs.setProtocolMappers(List.of(
-                    ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1"),
-                    ProtocolMapperUtils.getUserAttributeMapper("family_name", "lastName", "org.iso.18013.5.1"),
-                    ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.iso.18013.5.1")
+                    ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential"),
+                    ProtocolMapperUtils.getUserAttributeMapper("family_name", "lastName", "org.example.credential"),
+                    ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.example.credential")
             ));
             cs.getAttributes().put(VC_BINDING_REQUIRED_PROOF_TYPES, "jwt");
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocIssuerEndpointTest.java
@@ -113,8 +113,8 @@ public class OID4VCMdocIssuerEndpointTest extends OID4VCMdocTestBase {
                 "mdoc-optional-binding-endpoint-scope",
                 "mdoc-optional-binding-endpoint-config",
                 List.of(
-                        ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1"),
-                        ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.iso.18013.5.1")
+                        ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential"),
+                        ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.example.credential")
                 ),
                 null,
                 false
@@ -180,8 +180,8 @@ public class OID4VCMdocIssuerEndpointTest extends OID4VCMdocTestBase {
                 "mdoc-rsa-endpoint-scope",
                 "mdoc-rsa-endpoint-config",
                 List.of(
-                        ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1"),
-                        ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.iso.18013.5.1")
+                        ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential"),
+                        ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.example.credential")
                 ),
                 Algorithm.RS256,
                 true

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocIssuerWellKnownProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocIssuerWellKnownProviderTest.java
@@ -77,9 +77,9 @@ public class OID4VCMdocIssuerWellKnownProviderTest extends OID4VCMdocTestBase {
         assertNotNull(jwtProofSupport, "JWT proof support must be advertised for mDoc binding");
         assertEquals(Set.copyOf(getAllAsymmetricAlgorithms()), Set.copyOf(jwtProofSupport.getSigningAlgorithmsSupported()));
 
-        assertHasClaimPath(supportedConfig, List.of("org.iso.18013.5.1", "given_name"));
-        assertHasClaimPath(supportedConfig, List.of("org.iso.18013.5.1", "family_name"));
-        assertHasClaimPath(supportedConfig, List.of("org.iso.18013.5.1", "id"));
+        assertHasClaimPath(supportedConfig, List.of("org.example.credential", "given_name"));
+        assertHasClaimPath(supportedConfig, List.of("org.example.credential", "family_name"));
+        assertHasClaimPath(supportedConfig, List.of("org.example.credential", "id"));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class OID4VCMdocIssuerWellKnownProviderTest extends OID4VCMdocTestBase {
     @Test
     void testMdocCredentialConfigurationSupportsNestedClaimPaths() {
         ProtocolMapperRepresentation nestedAddressMapper =
-                ProtocolMapperUtils.getUserAttributeMapper("address.street", "address_street_address", "org.iso.18013.5.1");
+                ProtocolMapperUtils.getUserAttributeMapper("address.street", "address_street_address", "org.example.credential");
         nestedAddressMapper.getConfig().put(CredentialScopeModel.VC_INCLUDE_IN_METADATA, "true");
         CredentialScopeRepresentation scope =
                 createCustomMdocCredentialScope("mdoc-nested-claim-scope", "mdoc-nested-claim-config", List.of(nestedAddressMapper));
@@ -119,7 +119,7 @@ public class OID4VCMdocIssuerWellKnownProviderTest extends OID4VCMdocTestBase {
         SupportedCredentialConfiguration supportedConfig =
                 credentialIssuer.getCredentialsSupported().get(scope.getCredentialConfigurationId());
 
-        assertHasClaimPath(supportedConfig, List.of("org.iso.18013.5.1", "address", "street"));
+        assertHasClaimPath(supportedConfig, List.of("org.example.credential", "address", "street"));
     }
 
     @Test
@@ -160,7 +160,7 @@ public class OID4VCMdocIssuerWellKnownProviderTest extends OID4VCMdocTestBase {
         CredentialScopeRepresentation scope = createCustomMdocCredentialScope(
                 "mdoc-default-signing-scope",
                 "mdoc-default-signing-config",
-                List.of(ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1")),
+                List.of(ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential")),
                 null,
                 true
         );
@@ -181,7 +181,7 @@ public class OID4VCMdocIssuerWellKnownProviderTest extends OID4VCMdocTestBase {
         CredentialScopeRepresentation scope = createCustomMdocCredentialScope(
                 "mdoc-optional-binding-scope",
                 "mdoc-optional-binding-config",
-                List.of(ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1")),
+                List.of(ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential")),
                 "ES256",
                 false
         );

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocMapperTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocMapperTest.java
@@ -53,7 +53,7 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
         ensureEcSigningKeyProvider("mdoc-mapper-issuer-key", "P-256", "ES256", 200);
 
         ProtocolMapperRepresentation mapper =
-                ProtocolMapperUtils.getUserAttributeMapper("address.street", "address_street_address", "org.iso.18013.5.1");
+                ProtocolMapperUtils.getUserAttributeMapper("address.street", "address_street_address", "org.example.credential");
         mapper.getConfig().put(CredentialScopeModel.VC_INCLUDE_IN_METADATA, "true");
         CredentialScopeRepresentation scope = createCustomMdocCredentialScope("mdoc-mapper-scope", "mdoc-mapper-config", List.of(mapper));
 
@@ -65,7 +65,7 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
         List<List<String>> actualPaths = supportedConfig.getCredentialMetadata().getClaims().stream()
                 .map(Claim::getPath)
                 .toList();
-        assertTrue(actualPaths.stream().anyMatch(List.of("org.iso.18013.5.1", "address", "street")::equals),
+        assertTrue(actualPaths.stream().anyMatch(List.of("org.example.credential", "address", "street")::equals),
                 "Expected nested mDoc path in " + actualPaths);
 
         OID4VCTestContext ctx = new OID4VCTestContext(client, scope);
@@ -96,7 +96,7 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
         Object credential = credentialResponse.getCredentialResponse().getCredentials().get(0).getCredential();
         String encodedIssuerSigned = assertInstanceOf(String.class, credential);
         Map<String, Object> nameSpaces = getMdocNamespaces(encodedIssuerSigned);
-        Map<?, ?> namespaceClaims = assertInstanceOf(Map.class, nameSpaces.get("org.iso.18013.5.1"));
+        Map<?, ?> namespaceClaims = assertInstanceOf(Map.class, nameSpaces.get("org.example.credential"));
         Map<?, ?> addressClaim = assertInstanceOf(Map.class, namespaceClaims.get("address"));
         assertEquals("221B Baker Street", addressClaim.get("street"));
     }
@@ -106,27 +106,27 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
         ensureEcSigningKeyProvider("mdoc-vc-level-mapper-issuer-key", "P-256", "ES256", 200);
 
         ProtocolMapperRepresentation nameMapper =
-                ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1");
+                ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential");
         nameMapper.getConfig().put(CredentialScopeModel.VC_INCLUDE_IN_METADATA, "true");
 
         ProtocolMapperRepresentation issuedAtMapper =
                 ProtocolMapperUtils.getIssuedAtTimeMapper("iat", null, "COMPUTE");
         issuedAtMapper.setConfig(new HashMap<>(issuedAtMapper.getConfig()));
         issuedAtMapper.getConfig().put(CredentialScopeModel.VC_INCLUDE_IN_METADATA, "true");
-        issuedAtMapper.getConfig().put(OID4VCMapper.MDOC_NAMESPACE, "org.iso.18013.5.1");
+        issuedAtMapper.getConfig().put(OID4VCMapper.MDOC_NAMESPACE, "org.example.credential");
 
         ProtocolMapperRepresentation contextMapper = ProtocolMapperUtils.getProtocolMapper(
                 "context-mapper", "oid4vc-context-mapper", new HashMap<>(Map.of(
                         OID4VCContextMapper.TYPE_KEY, "https://www.w3.org/2018/credentials/v1",
                         CredentialScopeModel.VC_INCLUDE_IN_METADATA, "true",
-                        OID4VCMapper.MDOC_NAMESPACE, "org.iso.18013.5.1"
+                        OID4VCMapper.MDOC_NAMESPACE, "org.example.credential"
                 )));
 
         ProtocolMapperRepresentation typeMapper = ProtocolMapperUtils.getProtocolMapper(
                 "type-mapper", "oid4vc-vc-type-mapper", new HashMap<>(Map.of(
                         OID4VCTypeMapper.TYPE_KEY, "VerifiableCredential",
                         CredentialScopeModel.VC_INCLUDE_IN_METADATA, "true",
-                        OID4VCMapper.MDOC_NAMESPACE, "org.iso.18013.5.1"
+                        OID4VCMapper.MDOC_NAMESPACE, "org.example.credential"
                 )));
 
         CredentialScopeRepresentation scope = createCustomMdocCredentialScope(
@@ -142,8 +142,8 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
         List<List<String>> claimPaths = supportedConfig.getCredentialMetadata().getClaims().stream()
                 .map(Claim::getPath)
                 .toList();
-        assertTrue(claimPaths.contains(List.of("org.iso.18013.5.1", "given_name")));
-        assertFalse(claimPaths.contains(List.of("org.iso.18013.5.1", "iat")));
+        assertTrue(claimPaths.contains(List.of("org.example.credential", "given_name")));
+        assertFalse(claimPaths.contains(List.of("org.example.credential", "iat")));
         assertFalse(claimPaths.contains(List.of("context")));
         assertFalse(claimPaths.contains(List.of("type")));
 
@@ -175,9 +175,9 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
         Object credential = credentialResponse.getCredentialResponse().getCredentials().get(0).getCredential();
         String encodedIssuerSigned = assertInstanceOf(String.class, credential);
         Map<String, Object> nameSpaces = getMdocNamespaces(encodedIssuerSigned);
-        assertTrue(nameSpaces.containsKey("org.iso.18013.5.1"));
+        assertTrue(nameSpaces.containsKey("org.example.credential"));
         assertFalse(nameSpaces.containsKey("iat"), "VC-level iat mapper must not become an mDoc namespace");
-        Map<?, ?> namespaceClaims = assertInstanceOf(Map.class, nameSpaces.get("org.iso.18013.5.1"));
+        Map<?, ?> namespaceClaims = assertInstanceOf(Map.class, nameSpaces.get("org.example.credential"));
         assertFalse(namespaceClaims.containsKey("iat"));
         assertFalse(namespaceClaims.containsKey("context"));
         assertFalse(namespaceClaims.containsKey("type"));
@@ -187,8 +187,8 @@ public class OID4VCMdocMapperTest extends OID4VCMdocTestBase {
     public void testSameElementIdentifierInDistinctNamespacesKeepsSeparateValues() {
         ensureEcSigningKeyProvider("mdoc-namespace-collision-issuer-key", "P-256", "ES256", 200);
 
-        String namespaceA = "org.iso.18013.5.1";
-        String namespaceB = "org.iso.18013.5.1.aamva";
+        String namespaceA = "org.example.credential";
+        String namespaceB = "org.example.credential.other";
 
         // Two mappers emit the same mDoc element identifier into different namespaces from distinct user attributes.
         ProtocolMapperRepresentation givenNameInA =

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocTestBase.java
@@ -82,9 +82,9 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
                 scopeName,
                 credentialConfigurationId,
                 List.of(
-                        ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1"),
-                        ProtocolMapperUtils.getUserAttributeMapper("family_name", "lastName", "org.iso.18013.5.1"),
-                        ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.iso.18013.5.1")
+                        ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.example.credential"),
+                        ProtocolMapperUtils.getUserAttributeMapper("family_name", "lastName", "org.example.credential"),
+                        ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.example.credential")
                 ),
                 "ES256",
                 true
@@ -204,8 +204,8 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
         assertFalse(encodedIssuerSigned.isBlank(), "mDoc credential response must contain a base64url payload");
 
         Map<String, Object> nameSpaces = getMdocNamespacesFromCredential(encodedIssuerSigned);
-        assertTrue(nameSpaces.containsKey("org.iso.18013.5.1"), "mDoc payload must include the configured namespace");
-        Map<?, ?> namespaceClaims = assertInstanceOf(Map.class, nameSpaces.get("org.iso.18013.5.1"));
+        assertTrue(nameSpaces.containsKey("org.example.credential"), "mDoc payload must include the configured namespace");
+        Map<?, ?> namespaceClaims = assertInstanceOf(Map.class, nameSpaces.get("org.example.credential"));
         assertTrue(namespaceClaims.containsKey("given_name"), "mDoc payload must contain the given_name claim");
         assertTrue(namespaceClaims.containsKey("id"), "mDoc payload must contain the id claim");
 
@@ -222,7 +222,7 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
         assertInstanceOf(String.class, credential, "mDoc credential should be a string");
 
         Map<String, Object> nameSpaces = getMdocNamespacesFromCredential((String) credential);
-        assertTrue(nameSpaces.containsKey("org.iso.18013.5.1"));
+        assertTrue(nameSpaces.containsKey("org.example.credential"));
 
         Map<String, Object> mobileSecurityObject = getMdocMobileSecurityObjectFromCredential((String) credential);
         assertEquals(mdocTypeCredentialDocType, mobileSecurityObject.get("docType"));

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocTestBase.java
@@ -54,14 +54,16 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
     public static class VCTestServerWithMdocEnabled implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_MDOC);
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_MDOC)
+                    .spiOption("keys", "java-keystore", "keystores-path", MdocTestSigningKey.keystoresBaseDir());
         }
     }
 
     public static class VCTestServerWithPreAuthCodeAndMdocEnabled implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_VCI_REST_CREDENTIAL_OFFER, Profile.Feature.OID4VC_VCI_PREAUTH_CODE, Profile.Feature.OID4VC_MDOC);
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_VCI_REST_CREDENTIAL_OFFER, Profile.Feature.OID4VC_VCI_PREAUTH_CODE, Profile.Feature.OID4VC_MDOC)
+                    .spiOption("keys", "java-keystore", "keystores-path", MdocTestSigningKey.keystoresBaseDir());
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/OID4VCMdocAuthorizationCodeFlowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/OID4VCMdocAuthorizationCodeFlowTest.java
@@ -41,7 +41,7 @@ public class OID4VCMdocAuthorizationCodeFlowTest extends OID4VCAuthorizationCode
 
     @Override
     protected List<Object> getExpectedClaimPath() {
-        return List.of("org.iso.18013.5.1", "family_name");
+        return List.of("org.example.credential", "family_name");
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCMdocAuthorizationDetailsFlowPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCMdocAuthorizationDetailsFlowPreAuthTest.java
@@ -41,12 +41,12 @@ public class OID4VCMdocAuthorizationDetailsFlowPreAuthTest extends OID4VCAuthori
 
     @Override
     protected List<Object> getExpectedClaimPath() {
-        return List.of("org.iso.18013.5.1", "given_name");
+        return List.of("org.example.credential", "given_name");
     }
 
     @Override
     protected String getClaimsNamespace() {
-        return "org.iso.18013.5.1";
+        return "org.example.credential";
     }
 
     @Override

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
@@ -89,8 +89,10 @@ public class VciConformanceRealmConfig implements RealmConfig {
     public static final String CREDENTIAL_CONFIGURATION_ID = "conformance_sd_jwt_vc";
     public static final String MDOC_SCOPE = "conformance_mso_mdoc";
     public static final String MDOC_CREDENTIAL_CONFIGURATION_ID = "conformance_mso_mdoc";
-    public static final String MDOC_DOC_TYPE = "org.iso.18013.5.1.mDL";
-    public static final String MDOC_NAMESPACE = "org.iso.18013.5.1";
+    // An example doctype rather than org.iso.18013.5.1.mDL because Keycloak does not issue real mDLs
+    // and the suite would otherwise require all mandatory mDL data elements from ISO 18013 chapter 5
+    public static final String MDOC_DOC_TYPE = "org.example.conformance.mdoc";
+    public static final String MDOC_NAMESPACE = "org.example.conformance";
     // The credential_format plan variant value the conformance suite uses for ISO mdoc, see VCI1FinalCredentialFormat
     public static final String MDOC_CREDENTIAL_FORMAT_VARIANT = "mdoc";
     public static final String CONFORMANCE_CALLBACK = OpenIdConformanceSuite.INTERNAL_BASE_URI + "/test/a/keycloak/callback";
@@ -309,10 +311,7 @@ public class VciConformanceRealmConfig implements RealmConfig {
                         OID4VCIssuedAtTimeClaimMapper.VALUE_SOURCE, "COMPUTE")));
     }
 
-    // mDoc claims are organised into namespaces, so every mapper pins the ISO 18013-5 namespace. ISO/IEC
-    // 18013-5 marks a fixed set of org.iso.18013.5.1 data elements mandatory for an mDL, so a conformant
-    // issuer must emit all of them (the suite's EnsureMdocMdlMandatoryDataElementsPresent check enforces this).
-    // The holder-specific ones come from user attributes; the rest are static document values.
+    // mDoc claims are organised into namespaces, so every mapper pins the example namespace
     private List<ProtocolMapperRepresentation> mdocProtocolMappers() {
         return List.of(
                 mdocMapper("did-mapper", "oid4vc-subject-id-mapper", "id", "did"),

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciTestSigningKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciTestSigningKey.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -37,18 +38,28 @@ import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.def.DefaultCryptoProvider;
 import org.keycloak.tests.conformance.ConformanceSigningKey;
 
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.CRLDistPoint;
+import org.bouncycastle.asn1.x509.DistributionPoint;
+import org.bouncycastle.asn1.x509.DistributionPointName;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 // Not using org.keycloak.common.util.CertificateUtils as its leaf certificates are CA capable, which strict
-// trust chain validation rejects for an issuer signing certificate
+// trust chain validation rejects for an issuer signing certificate. The certificates follow the ISO/IEC 18013
+// part 5 certificate profiles the suite validates against.
 final class VciTestSigningKey {
 
     static final String KEY_ALIAS = "oid4vci-conformance-signing";
@@ -58,6 +69,12 @@ final class VciTestSigningKey {
     private static final String CA_CERTIFICATE_PEM;
 
     private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static final KeyPurposeId MDOC_DS_KEY_PURPOSE =
+            KeyPurposeId.getInstance(new ASN1ObjectIdentifier("1.0.18013.5.1.2"));
+
+    private static final GeneralNames ISSUER_CONTACT = new GeneralNames(
+            new GeneralName(GeneralName.rfc822Name, "oid4vci-conformance@example.com"));
 
     static {
         try {
@@ -70,8 +87,9 @@ final class VciTestSigningKey {
             KeyPair caKeyPair = keyGenerator.generateKeyPair();
             KeyPair leafKeyPair = keyGenerator.generateKeyPair();
 
-            X509Certificate caCertificate = generateCaCertificate(caKeyPair);
-            X509Certificate leafCertificate = generateLeafCertificate(leafKeyPair, caKeyPair, caCertificate);
+            X500Name caName = new X500Name("C=DE,CN=OID4VCI Conformance CA");
+            X509Certificate caCertificate = generateCaCertificate(caName, caKeyPair);
+            X509Certificate leafCertificate = generateLeafCertificate(caName, leafKeyPair, caKeyPair, caCertificate);
 
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
             keyStore.load(null, null);
@@ -104,33 +122,50 @@ final class VciTestSigningKey {
         return CA_CERTIFICATE_PEM;
     }
 
-    private static X509Certificate generateCaCertificate(KeyPair caKeyPair) throws Exception {
-        X500Name caName = new X500Name("CN=OID4VCI Conformance CA");
-        X509v3CertificateBuilder builder = certificateBuilder(caName, caName, caKeyPair);
-        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+    private static X509Certificate generateCaCertificate(X500Name caName, KeyPair caKeyPair) throws Exception {
+        X509v3CertificateBuilder builder = certificateBuilder(caName, caName, caKeyPair.getPublic());
+        JcaX509ExtensionUtils extensionUtils = new JcaX509ExtensionUtils();
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(0));
         builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        builder.addExtension(Extension.subjectKeyIdentifier, false,
+                extensionUtils.createSubjectKeyIdentifier(caKeyPair.getPublic()));
+        builder.addExtension(Extension.issuerAlternativeName, false, ISSUER_CONTACT);
+        builder.addExtension(Extension.cRLDistributionPoints, false, crlDistributionPoints());
         return sign(builder, caKeyPair);
     }
 
-    private static X509Certificate generateLeafCertificate(KeyPair leafKeyPair, KeyPair caKeyPair,
+    private static X509Certificate generateLeafCertificate(X500Name caName, KeyPair leafKeyPair, KeyPair caKeyPair,
             X509Certificate caCertificate) throws Exception {
-        X500Name caName = new X500Name(caCertificate.getSubjectX500Principal().getName());
-        X500Name leafName = new X500Name("CN=OID4VCI Conformance Issuer");
-        X509v3CertificateBuilder builder = certificateBuilder(caName, leafName, leafKeyPair);
-        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+        X500Name leafName = new X500Name("C=DE,CN=OID4VCI Conformance Issuer");
+        X509v3CertificateBuilder builder = certificateBuilder(caName, leafName, leafKeyPair.getPublic());
+        JcaX509ExtensionUtils extensionUtils = new JcaX509ExtensionUtils();
         builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+        builder.addExtension(Extension.extendedKeyUsage, true, new ExtendedKeyUsage(MDOC_DS_KEY_PURPOSE));
+        builder.addExtension(Extension.subjectKeyIdentifier, false,
+                extensionUtils.createSubjectKeyIdentifier(leafKeyPair.getPublic()));
+        builder.addExtension(Extension.authorityKeyIdentifier, false,
+                extensionUtils.createAuthorityKeyIdentifier(caCertificate));
+        builder.addExtension(Extension.issuerAlternativeName, false, ISSUER_CONTACT);
+        builder.addExtension(Extension.cRLDistributionPoints, false, crlDistributionPoints());
         return sign(builder, caKeyPair);
     }
 
-    private static X509v3CertificateBuilder certificateBuilder(X500Name issuer, X500Name subject, KeyPair keyPair) {
+    private static CRLDistPoint crlDistributionPoints() {
+        GeneralNames crlUri = new GeneralNames(new GeneralName(
+                GeneralName.uniformResourceIdentifier, "https://example.com/oid4vci-conformance.crl"));
+        return new CRLDistPoint(new DistributionPoint[] {
+                new DistributionPoint(new DistributionPointName(crlUri), null, null) });
+    }
+
+    private static X509v3CertificateBuilder certificateBuilder(X500Name issuer, X500Name subject, PublicKey publicKey) {
         Instant now = Instant.now();
-        return new X509v3CertificateBuilder(
+        return new JcaX509v3CertificateBuilder(
                 issuer,
-                new BigInteger(160, RANDOM),
+                new BigInteger(159, RANDOM),
                 Date.from(now.minus(1, ChronoUnit.DAYS)),
                 Date.from(now.plus(365, ChronoUnit.DAYS)),
                 subject,
-                SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
+                publicKey);
     }
 
     private static X509Certificate sign(X509v3CertificateBuilder builder, KeyPair signingKeyPair) throws Exception {


### PR DESCRIPTION
@mposolda @VinodAnandan Fixes conformance tests which check for mandatory mDL (driving license) claims if mDL-namespace is used for test data (also changed this for unit tests for consistency, as well as a minor problem with display locale which failed another conformance test).

@VinodAnandan also asked me to update to latest conformance suite version. This tightens the checks for mdoc signatures, which needed a few changes as well.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
