### PR TITLE
Decode \uXXXX escapes in SCIM filter string values

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/filter/FilterUtils.java
+++ b/scim/core/src/main/java/org/keycloak/scim/filter/FilterUtils.java
@@ -124,8 +124,10 @@ public class FilterUtils {
     }
 
     /**
-     * Unescapes a JSON string value (without surrounding quotes) per RFC 8259.
-     * Unicode escape sequences are handled by the ANTLR lexer.
+     * Unescapes a JSON string value (without surrounding quotes) per RFC 8259,
+     * including {@code \\uXXXX} Unicode escape sequences. The ANTLR lexer only
+     * recognizes these escapes; it does not decode them, so {@code getText()}
+     * returns them verbatim and they must be decoded here like every other escape.
      */
     public static String unescapeJsonString(String s) {
         if (s.indexOf('\\') == -1) {
@@ -145,6 +147,22 @@ public class FilterUtils {
                     case 'n'  -> sb.append('\n');
                     case 'r'  -> sb.append('\r');
                     case 't'  -> sb.append('\t');
+                    case 'u'  -> {
+                        int cp = -1;
+                        if (i + 4 < s.length()) {
+                            try {
+                                cp = Integer.parseInt(s, i + 1, i + 5, 16);
+                            } catch (NumberFormatException ignored) {
+                                // not four hex digits - leave the escape literal
+                            }
+                        }
+                        if (cp >= 0) {
+                            sb.append((char) cp);
+                            i += 4;
+                        } else {
+                            sb.append('\\').append(next);
+                        }
+                    }
                     default   -> sb.append('\\').append(next);
                 }
             } else {

--- a/scim/core/src/test/java/org/keycloak/scim/filter/FilterUtilsTest.java
+++ b/scim/core/src/test/java/org/keycloak/scim/filter/FilterUtilsTest.java
@@ -171,6 +171,21 @@ public class FilterUtilsTest {
     }
 
     @Test
+    public void testUnescapeUnicodeEscape() {
+        // \\uXXXX escapes are only recognized - not decoded - by the ANTLR lexer, so
+        // unescapeJsonString must decode them like every other JSON escape.
+        assertEquals("A", FilterUtils.unescapeJsonString("\\u0041"));
+        assertEquals("ABC", FilterUtils.unescapeJsonString("\\u0041BC"));
+        assertEquals("caf\u00e9", FilterUtils.unescapeJsonString("caf\\u00e9"));
+        // interleaved with other escapes
+        assertEquals("A\tB", FilterUtils.unescapeJsonString("\\u0041\\t\\u0042"));
+        // a malformed \\u (too few hex digits) is left literal rather than throwing
+        assertEquals("\\u12", FilterUtils.unescapeJsonString("\\u12"));
+        // end-to-end: a filter comparison value carrying a \\uXXXX escape
+        assertDoesNotThrow(() -> FilterUtils.parseFilter("userName eq \"\\u0041\""));
+    }
+
+    @Test
     public void testInvalidSyntax() {
         // Missing value
         ScimFilterException e1 = assertThrows(ScimFilterException.class,


### PR DESCRIPTION
Closes #52295

`FilterUtils.unescapeJsonString` decoded every JSON escape except the `\uXXXX` form, whose `default` arm left it literal - so the escape for `U+0041` stayed as its six characters instead of becoming `A`. The Javadoc claimed the ANTLR lexer handled Unicode escapes, but the lexer only *recognizes* `\uXXXX` (a grammar fragment) and returns the raw text via `getText()`.

Decode `\uXXXX` like the other escapes (a malformed escape without four hex digits is left literal), and correct the Javadoc.

Added regression coverage in `FilterUtilsTest`, verified fails-before / passes-after.