### PR TITLE
Refactor admin-ui Playwright specs to action-oriented helpers

### DIFF
--- a/js/apps/admin-ui/CONTRIBUTING.md
+++ b/js/apps/admin-ui/CONTRIBUTING.md
@@ -52,6 +52,7 @@ pnpm lint
 ## Integration testing with Playwright
 
 This repository contains integration tests developed with the [Playwright framework](https://playwright.dev/).
+For conventions on how tests should be structured and written, see the [Playwright Test Style Guide](./test/README.md).
 
 ### Prerequisites
 

--- a/js/apps/admin-ui/test/README.md
+++ b/js/apps/admin-ui/test/README.md
@@ -1,0 +1,76 @@
+# Playwright Test Style Guide
+
+This document describes how integration tests under `js/apps/admin-ui/test` should be written.
+
+## Core principle
+
+Tests should read like a user scenario. Prefer high-level action helpers over inline selector logic.
+
+Use this style:
+
+```ts
+await login(page, { to: toAddUser({ realm: testBed.realm }) });
+
+await fillUserForm(page, { username: "test-user" });
+await joinGroup(page, ["test-group"]);
+await clickSaveButton(page);
+await assertNotificationMessage(page, "The user has been created");
+```
+
+The `*.spec.ts` file should communicate intent. Low-level Playwright details should live in helper files.
+
+## File layout and naming
+
+- Keep test files in `*.spec.ts`.
+- Add companion helper files in the same folder (for example `main.ts`, `users.ts`, `flow.ts`).
+- Keep helper names action-oriented and explicit:
+  - `login`, `goToUsers`, `fillUserForm`, `joinGroup`, `clickSaveButton`
+  - `assertNotificationMessage`, `assertRowExists`
+- Use these prefixes consistently:
+  - `goTo*` for navigation
+  - `fill*` for form entry
+  - `select*` / `toggle*` / `click*` for user actions
+  - `assert*` for checks
+
+## What goes in specs vs helpers
+
+- `*.spec.ts` should contain:
+  - test setup
+  - scenario flow
+  - assertions that explain expected behavior
+- Helper `*.ts` files should contain:
+  - selectors and locator details
+  - reusable UI actions
+  - reusable assertions
+- Avoid embedding repeated selectors in specs. If a step appears in more than one test, extract it.
+
+## Navigation and setup conventions
+
+- Prefer route helpers and explicit destinations in login:
+  - `await login(page, { to: toUsers({ realm: testBed.realm }) });`
+- For isolated realm data, prefer `createTestBed()` and `await using` so cleanup is automatic:
+  - `await using testBed = await createTestBed({ ...overrides });`
+- Keep test data local to each test so scenarios are easy to understand.
+
+## Selector conventions
+
+- Prefer resilient selectors in helpers:
+  - first choice: `getByTestId`
+  - second choice: semantic queries (`getByRole`, `getByLabel`)
+- Avoid brittle selectors (deep CSS chains, text-dependent selectors that are not stable).
+- Keep selector changes localized to helper files to reduce churn.
+
+## Assertions and stability
+
+- Assert user-visible outcomes after meaningful actions (for example success notifications, row presence, URL change).
+- Prefer explicit helper assertions such as `assertNotificationMessage(...)`.
+- Rely on Playwright auto-waiting and expectations instead of manual sleeps.
+- Do not use `waitForTimeout()` unless there is no better technical option and the reason is documented.
+
+## Test design checklist
+
+- Can the spec be read top-to-bottom as a scenario?
+- Are action/assertion helper names describing intent clearly?
+- Are selectors hidden in helpers?
+- Is setup isolated and cleanup automatic?
+- Are assertions validating behavior that matters to users?

--- a/js/apps/admin-ui/test/clients/ssf-receiver.spec.ts
+++ b/js/apps/admin-ui/test/clients/ssf-receiver.spec.ts
@@ -1,9 +1,20 @@
-import { expect, test, type Page } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
-import { toSsfClientTab } from "../../src/clients/routes/ClientSsfTab.tsx";
 import adminClient from "../utils/AdminClient.ts";
-import { login, navigateTo } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
+import {
+  assertSsfAudienceValue,
+  assertSsfPollDeliveryMethodUnchecked,
+  assertSsfPushAndPollDeliveryMethodsChecked,
+  assertSsfPushDeliveryMethodChecked,
+  assertSsfReceiverSaveButtonVisible,
+  clickSsfReceiverRevert,
+  clickSsfReceiverSave,
+  disableSsfPollDeliveryMethod,
+  fillSsfAudience,
+  loginToSsfTab,
+  navigateToSsfTab,
+} from "./ssf.ts";
 
 // Exercises the Receiver sub-tab of a client's SSF view — the primary
 // configuration form (Save / Revert). The integration server is always
@@ -15,14 +26,6 @@ test.describe.serial("Client SSF receiver", () => {
   const realmName = `ssf-receiver-realm-${uuid()}`;
   const clientId = `ssf-receiver-client-${uuid()}`;
   const audience = "https://receiver.example.com/ssf";
-
-  // TextControl derives its data-testid from the form field name, which is the
-  // attribute path with dots after the first replaced by 🍺 (see
-  // convertAttributeNameToForm/beerify in src/util.ts). We reproduce that
-  // transform here rather than importing the helper — src/util.ts pulls the
-  // @keycloak/keycloak-ui-shared runtime into the Playwright transform, which
-  // fails to resolve — so the 🍺 path isn't embedded as a literal.
-  const audienceTestId = `attributes.${"ssf.streamAudience".replaceAll(".", "🍺")}`;
 
   let clientUuid: string;
 
@@ -45,78 +48,56 @@ test.describe.serial("Client SSF receiver", () => {
     await adminClient.deleteRealm(realmName);
   });
 
-  /**
-   * Navigate to the client's SSF Receiver sub-tab (the default SSF sub-tab).
-   * The integration server is always started with the `ssf` feature enabled
-   * (see js/apps/keycloak-server/scripts/start-server.js, #49977), so the SSF
-   * tab must render — assert it rather than skip, so a missing tab fails loudly.
-   */
-  async function goToReceiverTab(page: Page) {
-    await login(page, {
-      to: toSsfClientTab({
-        realm: realmName,
-        clientId: clientUuid,
-        tab: "receiver",
-      }),
-    });
-
-    await expect(page.getByTestId("ssfTab")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByTestId("ssfReceiverSave")).toBeVisible();
-  }
-
   // Runs first so the client is still pristine (audience empty), giving Revert
   // a deterministic baseline to restore to.
   test("reverts unsaved edits", async ({ page }) => {
-    await goToReceiverTab(page);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "receiver",
+    });
+    await assertSsfReceiverSaveButtonVisible(page);
+    await assertSsfAudienceValue(page, "");
 
-    const audienceField = page.getByTestId(audienceTestId);
-    await expect(audienceField).toHaveValue("");
-
-    await audienceField.fill("temporary-unsaved-value");
-    await page.getByTestId("ssfReceiverRevert").click();
-
-    await expect(audienceField).toHaveValue("");
+    await fillSsfAudience(page, "temporary-unsaved-value");
+    await clickSsfReceiverRevert(page);
+    await assertSsfAudienceValue(page, "");
   });
 
   test("saves receiver config and persists it across a reload", async ({
     page,
   }) => {
-    await goToReceiverTab(page);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "receiver",
+    });
+    await assertSsfReceiverSaveButtonVisible(page);
 
     // A plain text field...
-    await page.getByTestId(audienceTestId).fill(audience);
+    await fillSsfAudience(page, audience);
 
     // ...and the custom delivery-method checkboxes, which drive the
     // ssf.allowedDeliveryMethods attribute. Both render checked on a fresh
     // receiver (unset = both allowed); unchecking poll should persist "push".
-    const pushCheckbox = page.getByTestId("ssfAllowedDeliveryMethods.push");
-    const pollCheckbox = page.getByTestId("ssfAllowedDeliveryMethods.poll");
-    await expect(pushCheckbox).toBeChecked();
-    await expect(pollCheckbox).toBeChecked();
-    await pollCheckbox.click();
-    await expect(pollCheckbox).not.toBeChecked();
+    await assertSsfPushAndPollDeliveryMethodsChecked(page);
+    await disableSsfPollDeliveryMethod(page);
+    await assertSsfPollDeliveryMethodUnchecked(page);
 
-    await page.getByTestId("ssfReceiverSave").click();
+    await clickSsfReceiverSave(page);
     await assertNotificationMessage(page, "Client successfully updated");
 
     // Re-navigate from scratch (no re-login — the session persists, so
     // login() would hang waiting for a sign-in form that never appears) and
     // confirm the values round-tripped through storage and back into the form.
-    await navigateTo(
-      page,
-      toSsfClientTab({
-        realm: realmName,
-        clientId: clientUuid,
-        tab: "receiver",
-      }),
-    );
-    await expect(page.getByTestId("ssfReceiverSave")).toBeVisible();
-    await expect(page.getByTestId(audienceTestId)).toHaveValue(audience);
-    await expect(
-      page.getByTestId("ssfAllowedDeliveryMethods.push"),
-    ).toBeChecked();
-    await expect(
-      page.getByTestId("ssfAllowedDeliveryMethods.poll"),
-    ).not.toBeChecked();
+    await navigateToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "receiver",
+    });
+    await assertSsfReceiverSaveButtonVisible(page);
+    await assertSsfAudienceValue(page, audience);
+    await assertSsfPushDeliveryMethodChecked(page);
+    await assertSsfPollDeliveryMethodUnchecked(page);
   });
 });

--- a/js/apps/admin-ui/test/clients/ssf-stream.spec.ts
+++ b/js/apps/admin-ui/test/clients/ssf-stream.spec.ts
@@ -1,9 +1,21 @@
-import { expect, test, type Page } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
-import { toSsfClientTab } from "../../src/clients/routes/ClientSsfTab.tsx";
 import adminClient from "../utils/AdminClient.ts";
-import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
+import {
+  assertCreateSsfStreamEndpointErrorHidden,
+  assertCreateSsfStreamEndpointErrorVisible,
+  assertCreateSsfStreamEndpointVisible,
+  assertCreateSsfStreamSubmitDisabled,
+  assertCreateSsfStreamSubmitEnabled,
+  assertRegisteredSsfStreamView,
+  assertSsfStreamEmptyStateVisible,
+  fillCreateSsfStreamDescription,
+  fillCreateSsfStreamEndpoint,
+  loginToSsfTab,
+  openCreateSsfStreamForm,
+  submitCreateSsfStream,
+} from "./ssf.ts";
 
 // Exercises the admin-console "Create stream" flow on a client's SSF Stream
 // sub-tab. The integration server is always started with the `ssf` feature
@@ -42,65 +54,51 @@ test.describe.serial("Client SSF stream creation", () => {
     await adminClient.deleteRealm(realmName);
   });
 
-  /**
-   * Navigate to the client's SSF Stream sub-tab. The integration server is
-   * always started with the `ssf` feature enabled (see
-   * js/apps/keycloak-server/scripts/start-server.js, #49977), so the SSF tab
-   * must render — assert it rather than skip, so a missing tab fails loudly.
-   */
-  async function goToStreamTab(page: Page) {
-    await login(page, {
-      to: toSsfClientTab({
-        realm: realmName,
-        clientId: clientUuid,
-        tab: "stream",
-      }),
-    });
-
-    await expect(page.getByTestId("ssfTab")).toBeVisible({ timeout: 15_000 });
-  }
-
   test("validates the push endpoint URL before allowing submit", async ({
     page,
   }) => {
-    await goToStreamTab(page);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "stream",
+    });
 
     // Open the create-stream form from the empty state.
-    await expect(page.getByTestId("empty-state")).toBeVisible();
-    await page.getByRole("button", { name: "Create stream" }).click();
+    await assertSsfStreamEmptyStateVisible(page);
+    await openCreateSsfStreamForm(page);
 
     // PUSH is the default delivery method, so the endpoint URL field is
     // shown. With it empty, the submit button stays disabled.
-    const submit = page.getByTestId("ssfCreateStreamSubmit");
-    await expect(page.getByTestId("ssfCreateStreamEndpointUrl")).toBeVisible();
-    await expect(submit).toBeDisabled();
+    await assertCreateSsfStreamEndpointVisible(page);
+    await assertCreateSsfStreamSubmitDisabled(page);
 
     // A non-http(s) URL is rejected inline and submit remains disabled.
-    await page.getByTestId("ssfCreateStreamEndpointUrl").fill("ftp://nope");
-    await expect(page.getByTestId("endpointUrl-helper")).toBeVisible();
-    await expect(submit).toBeDisabled();
+    await fillCreateSsfStreamEndpoint(page, "ftp://nope");
+    await assertCreateSsfStreamEndpointErrorVisible(page);
+    await assertCreateSsfStreamSubmitDisabled(page);
 
     // A valid https URL clears the error and enables submit.
-    await page.getByTestId("ssfCreateStreamEndpointUrl").fill(pushEndpoint);
-    await expect(page.getByTestId("endpointUrl-helper")).toBeHidden();
-    await expect(submit).toBeEnabled();
+    await fillCreateSsfStreamEndpoint(page, pushEndpoint);
+    await assertCreateSsfStreamEndpointErrorHidden(page);
+    await assertCreateSsfStreamSubmitEnabled(page);
   });
 
   test("creates a push stream", async ({ page }) => {
-    await goToStreamTab(page);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "stream",
+    });
 
-    await page.getByRole("button", { name: "Create stream" }).click();
-    await page.getByTestId("ssfCreateStreamEndpointUrl").fill(pushEndpoint);
-    await page
-      .getByTestId("ssfCreateStreamDescription")
-      .fill("Created by test");
-    await page.getByTestId("ssfCreateStreamSubmit").click();
+    await openCreateSsfStreamForm(page);
+    await fillCreateSsfStreamEndpoint(page, pushEndpoint);
+    await fillCreateSsfStreamDescription(page, "Created by test");
+    await submitCreateSsfStream(page);
 
     await assertNotificationMessage(page, "SSF stream created successfully.");
 
     // The empty state is replaced by the registered-stream view, which
     // surfaces the stream id and a refresh action.
-    await expect(page.getByTestId("ssfRefresh")).toBeVisible();
-    await expect(page.getByTestId("empty-state")).toBeHidden();
+    await assertRegisteredSsfStreamView(page);
   });
 });

--- a/js/apps/admin-ui/test/clients/ssf-subjects.spec.ts
+++ b/js/apps/admin-ui/test/clients/ssf-subjects.spec.ts
@@ -1,9 +1,18 @@
-import { expect, test, type Page } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
-import { toSsfClientTab } from "../../src/clients/routes/ClientSsfTab.tsx";
 import adminClient from "../utils/AdminClient.ts";
-import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
+import {
+  addSsfSubject,
+  assertSsfSubjectStatus,
+  assertSsfSubjectTypeVisible,
+  assertSsfSubjectValueError,
+  checkSsfSubject,
+  fillSsfSubjectValue,
+  ignoreSsfSubject,
+  loginToSsfTab,
+  removeSsfSubject,
+} from "./ssf.ts";
 
 // Exercises the Subjects sub-tab of a client's SSF view: the per-subject
 // add / ignore / remove / check actions that map to
@@ -48,86 +57,80 @@ test.describe.serial("Client SSF subjects", () => {
     await adminClient.deleteRealm(realmName);
   });
 
-  /**
-   * Navigate to the client's SSF Subjects sub-tab. The integration server is
-   * always started with the `ssf` feature enabled (see
-   * js/apps/keycloak-server/scripts/start-server.js, #49977), so the SSF tab
-   * must render — assert it rather than skip, so a missing tab fails loudly.
-   */
-  async function goToSubjectsTab(page: Page) {
-    await login(page, {
-      to: toSsfClientTab({
-        realm: realmName,
-        clientId: clientUuid,
-        tab: "subjects",
-      }),
-    });
-
-    await expect(page.getByTestId("ssfTab")).toBeVisible({ timeout: 15_000 });
-
-    // Default subject type is "By email", so the value field takes an email.
-    await expect(page.getByTestId("ssfSubjectType")).toBeVisible();
-  }
-
   test("requires a subject value", async ({ page }) => {
-    await goToSubjectsTab(page);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "subjects",
+    });
+    await assertSsfSubjectTypeVisible(page);
 
-    await page.getByTestId("ssfSubjectCheck").click();
-    await expect(page.getByTestId("ssfSubjectValueError")).toHaveText(
-      "Please enter a subject value.",
-    );
+    await checkSsfSubject(page);
+    await assertSsfSubjectValueError(page, "Please enter a subject value.");
   });
 
   test("reports an unknown subject as not found", async ({ page }) => {
-    await goToSubjectsTab(page);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "subjects",
+    });
+    await assertSsfSubjectTypeVisible(page);
 
-    await page.getByTestId("ssfSubjectValue").fill("nobody@example.com");
-    await page.getByTestId("ssfSubjectCheck").click();
-    await expect(page.getByTestId("ssfSubjectValueError")).toHaveText(
+    await fillSsfSubjectValue(page, "nobody@example.com");
+    await checkSsfSubject(page);
+    await assertSsfSubjectValueError(
+      page,
       "Subject not found. Verify the value and subject type.",
     );
   });
 
   test("adds, checks, ignores, and removes a subject", async ({ page }) => {
-    await goToSubjectsTab(page);
-
-    const value = page.getByTestId("ssfSubjectValue");
-    const status = page.getByTestId("ssfSubjectStatus");
-    await value.fill(userEmail);
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid,
+      tab: "subjects",
+    });
+    await assertSsfSubjectTypeVisible(page);
+    await fillSsfSubjectValue(page, userEmail);
 
     // Check first: a brand-new subject is not yet part of event delivery.
-    await page.getByTestId("ssfSubjectCheck").click();
-    await expect(status).toHaveText(
+    await checkSsfSubject(page);
+    await assertSsfSubjectStatus(
+      page,
       "Subject is not included in event delivery for this stream.",
     );
 
     // Add: success notification and the status flips to "notified".
-    await page.getByTestId("ssfSubjectAdd").click();
+    await addSsfSubject(page);
     await assertNotificationMessage(
       page,
       "Subject has been added to this stream.",
     );
-    await expect(status).toHaveText(
+    await assertSsfSubjectStatus(
+      page,
       "Events for this subject are delivered to this stream.",
     );
 
     // Ignore: explicitly excludes the subject.
-    await page.getByTestId("ssfSubjectIgnore").click();
+    await ignoreSsfSubject(page);
     await assertNotificationMessage(
       page,
       "Subject has been ignored for this stream.",
     );
-    await expect(status).toHaveText(
+    await assertSsfSubjectStatus(
+      page,
       "Subject is explicitly excluded from event delivery for this stream.",
     );
 
     // Remove: clears the explicit entry, back to not-included.
-    await page.getByTestId("ssfSubjectRemove").click();
+    await removeSsfSubject(page);
     await assertNotificationMessage(
       page,
       "Subject has been removed from this stream.",
     );
-    await expect(status).toHaveText(
+    await assertSsfSubjectStatus(
+      page,
       "Subject is not included in event delivery for this stream.",
     );
   });

--- a/js/apps/admin-ui/test/clients/ssf.spec.ts
+++ b/js/apps/admin-ui/test/clients/ssf.spec.ts
@@ -1,9 +1,18 @@
-import { expect, test, type Page } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
-import { toClient } from "../../src/clients/routes/Client.tsx";
-import { toSsfClientTab } from "../../src/clients/routes/ClientSsfTab.tsx";
 import adminClient from "../utils/AdminClient.ts";
-import { login, navigateTo } from "../utils/login.ts";
+import {
+  assertClientSettingsLoaded,
+  assertSsfNavigationTabsVisible,
+  assertSsfPendingLookupVisible,
+  assertSsfReceiverSaveButtonVisible,
+  assertSsfStreamEmptyStateVisible,
+  assertSsfSubjectTypeVisible,
+  assertSsfTabHidden,
+  loginToSsfTab,
+  navigateToClientSettings,
+  openSsfSubTab,
+} from "./ssf.ts";
 
 // The SSF (Shared Signals Framework) client view is triple-gated in
 // ClientDetails: the server `ssf` feature must be enabled, the realm must
@@ -57,57 +66,38 @@ test.describe.serial("Client SSF tab", () => {
     await adminClient.deleteRealm(realmName);
   });
 
-  /**
-   * Navigate straight to a client's SSF sub-tab via deep link and assert the
-   * SSF tab rendered. The server always has the `ssf` feature enabled (see
-   * file header), so a missing tab is a real failure, not a skip.
-   */
-  async function goToSsfTab(
-    page: Page,
-    tab: Parameters<typeof toSsfClientTab>[0]["tab"],
-  ) {
-    await login(page, {
-      to: toSsfClientTab({ realm: realmName, clientId: ssfClientUuid, tab }),
-    });
-
-    // Use a generous timeout here (not the expect default) to absorb the
-    // login + SPA load on the first navigation of the run.
-    await expect(page.getByTestId("ssfTab")).toBeVisible({ timeout: 15_000 });
-  }
-
   test("shows the SSF tab and all sub-tabs for an opted-in client", async ({
     page,
   }) => {
-    await goToSsfTab(page, "receiver");
-
-    await expect(page.getByTestId("ssfTab")).toBeVisible();
-    await expect(page.getByTestId("ssfReceiverTab")).toBeVisible();
-    await expect(page.getByTestId("ssfStreamTab")).toBeVisible();
-    await expect(page.getByTestId("ssfSubjectsTab")).toBeVisible();
-    await expect(page.getByTestId("ssfEventSearchTab")).toBeVisible();
-    await expect(page.getByTestId("ssfEmitEventsTab")).toBeVisible();
-
-    // The Receiver sub-tab is the default landing page; its save action
-    // confirms the form rendered.
-    await expect(page.getByTestId("ssfReceiverSave")).toBeVisible();
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid: ssfClientUuid,
+      tab: "receiver",
+    });
+    await assertSsfNavigationTabsVisible(page);
+    await assertSsfReceiverSaveButtonVisible(page);
   });
 
   test("navigates between the SSF sub-tabs", async ({ page }) => {
-    await goToSsfTab(page, "receiver");
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid: ssfClientUuid,
+      tab: "receiver",
+    });
 
     // The test client has no registered stream, so the Stream sub-tab shows
     // the "not registered" empty state rather than the refresh/stream card.
-    await page.getByTestId("ssfStreamTab").click();
-    await expect(page.getByTestId("empty-state")).toBeVisible();
+    await openSsfSubTab(page, "stream");
+    await assertSsfStreamEmptyStateVisible(page);
 
-    await page.getByTestId("ssfSubjectsTab").click();
-    await expect(page.getByTestId("ssfSubjectType")).toBeVisible();
+    await openSsfSubTab(page, "subjects");
+    await assertSsfSubjectTypeVisible(page);
 
-    await page.getByTestId("ssfEventSearchTab").click();
-    await expect(page.getByTestId("ssfPendingLookup")).toBeVisible();
+    await openSsfSubTab(page, "event-search");
+    await assertSsfPendingLookupVisible(page);
 
-    await page.getByTestId("ssfReceiverTab").click();
-    await expect(page.getByTestId("ssfReceiverSave")).toBeVisible();
+    await openSsfSubTab(page, "receiver");
+    await assertSsfReceiverSaveButtonVisible(page);
   });
 
   test("hides the SSF tab for a client that has not opted in", async ({
@@ -116,21 +106,16 @@ test.describe.serial("Client SSF tab", () => {
     // First prove the SSF tab does render for the opted-in client — otherwise
     // the negative assertion below could pass vacuously (e.g. if the feature
     // were off, the tab would be absent for every client).
-    await goToSsfTab(page, "receiver");
-    await expect(page.getByTestId("ssfTab")).toBeVisible();
+    await loginToSsfTab(page, {
+      realm: realmName,
+      clientUuid: ssfClientUuid,
+      tab: "receiver",
+    });
 
     // Then, without re-logging in (the session persists), open the client that
     // has NOT opted in and confirm the tab is absent.
-    await navigateTo(
-      page,
-      toClient({
-        realm: realmName,
-        clientId: plainClientUuid,
-        tab: "settings",
-      }),
-    );
-
-    await expect(page.getByTestId("clientId")).toBeVisible();
-    await expect(page.getByTestId("ssfTab")).toHaveCount(0);
+    await navigateToClientSettings(page, realmName, plainClientUuid);
+    await assertClientSettingsLoaded(page);
+    await assertSsfTabHidden(page);
   });
 });

--- a/js/apps/admin-ui/test/clients/ssf.ts
+++ b/js/apps/admin-ui/test/clients/ssf.ts
@@ -1,0 +1,223 @@
+import { expect, type Page } from "@playwright/test";
+import { toClient } from "../../src/clients/routes/Client.tsx";
+import {
+  type SsfClientTab,
+  toSsfClientTab,
+} from "../../src/clients/routes/ClientSsfTab.tsx";
+import { login, navigateTo } from "../utils/login.ts";
+
+type SsfTabOptions = {
+  realm: string;
+  clientUuid: string;
+  tab: SsfClientTab;
+};
+
+const SSF_TAB_TEST_IDS: Record<SsfClientTab, string> = {
+  receiver: "ssfReceiverTab",
+  stream: "ssfStreamTab",
+  subjects: "ssfSubjectsTab",
+  "event-search": "ssfEventSearchTab",
+  "emit-events": "ssfEmitEventsTab",
+};
+
+const SSF_STREAM_AUDIENCE_FIELD_TEST_ID = `attributes.${"ssf.streamAudience".replaceAll(".", "🍺")}`;
+
+function getSsfSubTab(page: Page, tab: SsfClientTab) {
+  return page.getByTestId(SSF_TAB_TEST_IDS[tab]);
+}
+
+function getSsfPushDeliveryMethodCheckbox(page: Page) {
+  return page.getByTestId("ssfAllowedDeliveryMethods.push");
+}
+
+function getSsfPollDeliveryMethodCheckbox(page: Page) {
+  return page.getByTestId("ssfAllowedDeliveryMethods.poll");
+}
+
+function getSsfAudienceField(page: Page) {
+  return page.getByTestId(SSF_STREAM_AUDIENCE_FIELD_TEST_ID);
+}
+
+export async function loginToSsfTab(page: Page, options: SsfTabOptions) {
+  await login(page, {
+    to: toSsfClientTab({
+      realm: options.realm,
+      clientId: options.clientUuid,
+      tab: options.tab,
+    }),
+  });
+  await assertSsfTabVisible(page);
+}
+
+export async function navigateToSsfTab(page: Page, options: SsfTabOptions) {
+  await navigateTo(
+    page,
+    toSsfClientTab({
+      realm: options.realm,
+      clientId: options.clientUuid,
+      tab: options.tab,
+    }),
+  );
+  await assertSsfTabVisible(page);
+}
+
+export async function navigateToClientSettings(
+  page: Page,
+  realm: string,
+  clientUuid: string,
+) {
+  await navigateTo(
+    page,
+    toClient({ realm, clientId: clientUuid, tab: "settings" }),
+  );
+}
+
+export async function assertSsfTabVisible(page: Page) {
+  await expect(page.getByTestId("ssfTab")).toBeVisible({ timeout: 15_000 });
+}
+
+export async function assertSsfTabHidden(page: Page) {
+  await expect(page.getByTestId("ssfTab")).toHaveCount(0);
+}
+
+export async function assertSsfNavigationTabsVisible(page: Page) {
+  await assertSsfTabVisible(page);
+  await expect(page.getByTestId("ssfReceiverTab")).toBeVisible();
+  await expect(page.getByTestId("ssfStreamTab")).toBeVisible();
+  await expect(page.getByTestId("ssfSubjectsTab")).toBeVisible();
+  await expect(page.getByTestId("ssfEventSearchTab")).toBeVisible();
+  await expect(page.getByTestId("ssfEmitEventsTab")).toBeVisible();
+}
+
+export async function openSsfSubTab(page: Page, tab: SsfClientTab) {
+  await getSsfSubTab(page, tab).click();
+}
+
+export async function assertClientSettingsLoaded(page: Page) {
+  await expect(page.getByTestId("clientId")).toBeVisible();
+}
+
+export async function assertSsfReceiverSaveButtonVisible(page: Page) {
+  await expect(page.getByTestId("ssfReceiverSave")).toBeVisible();
+}
+
+export async function assertSsfStreamEmptyStateVisible(page: Page) {
+  await expect(page.getByTestId("empty-state")).toBeVisible();
+}
+
+export async function assertSsfPendingLookupVisible(page: Page) {
+  await expect(page.getByTestId("ssfPendingLookup")).toBeVisible();
+}
+
+export async function assertSsfSubjectTypeVisible(page: Page) {
+  await expect(page.getByTestId("ssfSubjectType")).toBeVisible();
+}
+
+export async function openCreateSsfStreamForm(page: Page) {
+  await page.getByRole("button", { name: "Create stream" }).click();
+}
+
+function getCreateSsfStreamSubmitButton(page: Page) {
+  return page.getByTestId("ssfCreateStreamSubmit");
+}
+
+export async function assertCreateSsfStreamEndpointVisible(page: Page) {
+  await expect(page.getByTestId("ssfCreateStreamEndpointUrl")).toBeVisible();
+}
+
+export async function fillCreateSsfStreamEndpoint(page: Page, value: string) {
+  await page.getByTestId("ssfCreateStreamEndpointUrl").fill(value);
+}
+
+export async function fillCreateSsfStreamDescription(
+  page: Page,
+  value: string,
+) {
+  await page.getByTestId("ssfCreateStreamDescription").fill(value);
+}
+
+export async function assertCreateSsfStreamSubmitDisabled(page: Page) {
+  await expect(getCreateSsfStreamSubmitButton(page)).toBeDisabled();
+}
+
+export async function assertCreateSsfStreamSubmitEnabled(page: Page) {
+  await expect(getCreateSsfStreamSubmitButton(page)).toBeEnabled();
+}
+
+export async function assertCreateSsfStreamEndpointErrorVisible(page: Page) {
+  await expect(page.getByTestId("endpointUrl-helper")).toBeVisible();
+}
+
+export async function assertCreateSsfStreamEndpointErrorHidden(page: Page) {
+  await expect(page.getByTestId("endpointUrl-helper")).toBeHidden();
+}
+
+export async function submitCreateSsfStream(page: Page) {
+  await getCreateSsfStreamSubmitButton(page).click();
+}
+
+export async function assertRegisteredSsfStreamView(page: Page) {
+  await expect(page.getByTestId("ssfRefresh")).toBeVisible();
+  await expect(page.getByTestId("empty-state")).toBeHidden();
+}
+
+export async function fillSsfSubjectValue(page: Page, value: string) {
+  await page.getByTestId("ssfSubjectValue").fill(value);
+}
+
+export async function checkSsfSubject(page: Page) {
+  await page.getByTestId("ssfSubjectCheck").click();
+}
+
+export async function addSsfSubject(page: Page) {
+  await page.getByTestId("ssfSubjectAdd").click();
+}
+
+export async function ignoreSsfSubject(page: Page) {
+  await page.getByTestId("ssfSubjectIgnore").click();
+}
+
+export async function removeSsfSubject(page: Page) {
+  await page.getByTestId("ssfSubjectRemove").click();
+}
+
+export async function assertSsfSubjectValueError(page: Page, message: string) {
+  await expect(page.getByTestId("ssfSubjectValueError")).toHaveText(message);
+}
+
+export async function assertSsfSubjectStatus(page: Page, message: string) {
+  await expect(page.getByTestId("ssfSubjectStatus")).toHaveText(message);
+}
+
+export async function assertSsfAudienceValue(page: Page, value: string) {
+  await expect(getSsfAudienceField(page)).toHaveValue(value);
+}
+
+export async function fillSsfAudience(page: Page, value: string) {
+  await getSsfAudienceField(page).fill(value);
+}
+
+export async function clickSsfReceiverRevert(page: Page) {
+  await page.getByTestId("ssfReceiverRevert").click();
+}
+
+export async function clickSsfReceiverSave(page: Page) {
+  await page.getByTestId("ssfReceiverSave").click();
+}
+
+export async function assertSsfPushAndPollDeliveryMethodsChecked(page: Page) {
+  await expect(getSsfPushDeliveryMethodCheckbox(page)).toBeChecked();
+  await expect(getSsfPollDeliveryMethodCheckbox(page)).toBeChecked();
+}
+
+export async function disableSsfPollDeliveryMethod(page: Page) {
+  await getSsfPollDeliveryMethodCheckbox(page).click();
+}
+
+export async function assertSsfPushDeliveryMethodChecked(page: Page) {
+  await expect(getSsfPushDeliveryMethodCheckbox(page)).toBeChecked();
+}
+
+export async function assertSsfPollDeliveryMethodUnchecked(page: Page) {
+  await expect(getSsfPollDeliveryMethodCheckbox(page)).not.toBeChecked();
+}

--- a/js/apps/admin-ui/test/identity-providers/default-trust.spec.ts
+++ b/js/apps/admin-ui/test/identity-providers/default-trust.spec.ts
@@ -1,14 +1,26 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import adminClient from "../utils/AdminClient.ts";
 import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
 import { goToIdentityProviders } from "../utils/sidebar.ts";
-import { clickTableRowItem } from "../utils/table.ts";
-import { SERVER_URL } from "../utils/constants.ts";
 import { clickSaveButton, createDefaultTrustProvider } from "./main.ts";
+import {
+  assertClientIdentityFieldsAreHidden,
+  assertDefaultTrustFormDefaults,
+  assertDefaultTrustProviderValues,
+  assertPublicKeySignatureVerifierFields,
+  assertPublicKeySignatureVerifierSaved,
+  assertX509TrustMaterialFields,
+  disableJwksUrl,
+  disableX509TrustMaterial,
+  enableX509TrustMaterial,
+  fillPublicKeySignatureVerifier,
+  fillX509TrustMaterial,
+  goToAddDefaultTrustProvider,
+  openDefaultTrustProvider,
+} from "./default-trust.ts";
 
 const alias = "default-trust";
-const addDefaultTrustProviderUrl = `${SERVER_URL}/admin/master/console/#/master/identity-providers/default-trust/add`;
 const jwksUrl = "https://localhost/realms/test/protocol/openid-connect/certs";
 const jwks = '{"keys":[]}';
 
@@ -31,68 +43,33 @@ test.describe.serial("Default Trust identity provider test", () => {
   });
 
   test("should only show trust material settings", async ({ page }) => {
-    await page.goto(addDefaultTrustProviderUrl);
+    await goToAddDefaultTrustProvider(page);
+    await assertDefaultTrustFormDefaults(page, alias);
+    await assertClientIdentityFieldsAreHidden(page);
 
-    await expect(page.getByTestId("alias")).toHaveValue(alias);
-    await expect(page.getByTestId("config.useX509")).not.toBeChecked();
-    await expect(page.getByTestId("config.useJwksUrl")).toBeChecked();
-    await expect(page.getByTestId("config.jwksUrl")).toBeVisible();
+    await disableJwksUrl(page);
+    await assertPublicKeySignatureVerifierFields(page);
 
-    await expect(page.getByTestId("displayName")).toBeHidden();
-    await expect(page.getByTestId("config.clientId")).toBeHidden();
-    await expect(page.getByTestId("config.clientSecret")).toBeHidden();
-    await expect(page.getByTestId("displayOrder")).toBeHidden();
-
-    await page.getByTestId("config.useJwksUrl").click({ force: true });
-
-    await expect(page.getByTestId("config.jwksUrl")).toBeHidden();
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifier"),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifierKeyId"),
-    ).toBeVisible();
-    await expect(page.getByTestId("import-certificate-button")).toBeVisible();
-
-    await page.getByTestId("config.useX509").click({ force: true });
-    await expect(page.getByTestId("config.useJwksUrl")).toBeHidden();
-    await expect(page.getByTestId("config.trustedCertificates")).toBeVisible();
-    await expect(
-      page.getByTestId("config.requiredExtendedKeyUsages"),
-    ).toBeVisible();
+    await enableX509TrustMaterial(page);
+    await assertX509TrustMaterialFields(page);
   });
 
   test("should create and edit a Default Trust provider", async ({ page }) => {
     await createDefaultTrustProvider(page, alias, jwksUrl);
 
-    await goToIdentityProviders(page);
-    await clickTableRowItem(page, alias);
+    await openDefaultTrustProvider(page, alias);
+    await assertDefaultTrustProviderValues(page, jwksUrl);
 
-    await expect(page.getByTestId("config.useJwksUrl")).toBeChecked();
-    await expect(page.getByTestId("config.jwksUrl")).toHaveValue(jwksUrl);
-    await expect(page.getByTestId("displayName")).toBeHidden();
-    await expect(page.getByTestId("config.clientId")).toBeHidden();
-    await expect(page.getByTestId("config.clientSecret")).toBeHidden();
-    await expect(page.getByTestId("mappers-tab")).toBeHidden();
-
-    await page.getByTestId("config.useX509").click({ force: true });
-    await page
-      .getByTestId("config.trustedCertificates")
-      .fill("stale certificate");
-    await page.getByTestId("config.requiredExtendedKeyUsages").fill("1.2.3.4");
-    await page.getByTestId("config.useX509").click({ force: true });
+    await enableX509TrustMaterial(page);
+    await fillX509TrustMaterial(page, "stale certificate", "1.2.3.4");
+    await disableX509TrustMaterial(page);
     await clickSaveButton(page);
-
     await assertNotificationMessage(page, "Provider successfully updated");
 
-    await page.getByTestId("config.useJwksUrl").click({ force: true });
-    await page.getByTestId("config.publicKeySignatureVerifier").fill(jwks);
+    await disableJwksUrl(page);
+    await fillPublicKeySignatureVerifier(page, jwks);
     await clickSaveButton(page);
-
     await assertNotificationMessage(page, "Provider successfully updated");
-    await expect(page.getByTestId("config.useJwksUrl")).not.toBeChecked();
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifier"),
-    ).toHaveValue(jwks);
+    await assertPublicKeySignatureVerifierSaved(page, jwks);
   });
 });

--- a/js/apps/admin-ui/test/identity-providers/default-trust.ts
+++ b/js/apps/admin-ui/test/identity-providers/default-trust.ts
@@ -1,0 +1,106 @@
+import { expect, type Page } from "@playwright/test";
+import { SERVER_URL } from "../utils/constants.ts";
+import { clickSwitch } from "../utils/form.ts";
+import { goToIdentityProviders } from "../utils/sidebar.ts";
+import { clickTableRowItem } from "../utils/table.ts";
+
+async function getCurrentRealm(page: Page) {
+  return (await page.getByTestId("currentRealm").textContent()) ?? "master";
+}
+
+export async function goToAddDefaultTrustProvider(page: Page) {
+  const realm = await getCurrentRealm(page);
+  await page.goto(
+    `${SERVER_URL}/admin/master/console/#/${realm}/identity-providers/default-trust/add`,
+  );
+}
+
+export async function assertDefaultTrustFormDefaults(
+  page: Page,
+  alias: string,
+) {
+  await expect(page.getByTestId("alias")).toHaveValue(alias);
+  await expect(page.getByTestId("config.useX509")).not.toBeChecked();
+  await expect(page.getByTestId("config.useJwksUrl")).toBeChecked();
+  await expect(page.getByTestId("config.jwksUrl")).toBeVisible();
+}
+
+export async function assertClientIdentityFieldsAreHidden(page: Page) {
+  await expect(page.getByTestId("displayName")).toBeHidden();
+  await expect(page.getByTestId("config.clientId")).toBeHidden();
+  await expect(page.getByTestId("config.clientSecret")).toBeHidden();
+  await expect(page.getByTestId("displayOrder")).toBeHidden();
+}
+
+export async function disableJwksUrl(page: Page) {
+  await clickSwitch(page, page.getByTestId("config.useJwksUrl"));
+}
+
+export async function assertPublicKeySignatureVerifierFields(page: Page) {
+  await expect(page.getByTestId("config.jwksUrl")).toBeHidden();
+  await expect(
+    page.getByTestId("config.publicKeySignatureVerifier"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("config.publicKeySignatureVerifierKeyId"),
+  ).toBeVisible();
+  await expect(page.getByTestId("import-certificate-button")).toBeVisible();
+}
+
+export async function enableX509TrustMaterial(page: Page) {
+  await clickSwitch(page, page.getByTestId("config.useX509"));
+}
+
+export async function disableX509TrustMaterial(page: Page) {
+  await clickSwitch(page, page.getByTestId("config.useX509"));
+}
+
+export async function assertX509TrustMaterialFields(page: Page) {
+  await expect(page.getByTestId("config.useJwksUrl")).toBeHidden();
+  await expect(page.getByTestId("config.trustedCertificates")).toBeVisible();
+  await expect(
+    page.getByTestId("config.requiredExtendedKeyUsages"),
+  ).toBeVisible();
+}
+
+export async function openDefaultTrustProvider(page: Page, alias: string) {
+  await goToIdentityProviders(page);
+  await clickTableRowItem(page, alias);
+}
+
+export async function assertDefaultTrustProviderValues(
+  page: Page,
+  jwksUrl: string,
+) {
+  await expect(page.getByTestId("config.useJwksUrl")).toBeChecked();
+  await expect(page.getByTestId("config.jwksUrl")).toHaveValue(jwksUrl);
+  await expect(page.getByTestId("displayName")).toBeHidden();
+  await expect(page.getByTestId("config.clientId")).toBeHidden();
+  await expect(page.getByTestId("config.clientSecret")).toBeHidden();
+  await expect(page.getByTestId("mappers-tab")).toBeHidden();
+}
+
+export async function fillX509TrustMaterial(
+  page: Page,
+  certificate: string,
+  requiredExtendedKeyUsages: string,
+) {
+  await page.getByTestId("config.trustedCertificates").fill(certificate);
+  await page
+    .getByTestId("config.requiredExtendedKeyUsages")
+    .fill(requiredExtendedKeyUsages);
+}
+
+export async function fillPublicKeySignatureVerifier(page: Page, key: string) {
+  await page.getByTestId("config.publicKeySignatureVerifier").fill(key);
+}
+
+export async function assertPublicKeySignatureVerifierSaved(
+  page: Page,
+  key: string,
+) {
+  await expect(page.getByTestId("config.useJwksUrl")).not.toBeChecked();
+  await expect(
+    page.getByTestId("config.publicKeySignatureVerifier"),
+  ).toHaveValue(key);
+}

--- a/js/apps/admin-ui/test/identity-providers/jwt-authorization-grant.spec.ts
+++ b/js/apps/admin-ui/test/identity-providers/jwt-authorization-grant.spec.ts
@@ -1,17 +1,22 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import {
   createJwtAuthorizationGrantProvider,
   createJwtAuthorizationGrantProviderKey,
   clickSaveButton,
 } from "./main.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
-import { goToIdentityProviders } from "../utils/sidebar.ts";
-import { clickTableRowItem } from "../utils/table.ts";
 import { login } from "../utils/login.ts";
 import adminClient from "../utils/AdminClient.ts";
-import { assertModalTitle, confirmModal } from "../utils/modal.ts";
-import { selectItem } from "../utils/form.ts";
-import { chooseFileByLocator } from "../utils/file-chooser.ts";
+import { goToIdentityProviders } from "../utils/sidebar.ts";
+import {
+  assertJwtProviderWithJwksUrl,
+  assertJwtProviderWithPublicKey,
+  assertJwtPublicKeySignatureVerifier,
+  fillJwtProviderWithJwksUrl,
+  importJwtJwksFile,
+  importJwtPublicKeyPemFile,
+  openJwtAuthorizationGrantProvider,
+} from "./jwt-authorization-grant.ts";
 
 test.describe.serial("JWT Authorization Grant identity provider test", () => {
   test.beforeEach(async ({ page }) => {
@@ -38,32 +43,26 @@ test.describe.serial("JWT Authorization Grant identity provider test", () => {
       "Identity provider successfully created",
     );
 
-    await goToIdentityProviders(page);
-    await clickTableRowItem(page, "jwt-authorization");
-
-    await expect(page.getByTestId("config.issuer")).toHaveValue(
+    await openJwtAuthorizationGrantProvider(page, "jwt-authorization");
+    await assertJwtProviderWithJwksUrl(
+      page,
       "https://localhost/realms/test",
-    );
-    await expect(page.getByTestId("config.useJwksUrl")).toBeChecked();
-    await expect(page.getByTestId("config.jwksUrl")).toHaveValue(
       "https://localhost/realms/test/protocol/openid-connect/certs",
     );
 
-    await page
-      .getByTestId("config.issuer")
-      .fill("https://localhost/realms/test2");
-    await page
-      .getByTestId("config.jwksUrl")
-      .fill("https://localhost/realms/test2/protocol/openid-connect/certs");
+    await fillJwtProviderWithJwksUrl(
+      page,
+      "https://localhost/realms/test2",
+      "https://localhost/realms/test2/protocol/openid-connect/certs",
+    );
 
     await clickSaveButton(page);
 
     await assertNotificationMessage(page, "Provider successfully updated");
 
-    await expect(page.getByTestId("config.issuer")).toHaveValue(
+    await assertJwtProviderWithJwksUrl(
+      page,
       "https://localhost/realms/test2",
-    );
-    await expect(page.getByTestId("config.jwksUrl")).toHaveValue(
       "https://localhost/realms/test2/protocol/openid-connect/certs",
     );
   });
@@ -84,53 +83,22 @@ test.describe.serial("JWT Authorization Grant identity provider test", () => {
       "Identity provider successfully created",
     );
 
-    await goToIdentityProviders(page);
-    await clickTableRowItem(page, "jwt-authorization-grant");
-
-    await expect(page.getByTestId("config.issuer")).toHaveValue(
+    await openJwtAuthorizationGrantProvider(page);
+    await assertJwtProviderWithPublicKey(
+      page,
       "https://localhost/realms/test",
-    );
-    await expect(page.getByTestId("config.useJwksUrl")).not.toBeChecked();
-    await expect(page.getByTestId("config.jwksUrl")).toBeHidden();
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifierKeyId"),
-    ).toHaveValue("keyId");
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifier"),
-    ).toHaveValue(
+      "keyId",
       "MEMwBQYDK2VxAzoAWOVoLNsZlgw5dvat/Xi83Rh7zQMOerq3XrTT1xVbqDX2naZPlza0gwyNnMV6H6vnUGbaCK/+mgCA",
     );
 
-    await page.getByTestId("import-certificate-button").click();
-    await assertModalTitle(page, "Import key");
-    await selectItem(page, page.locator("#keystoreFormat"), "Public Key PEM");
-    await chooseFileByLocator(
-      page,
-      "../utils/files/key.pem",
-      page.locator("#importFile-browse-button"),
-    );
-    await confirmModal(page);
-
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifier"),
-    ).toHaveValue(/MIIBI/);
+    await importJwtPublicKeyPemFile(page);
+    await assertJwtPublicKeySignatureVerifier(page, /MIIBI/);
 
     await clickSaveButton(page);
     await assertNotificationMessage(page, "Provider successfully updated");
 
-    await page.getByTestId("import-certificate-button").click();
-    await assertModalTitle(page, "Import key");
-    await selectItem(page, page.locator("#keystoreFormat"), "JSON Web Key Set");
-    await chooseFileByLocator(
-      page,
-      "../utils/files/key.jwks",
-      page.locator("#importFile-browse-button"),
-    );
-    await confirmModal(page);
-
-    await expect(
-      page.getByTestId("config.publicKeySignatureVerifier"),
-    ).toHaveValue(/{\s*"keys"\s*:\s*/);
+    await importJwtJwksFile(page);
+    await assertJwtPublicKeySignatureVerifier(page, /{\s*"keys"\s*:\s*/);
 
     await clickSaveButton(page);
     await assertNotificationMessage(page, "Provider successfully updated");

--- a/js/apps/admin-ui/test/identity-providers/jwt-authorization-grant.ts
+++ b/js/apps/admin-ui/test/identity-providers/jwt-authorization-grant.ts
@@ -1,0 +1,86 @@
+import { expect, type Page } from "@playwright/test";
+import { chooseFileByLocator } from "../utils/file-chooser.ts";
+import { selectItem } from "../utils/form.ts";
+import { assertModalTitle, confirmModal } from "../utils/modal.ts";
+import { goToIdentityProviders } from "../utils/sidebar.ts";
+import { clickTableRowItem } from "../utils/table.ts";
+
+export async function openJwtAuthorizationGrantProvider(
+  page: Page,
+  alias = "jwt-authorization-grant",
+) {
+  await goToIdentityProviders(page);
+  await clickTableRowItem(page, alias);
+}
+
+export async function assertJwtProviderWithJwksUrl(
+  page: Page,
+  issuer: string,
+  jwksUrl: string,
+) {
+  await expect(page.getByTestId("config.issuer")).toHaveValue(issuer);
+  await expect(page.getByTestId("config.useJwksUrl")).toBeChecked();
+  await expect(page.getByTestId("config.jwksUrl")).toHaveValue(jwksUrl);
+}
+
+export async function fillJwtProviderWithJwksUrl(
+  page: Page,
+  issuer: string,
+  jwksUrl: string,
+) {
+  await page.getByTestId("config.issuer").fill(issuer);
+  await page.getByTestId("config.jwksUrl").fill(jwksUrl);
+}
+
+export async function assertJwtProviderWithPublicKey(
+  page: Page,
+  issuer: string,
+  keyId: string,
+  key: string,
+) {
+  await expect(page.getByTestId("config.issuer")).toHaveValue(issuer);
+  await expect(page.getByTestId("config.useJwksUrl")).not.toBeChecked();
+  await expect(page.getByTestId("config.jwksUrl")).toBeHidden();
+  await expect(
+    page.getByTestId("config.publicKeySignatureVerifierKeyId"),
+  ).toHaveValue(keyId);
+  await expect(
+    page.getByTestId("config.publicKeySignatureVerifier"),
+  ).toHaveValue(key);
+}
+
+export async function assertJwtPublicKeySignatureVerifier(
+  page: Page,
+  value: string | RegExp,
+) {
+  await expect(
+    page.getByTestId("config.publicKeySignatureVerifier"),
+  ).toHaveValue(value);
+}
+
+async function openImportKeyDialog(page: Page) {
+  await page.getByTestId("import-certificate-button").click();
+  await assertModalTitle(page, "Import key");
+}
+
+export async function importJwtPublicKeyPemFile(page: Page) {
+  await openImportKeyDialog(page);
+  await selectItem(page, page.locator("#keystoreFormat"), "Public Key PEM");
+  await chooseFileByLocator(
+    page,
+    "../utils/files/key.pem",
+    page.locator("#importFile-browse-button"),
+  );
+  await confirmModal(page);
+}
+
+export async function importJwtJwksFile(page: Page) {
+  await openImportKeyDialog(page);
+  await selectItem(page, page.locator("#keystoreFormat"), "JSON Web Key Set");
+  await chooseFileByLocator(
+    page,
+    "../utils/files/key.jwks",
+    page.locator("#importFile-browse-button"),
+  );
+  await confirmModal(page);
+}

--- a/js/apps/admin-ui/test/realm-settings/general.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/general.spec.ts
@@ -1,22 +1,27 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
-import { clickSwitch, switchOff, switchOn } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
-import { confirmModal } from "../utils/modal.ts";
 import { goToClients, goToRealm, goToRealmSettings } from "../utils/sidebar.ts";
 import {
   assertDisplayName,
   assertFrontendURL,
+  assertOpenIdEndpointConfigurationLink,
+  assertOpenIdEndpointConfigurationReachable,
+  assertRequiredFieldMessage,
   assertRequireSSL,
+  clearRealmId,
   clickRevertButton,
   clickSaveRealm,
+  disableRealm,
+  disableUserManagedAccess,
+  enableRealm,
+  enableUserManagedAccess,
   fillDisplayName,
   fillFrontendURL,
   fillRequireSSL,
 } from "./general.ts";
-import { SERVER_URL } from "../utils/constants.ts";
 
 test.describe.serial("Realm settings general tab tests", () => {
   const realmName = `general-realm-settings-${uuid()}`;
@@ -33,51 +38,32 @@ test.describe.serial("Realm settings general tab tests", () => {
   test("Check Access Endpoints OpenID Endpoint Configuration link", async ({
     page,
   }) => {
-    const locator = page.getByRole("link", {
-      name: "OpenID Endpoint Configuration",
-    });
-
-    await expect(locator).toHaveAttribute(
-      "href",
-      `${SERVER_URL}/realms/${realmName}/.well-known/openid-configuration`,
-    );
-    await expect(locator).toHaveAttribute("target", "_blank");
-    await expect(locator).toHaveAttribute("rel", "noreferrer noopener");
-
-    const link = await page
-      .getByRole("link", { name: "OpenID Endpoint Configuration" })
-      .getAttribute("href");
-    const response = await page.request.get(link!);
-    expect(response.status()).toBe(200);
+    await assertOpenIdEndpointConfigurationLink(page, realmName);
+    await assertOpenIdEndpointConfigurationReachable(page);
   });
 
   test("all general tab switches", async ({ page }) => {
-    await switchOn(page, "#userManagedAccessAllowed");
+    await enableUserManagedAccess(page);
     await clickSaveRealm(page);
     await assertNotificationMessage(page, "Realm successfully updated");
 
-    await switchOff(page, "#userManagedAccessAllowed");
+    await disableUserManagedAccess(page);
     await clickSaveRealm(page);
     await assertNotificationMessage(page, "Realm successfully updated");
   });
 
   test("realm enable/disable switch", async ({ page }) => {
-    // Enable realm
-    const realmSwitch = page.locator(`#${realmName}-switch`);
-    await expect(realmSwitch).not.toBeChecked();
-    await switchOn(page, realmSwitch);
+    await enableRealm(page, realmName);
     await assertNotificationMessage(page, "Realm successfully updated");
 
-    // Disable realm
-    await clickSwitch(page, realmSwitch);
-    await confirmModal(page);
+    await disableRealm(page, realmName);
     await assertNotificationMessage(page, "Realm successfully updated");
   });
 
   test("Fail to set Realm ID to empty", async ({ page }) => {
-    await page.getByRole("textbox", { name: "Copyable input" }).fill("");
+    await clearRealmId(page);
     await clickSaveRealm(page);
-    await expect(page.getByText("Required field")).toBeVisible();
+    await assertRequiredFieldMessage(page);
   });
 
   test("Modify Display name", async ({ page }) => {

--- a/js/apps/admin-ui/test/realm-settings/general.ts
+++ b/js/apps/admin-ui/test/realm-settings/general.ts
@@ -1,8 +1,44 @@
-import { Page, expect } from "@playwright/test";
-import { selectItem } from "../utils/form.ts";
+import { type Page, expect } from "@playwright/test";
+import { SERVER_URL } from "../utils/constants.ts";
+import { clickSwitch, selectItem, switchOff, switchOn } from "../utils/form.ts";
+import { confirmModal } from "../utils/modal.ts";
 
 export async function clickSaveRealm(page: Page) {
   await page.getByTestId("realmSettingsGeneralTab-save").click();
+}
+
+function getOpenIdEndpointConfigurationLink(page: Page) {
+  return page.getByRole("link", {
+    name: "OpenID Endpoint Configuration",
+  });
+}
+
+export async function assertOpenIdEndpointConfigurationLink(
+  page: Page,
+  realmName: string,
+) {
+  const openIdEndpointLink = getOpenIdEndpointConfigurationLink(page);
+  await expect(openIdEndpointLink).toHaveAttribute(
+    "href",
+    `${SERVER_URL}/realms/${realmName}/.well-known/openid-configuration`,
+  );
+  await expect(openIdEndpointLink).toHaveAttribute("target", "_blank");
+  await expect(openIdEndpointLink).toHaveAttribute(
+    "rel",
+    "noreferrer noopener",
+  );
+}
+
+export async function assertOpenIdEndpointConfigurationReachable(page: Page) {
+  const link =
+    await getOpenIdEndpointConfigurationLink(page).getAttribute("href");
+
+  if (!link) {
+    throw new Error("OpenID Endpoint Configuration link is missing");
+  }
+
+  const response = await page.request.get(link);
+  expect(response.status()).toBe(200);
 }
 
 function getDisplayName(page: Page) {
@@ -39,4 +75,35 @@ export async function assertRequireSSL(page: Page, value: string) {
 
 export async function clickRevertButton(page: Page) {
   await page.getByTestId("realmSettingsGeneralTab-revert").click();
+}
+
+export async function enableUserManagedAccess(page: Page) {
+  await switchOn(page, "#userManagedAccessAllowed");
+}
+
+export async function disableUserManagedAccess(page: Page) {
+  await switchOff(page, "#userManagedAccessAllowed");
+}
+
+function getRealmSwitch(page: Page, realmName: string) {
+  return page.locator(`#${realmName}-switch`);
+}
+
+export async function enableRealm(page: Page, realmName: string) {
+  const realmSwitch = getRealmSwitch(page, realmName);
+  await expect(realmSwitch).not.toBeChecked();
+  await switchOn(page, realmSwitch);
+}
+
+export async function disableRealm(page: Page, realmName: string) {
+  await clickSwitch(page, getRealmSwitch(page, realmName));
+  await confirmModal(page);
+}
+
+export async function clearRealmId(page: Page) {
+  await page.getByRole("textbox", { name: "Copyable input" }).fill("");
+}
+
+export async function assertRequiredFieldMessage(page: Page) {
+  await expect(page.getByText("Required field")).toBeVisible();
 }

--- a/js/apps/admin-ui/test/workflows/workflow-user-tab.spec.ts
+++ b/js/apps/admin-ui/test/workflows/workflow-user-tab.spec.ts
@@ -1,13 +1,14 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
 import { login } from "../utils/login.ts";
 import { toUser } from "../../src/user/routes/User.tsx";
+import { assertRowExists, openRowDetails } from "../utils/table.ts";
 import {
-  assertRowExists,
-  getTableData,
-  openRowDetails,
-} from "../utils/table.ts";
+  assertPendingWorkflowSteps,
+  assertWorkflowYaml,
+  toggleWorkflowYaml,
+} from "./workflow-user-tab.ts";
 
 function statusWorkflowStr(status: string): string {
   return `
@@ -61,24 +62,15 @@ test.describe.serial("Workflow tab in Users section", () => {
     await openRowDetails(page, silverStatusName);
     await openRowDetails(page, goldStatusName);
 
-    await page.getByTestId(`yaml-ex-toggle-${silverStatusName}`).click();
-    await page.getByTestId(`yaml-ex-toggle-${goldStatusName}`).click();
+    await toggleWorkflowYaml(page, silverStatusName);
+    await toggleWorkflowYaml(page, goldStatusName);
 
-    await expect(
-      page.getByTestId(`workflowYAML-${silverStatusName}`),
-    ).toHaveText(statusWorkflowStr("Silver"));
-
-    await expect(page.getByTestId(`workflowYAML-${goldStatusName}`)).toHaveText(
-      statusWorkflowStr("Gold"),
+    await assertWorkflowYaml(
+      page,
+      silverStatusName,
+      statusWorkflowStr("Silver"),
     );
-
-    const tableData = await getTableData(page, `${silverStatusName}-Steps`);
-    expect(tableData).toHaveLength(2);
-    expect(tableData[0][0]).toBe("set-user-attribute");
-    expect(tableData[0][1]).toBe("");
-    expect(tableData[0][2]).toBe("Completed");
-    expect(tableData[1][0]).toBe("disable-user");
-    expect(new Date(tableData[1][1]).getTime()).not.toBeNaN(); // test if date string is valid
-    expect(tableData[1][2]).toBe("Pending");
+    await assertWorkflowYaml(page, goldStatusName, statusWorkflowStr("Gold"));
+    await assertPendingWorkflowSteps(page, silverStatusName);
   });
 });

--- a/js/apps/admin-ui/test/workflows/workflow-user-tab.ts
+++ b/js/apps/admin-ui/test/workflows/workflow-user-tab.ts
@@ -1,0 +1,30 @@
+import { expect, type Page } from "@playwright/test";
+import { getTableData } from "../utils/table.ts";
+
+export async function toggleWorkflowYaml(page: Page, workflowName: string) {
+  await page.getByTestId(`yaml-ex-toggle-${workflowName}`).click();
+}
+
+export async function assertWorkflowYaml(
+  page: Page,
+  workflowName: string,
+  expectedYaml: string,
+) {
+  await expect(page.getByTestId(`workflowYAML-${workflowName}`)).toHaveText(
+    expectedYaml,
+  );
+}
+
+export async function assertPendingWorkflowSteps(
+  page: Page,
+  workflowName: string,
+) {
+  const tableData = await getTableData(page, `${workflowName}-Steps`);
+  expect(tableData).toHaveLength(2);
+  expect(tableData[0][0]).toBe("set-user-attribute");
+  expect(tableData[0][1]).toBe("");
+  expect(tableData[0][2]).toBe("Completed");
+  expect(tableData[1][0]).toBe("disable-user");
+  expect(new Date(tableData[1][1]).getTime()).not.toBeNaN();
+  expect(tableData[1][2]).toBe("Pending");
+}


### PR DESCRIPTION
## Summary
- add a Playwright test style guide at `js/apps/admin-ui/test/README.md` and link it from `js/apps/admin-ui/CONTRIBUTING.md`
- introduce action/assertion helper modules for SSF, default trust provider, JWT authorization grant provider, and workflow user tab test flows
- refactor selected Admin UI Playwright specs so test files read as scenario steps while selectors remain in helper files

Closes #52266
