### PR TITLE
(26.6) Read the user managed access flag from the updated realm delegate

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -184,7 +184,7 @@ public class RealmAdapter implements CachedRealmModel {
 
     @Override
     public boolean isUserManagedAccessAllowed() {
-        if (isUpdated()) return updated.isEnabled();
+        if (isUpdated()) return updated.isUserManagedAccessAllowed();
         return cached.isAllowUserManagedAccess();
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/model/CacheTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/CacheTest.java
@@ -90,6 +90,26 @@ public class CacheTest {
     }
 
     @Test
+    public void testUserManagedAccessAllowedReadAfterRealmUpdated() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            assertTrue(realm instanceof RealmAdapter);
+            assertTrue(realm.isEnabled());
+            Assertions.assertFalse(realm.isUserManagedAccessAllowed());
+
+            // any update to the realm makes the following reads go through the updated delegate
+            realm.setDisplayName("cache-test");
+            Assertions.assertFalse(realm.isUserManagedAccessAllowed());
+
+            realm.setUserManagedAccessAllowed(true);
+            assertTrue(realm.isUserManagedAccessAllowed());
+
+            realm.setUserManagedAccessAllowed(false);
+            realm.setDisplayName(null);
+        });
+    }
+
+    @Test
     public void testAddUserNotAddedToCache() {
 
     	runOnServer.run(session -> {


### PR DESCRIPTION
Backport of #52177 to `release/26.6`, as requested in https://github.com/keycloak/keycloak/issues/52172#issuecomment-5478958053
