### PR TITLE
Prevent Shift+Enter from submitting login form

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
@@ -3,6 +3,7 @@ package org.keycloak.testsuite.forms;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.keycloak.admin.client.resource.RealmResource;
@@ -37,6 +38,7 @@ import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.ActionURIUtils;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AdminApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.IgnoreBrowserDriver;
 import org.keycloak.testsuite.auth.page.login.OneTimeCode;
 import org.keycloak.testsuite.authentication.SetUserAttributeAuthenticatorFactory;
 import org.keycloak.testsuite.broker.SocialLoginTest;
@@ -57,8 +59,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.broker.SocialLoginTest.Provider.GITHUB;
@@ -686,6 +692,71 @@ public class BrowserFlowTest extends AbstractChangeImportedUserPasswordsTest {
                 // Activate this new flow
                 .defineAsBrowserFlow()
         );
+    }
+
+    @Test
+    @IgnoreBrowserDriver(value = { ChromeDriver.class, FirefoxDriver.class }, negate = true)
+    public void testShiftEnterDoesNotSubmitLoginForms() {
+        oauth.openLoginForm();
+        loginPage.assertCurrent();
+        assertShiftEnterIsPrevented();
+
+        String newFlowAlias = "browser - separate username and password";
+        testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow(newFlowAlias));
+        testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session)
+                .selectFlow(newFlowAlias)
+                .inForms(forms -> forms
+                        .clear()
+                        .addAuthenticatorExecution(Requirement.REQUIRED, UsernameFormFactory.PROVIDER_ID)
+                        .addAuthenticatorExecution(Requirement.REQUIRED, PasswordFormFactory.PROVIDER_ID))
+                .defineAsBrowserFlow());
+
+        try {
+            oauth.openLoginForm();
+            loginUsernameOnlyPage.assertCurrent();
+            assertShiftEnterIsPrevented();
+
+            WebElement username = driver.findElement(By.cssSelector("#kc-form-login #username"));
+            username.sendKeys("test-user@localhost", Keys.ENTER);
+            WaitUtils.waitForPageToLoad();
+            passwordPage.assertCurrent();
+        } finally {
+            revertFlows(newFlowAlias);
+        }
+    }
+
+    private void assertShiftEnterIsPrevented() {
+        JavascriptExecutor javascriptExecutor = (JavascriptExecutor) driver;
+        boolean shiftEnterDefaultAllowed = (Boolean) javascriptExecutor.executeScript("""
+                return document.querySelector('#kc-form-login #username').dispatchEvent(new KeyboardEvent('keydown', {
+                    key: 'Enter',
+                    shiftKey: true,
+                    bubbles: true,
+                    cancelable: true
+                }));
+                """);
+        Assertions.assertFalse(shiftEnterDefaultAllowed);
+
+        String currentWindow = driver.getWindowHandle();
+        String currentUrl = driver.getCurrentUrl();
+        Set<String> windowHandles = driver.getWindowHandles();
+        try {
+            driver.findElement(By.cssSelector("#kc-form-login #username"))
+                    .sendKeys(Keys.chord(Keys.SHIFT, Keys.ENTER));
+            WaitUtils.pause(250);
+
+            Assertions.assertEquals(windowHandles, driver.getWindowHandles());
+            Assertions.assertEquals(currentUrl, driver.getCurrentUrl());
+            Assertions.assertTrue(driver.findElement(By.id("kc-login")).isEnabled());
+        } finally {
+            driver.getWindowHandles().stream()
+                    .filter(windowHandle -> !windowHandles.contains(windowHandle))
+                    .forEach(windowHandle -> {
+                        driver.switchTo().window(windowHandle);
+                        driver.close();
+                    });
+            driver.switchTo().window(currentWindow);
+        }
     }
 
     @Test

--- a/themes/src/main/resources/theme/base/login/resources/js/preventShiftEnter.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/preventShiftEnter.js
@@ -1,0 +1,7 @@
+document
+  .querySelector("#kc-form-login #username")
+  ?.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" && event.shiftKey) {
+      event.preventDefault();
+    }
+  });

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -48,6 +48,7 @@
         }
     </script>
     <script src="${url.resourcesPath}/js/menu-button-links.js" type="module"></script>
+    <script src="${url.resourcesPath}/js/preventShiftEnter.js" type="module"></script>
     <#if scripts??>
         <#list scripts as script>
             <script src="${script}" type="text/javascript"></script>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -99,6 +99,7 @@
         </#list>
     </#if>
     <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
+    <script type="module" src="${url.resourcesPath}/js/preventShiftEnter.js"></script>
     <script type="module">
         <#outputformat "JavaScript">
         import { startSessionPolling } from ${(url.resourcesPath + "/js/authChecker.js")?c};


### PR DESCRIPTION
## Summary

- Prevent `Shift+Enter` in the username field from submitting the login form in a new browsing context.
- Load the handler in the base and `keycloak.v2` login themes.
- Add a browser regression test covering combined and username-first login flows while preserving ordinary Enter behavior.

## Testing

- `./mvnw -pl testsuite/integration-arquillian/tests/base spotless:check`
- `./mvnw -pl themes -DskipTests process-resources`
- `node --check themes/src/main/resources/theme/base/login/resources/js/preventShiftEnter.js`
- `./mvnw -f testsuite/integration-arquillian/tests/base/pom.xml -Dtest=org.keycloak.testsuite.forms.BrowserFlowTest#testShiftEnterDoesNotSubmitLoginForms -Dbrowser=chrome test`

The targeted browser test passed with Chrome 152: 1 test run, 0 failures, 0 errors, and 0 skipped tests.

## AI usage disclosure

An AI coding agent was used to help investigate, implement, and test this change.

Closes #52056
