### PR TITLE
Only disable login submit button on same-tab form submission

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/organization/login/login-username.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/organization/login/login-username.ftl
@@ -7,7 +7,7 @@
         <div id="kc-form">
             <div id="kc-form-wrapper">
                 <#if realm.password>
-                    <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                    <form id="kc-form-login" data-kc-disable-submit="login" action="${url.loginAction}"
                           method="post">
                         <#if !usernameHidden??>
                             <div class="${properties.kcFormGroupClass!}">

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/organization/login/login.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/organization/login/login.ftl
@@ -6,7 +6,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password>
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                <form id="kc-form-login" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
                     <#if !usernameHidden??>
                         <div class="${properties.kcFormGroupClass!}">
                             <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>

--- a/themes/src/main/resources/theme/base/login/login-otp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-otp.ftl
@@ -3,7 +3,7 @@
     <#if section="header">
         ${msg("doLogIn")}
     <#elseif section="form">
-        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}"
             method="post">
             <#if otpLogin.userOtpCredentials?size gt 1>
                 <div class="${properties.kcFormGroupClass!}">

--- a/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
+++ b/themes/src/main/resources/theme/base/login/login-passkeys-conditional-authenticate.ftl
@@ -70,7 +70,7 @@
             <div id="kc-form">
                 <div id="kc-form-wrapper">
                     <#if realm.password>
-                        <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" style="display:none">
+                        <form id="kc-form-login" data-kc-disable-submit="login" action="${url.loginAction}" method="post" style="display:none">
                             <#if !usernameHidden??>
                                 <div class="${properties.kcFormGroupClass!}">
                                     <label for="username" class="${properties.kcLabelClass!}">${msg("passkey-autofill-select")}</label>

--- a/themes/src/main/resources/theme/base/login/login-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-password.ftl
@@ -5,7 +5,7 @@
     <#elseif section = "form">
         <div id="kc-form">
             <div id="kc-form-wrapper">
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                <form id="kc-form-login" data-kc-disable-submit="login" action="${url.loginAction}"
                       method="post">
                     <div class="${properties.kcFormGroupClass!} no-bottom-margin">
                         <hr/>

--- a/themes/src/main/resources/theme/base/login/login-recovery-authn-code-input.ftl
+++ b/themes/src/main/resources/theme/base/login/login-recovery-authn-code-input.ftl
@@ -4,7 +4,7 @@
     <#if section = "header">
         ${msg("auth-recovery-code-header")}
     <#elseif section = "form">
-        <form id="kc-recovery-code-login-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+        <form id="kc-recovery-code-login-form" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
                     <label for="recoveryCodeInput" class="${properties.kcLabelClass!}">${msg("auth-recovery-code-prompt", recoveryAuthnCodesInputBean.codeNumber?c)}</label>

--- a/themes/src/main/resources/theme/base/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-update-password.ftl
@@ -4,7 +4,7 @@
     <#if section = "header">
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">
-        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
                     <label for="password-new" class="${properties.kcLabelClass!}">${msg("passwordNew")}</label>

--- a/themes/src/main/resources/theme/base/login/login-username.ftl
+++ b/themes/src/main/resources/theme/base/login/login-username.ftl
@@ -7,7 +7,7 @@
         <div id="kc-form">
             <div id="kc-form-wrapper">
                 <#if realm.password>
-                    <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                    <form id="kc-form-login" data-kc-disable-submit="login" action="${url.loginAction}"
                           method="post">
                         <#if !usernameHidden??>
                             <div class="${properties.kcFormGroupClass!}">

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -7,7 +7,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password>
-                <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                <form id="kc-form-login" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
                     <#if !usernameHidden??>
                         <div class="${properties.kcFormGroupClass!}">
                             <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>

--- a/themes/src/main/resources/theme/base/login/logout-confirm.ftl
+++ b/themes/src/main/resources/theme/base/login/logout-confirm.ftl
@@ -6,7 +6,7 @@
         <div id="kc-logout-confirm" class="content-area">
             <p class="instruction">${msg("logoutConfirmHeader")}</p>
 
-            <form class="form-actions" action="${url.logoutConfirmAction}" onsubmit="confirmLogout.disabled = true; return true;" method="POST">
+            <form class="form-actions" action="${url.logoutConfirmAction}" data-kc-disable-submit="confirmLogout" method="POST">
                 <input type="hidden" name="session_code" value="${logoutConfirm.code}">
                 <div class="${properties.kcFormGroupClass!}">
                     <div id="kc-form-options">

--- a/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
@@ -1,0 +1,45 @@
+const NEW_TAB_MODIFIERS = ["shiftKey", "ctrlKey", "metaKey"];
+
+function hasNewTabModifiers(event) {
+    return NEW_TAB_MODIFIERS.some((modifier) => event[modifier]);
+}
+
+function opensInNewTab(form, event) {
+    if (form.target && form.target !== "_self") {
+        return true;
+    }
+
+    const submitter = event.submitter;
+    return submitter != null && hasNewTabModifiers(submitter);
+}
+
+export function bindDisableSubmitOnSameTab(form) {
+    const buttonName = form.dataset.kcDisableSubmit;
+    if (!buttonName) {
+        return;
+    }
+
+    let keyboardNewTabSubmit = false;
+
+    form.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && hasNewTabModifiers(event)) {
+            keyboardNewTabSubmit = true;
+        }
+    }, true);
+
+    form.addEventListener("submit", (event) => {
+        if (keyboardNewTabSubmit || opensInNewTab(form, event)) {
+            keyboardNewTabSubmit = false;
+            return;
+        }
+
+        keyboardNewTabSubmit = false;
+
+        const button = event.submitter ?? form.elements.namedItem(buttonName);
+        if (button) {
+            button.disabled = true;
+        }
+    });
+}
+
+document.querySelectorAll("form[data-kc-disable-submit]").forEach(bindDisableSubmitOnSameTab);

--- a/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
@@ -4,8 +4,20 @@ function hasNewTabModifiers(event) {
     return NEW_TAB_MODIFIERS.some((modifier) => event[modifier]);
 }
 
-function opensInNewTab(form) {
-    return form.target && form.target !== "_self";
+function opensInNewTab(form, event) {
+    if (form.target && form.target !== "_self") {
+        return true;
+    }
+
+    const submitter = event.submitter;
+    if (submitter instanceof HTMLButtonElement || submitter instanceof HTMLInputElement) {
+        const formTarget = submitter.formTarget || submitter.getAttribute("formtarget");
+        if (formTarget && formTarget !== "_self") {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 function isImplicitSubmitControl(element) {
@@ -35,12 +47,12 @@ export function bindDisableSubmitOnSameTab(form) {
     let modifierNewTabSubmit = false;
 
     form.addEventListener("click", (event) => {
-        const submitButton = event.target.closest('button[type="submit"], input[type="submit"]');
+        const submitButton = event.target?.closest?.('button[type="submit"], input[type="submit"]');
         if (submitButton && form.contains(submitButton) && hasNewTabModifiers(event)) {
             modifierNewTabSubmit = true;
-            queueMicrotask(() => {
+            setTimeout(() => {
                 modifierNewTabSubmit = false;
-            });
+            }, 0);
         }
     }, true);
 
@@ -50,13 +62,13 @@ export function bindDisableSubmitOnSameTab(form) {
         }
 
         modifierNewTabSubmit = true;
-        queueMicrotask(() => {
+        setTimeout(() => {
             modifierNewTabSubmit = false;
-        });
+        }, 0);
     }, true);
 
     form.addEventListener("submit", (event) => {
-        const newTabSubmit = modifierNewTabSubmit || opensInNewTab(form);
+        const newTabSubmit = modifierNewTabSubmit || opensInNewTab(form, event);
         modifierNewTabSubmit = false;
 
         if (newTabSubmit) {
@@ -64,7 +76,7 @@ export function bindDisableSubmitOnSameTab(form) {
         }
 
         const button = form.elements.namedItem(buttonName);
-        if (button) {
+        if (button instanceof HTMLButtonElement || button instanceof HTMLInputElement) {
             button.disabled = true;
         }
     });

--- a/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
@@ -4,13 +4,26 @@ function hasNewTabModifiers(event) {
     return NEW_TAB_MODIFIERS.some((modifier) => event[modifier]);
 }
 
-function opensInNewTab(form, event) {
-    if (form.target && form.target !== "_self") {
+function opensInNewTab(form) {
+    return form.target && form.target !== "_self";
+}
+
+function isImplicitSubmitControl(element) {
+    if (!element) {
+        return false;
+    }
+
+    const tagName = element.tagName;
+    if (tagName === "TEXTAREA" || tagName === "SELECT") {
         return true;
     }
 
-    const submitter = event.submitter;
-    return submitter != null && hasNewTabModifiers(submitter);
+    if (tagName !== "INPUT") {
+        return false;
+    }
+
+    const type = (element.type || "text").toLowerCase();
+    return type !== "button" && type !== "submit" && type !== "reset" && type !== "checkbox" && type !== "radio";
 }
 
 export function bindDisableSubmitOnSameTab(form) {
@@ -19,23 +32,35 @@ export function bindDisableSubmitOnSameTab(form) {
         return;
     }
 
-    let keyboardNewTabSubmit = false;
+    let modifierNewTabSubmit = false;
 
-    form.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" && hasNewTabModifiers(event)) {
-            keyboardNewTabSubmit = true;
+    form.addEventListener("click", (event) => {
+        const submitButton = event.target.closest('button[type="submit"], input[type="submit"]');
+        if (submitButton && form.contains(submitButton) && hasNewTabModifiers(event)) {
+            modifierNewTabSubmit = true;
         }
     }, true);
 
-    form.addEventListener("submit", (event) => {
-        if (keyboardNewTabSubmit || opensInNewTab(form, event)) {
-            keyboardNewTabSubmit = false;
+    form.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" || !hasNewTabModifiers(event) || !isImplicitSubmitControl(event.target)) {
             return;
         }
 
-        keyboardNewTabSubmit = false;
+        modifierNewTabSubmit = true;
+        queueMicrotask(() => {
+            modifierNewTabSubmit = false;
+        });
+    }, true);
 
-        const button = event.submitter ?? form.elements.namedItem(buttonName);
+    form.addEventListener("submit", (event) => {
+        const newTabSubmit = modifierNewTabSubmit || opensInNewTab(form);
+        modifierNewTabSubmit = false;
+
+        if (newTabSubmit) {
+            return;
+        }
+
+        const button = form.elements.namedItem(buttonName);
         if (button) {
             button.disabled = true;
         }

--- a/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/disableSubmitOnSameTab.js
@@ -38,6 +38,9 @@ export function bindDisableSubmitOnSameTab(form) {
         const submitButton = event.target.closest('button[type="submit"], input[type="submit"]');
         if (submitButton && form.contains(submitButton) && hasNewTabModifiers(event)) {
             modifierNewTabSubmit = true;
+            queueMicrotask(() => {
+                modifierNewTabSubmit = false;
+            });
         }
     }, true);
 

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -48,6 +48,7 @@
         }
     </script>
     <script src="${url.resourcesPath}/js/menu-button-links.js" type="module"></script>
+    <script type="module" src="${url.resourcesPath}/js/disableSubmitOnSameTab.js"></script>
     <#if scripts??>
         <#list scripts as script>
             <script src="${script}" type="text/javascript"></script>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-otp.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-otp.ftl
@@ -7,7 +7,7 @@
     <#if section="header">
         ${msg("doLogIn")}
     <#elseif section="form">
-        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
             <input id="selectedCredentialId" type="hidden" name="selectedCredentialId" value="${otpLogin.selectedCredentialId!''}">
             <#if otpLogin.userOtpCredentials?size gt 1>
                 <div class="${properties.kcFormGroupClass!}">

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-passkeys-conditional-authenticate.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-passkeys-conditional-authenticate.ftl
@@ -73,7 +73,7 @@
             <div id="kc-form">
                 <div id="kc-form-wrapper">
                     <#if realm.password>
-                        <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" style="display:none">
+                        <form id="kc-form-login" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post" style="display:none">
                             <#if !usernameHidden??>
                                 <@field.input name="username" label=msg("passkey-autofill-select") value=login.username!'' autofocus=true autocomplete="username webauthn" />
                             </#if>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-password.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-password.ftl
@@ -9,7 +9,7 @@
     <#elseif section = "form">
         <div id="kc-form">
             <div id="kc-form-wrapper">
-                <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+                <form id="kc-form-login" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
                     <@field.password name="password" label=msg("password") forgotPassword=realm.resetPasswordAllowed autofocus=true autocomplete="current-password" />
                     <@buttons.loginButton />
                 </form>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-recovery-authn-code-input.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-recovery-authn-code-input.ftl
@@ -6,7 +6,7 @@
     <#if section = "header">
         ${msg("auth-recovery-code-header")}
     <#elseif section = "form">
-        <form id="kc-recovery-code-login-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
+        <form id="kc-recovery-code-login-form" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post">
             <@field.input name="recoveryCodeInput" label=msg("auth-recovery-code-prompt", recoveryAuthnCodesInputBean.codeNumber?c) autofocus=true />
 
             <@buttons.loginButton />

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-update-password.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-update-password.ftl
@@ -8,7 +8,7 @@
     <#if section = "header">
         ${msg("updatePasswordTitle")}
     <#elseif section = "form">
-        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" novalidate="novalidate">
+        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post" novalidate="novalidate">
             <@field.password name="password-new" label=msg("passwordNew") fieldName="password" autocomplete="new-password" autofocus=true />
             <@field.password name="password-confirm" label=msg("passwordConfirm") autocomplete="new-password" />
 

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
@@ -12,7 +12,7 @@
         <div id="kc-form">
             <div id="kc-form-wrapper">
                 <#if realm.password>
-                    <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                    <form id="kc-form-login" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}"
                           method="post">
                         <#if !usernameHidden??>
                             <div class="${properties.kcFormGroupClass!}">

--- a/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
@@ -12,7 +12,7 @@
         <div id="kc-form">
           <div id="kc-form-wrapper">
             <#if realm.password>
-                <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" novalidate="novalidate">
+                <form id="kc-form-login" class="${properties.kcFormClass!}" data-kc-disable-submit="login" action="${url.loginAction}" method="post" novalidate="novalidate">
                     <#if !usernameHidden??>
                         <#assign label>
                             <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -99,6 +99,7 @@
         </#list>
     </#if>
     <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
+    <script type="module" src="${url.resourcesPath}/js/disableSubmitOnSameTab.js"></script>
     <script type="module">
         <#outputformat "JavaScript">
         import { startSessionPolling } from ${(url.resourcesPath + "/js/authChecker.js")?c};


### PR DESCRIPTION
## Summary

- Fixes login pages leaving the Sign In button permanently disabled when the form is submitted in a new tab/window (e.g. Shift+Enter or Shift+click in Chrome)
- Replaces inline `onsubmit="login.disabled = true"` handlers with a shared `disableSubmitOnSameTab.js` script that only disables the submit button for same-tab submissions
- Applies the fix across base and keycloak.v2 login templates, including logout confirm

Closes #52056

## Test plan

- [ ] Open the login page and submit with Enter — Sign In button should disable while the request is in flight
- [ ] Open the login page, focus the username field, and press Shift+Enter — auth should open in a new tab and the original tab's Sign In button should remain enabled
- [ ] Shift+click the Sign In button — same as above, original tab stays usable
- [ ] Verify OTP, password-only, username-only, and update-password steps still disable the button on normal submit
- [ ] Verify logout confirm still disables the Logout button on normal submit