### PR TITLE
Apply PKCE validation only to response types issuing an authorization code

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -335,10 +335,10 @@ public class AuthorizationEndpointChecker {
         String codeChallenge = request.getCodeChallenge();
         String codeChallengeMethod = request.getCodeChallengeMethod();
 
-        // PKCE not adopted to OAuth2 Implicit Grant and OIDC Implicit Flow,
-        // adopted to OAuth2 Authorization Code Grant and OIDC Authorization Code Flow, Hybrid Flow
-        // Namely, flows using authorization code.
-        if (parsedResponseType != null && parsedResponseType.isImplicitFlow()) return;
+        // PKCE applies only to authorization requests that issue an authorization code.
+        if (parsedResponseType != null && !parsedResponseType.hasResponseType(OIDCResponseType.CODE)) {
+            return;
+        }
 
         String pkceCodeChallengeMethod = OIDCAdvancedConfigWrapper.fromClientModel(client).getPkceCodeChallengeMethod();
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/PKCEEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/PKCEEnforcerExecutor.java
@@ -132,6 +132,11 @@ public class PKCEEnforcerExecutor implements ClientPolicyExecutorProvider<PKCEEn
         String codeChallengeMethod = request.getCodeChallengeMethod();
         String pkceCodeChallengeMethod = OIDCAdvancedConfigWrapper.fromClientModel(client).getPkceCodeChallengeMethod();
 
+        // PKCE applies only to response types that issue an authorization code
+        if (parsedResponseType == null || !parsedResponseType.hasResponseType(OIDCResponseType.CODE)) {
+            return;
+        }
+
         // check whether code challenge method is specified
         if (codeChallengeMethod == null) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter: code_challenge_method");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -1557,6 +1557,57 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         revertToBuiltinPolicies();
     }
 
+    @Test
+    public void testPKCEEnforcerDoesNotApplyToResponseTypeNone() throws Exception {
+        try {
+            String pkceProfileName = "PKCE profile";
+            String json = new ClientProfilesBuilder()
+                    .addProfile(
+                            new ClientProfileBuilder()
+                                    .createProfile(pkceProfileName, "PKCE profile")
+                                    .addExecutor(
+                                            PKCEEnforcerExecutorFactory.PROVIDER_ID,
+                                            createPKCEEnforceExecutorConfig(Boolean.TRUE))
+                                    .toRepresentation())
+                    .toString();
+            updateProfiles(json);
+
+            json = new ClientPoliciesBuilder()
+                    .addPolicy(
+                            new ClientPolicyBuilder()
+                                    .createPolicy(POLICY_NAME, "PKCE policy", Boolean.TRUE)
+                                    .addCondition(
+                                            AnyClientConditionFactory.PROVIDER_ID,
+                                            createAnyClientConditionConfig())
+                                    .addProfile(pkceProfileName)
+                                    .toRepresentation())
+                    .toString();
+            updatePolicies(json);
+
+            String clientId = generateSuffixedName(CLIENT_NAME);
+
+            createClientByAdmin(clientId, clientRep -> {
+                clientRep.setPublicClient(true);
+                clientRep.setStandardFlowEnabled(true);
+            });
+
+            oauth.client(clientId);
+            oauth.responseType(OIDCResponseType.NONE);
+
+            oauth.loginForm().prompt(OIDCLoginProtocol.PROMPT_VALUE_NONE).open();
+
+            AuthorizationEndpointResponse response = oauth.parseLoginResponse();
+
+            assertNull(response.getCode());
+            // The request is not rejected by the PKCE enforcer and reaches prompt=none handling.
+            assertEquals(OAuthErrorException.LOGIN_REQUIRED, response.getError());
+        } finally {
+            oauth.responseType(OIDCResponseType.CODE);
+            revertToBuiltinPolicies();
+            revertToBuiltinProfiles();
+        }
+    }
+
     private void assertGrantTypeBlock(AccessTokenResponse response, ClientPolicyEvent event){
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(event.toString(), response.getError());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -19,6 +19,8 @@ import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.Constants;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -679,6 +681,25 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
                     .sessionId(sessionId)
                     .error(Errors.CODE_VERIFIER_MISSING);
         } finally {
+            setPkceActivationSettings("test-app", null);
+        }
+    }
+
+    @Test
+    public void authorizationRequestWithResponseTypeNoneDoesNotRequirePKCE() {
+        try {
+            setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
+            oauth.responseType(OIDCResponseType.NONE);
+
+            oauth.loginForm().prompt(OIDCLoginProtocol.PROMPT_VALUE_NONE).open();
+
+            final AuthorizationEndpointResponse response = oauth.parseLoginResponse();
+
+            assertNull(response.getCode());
+            // The request is not rejected by PKCE validation and reaches prompt=none handling.
+            assertEquals(OAuthErrorException.LOGIN_REQUIRED, response.getError());
+        } finally {
+            oauth.responseType(OIDCResponseType.CODE);
             setPkceActivationSettings("test-app", null);
         }
     }


### PR DESCRIPTION
PKCE validation is currently applied to authorization requests using `response_type=none`, even though no authorization code is issued.

This PR changes PKCE validation to apply only when the requested response type contains `code`. The change is applied to both the authorization endpoint validation and the Client Policy PKCE enforcer.

Regression tests have been added for both paths to verify that `response_type=none` does not require PKCE parameters, while existing PKCE behavior for response types issuing an authorization code remains unchanged.

Closes #52302