### PR TITLE
Enforce UP validation when managing users

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/spi/AbstractScimResourceTypeProvider.java
@@ -62,6 +62,10 @@ public abstract class AbstractScimResourceTypeProvider<M extends Model, R extend
             throw new ForbiddenException();
         }
 
+        applyPatch(existing, model, operations);
+    }
+
+    protected void applyPatch(R existing, M model, List<PatchOperation> operations) {
         for (PatchOperation operation : operations) {
             String op = operation.getOp();
 

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserModelAttributeRecorder.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserModelAttributeRecorder.java
@@ -1,0 +1,97 @@
+package org.keycloak.scim.model.user;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.UserModelDelegate;
+
+public class UserModelAttributeRecorder extends UserModelDelegate {
+
+    private final Map<String, List<String>> attributes;
+
+    public UserModelAttributeRecorder(UserModel delegate, Map<String, List<String>> attributes) {
+        super(delegate);
+        this.attributes = attributes;
+    }
+
+    @Override
+    public void setSingleAttribute(String name, String value) {
+        attributes.put(name, value == null ? List.of() : List.of(value));
+    }
+
+    @Override
+    public void setAttribute(String name, List<String> values) {
+        attributes.put(name, values == null ? List.of() : new ArrayList<>(values));
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        attributes.put(name, List.of());
+    }
+
+    @Override
+    public void setUsername(String username) {
+        setSingleAttribute(UserModel.USERNAME, username);
+    }
+
+    @Override
+    public void setEmail(String email) {
+        setSingleAttribute(UserModel.EMAIL, email);
+    }
+
+    @Override
+    public void setFirstName(String firstName) {
+        setSingleAttribute(UserModel.FIRST_NAME, firstName);
+    }
+
+    @Override
+    public void setLastName(String lastName) {
+        setSingleAttribute(UserModel.LAST_NAME, lastName);
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        if (attributes.containsKey(name)) {
+            return attributes.get(name).stream();
+        }
+        return super.getAttributeStream(name);
+    }
+
+    @Override
+    public String getFirstAttribute(String name) {
+        if (attributes.containsKey(name)) {
+            List<String> values = attributes.get(name);
+            return values.isEmpty() ? null : values.get(0);
+        }
+        return super.getFirstAttribute(name);
+    }
+
+    @Override
+    public Map<String, List<String>> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    @Override
+    public String getUsername() {
+        return attributes.containsKey(UserModel.USERNAME) ? getFirstAttribute(UserModel.USERNAME) : super.getUsername();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.containsKey(UserModel.EMAIL) ? getFirstAttribute(UserModel.EMAIL) : super.getEmail();
+    }
+
+    @Override
+    public String getFirstName() {
+        return attributes.containsKey(UserModel.FIRST_NAME) ? getFirstAttribute(UserModel.FIRST_NAME) : super.getFirstName();
+    }
+
+    @Override
+    public String getLastName() {
+        return attributes.containsKey(UserModel.LAST_NAME) ? getFirstAttribute(UserModel.LAST_NAME) : super.getLastName();
+    }
+}

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserResourceTypeProvider.java
@@ -1,6 +1,7 @@
 package org.keycloak.scim.model.user;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,9 +35,12 @@ import org.keycloak.scim.filter.ScimFilterParser;
 import org.keycloak.scim.filter.ScimFilterParser.FilterContext;
 import org.keycloak.scim.model.filter.ScimAttributeJpaExpressionResolver;
 import org.keycloak.scim.model.filter.ScimJPAPredicateEvaluator;
+import org.keycloak.scim.protocol.ForbiddenException;
+import org.keycloak.scim.protocol.request.PatchRequest.PatchOperation;
 import org.keycloak.scim.protocol.request.SearchRequest;
 import org.keycloak.scim.resource.schema.attribute.Attribute;
 import org.keycloak.scim.resource.spi.AbstractScimResourceTypeProvider;
+import org.keycloak.scim.resource.spi.ScimPatchException;
 import org.keycloak.scim.resource.user.User;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.userprofile.UserProfile;
@@ -47,6 +51,7 @@ import org.keycloak.userprofile.ValidationException.Error;
 
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
+import static org.keycloak.utils.StringUtil.isBlank;
 
 public class UserResourceTypeProvider extends AbstractScimResourceTypeProvider<UserModel, User> implements ScimAttributeJpaExpressionResolver {
 
@@ -62,39 +67,94 @@ public class UserResourceTypeProvider extends AbstractScimResourceTypeProvider<U
     @Override
     public User onCreate(User resource) {
         UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
-        String userName = resource.getUserName();
+        RealmModel realm = session.getContext().getRealm();
+        String username = realm.isRegistrationEmailAsUsername() ? resource.getEmail() : resource.getUserName();
 
-        if (userName == null) {
-            throw new ModelValidationException("username is required");
+        if (username == null) {
+            throw new ModelValidationException(realm.isRegistrationEmailAsUsername() ? "email is required" : "username is required");
         }
 
-        UserProfile profile = provider.create(UserProfileContext.SCIM, Map.of(UserModel.USERNAME, userName));
+        UserProfile profile = provider.create(UserProfileContext.SCIM, Map.of(UserModel.USERNAME, username));
         UserModel model = profile.create(false);
+        UserModelAttributeRecorder recorder = new UserModelAttributeRecorder(model, new HashMap<>());
 
-        populate(model, resource);
-
-        try {
-            profile = provider.create(UserProfileContext.SCIM, model);
-            profile.validate();
-        } catch (ValidationException ve) {
-            throw handleValidationException(ve);
-        }
+        populate(recorder, resource);
+        persist(recorder);
 
         return createResourceTypeInstance(model, null, null);
     }
 
     @Override
-    protected User onUpdate(UserModel model, User resource) {
+    public User update(User resource) {
+        UserModel model = getModel(resource.getId());
+
+        if (model == null || !hasPermission(model, getRealmResourceType(), AdminPermissionsSchema.MANAGE)) {
+            throw new ForbiddenException();
+        }
+
+        UserModelAttributeRecorder recorder = createUserModelAttributeRecorder(model);
+
+        populate(recorder, resource);
+        persist(recorder);
+
+        return onUpdate(model, resource);
+    }
+
+    @Override
+    public void patch(User existing, List<PatchOperation> operations) {
+        Objects.requireNonNull(existing, "existing cannot be null");
+        Objects.requireNonNull(operations, "operations cannot be null");
+
+        if (operations.size() > MAX_PATCH_OPERATIONS) {
+            throw new ScimPatchException(
+                    "PATCH request exceeds maximum allowed number of %d operations".formatted(MAX_PATCH_OPERATIONS));
+        }
+
+        UserModel model = getModel(existing.getId());
+
+        if (model == null || !hasPermission(model, getRealmResourceType(), AdminPermissionsSchema.MANAGE)) {
+            throw new ForbiddenException();
+        }
+
+        UserModelAttributeRecorder recorder = createUserModelAttributeRecorder(model);
+
+        applyPatch(existing, recorder, operations);
+
+        String stagedUsername = recorder.getUsername();
+
+        if (isBlank(stagedUsername) && isUsernameReadOnly(recorder)) {
+            throw new ModelValidationException("userName is required");
+        }
+
+        persist(recorder);
+        onUpdate(model, existing);
+    }
+
+    private UserModelAttributeRecorder createUserModelAttributeRecorder(UserModel model) {
+        return new UserModelAttributeRecorder(model, new HashMap<>(model.getAttributes()));
+    }
+
+    private boolean isUsernameReadOnly(UserModelAttributeRecorder recorder) {
+        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
+        UserProfile profile = provider.create(UserProfileContext.SCIM, recorder.getAttributes(), recorder.getDelegate());
+        return profile.getAttributes().isReadOnly(UserModel.USERNAME);
+    }
+
+    private void persist(UserModelAttributeRecorder recorder) {
+        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
+        UserProfile profile = provider.create(UserProfileContext.SCIM, recorder.getAttributes(), recorder.getDelegate());
+
         try {
-            UserProfileProvider userProfileProvider = session.getProvider(UserProfileProvider.class);
-            UserProfile profile = userProfileProvider.create(UserProfileContext.SCIM, model);
-            profile.update();
+            profile.validate();
+            profile.update(true);
         } catch (ValidationException ve) {
             throw handleValidationException(ve);
         }
+    }
 
+    @Override
+    protected User onUpdate(UserModel model, User resource) {
         model.setLastModifiedTimestamp(Time.currentTimeMillis());
-
         return createResourceTypeInstance(model, null, null);
     }
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -52,7 +52,9 @@ import org.keycloak.testframework.realm.GroupBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.scim.client.annotations.InjectScimClient;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.userprofile.UserProfileConstants;
 import org.keycloak.userprofile.config.UPConfigUtils;
+import org.keycloak.validate.validators.LengthValidator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.http.client.HttpClient;
@@ -95,9 +97,12 @@ public class UserTest extends AbstractScimTest {
     @BeforeEach
     public void onBefore() {
         UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        upConfig.setUnmanagedAttributePolicy(null);
         upConfig.getAttribute(UserModel.FIRST_NAME).setRequired(null);
         upConfig.getAttribute(UserModel.LAST_NAME).setRequired(null);
         upConfig.getAttribute(UserModel.EMAIL).setRequired(null);
+        upConfig.getAttribute(UserModel.USERNAME).setRequired(null);
+        upConfig.getAttribute(UserModel.USERNAME).setPermissions(null);
         Iterator<UPAttribute> iterator = upConfig.getAttributes().iterator();
         while (iterator.hasNext()) {
             UPAttribute attribute = iterator.next();
@@ -107,6 +112,10 @@ public class UserTest extends AbstractScimTest {
             iterator.remove();
         }
         realm.admin().users().userProfile().update(upConfig);
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(false);
+        realmRep.setEditUsernameAllowed(false);
+        realm.admin().update(realmRep);
         adminEvents.clear();
     }
 
@@ -195,6 +204,87 @@ public class UserTest extends AbstractScimTest {
         assertEquals(name.getHonorificPrefix(), actualName.getHonorificPrefix());
         assertEquals(name.getHonorificSuffix(), actualName.getHonorificSuffix());
         assertEquals("Mr. John M Doe Jr.", actualName.getFormatted());
+    }
+
+    @Test
+    public void testCreateWithRequiredCoreSchemaAttribute() {
+        // Regression test for #52207: required core-schema attributes must be validated on create
+        UPConfig configuration = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute upAttr = new UPAttribute("middleName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "name.middleName"));
+        upAttr.setRequired(new UPAttributeRequired());
+        UPAttributePermissions scimPermissions = new UPAttributePermissions(
+                Set.of(UPConfigUtils.ROLE_ADMIN, UPConfigUtils.ROLE_USER),
+                Set.of(UPConfigUtils.ROLE_ADMIN, UPConfigUtils.ROLE_USER));
+        upAttr.setPermissions(scimPermissions);
+        configuration.addOrReplaceAttribute(upAttr);
+        realm.admin().users().userProfile().update(configuration);
+
+        // Attempt to create without providing the required core-schema attribute
+        User user = new User();
+        user.setUserName(KeycloakModelUtils.generateId());
+        Name name = new Name();
+        name.setGivenName("John");
+        name.setFamilyName("Doe");
+        // Intentionally omit: name.setMiddleName(...)
+        user.setName(name);
+
+        try {
+            client.users().create(user);
+            fail("should fail because middleName is required");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertNotNull(error.getDetail());
+        }
+
+        // Create with the required core-schema attribute provided
+        User expected = new User();
+        expected.setUserName(KeycloakModelUtils.generateId());
+        Name nameWithMiddle = new Name();
+        nameWithMiddle.setGivenName("John");
+        nameWithMiddle.setFamilyName("Doe");
+        nameWithMiddle.setMiddleName("M");
+        expected.setName(nameWithMiddle);
+
+        User actual = client.users().create(expected);
+
+        actual = client.users().get(actual.getId());
+        assertRootAttributes(actual, expected);
+        Name actualName = actual.getName();
+        assertNotNull(actualName);
+        assertEquals(nameWithMiddle.getMiddleName(), actualName.getMiddleName());
+
+        // PATCH: Attempt to remove the required core-schema attribute
+        try {
+            client.users().patch(actual.getId(), PatchRequest.create()
+                    .remove("name.middleName")
+                    .build());
+            fail("PATCH remove should fail because middleName is required");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+        }
+
+        // PATCH: Replace the required core-schema attribute with a new value
+        client.users().patch(actual.getId(), PatchRequest.create()
+                .replace("name.middleName", "Updated")
+                .build());
+        actual = client.users().get(actual.getId());
+        assertEquals("Updated", actual.getName().getMiddleName());
+
+        // PUT: Attempt to update without providing the required core-schema attribute
+        actual.getName().setMiddleName("");
+        client.users().update(actual);
+        actual = client.users().get(actual.getId());
+        assertEquals("Updated", actual.getName().getMiddleName());
+
+        // PUT: Update with the required core-schema attribute provided
+        User toUpdate = client.users().get(actual.getId());
+        toUpdate.getName().setMiddleName("Final");
+        User updated = client.users().update(toUpdate);
+        assertEquals("Final", updated.getName().getMiddleName());
     }
 
     @Test
@@ -426,6 +516,128 @@ public class UserTest extends AbstractScimTest {
             assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
             assertEquals("Invalid email address.", sce.getError().getDetail());
         }
+    }
+
+    @Test
+    public void testAttributeNotWrittenOnUpdateIfNoPermissionSet() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User created = client.users().create(createUser());
+        assertNotNull(created.getId());
+        assertNull(created.getNickName());
+
+        created.setNickName("SomeValue");
+        User updated = client.users().update(created);
+        assertNull(updated.getNickName());
+        UserRepresentation userRep = realm.admin().users().get(created.getId()).toRepresentation();
+        assertNull(userRep.getAttributes() != null ? userRep.getAttributes().get("nickName") : null);
+
+        upConfig = realm.admin().users().userProfile().getConfiguration();
+        upConfig.setUnmanagedAttributePolicy(UPConfig.UnmanagedAttributePolicy.ADMIN_EDIT);
+        realm.admin().users().userProfile().update(upConfig);
+        created.setNickName("OtherValue");
+        updated = client.users().update(created);
+        assertNull(updated.getNickName());
+        userRep = realm.admin().users().get(created.getId()).toRepresentation();
+        assertNull(userRep.getAttributes() != null ? userRep.getAttributes().get("nickName") : null);
+    }
+
+    @Test
+    public void testAttributeNotWrittenOnCreateIfNoPermissionSet() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = createUser();
+        user.setNickName("Allie");
+
+        User created = client.users().create(user);
+        assertNotNull(created.getId());
+        // Read-only attribute sent in request must be ignored and not populated into the model
+        assertNull(created.getNickName());
+        UserRepresentation userRep = realm.admin().users().get(created.getId()).toRepresentation();
+        assertNull(userRep.getAttributes() != null ? userRep.getAttributes().get("nickName") : null);
+    }
+
+    @Test
+    public void testEnforceUserProfileValidatorsOnCreateAndUpdate() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        nickNameAttr.setPermissions(new UPAttributePermissions(Set.of(), Set.of(UserProfileConstants.ROLE_ADMIN)));
+        nickNameAttr.addValidation(LengthValidator.ID, Map.of(LengthValidator.KEY_MIN, "10", LengthValidator.KEY_MAX, "20"));
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = createUser();
+        user.setNickName("Allie"); // 5 characters, violates min length 10
+
+        try {
+            client.users().create(user);
+            fail("should fail because nickName length validator is violated on create");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), error.getStatusInt());
+        }
+
+        user.setNickName("AllieLongerName"); // 15 characters, valid length
+        User created = client.users().create(user);
+        assertNotNull(created.getId());
+
+        created.setNickName("Short"); // 5 characters, violates min length 10
+        try {
+            client.users().update(created);
+            fail("should fail because nickName length validator is violated on update");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), error.getStatusInt());
+        }
+
+        created.setNickName("ValidNickName"); // 13 chars — valid
+        User updated = client.users().update(created);
+        assertEquals("ValidNickName", updated.getNickName());
+    }
+
+    @Test
+    public void testValidatorConfiguredOnNoPermissionAttributeDoesNotLeakInvalidValueIntoModel() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        nickNameAttr.addValidation(LengthValidator.ID, Map.of(LengthValidator.KEY_MIN, "10", LengthValidator.KEY_MAX, "20"));
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = createUser();
+        user.setNickName("Allie");
+
+        User created = client.users().create(user);
+        assertNotNull(created.getId());
+        assertNull(created.getNickName());
+        UserRepresentation userRep = realm.admin().users().get(created.getId()).toRepresentation();
+        assertNull(userRep.getAttributes() != null ? userRep.getAttributes().get("nickName") : null);
+    }
+
+    @Test
+    public void testValidatorConfiguredOnNoPermissionAttributeDoesNotLeakInvalidValueIntoModelOnUpdate() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        nickNameAttr.addValidation(LengthValidator.ID, Map.of(LengthValidator.KEY_MIN, "10", LengthValidator.KEY_MAX, "20"));
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User created = client.users().create(createUser());
+        assertNotNull(created.getId());
+        assertNull(created.getNickName());
+
+        created.setNickName("Allie"); // 5 chars — violates the min=10 validator
+        User updated = client.users().update(created);
+        assertNull(updated.getNickName());
+        UserRepresentation userRep = realm.admin().users().get(created.getId()).toRepresentation();
+        assertNull(userRep.getAttributes() != null ? userRep.getAttributes().get("nickName") : null);
     }
 
     @Test
@@ -840,6 +1052,16 @@ public class UserTest extends AbstractScimTest {
     }
 
     @Test
+    public void testPatchNonExistentUserError() {
+        ScimClientException sce = assertThrows(ScimClientException.class,
+                () -> client.users().patch(KeycloakModelUtils.generateId(), PatchRequest.create()
+                        .replace("displayName", "whatever")
+                        .build()));
+        assertEquals(404, sce.getError().getStatusInt(),
+                "Expected a 4xx response for patch on non-existent user, got " + sce.getError().getStatusInt());
+    }
+
+    @Test
     public void testPatchImmutableMetaCreated() {
         User user = client.users().create(createUser());
         adminEvents.clear();
@@ -855,6 +1077,605 @@ public class UserTest extends AbstractScimTest {
             assertEquals(400, error.getStatusInt());
             assertEquals("mutability", error.getScimType());
         }
+    }
+
+    @Test
+    public void testEnforceUserProfileValidatorsOnPatch() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        nickNameAttr.setPermissions(new UPAttributePermissions(Set.of(), Set.of(UserProfileConstants.ROLE_ADMIN)));
+        nickNameAttr.addValidation(LengthValidator.ID, Map.of(LengthValidator.KEY_MIN, "10", LengthValidator.KEY_MAX, "20"));
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = client.users().create(createUser());
+
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .add("nickName", "Allie") // 5 chars — violates min length of 10
+                    .build());
+            fail("PATCH add should fail because nickName length validator is violated");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .replace("nickName", "Short") // 5 chars — violates min length of 10
+                    .build());
+            fail("PATCH replace should fail because nickName length validator is violated");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        client.users().patch(user.getId(), PatchRequest.create()
+                .replace("nickName", "ValidNickName") // 13 chars — valid
+                .build());
+        assertEquals("ValidNickName", client.users().get(user.getId()).getNickName());
+    }
+
+    @Test
+    public void testAttributeNotWrittenOnPatchIfNoPermissionSet() {
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute nickNameAttr = new UPAttribute("nickName", Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, "nickName"));
+        // No permissions — attribute is read-only for all callers
+        upConfig.addOrReplaceAttribute(nickNameAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = client.users().create(createUser());
+        assertNull(user.getNickName());
+
+        client.users().patch(user.getId(), PatchRequest.create()
+                .add("nickName", "SomeValue")
+                .build());
+        assertNull(client.users().get(user.getId()).getNickName());
+
+        client.users().patch(user.getId(), PatchRequest.create()
+                .replace("nickName", "AnotherValue")
+                .build());
+        assertNull(client.users().get(user.getId()).getNickName());
+    }
+
+    @Test
+    public void testRequiredAttributeNotRemovableViaPatch() {
+        // userName is writable only when editUsernameAllowed is enabled; otherwise the read-only
+        // attribute is silently preserved by the framework and the required validator never fires.
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setEditUsernameAllowed(true);
+        realm.admin().update(realmRep);
+
+        try {
+            client.users().patch(client.users().create(createUser()).getId(), PatchRequest.create()
+                    .remove("userName")
+                    .build());
+            fail("PATCH remove should fail because userName is required");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute employeeNumberAttr = new UPAttribute("employeeNumber",
+                Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, ENTERPRISE_USER_SCHEMA + ":employeeNumber"));
+        employeeNumberAttr.setPermissions(new UPAttributePermissions(Set.of(), Set.of(UserProfileConstants.ROLE_ADMIN)));
+        employeeNumberAttr.setRequired(new UPAttributeRequired());
+        upConfig.addOrReplaceAttribute(employeeNumberAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        try {
+            User user = client.users().create(createUser());
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .remove(ENTERPRISE_USER_SCHEMA + ":employeeNumber")
+                    .build());
+            fail("PATCH remove should fail because employeeNumber is required");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        User rep = createUser();
+        rep.setEnterpriseUser(new EnterpriseUser());
+        rep.getEnterpriseUser().setEmployeeNumber("E54321");
+        User user = client.users().create(rep);
+        client.users().patch(user.getId(), PatchRequest.create()
+                .add(ENTERPRISE_USER_SCHEMA + ":employeeNumber", "E12345")
+                .build());
+        assertEquals("E12345", client.users().get(user.getId()).getEnterpriseUser().getEmployeeNumber());
+
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .remove(ENTERPRISE_USER_SCHEMA + ":employeeNumber")
+                    .build());
+            fail("PATCH remove should fail because employeeNumber is required");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testCannotUpdateUsernameWhenEditDisabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setEditUsernameAllowed(false);
+        realm.admin().update(realmRep);
+
+        User user = client.users().create(createUser());
+
+        user.setUserName("newusername");
+        try {
+            client.users().update(user);
+            fail("PUT update should fail because editUsernameAllowed is false");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .replace("userName", "anotheruser")
+                    .build());
+            fail("PATCH replace should fail because editUsernameAllowed is false");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testCanUpdateUsernameWhenEditEnabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setEditUsernameAllowed(true);
+        realm.admin().update(realmRep);
+
+        User user = client.users().create(createUser());
+
+        String newUserName = KeycloakModelUtils.generateId();
+        user.setUserName(newUserName);
+        User updated = client.users().update(user);
+        assertEquals(newUserName, updated.getUserName());
+
+        String anotherUserName = KeycloakModelUtils.generateId();
+        client.users().patch(user.getId(), PatchRequest.create()
+                .replace("userName", anotherUserName)
+                .build());
+        assertEquals(anotherUserName, client.users().get(user.getId()).getUserName());
+    }
+
+    @Test
+    public void testCannotUpdateUsernameWhenEditPermissionExcludesAdmin() {
+        // editUsernameAllowed is enabled at the realm level, but the username User Profile edit
+        // permissions exclude admins. Since SCIM is an admin context, the username must stay
+        // read-only and any change must be rejected regardless of the realm switch (see #52223).
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setEditUsernameAllowed(true);
+        realm.admin().update(realmRep);
+
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        upConfig.getAttribute(UserModel.USERNAME).setPermissions(
+                new UPAttributePermissions(Set.of(UPConfigUtils.ROLE_ADMIN, UPConfigUtils.ROLE_USER), Set.of(UPConfigUtils.ROLE_USER)));
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = client.users().create(createUser());
+
+        user.setUserName("newusername");
+        try {
+            client.users().update(user);
+            fail("PUT update should fail because the username edit permission excludes admins");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .replace("userName", "anotheruser")
+                    .build());
+            fail("PATCH replace should fail because the username edit permission excludes admins");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+
+        try {
+            client.users().patch(user.getId(), PatchRequest.create()
+                    .remove("userName")
+                    .build());
+            fail("PATCH remove should fail because the username edit permission excludes admins");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testRegistrationEmailAsUsernameEnabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realm.admin().update(realmRep);
+
+        String testEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        User user = new User();
+        user.setEmail(testEmail);
+        User created = client.users().create(user);
+
+        assertNotNull(created.getId());
+        // When registrationEmailAsUsername is enabled, the userName should be set to email
+        assertEquals(testEmail, created.getUserName());
+        assertEquals(testEmail, created.getEmail());
+
+        User retrieved = client.users().get(created.getId());
+        assertEquals(testEmail, retrieved.getUserName());
+        assertEquals(testEmail, retrieved.getEmail());
+    }
+
+    @Test
+    public void testRegistrationEmailAsUsernameDisabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(false);
+        realm.admin().update(realmRep);
+
+        String testEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        User user = createUser();
+        user.setEmail(testEmail);
+        User created = client.users().create(user);
+
+        assertNotNull(created.getId());
+        // When registrationEmailAsUsername is disabled, userName is independent of email
+        assertNotEquals(testEmail, created.getUserName());
+        assertEquals(testEmail, created.getEmail());
+
+        User retrieved = client.users().get(created.getId());
+        assertEquals(created.getUserName(), retrieved.getUserName());
+        assertEquals(testEmail, retrieved.getEmail());
+    }
+
+    @Test
+    public void testEmailUpdatableWhenEmailAsUsernameEnabled() {
+        // emailAsUsername=true, editUsername=false (onBefore default): mirrors the Admin API, where an
+        // admin can change the email and the derived userName follows it, regardless of editUsernameAllowed.
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realm.admin().update(realmRep);
+
+        String originalEmail = KeycloakModelUtils.generateId() + "@example.com";
+        String patchEmail = KeycloakModelUtils.generateId() + "@example.com";
+        String putEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        User user = new User();
+        user.setEmail(originalEmail);
+        User created = client.users().create(user);
+        assertEquals(originalEmail, created.getUserName());
+        assertEquals(originalEmail, created.getEmail());
+
+        // PATCH: email change succeeds and the derived userName follows the new email
+        client.users().patch(created.getId(), PatchRequest.create()
+                .replace("emails", "{\"value\": \"" + patchEmail + "\", \"type\": \"work\", \"primary\": true}")
+                .build());
+
+        User patched = client.users().get(created.getId());
+        assertEquals(patchEmail, patched.getEmail());
+        assertEquals(patchEmail, patched.getUserName());
+
+        // PUT: same behavior
+        patched.setEmail(putEmail);
+        User updated = client.users().update(patched);
+        assertEquals(putEmail, updated.getEmail());
+        assertEquals(putEmail, updated.getUserName());
+    }
+
+    @Test
+    public void testEmailUpdatableWhenEmailAsUsernameAndEditUsernameEnabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realmRep.setEditUsernameAllowed(true);
+        realm.admin().update(realmRep);
+
+        String originalEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        User user = new User();
+        user.setEmail(originalEmail);
+        User created = client.users().create(user);
+        assertEquals(originalEmail, created.getUserName());
+        assertEquals(originalEmail, created.getEmail());
+
+        // PUT: email is writable when editing the username is allowed, and userName follows the new email
+        String putEmail = KeycloakModelUtils.generateId() + "@example.com";
+        created.setEmail(putEmail);
+        User updated = client.users().update(created);
+        assertEquals(putEmail, updated.getEmail());
+        assertEquals(putEmail, updated.getUserName());
+
+        // PATCH: same behavior when replacing the email
+        String patchEmail = KeycloakModelUtils.generateId() + "@example.com";
+        client.users().patch(created.getId(), PatchRequest.create()
+                .replace("emails", "{\"value\": \"" + patchEmail + "\", \"type\": \"work\", \"primary\": true}")
+                .build());
+
+        User retrieved = client.users().get(created.getId());
+        assertEquals(patchEmail, retrieved.getEmail());
+        assertEquals(patchEmail, retrieved.getUserName());
+    }
+
+    @Test
+    public void testPatchUsernameAndEmailWhenEditUsernameDisabled() {
+        // emailAsUsername=false, editUsername=false (onBefore defaults): userName is read-only
+        User created = client.users().create(createUser());
+
+        String newUsername = KeycloakModelUtils.generateId();
+        String newEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .replace("userName", newUsername)
+                    .replace("emails", "{\"value\": \"" + newEmail + "\", \"type\": \"work\", \"primary\": true}")
+                    .build());
+            fail("PATCH should fail: userName is read only when editing the username is not allowed");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchRemoveUsernameWhenEditUsernameDisabled() {
+        // emailAsUsername=false, editUsername=false (onBefore defaults): userName is required and read-only
+        // PATCH remove should fail because userName cannot be removed when editing is disabled
+        User created = client.users().create(createUser());
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .remove("userName")
+                    .build());
+            fail("PATCH remove should fail: userName is required and cannot be removed when editing the username is not allowed");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchRemoveUsernameWhenEmailAsUsernameAndEditUsernameDisabled() {
+        // emailAsUsername=true, editUsername=false: userName is derived from email, so it's also read-only
+        // PATCH remove should fail because userName cannot be removed when email-as-username is enabled
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realm.admin().update(realmRep);
+
+        String originalEmail = KeycloakModelUtils.generateId() + "@example.com";
+        User user = new User();
+        user.setEmail(originalEmail);
+        User created = client.users().create(user);
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .remove("userName")
+                    .build());
+            fail("PATCH remove should fail: userName is required and derived from email when email-as-username is enabled");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchAddFirstNameWhenEditUsernameDisabled() {
+        // Verify that other attributes can still be modified when editUsernameAllowed=false
+        // editUsernameAllowed=false (onBefore default) should only restrict username, not other attributes
+        User created = client.users().create(createUser());
+        String newFirstName = "NewFirstName";
+
+        client.users().patch(created.getId(), PatchRequest.create()
+                .add("name", "{\"givenName\": \"" + newFirstName + "\"}")
+                .build());
+
+        User retrieved = client.users().get(created.getId());
+        assertEquals(newFirstName, retrieved.getFirstName());
+    }
+
+    @Test
+    public void testPatchReplaceUsernameWithBlankValueWhenEditUsernameDisabled() {
+        // Replacing username with blank/empty value should fail like removal
+        // editUsernameAllowed=false (onBefore default)
+        User created = client.users().create(createUser());
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .replace("userName", "")
+                    .build());
+            fail("PATCH replace with blank username should fail when editing is disabled");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchRemoveEmailWhenEmailAsUsernameAndEditUsernameDisabled() {
+        // When registrationEmailAsUsername=true, email derives the username
+        // Removing email should fail because it would also remove the derived username
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realm.admin().update(realmRep);
+
+        String originalEmail = KeycloakModelUtils.generateId() + "@example.com";
+        User user = new User();
+        user.setEmail(originalEmail);
+        User created = client.users().create(user);
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .remove("emails")
+                    .build());
+            fail("PATCH remove should fail: email is required when email-as-username is enabled");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchMultipleOperationsWithForbiddenRemovalWhenEditUsernameDisabled() {
+        // When a PATCH includes multiple operations and one is forbidden (remove username),
+        // the entire PATCH should fail
+        User created = client.users().create(createUser());
+        String newFirstName = "NewFirstName";
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .remove("userName")
+                    .add("name", "{\"givenName\": \"" + newFirstName + "\"}")
+                    .build());
+            fail("PATCH should fail because userName removal is forbidden, even though firstName modification is allowed");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchRemoveReadOnlyExtensionSchemaAttributeWhenEditUsernameDisabled() {
+        // Issue #52208: Verify that removal validation works for extension schema attributes, not just core userName
+        // Add a read-only extension attribute and verify PATCH remove fails
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+        UPAttribute departmentAttr = new UPAttribute("department",
+                Map.of(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, ENTERPRISE_USER_SCHEMA + ":department"));
+        // Set as read-only for admin context (SCIM is admin context)
+        departmentAttr.setPermissions(new UPAttributePermissions(Set.of(), Set.of(UserProfileConstants.ROLE_ADMIN)));
+        departmentAttr.setRequired(new UPAttributeRequired());
+        upConfig.addOrReplaceAttribute(departmentAttr);
+        realm.admin().users().userProfile().update(upConfig);
+
+        User user = createUser();
+        user.setEnterpriseUser(new EnterpriseUser());
+        user.getEnterpriseUser().setDepartment("Engineering");
+        User created = client.users().create(user);
+
+        try {
+            client.users().patch(created.getId(), PatchRequest.create()
+                    .remove(ENTERPRISE_USER_SCHEMA + ":department")
+                    .build());
+            fail("PATCH remove should fail: read-only extension schema attribute cannot be removed");
+        } catch (ScimClientException sce) {
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), sce.getError().getStatusInt());
+        }
+    }
+
+    @Test
+    public void testPatchUsernameAndEmailWhenEditUsernameEnabled() {
+        // emailAsUsername=false, editUsername=true: userName and email are independent and both editable
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setEditUsernameAllowed(true);
+        realm.admin().update(realmRep);
+
+        User created = client.users().create(createUser());
+
+        String newUsername = KeycloakModelUtils.generateId();
+        String newEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        client.users().patch(created.getId(), PatchRequest.create()
+                .replace("userName", newUsername)
+                .replace("emails", "{\"value\": \"" + newEmail + "\", \"type\": \"work\", \"primary\": true}")
+                .build());
+
+        User retrieved = client.users().get(created.getId());
+        assertNotEquals(retrieved.getUserName(), retrieved.getEmail());
+        assertEquals(newUsername, retrieved.getUserName());
+        assertEquals(newEmail, retrieved.getEmail());
+    }
+
+    @Test
+    public void testPatchUsernameAndEmailWhenEmailAsUsernameAndEditUsernameDisabled() {
+        // emailAsUsername=true, editUsername=false: mirrors the Admin API, where the email change
+        // succeeds and the derived userName follows it. The supplied userName is ignored.
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realm.admin().update(realmRep);
+
+        String originalEmail = KeycloakModelUtils.generateId() + "@example.com";
+        User user = new User();
+        user.setEmail(originalEmail);
+        User created = client.users().create(user);
+
+        String newEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        client.users().patch(created.getId(), PatchRequest.create()
+                .replace("userName", newEmail)
+                .replace("emails", "{\"value\": \"" + newEmail + "\", \"type\": \"work\", \"primary\": true}")
+                .build());
+
+        User retrieved = client.users().get(created.getId());
+        assertEquals(newEmail, retrieved.getUserName());
+        assertEquals(newEmail, retrieved.getEmail());
+    }
+
+    @Test
+    public void testPatchUsernameAndEmailWhenEmailAsUsernameAndEditUsernameEnabled() {
+        // emailAsUsername=true, editUsername=true: userName must follow the email
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realmRep.setEditUsernameAllowed(true);
+        realm.admin().update(realmRep);
+
+        String originalEmail = KeycloakModelUtils.generateId() + "@example.com";
+        User user = new User();
+        user.setEmail(originalEmail);
+        User created = client.users().create(user);
+
+        // userName matching the new email is allowed and the userName follows the email
+        String newEmail = KeycloakModelUtils.generateId() + "@example.com";
+        client.users().patch(created.getId(), PatchRequest.create()
+                .replace("userName", newEmail)
+                .replace("emails", "{\"value\": \"" + newEmail + "\", \"type\": \"work\", \"primary\": true}")
+                .build());
+
+        User retrieved = client.users().get(created.getId());
+        assertEquals(newEmail, retrieved.getUserName());
+        assertEquals(newEmail, retrieved.getEmail());
+
+        // userName conflicting with the new email is ignored: the derived userName follows the email
+        String conflictingUsername = KeycloakModelUtils.generateId() + "@example.com";
+        String anotherEmail = KeycloakModelUtils.generateId() + "@example.com";
+        client.users().patch(created.getId(), PatchRequest.create()
+                .replace("userName", conflictingUsername)
+                .replace("emails", "{\"value\": \"" + anotherEmail + "\", \"type\": \"work\", \"primary\": true}")
+                .build());
+
+        retrieved = client.users().get(created.getId());
+        assertEquals(anotherEmail, retrieved.getUserName());
+        assertEquals(anotherEmail, retrieved.getEmail());
+    }
+
+    @Test
+    public void testCreationWithEmailAsUsernameAndUsernameEditDisabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realmRep.setEditUsernameAllowed(false);
+        realm.admin().update(realmRep);
+
+        String newEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        User user = new User();
+        user.setEmail(newEmail);
+        // Email should be writable on creation even though it will be read-only on existing users
+        // (email is derived to userName when emailAsUsername=true and editUsernameAllowed=false)
+        User created = client.users().create(user);
+
+        assertNotNull(created.getId());
+        assertEquals(newEmail, created.getUserName());
+        assertEquals(newEmail, created.getEmail());
+    }
+
+    @Test
+    public void testCreationWithEmailWhenEditUsernameDisabledButEmailAsUsernameDisabled() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(false);
+        realmRep.setEditUsernameAllowed(false);
+        realm.admin().update(realmRep);
+
+        String testEmail = KeycloakModelUtils.generateId() + "@example.com";
+
+        User user = createUser();
+        user.setEmail(testEmail);
+        User created = client.users().create(user);
+
+        assertNotNull(created.getId());
+        assertNotEquals(testEmail, created.getUserName());
+        assertEquals(testEmail, created.getEmail());
+
+        // Email can be updated (it's not derived from username)
+        String updatedEmail = KeycloakModelUtils.generateId() + "@example.com";
+        created.setEmail(updatedEmail);
+        User updated = client.users().update(created);
+        assertEquals(updatedEmail, updated.getEmail());
+        assertEquals(created.getUserName(), updated.getUserName()); // userName unchanged
     }
 
     @Test
@@ -1591,6 +2412,43 @@ public class UserTest extends AbstractScimTest {
             assertEquals(400, error.getStatusInt());
             assertNotNull(error.getDetail());
             assertTrue(error.getDetail().contains("invalidAttribute"));
+        }
+    }
+
+    @Test
+    public void testCreateWithoutUserNameFails() {
+        User user = new User();
+
+        try {
+            client.users().create(user);
+            fail("should fail because userName is required");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertNotNull(error.getDetail());
+            assertTrue(error.getDetail().contains("username is required"));
+        }
+    }
+
+    @Test
+    public void testCreateWithoutEmailFailsWhenEmailAsUsername() {
+        RealmRepresentation realmRep = realm.admin().toRepresentation();
+        realmRep.setRegistrationEmailAsUsername(true);
+        realm.admin().update(realmRep);
+
+        User user = new User();
+        user.setUserName(KeycloakModelUtils.generateId());
+
+        try {
+            client.users().create(user);
+            fail("should fail because email is required when registrationEmailAsUsername is enabled");
+        } catch (ScimClientException sce) {
+            ErrorResponse error = sce.getError();
+            assertNotNull(error);
+            assertEquals(400, error.getStatusInt());
+            assertNotNull(error.getDetail());
+            assertTrue(error.getDetail().contains("email is required"));
         }
     }
 

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProvider.java
@@ -78,8 +78,8 @@ public class DeclarativeUserProfileProvider implements UserProfileProvider {
      * @param configuredScopes to be evaluated
      */
     private static boolean requestedScopePredicate(AttributeContext context, Set<String> configuredScopes) {
-        // any attribute is enabled and available when managing through the User Admin API
-        if (UserProfileContext.USER_API.equals(context.getContext())) {
+        // any attribute is enabled and available when managing through an admin context
+        if (context.getContext().isAdminContext()) {
             return true;
         }
 

--- a/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
+++ b/services/src/main/java/org/keycloak/userprofile/DeclarativeUserProfileProviderFactory.java
@@ -156,7 +156,7 @@ public class DeclarativeUserProfileProviderFactory implements UserProfileProvide
     private static boolean editEmailCondition(AttributeContext c) {
         RealmModel realm = c.getSession().getContext().getRealm();
 
-        if (REGISTRATION.equals(c.getContext()) || USER_API.equals(c.getContext())) {
+        if (REGISTRATION.equals(c.getContext()) || c.getContext().isAdminContext()) {
             return true;
         }
 
@@ -188,7 +188,7 @@ public class DeclarativeUserProfileProviderFactory implements UserProfileProvide
     private static boolean readEmailCondition(AttributeContext c) {
         UserProfileContext context = c.getContext();
 
-        if (REGISTRATION.equals(context) || USER_API.equals(c.getContext())) {
+        if (REGISTRATION.equals(context) || context.isAdminContext()) {
             return true;
         }
 


### PR DESCRIPTION
Closes #52229
Closes #52207
Closes #52223
Closes #52208
Closes #52224

* Adds a new capability to UP to allow (re) validating the underlying model linked with a `UserProfile` object against the original attributes when the instance was created. The main goal for this is to allow UP callers to run validations when the model is "dirty" and was updated outside the boundaries of UP.
* Updated tests to cover all the scenarios from https://github.com/keycloak/keycloak/issues/52207, https://github.com/keycloak/keycloak/issues/52223, https://github.com/keycloak/keycloak/issues/52229, https://github.com/keycloak/keycloak/issues/52208 and https://github.com/keycloak/keycloak/issues/52224

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
