### PR TITLE
(26.7) Do not persist the computed realm_client client attribute

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -547,6 +547,10 @@ public class RepresentationToModel {
         // Extended client attributes
         if (rep.getAttributes() != null) {
             for (Map.Entry<String, String> entry : rep.getAttributes().entrySet()) {
+                // realm_client is computed when a client is converted to a representation, it must not be stored
+                if (Constants.REALM_CLIENT.equals(entry.getKey())) {
+                    continue;
+                }
                 clientPropertyUpdates.add(
                     updatePropertyAction(val -> client.setAttribute(entry.getKey(), val), entry::getValue));
             }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -51,7 +51,9 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.CibaConfig;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.SystemClientUtil;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
@@ -83,6 +85,8 @@ import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.RoleBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.Assert;
@@ -146,6 +150,9 @@ public class ClientTest {
     @InjectAdminEvents(realmRef = "default")
     AdminEvents adminEvents;
 
+    @InjectRunOnServer(realmRef = "default")
+    RunOnServerClient runOnServer;
+
     @Test
     public void getClients() {
         Assert.assertNames(managedRealm.admin().clients().findAll(), "account", "account-console", "realm-management", "security-admin-console", "broker", "test-app", Constants.ADMIN_CLI_CLIENT_ID);
@@ -156,6 +163,28 @@ public class ClientTest {
         assertTrue(managedRealm.admin().clients().findAll().stream().filter(client -> client.getAttributes().get(Constants.REALM_CLIENT).equals("true"))
                 .map(ClientRepresentation::getClientId)
                 .allMatch(clientId -> clientId.equals(Constants.REALM_MANAGEMENT_CLIENT_ID) || clientId.equals(Constants.BROKER_SERVICE_CLIENT_ID) || clientId.endsWith("-realm")));
+    }
+
+    @Test
+    public void realmClientAttributeIsNotPersistedOnUpdate() {
+        ClientRepresentation client = createClient();
+        ClientResource clientResource = managedRealm.admin().clients().get(client.getId());
+
+        ClientRepresentation stored = clientResource.toRepresentation();
+        assertThat(stored.getAttributes(), Matchers.hasEntry(Constants.REALM_CLIENT, "false"));
+
+        // write the representation straight back, changing nothing
+        clientResource.update(stored);
+        adminEvents.poll();
+
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("default");
+            ClientModel clientModel = realm.getClientByClientId("my-app");
+            Assertions.assertFalse(clientModel.getAttributes().containsKey(Constants.REALM_CLIENT));
+        });
+
+        // the attribute is still computed for every read
+        assertThat(clientResource.toRepresentation().getAttributes(), Matchers.hasEntry(Constants.REALM_CLIENT, "false"));
     }
 
     private ClientRepresentation createClient() {


### PR DESCRIPTION
Backport of #52178 to `release/26.7`, as requested in https://github.com/keycloak/keycloak/issues/52173#issuecomment-5479114823

Closes https://github.com/keycloak/keycloak/issues/52173
