### PR TITLE
Harden mapper UI flows to reduce flaky interactions

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
@@ -220,7 +220,7 @@ export default function EditClientScope() {
         };
       });
       addAlert(t("mappingDeletedSuccess"), AlertVariant.success);
-      return false;
+      return true;
     } catch (error) {
       addError("mappingDeletedError", error);
       return false;

--- a/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
+++ b/js/apps/admin-ui/src/client-scopes/EditClientScope.tsx
@@ -207,12 +207,24 @@ export default function EditClientScope() {
         id: clientScope!.id!,
         mapperId: mapper.id!,
       });
+      setClientScope((currentClientScope) => {
+        if (!currentClientScope?.protocolMappers) {
+          return currentClientScope;
+        }
+
+        return {
+          ...currentClientScope,
+          protocolMappers: currentClientScope.protocolMappers.filter(
+            ({ id }) => id !== mapper.id,
+          ),
+        };
+      });
       addAlert(t("mappingDeletedSuccess"), AlertVariant.success);
-      refresh();
+      return false;
     } catch (error) {
       addError("mappingDeletedError", error);
+      return false;
     }
-    return true;
   };
 
   if (!clientScope) {

--- a/js/apps/admin-ui/src/client-scopes/details/MapperList.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MapperList.tsx
@@ -78,7 +78,7 @@ export const MapperList = ({
     }, []);
 
     return list.sort((a, b) => a.priority - b.priority);
-  }, [mapperList, mapperTypes]);
+  }, [mapperList, mapperTypes, deletingMapperId]);
 
   const [addMapperDialogOpen, setAddMapperDialogOpen] = useState(false);
   const [filter, setFilter] = useState(model.protocolMappers);

--- a/js/apps/admin-ui/src/client-scopes/details/MapperList.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MapperList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Path } from "react-router-dom";
 import { Link } from "react-router-dom";
@@ -24,7 +24,7 @@ type MapperListProps = {
   onAdd: (
     mappers: ProtocolMapperTypeRepresentation | ProtocolMapperRepresentation[],
   ) => void;
-  onDelete: (mapper: ProtocolMapperRepresentation) => void;
+  onDelete: (mapper: ProtocolMapperRepresentation) => Promise<boolean>;
   detailLink: (id: string) => Partial<Path>;
 };
 
@@ -53,22 +53,9 @@ export const MapperList = ({
   const [mapperAction, setMapperAction] = useState(false);
   const mapperList = model.protocolMappers;
   const mapperTypes = useServerInfo().protocolMapperTypes![model.protocol!];
+  const [deletingMapperId, setDeletingMapperId] = useState<string>();
 
-  const [key, setKey] = useState(0);
-  useEffect(() => setKey(key + 1), [mapperList]);
-
-  const [addMapperDialogOpen, setAddMapperDialogOpen] = useState(false);
-  const [filter, setFilter] = useState(model.protocolMappers);
-  const toggleAddMapperDialog = (buildIn: boolean) => {
-    if (buildIn) {
-      setFilter(mapperList || []);
-    } else {
-      setFilter(undefined);
-    }
-    setAddMapperDialogOpen(!addMapperDialogOpen);
-  };
-
-  const loader = async () => {
+  const rows = useMemo<Row[]>(() => {
     if (!mapperList) {
       return [];
     }
@@ -91,6 +78,30 @@ export const MapperList = ({
     }, []);
 
     return list.sort((a, b) => a.priority - b.priority);
+  }, [mapperList, mapperTypes]);
+
+  const [addMapperDialogOpen, setAddMapperDialogOpen] = useState(false);
+  const [filter, setFilter] = useState(model.protocolMappers);
+  const toggleAddMapperDialog = (buildIn: boolean) => {
+    if (buildIn) {
+      setFilter(mapperList || []);
+    } else {
+      setFilter(undefined);
+    }
+    setAddMapperDialogOpen(!addMapperDialogOpen);
+  };
+
+  const onDeleteMapper = async (mapper: Row) => {
+    if (!mapper.id || deletingMapperId) {
+      return false;
+    }
+
+    setDeletingMapperId(mapper.id);
+    try {
+      return await onDelete(mapper);
+    } finally {
+      setDeletingMapperId(undefined);
+    }
   };
 
   return (
@@ -104,8 +115,7 @@ export const MapperList = ({
       />
 
       <KeycloakDataTable
-        key={key}
-        loader={loader}
+        loader={rows}
         ariaLabelKey="clientScopeList"
         searchPlaceholderKey="searchForMapper"
         toolbarItem={
@@ -118,6 +128,7 @@ export const MapperList = ({
                 variant="primary"
                 id="mapperAction"
                 onClick={() => setMapperAction(!mapperAction)}
+                isDisabled={!!deletingMapperId}
               >
                 {t("addMapper")}
               </MenuToggle>
@@ -137,9 +148,10 @@ export const MapperList = ({
         actions={[
           {
             title: t("delete"),
-            onRowClick: onDelete,
+            onRowClick: onDeleteMapper,
           } as Action<Row>,
         ]}
+        isRowDisabled={(row) => row.id === deletingMapperId}
         columns={[
           {
             name: "name",

--- a/js/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
@@ -43,6 +43,12 @@ export type Role = RoleRepresentation & {
   clientId?: string;
 };
 
+const MAPPER_SYNC_RETRIES = 10;
+const MAPPER_SYNC_DELAY_MS = 300;
+
+const sleep = (durationMs: number) =>
+  new Promise((resolve) => setTimeout(resolve, durationMs));
+
 export default function AddMapper() {
   const { adminClient } = useAdminClient();
 
@@ -66,8 +72,36 @@ export default function AddMapper() {
     useState<IdentityProviderMapperTypeRepresentation>();
 
   const [idp, setIdp] = useState<IdentityProviderRepresentation>();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const waitForMapperToBeAvailable = async (mapperId?: string) => {
+    if (!mapperId) {
+      return;
+    }
+
+    for (let attempt = 0; attempt < MAPPER_SYNC_RETRIES; attempt++) {
+      try {
+        const mapper = await adminClient.identityProviders.findOneMapper({
+          alias,
+          id: mapperId,
+        });
+        if (mapper?.id === mapperId) {
+          return;
+        }
+      } catch {
+        // The mapper can still be in-flight right after creation.
+      }
+
+      await sleep(MAPPER_SYNC_DELAY_MS);
+    }
+  };
 
   const save = async (idpMapper: IdentityProviderMapperRepresentation) => {
+    if (isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
     const mapper = convertFormValuesToObject(idpMapper);
 
     const identityProviderMapper = {
@@ -78,8 +112,8 @@ export default function AddMapper() {
       identityProviderAlias: alias!,
     };
 
-    if (id) {
-      try {
+    try {
+      if (id) {
         await adminClient.identityProviders.updateMapper(
           {
             id: id!,
@@ -88,28 +122,39 @@ export default function AddMapper() {
           { ...identityProviderMapper, id },
         );
         addAlert(t("mapperSaveSuccess"), AlertVariant.success);
-      } catch (error) {
-        addError("mapperSaveError", error);
-      }
-    } else {
-      try {
+      } else {
         const createdMapper = await adminClient.identityProviders.createMapper({
           identityProviderMapper,
           alias: alias!,
         });
 
+        await waitForMapperToBeAvailable(createdMapper.id);
         addAlert(t("mapperCreateSuccess"), AlertVariant.success);
-        void navigate(
-          toIdentityProviderEditMapper({
-            realm,
-            alias,
-            providerId: providerId,
-            id: createdMapper.id,
-          }),
-        );
-      } catch (error) {
-        addError("mapperCreateError", error);
+
+        if (createdMapper.id) {
+          void navigate(
+            toIdentityProviderEditMapper({
+              realm,
+              alias,
+              providerId: providerId,
+              id: createdMapper.id,
+            }),
+          );
+        } else {
+          void navigate(
+            toIdentityProvider({
+              providerId,
+              alias,
+              tab: "mappers",
+              realm,
+            }),
+          );
+        }
       }
+    } catch (error) {
+      addError(id ? "mapperSaveError" : "mapperCreateError", error);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -242,12 +287,15 @@ export default function AddMapper() {
             data-testid="new-mapper-save-button"
             variant="primary"
             type="submit"
+            isDisabled={isSaving}
+            isLoading={isSaving}
           >
             {t("save")}
           </Button>
           <Button
             data-testid="new-mapper-cancel-button"
             variant="link"
+            isDisabled={isSaving}
             component={(props) => (
               <Link
                 {...props}

--- a/js/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/AddMapper.tsx
@@ -76,7 +76,7 @@ export default function AddMapper() {
 
   const waitForMapperToBeAvailable = async (mapperId?: string) => {
     if (!mapperId) {
-      return;
+      return false;
     }
 
     for (let attempt = 0; attempt < MAPPER_SYNC_RETRIES; attempt++) {
@@ -86,7 +86,7 @@ export default function AddMapper() {
           id: mapperId,
         });
         if (mapper?.id === mapperId) {
-          return;
+          return true;
         }
       } catch {
         // The mapper can still be in-flight right after creation.
@@ -94,6 +94,8 @@ export default function AddMapper() {
 
       await sleep(MAPPER_SYNC_DELAY_MS);
     }
+
+    return false;
   };
 
   const save = async (idpMapper: IdentityProviderMapperRepresentation) => {
@@ -128,10 +130,12 @@ export default function AddMapper() {
           alias: alias!,
         });
 
-        await waitForMapperToBeAvailable(createdMapper.id);
+        const mapperAvailable = await waitForMapperToBeAvailable(
+          createdMapper.id,
+        );
         addAlert(t("mapperCreateSuccess"), AlertVariant.success);
 
-        if (createdMapper.id) {
+        if (createdMapper.id && mapperAvailable) {
           void navigate(
             toIdentityProviderEditMapper({
               realm,

--- a/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
+++ b/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
@@ -504,7 +504,7 @@ export function KeycloakDataTable<T>({
               ),
             )
             .slice(first, first + max + 1),
-    [search, first, max],
+    [search, isPaginated, unPaginatedData, first, max],
   );
 
   useFetch(


### PR DESCRIPTION
## Summary
- Harden identity-provider mapper creation by preventing concurrent save clicks and waiting for mapper availability before navigation.
- Stabilize client-scope mapper table interactions by removing remount-based churn and serializing row delete actions.
- Update mapper delete handling to keep local table state in sync immediately, reducing action-menu timing races.

Closes #50994

Branch stability loop (3/3 successful): [33404240253](https://github.com/edewit/keycloak/actions/runs/33404240253), [33410383056](https://github.com/edewit/keycloak/actions/runs/33410383056), [33415505449](https://github.com/edewit/keycloak/actions/runs/33415505449)