### PR TITLE
Fix NPE parsing an EC JWK with a missing x or y coordinate

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jwk/JWKParser.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKParser.java
@@ -93,8 +93,8 @@ public class JWKParser {
 
         /* Try retrieving the necessary fields */
         String crv = jwk.path(ECPublicJWK.CRV).asText(null);
-        String xStr = jwk.get(ECPublicJWK.X).asText(null);
-        String yStr = jwk.get(ECPublicJWK.Y).asText(null);
+        String xStr = jwk.path(ECPublicJWK.X).asText(null);
+        String yStr = jwk.path(ECPublicJWK.Y).asText(null);
 
         /* Check if the retrieving of necessary fields success */
         if (crv == null || xStr == null || yStr == null) {

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This is not tested in keycloak-core. The subclasses should be created in the crypto modules to make sure it is tested with corresponding modules (bouncycastle VS bouncycastle-fips)
@@ -279,6 +280,33 @@ public abstract class JWKTest {
         assertNotNull(pub);
         assertTrue(pub.getAlgorithm().startsWith("EC"));
         assertEquals("X.509", pub.getFormat());
+    }
+
+    @Test
+    public void toPublicKeyEcMissingCoordinate() {
+        // An EC JWK missing the "x" (or "y") coordinate must fail with the explicit
+        // "Fail to retrieve ..." error, not a NullPointerException. Before the fix the
+        // x/y fields were read with get() (which returns null for a missing key) instead
+        // of path() (a non-null MissingNode, as crv and the RSA path already use), so a
+        // missing coordinate dereferenced null and threw NPE before the null-guard - which
+        // explicitly lists X and Y as nullable - could ever run.
+        String jwkJson = "{\n" +
+                         "    \"kty\": \"EC\",\n" +
+                         "    \"crv\": \"P-256\",\n" +
+                         "    \"y\": \"cOsAvnh6olE8KHWPHmB-pJawRWmTtbChmWtSeWZRJdc\"\n" +
+                         "}";
+
+        JWKParser sut = JWKParser.create().parse(jwkJson);
+
+        try {
+            sut.toPublicKey();
+            fail("Expected a RuntimeException for the missing EC 'x' coordinate");
+        } catch (NullPointerException e) {
+            fail("Missing EC coordinate must not surface as NullPointerException: " + e);
+        } catch (RuntimeException e) {
+            assertNotNull("Expected an explanatory message", e.getMessage());
+            assertTrue("Unexpected message: " + e.getMessage(), e.getMessage().contains("Fail to retrieve"));
+        }
     }
 
     private byte[] sign(byte[] data, String javaAlgorithm, PrivateKey key) throws Exception {


### PR DESCRIPTION
Closes #52294

`JWKParser#createECPublicKey` read the `x`/`y` fields with `get()` (which returns `null` for a missing key) instead of `path()` (a non-null `MissingNode`, as `crv` and the RSA path already use). So a JWK missing a coordinate threw `NullPointerException` before the null-guard - which explicitly lists `crv`, `x` and `y` as nullable - could run.

Read `x`/`y` with `path()` too, so a malformed externally-supplied EC JWK fails with the intended `Fail to retrieve ...` message instead of an NPE.

Added `JWKTest#toPublicKeyEcMissingCoordinate`, verified in the crypto modules (`DefaultCryptoJWKTest`) fails-before / passes-after.