### PR TITLE
Format the recovery codes download timestamp in the user's locale

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-config.ftl
@@ -103,7 +103,7 @@
                 timeZoneName: 'short'
             };
 
-            return dt.toLocaleString('en-US', options);
+            return dt.toLocaleString('${lang}', options);
         }
 
         function parseRecoveryCodeList() {
@@ -120,15 +120,6 @@
 
         function buildDownloadContent() {
             var recoveryCodeList = parseRecoveryCodeList();
-            var dt = new Date();
-            var options = {
-                month: 'long',
-                day: 'numeric',
-                year: 'numeric',
-                hour: 'numeric',
-                minute: 'numeric',
-                timeZoneName: 'short'
-            };
 
             return fileBodyContent =
                 ${msg("recovery-codes-download-file-header")?c} + "\n\n" +

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-recovery-authn-code-config.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-recovery-authn-code-config.ftl
@@ -101,7 +101,7 @@
                 timeZoneName: 'short'
             };
 
-            return dt.toLocaleString('en-US', options);
+            return dt.toLocaleString('${lang}', options);
         }
 
         function parseRecoveryCodeList() {
@@ -120,15 +120,6 @@
 
         function buildDownloadContent() {
             const recoveryCodeList = parseRecoveryCodeList();
-            const dt = new Date();
-            const options = {
-                month: 'long',
-                day: 'numeric',
-                year: 'numeric',
-                hour: 'numeric',
-                minute: 'numeric',
-                timeZoneName: 'short'
-            };
 
             return fileBodyContent =
                 ${msg("recovery-codes-download-file-header")?c} + "\n\n" +


### PR DESCRIPTION
New description/fix:
Use Keycloak's negotiated user language (from i18n context, locale attribute, ...) for formatting the the recovery codes download timestamp.

Was previously:
Trying to use the browsers preferred language first (it's the first entry in `navigator.languages[]`, otherwise the default browser language from `navigator.language`. If nothing is available, use the hardcoded `en-US` locale.

Also removed old and unused code from a previous refactoring.

closes #52291
