### PR TITLE
Adding maintainer affiliations

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 * [Marek Posolda](https://github.com/mposolda) (IBM)
 * [Pedro Igor](https://github.com/pedroigor) (IBM)
 * [Ricardo Martin](https://github.com/rmartinc) (IBM)
-* [Sebastian Schuster](https://github.com/sschu) (Bosch)
+* [Sebastian Schuster](https://github.com/sschu) (Robert Bosch GmbH)
 * [Stan Silvert](https://github.com/ssilvert) (IBM)
 * [Steven Hawkins](https://github.com/shawkins) (IBM)
 * [Stian Thorgersen](https://github.com/stianst) (IBM) (project lead)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,16 +1,16 @@
 # Active maintainers
 
-* [Alexander Schwartz](https://github.com/ahus1)
-* [Marek Posolda](https://github.com/mposolda)
-* [Pedro Igor](https://github.com/pedroigor)
-* [Ricardo Martin](https://github.com/rmartinc)
-* [Sebastian Schuster](https://github.com/sschu)
-* [Stan Silvert](https://github.com/ssilvert)
-* [Steven Hawkins](https://github.com/shawkins)
-* [Stian Thorgersen](https://github.com/stianst) (project lead)
-* [Takashi Norimatsu](https://github.com/tnorimat)
-* [Thomas Darimont](https://github.com/thomasdarimont)
-* [Václav Muzikář](https://github.com/vmuzikar)
+* [Alexander Schwartz](https://github.com/ahus1) (IBM)
+* [Marek Posolda](https://github.com/mposolda) (IBM)
+* [Pedro Igor](https://github.com/pedroigor) (IBM)
+* [Ricardo Martin](https://github.com/rmartinc) (IBM)
+* [Sebastian Schuster](https://github.com/sschu) (Bosch)
+* [Stan Silvert](https://github.com/ssilvert) (IBM)
+* [Steven Hawkins](https://github.com/shawkins) (IBM)
+* [Stian Thorgersen](https://github.com/stianst) (IBM) (project lead)
+* [Takashi Norimatsu](https://github.com/tnorimat) (Hitachi, Ltd.)
+* [Thomas Darimont](https://github.com/thomasdarimont) (Identity Tailor GmbH)
+* [Václav Muzikář](https://github.com/vmuzikar) (IBM)
 
 # Emeritus maintainers
 


### PR DESCRIPTION
This adds affiliations of maintainers similar to [Cilium](https://github.com/cilium/cilium/blob/main/MAINTAINERS.md) which is a graduated CNCF project.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
