### PR TITLE
Fix attribute-group localization cleanup and share deletion logic

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupTab.tsx
@@ -14,6 +14,7 @@ import { Action, KeycloakDataTable } from "@keycloak/keycloak-ui-shared";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toEditAttributesGroup } from "../routes/EditAttributesGroup";
 import { toNewAttributesGroup } from "../routes/NewAttributesGroup";
+import { deleteLocalizationKeys } from "./localization";
 import { useUserProfile } from "./UserProfileContext";
 import useLocale from "../../utils/useLocale";
 import { useAdminClient } from "../../admin-client";
@@ -55,51 +56,20 @@ export const AttributesGroupTab = ({
     continueButtonVariant: ButtonVariant.danger,
     onConfirm: async () => {
       const groups = (config?.groups ?? []).filter(
-        (group) => group !== groupToDelete,
+        (group) => group.name !== groupToDelete?.name,
       );
-      const translationsForDisplayHeaderToDelete =
-        groupToDelete?.displayHeader?.substring(
-          2,
-          groupToDelete.displayHeader.length - 1,
-        );
-      const translationsForDisplayDescriptionToDelete =
-        groupToDelete?.displayDescription?.substring(
-          2,
-          groupToDelete.displayDescription.length - 1,
-        );
 
       try {
-        await Promise.all(
-          combinedLocales.map(async (locale) => {
-            try {
-              await adminClient.realms.getRealmLocalizationTexts({
-                realm,
-                selectedLocale: locale,
-              });
-
-              await adminClient.realms.deleteRealmLocalizationTexts({
-                realm,
-                selectedLocale: locale,
-                key: translationsForDisplayHeaderToDelete,
-              });
-
-              await adminClient.realms.deleteRealmLocalizationTexts({
-                realm,
-                selectedLocale: locale,
-                key: translationsForDisplayDescriptionToDelete,
-              });
-
-              const updatedData =
-                await adminClient.realms.getRealmLocalizationTexts({
-                  realm,
-                  selectedLocale: locale,
-                });
-              setTableData([updatedData]);
-            } catch {
-              console.error(`Error removing translations for ${locale}`);
-            }
-          }),
-        );
+        await deleteLocalizationKeys({
+          adminClient,
+          realm,
+          locales: combinedLocales,
+          translationValues: [
+            groupToDelete?.displayHeader,
+            groupToDelete?.displayDescription,
+          ],
+          setTableData,
+        });
 
         await save(
           { ...config, groups },

--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesTab.tsx
@@ -23,6 +23,7 @@ import useLocale from "../../utils/useLocale";
 import useToggle from "../../utils/useToggle";
 import { toAddAttribute } from "../routes/AddAttribute";
 import { toAttribute } from "../routes/Attribute";
+import { deleteLocalizationKeys } from "./localization";
 import { useUserProfile } from "./UserProfileContext";
 
 const RESTRICTED_ATTRIBUTES = ["username", "email"];
@@ -61,42 +62,16 @@ export const AttributesTab = ({ setTableData }: AttributesTabProps) => {
       const translationsToDelete = config.attributes.find(
         (attribute) => attribute.name === attributeToDelete,
       )?.displayName;
-
-      // Remove the the `${}` from translationsToDelete string
-      const formattedTranslationsToDelete = translationsToDelete?.substring(
-        2,
-        translationsToDelete.length - 1,
-      );
+      const translationValueToDelete = translationsToDelete;
 
       try {
-        await Promise.all(
-          combinedLocales.map(async (locale) => {
-            try {
-              const response =
-                (await adminClient.realms.getRealmLocalizationTexts({
-                  realm,
-                  selectedLocale: locale,
-                })) as Record<string, string> | undefined;
-
-              if (response) {
-                await adminClient.realms.deleteRealmLocalizationTexts({
-                  realm,
-                  selectedLocale: locale,
-                  key: formattedTranslationsToDelete,
-                });
-
-                const updatedData =
-                  await adminClient.realms.getRealmLocalizationTexts({
-                    realm,
-                    selectedLocale: locale,
-                  });
-                setTableData([updatedData]);
-              }
-            } catch {
-              console.error(`Error removing translations for ${locale}`);
-            }
-          }),
-        );
+        await deleteLocalizationKeys({
+          adminClient,
+          realm,
+          locales: combinedLocales,
+          translationValues: [translationValueToDelete],
+          setTableData,
+        });
 
         const updatedAttributes = config.attributes.filter(
           (attribute) => attribute.name !== attributeToDelete,

--- a/js/apps/admin-ui/src/realm-settings/user-profile/localization.ts
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/localization.ts
@@ -1,0 +1,80 @@
+import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
+import type { Dispatch, SetStateAction } from "react";
+
+type DeleteLocalizationKeysProps = {
+  adminClient: KeycloakAdminClient;
+  realm: string;
+  locales: string[];
+  translationValues: Array<string | undefined>;
+  setTableData: Dispatch<SetStateAction<Record<string, string>[] | undefined>>;
+};
+
+export const getTranslationKey = (value?: string): string | undefined => {
+  if (!value?.startsWith("${") || !value.endsWith("}")) {
+    return undefined;
+  }
+
+  const translationKey = value.slice(2, -1).trim();
+  return translationKey.length > 0 ? translationKey : undefined;
+};
+
+export const deleteLocalizationKeys = async ({
+  adminClient,
+  realm,
+  locales,
+  translationValues,
+  setTableData,
+}: DeleteLocalizationKeysProps) => {
+  const keysToDelete = [
+    ...new Set(
+      translationValues
+        .map(getTranslationKey)
+        .filter((key): key is string => Boolean(key)),
+    ),
+  ];
+
+  if (keysToDelete.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    locales.map(async (locale) => {
+      try {
+        const localeMessages =
+          (await adminClient.realms.getRealmLocalizationTexts({
+            realm,
+            selectedLocale: locale,
+          })) as Record<string, string> | undefined;
+
+        if (!localeMessages) {
+          return;
+        }
+
+        const localeKeysToDelete = keysToDelete.filter(
+          (key) => key in localeMessages,
+        );
+        if (localeKeysToDelete.length === 0) {
+          return;
+        }
+
+        await Promise.all(
+          localeKeysToDelete.map((key) =>
+            adminClient.realms.deleteRealmLocalizationTexts({
+              realm,
+              selectedLocale: locale,
+              key,
+            }),
+          ),
+        );
+
+        const updatedData = await adminClient.realms.getRealmLocalizationTexts({
+          realm,
+          selectedLocale: locale,
+        });
+        setTableData([updatedData]);
+      } catch {
+        console.error(`Error removing translations for ${locale}`);
+      }
+    }),
+  );
+};

--- a/js/apps/admin-ui/src/realm-settings/user-profile/localization.ts
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/localization.ts
@@ -14,8 +14,8 @@ export const getTranslationKey = (value?: string): string | undefined => {
     return undefined;
   }
 
-  const translationKey = value.slice(2, -1).trim();
-  return translationKey.length > 0 ? translationKey : undefined;
+  const translationKey = value.slice(2, -1);
+  return translationKey.trim().length > 0 ? translationKey : undefined;
 };
 
 export const deleteLocalizationKeys = async ({

--- a/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
@@ -126,6 +126,34 @@ test.describe.serial("User profile tabs", () => {
         "No validators.",
       );
     });
+
+    test("Keeps realm overrides when deleting an attribute without a translation key", async ({
+      page,
+    }) => {
+      const attributeWithoutDisplayName = "NoTranslationKey";
+      await adminClient.addLocalizationText(
+        "en",
+        "loginAccountTitle",
+        "My Custom Login",
+        realmName,
+      );
+
+      await clickCreateAttribute(page);
+      await fillAttributeForm(page, { name: attributeWithoutDisplayName });
+      await clickSaveAttribute(page);
+      await assertNotificationMessage(
+        page,
+        "Success! User Profile configuration has been saved.",
+      );
+
+      await clickRowKebabItem(page, attributeWithoutDisplayName, "Delete");
+      await confirmModal(page);
+      await assertNotificationMessage(page, "Attribute deleted");
+
+      expect(await adminClient.getLocalizationTexts("en", realmName)).toEqual({
+        loginAccountTitle: "My Custom Login",
+      });
+    });
   });
 
   test("Deletes an attributes group", async ({ page }) => {
@@ -133,6 +161,31 @@ test.describe.serial("User profile tabs", () => {
     await clickRowKebabItem(page, group, "Delete");
     await confirmModal(page);
     await assertRowExists(page, group, false);
+  });
+
+  test("Keeps realm overrides when deleting an attribute group without translation keys", async ({
+    page,
+  }) => {
+    const groupWithoutTranslation = `group-without-translation-${uuid()}`;
+    await adminClient.addLocalizationText(
+      "en",
+      "loginAccountTitle",
+      "My Custom Login",
+      realmName,
+    );
+
+    await goToAttributeGroupsTab(page);
+    await page.getByTestId("create-attributes-groups-action").click();
+    await page.getByTestId("name").fill(groupWithoutTranslation);
+    await page.getByTestId("saveGroupBtn").click();
+
+    await clickRowKebabItem(page, groupWithoutTranslation, "Delete");
+    await confirmModal(page);
+    await assertRowExists(page, groupWithoutTranslation, false);
+
+    expect(await adminClient.getLocalizationTexts("en", realmName)).toEqual({
+      loginAccountTitle: "My Custom Login",
+    });
   });
 
   test("Checks that not required attribute is not present when user is created with email as username and edit username set to disabled", async ({

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -388,6 +388,17 @@ class AdminClient {
     );
   }
 
+  async getLocalizationTexts(
+    locale: string,
+    realm: string = this.#client.realmName,
+  ) {
+    await this.#login();
+    return await this.#client.realms.getRealmLocalizationTexts({
+      realm,
+      selectedLocale: locale,
+    });
+  }
+
   async removeAllLocalizationTexts() {
     await this.#login();
     const localesWithTexts = await this.#client.realms.getRealmSpecificLocales({


### PR DESCRIPTION
## Summary
- add a shared user-profile localization helper that only extracts/deletes valid `${...}` translation keys
- reuse the shared helper in both `AttributesTab` and `AttributesGroupTab` delete flows to avoid locale-wide message deletion
- add a regression test that verifies deleting an attribute group without translation keys preserves existing realm override messages

Related to https://github.com/keycloak/keycloak/issues/51496