### PR TITLE
Avoiding flagged unsafe action

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .github/scripts
-          ref: ${{ github.event.pull_request.base.sha }}
+
       - name: Add release labels on merge
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
With the fix in 7.0.1 of the checkout action, referencing this commit is no longer necessary

Closes #52285

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
