### PR TITLE
Percent-encode spaces in the OTP key URI account name

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/OTPPolicy.java
+++ b/server-spi/src/main/java/org/keycloak/models/OTPPolicy.java
@@ -164,7 +164,12 @@ public class OTPPolicy implements Serializable {
      */
     public String getKeyURI(String rawIssuerName, String rawAccountName, String secret) {
 
-        String accountName = URLEncoder.encode(rawAccountName, UTF_8);
+        /*
+         * The label components are URI path segments, where '+' is a literal plus, not a space.
+         * URLEncoder produces the application/x-www-form-urlencoded form (space -> '+'), so - like
+         * the issuerName below - the account name must rewrite '+' back to '%20'.
+         */
+        String accountName = URLEncoder.encode(rawAccountName, UTF_8).replaceAll("\\+", "%20");
         /*
          * Replacing ':' in issuerName with a space because the ':' is not allowed in the issuer part of the label.
          * See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label

--- a/server-spi/src/test/java/org/keycloak/models/OtpPolicyTest.java
+++ b/server-spi/src/test/java/org/keycloak/models/OtpPolicyTest.java
@@ -35,7 +35,23 @@ public class OtpPolicyTest {
         Assert.assertEquals("Test/Realm", getLabelComponent(keyURI));
     }
 
+    @Test
+    public void keyUriShouldPercentEncodeSpaceInAccountName() {
+
+        String keyURI = totpPolicy.getKeyURI("Realm", "john doe", "secret");
+
+        // The account-name label segment is a URI path component, where '+' is a literal
+        // plus, not a space. URLEncoder emits '+' for a space, so it must be rewritten to
+        // %20 (as the issuer segment already is); otherwise authenticator apps show "john+doe".
+        Assert.assertEquals("john doe", getAccountComponent(keyURI));
+        Assert.assertFalse("account name must be %20-encoded, not '+'", keyURI.contains("john+doe"));
+    }
+
     static String getLabelComponent(String keyURI) {
         return URI.create(keyURI).getPath().substring(1).split(":")[0];
+    }
+
+    static String getAccountComponent(String keyURI) {
+        return URI.create(keyURI).getPath().substring(1).split(":", 2)[1];
     }
 }


### PR DESCRIPTION
Closes #52296

`OTPPolicy#getKeyURI` built the account-name half of the `otpauth://` label with `URLEncoder.encode`, which emits the form-urlencoded shape where a space becomes `+`. The label is a URI path component, in which `+` is a literal plus - so an account name such as `john doe` was rendered as `john+doe` and shown verbatim by authenticator apps.

Rewrite `+` to `%20` for the account name, exactly as the adjacent `issuerName` line already does.

Added `OtpPolicyTest#keyUriShouldPercentEncodeSpaceInAccountName`, verified fails-before / passes-after.