### PR TITLE
Stabilizing CI by downloading test dependency early

### DIFF
--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -39,8 +39,15 @@ runs:
       run: |
         # Ensure this plugin is built first to avoid warnings in the build
         ./mvnw install -Pdistribution -am -pl distribution/maven-plugins/licenses-processor
-        # By using "dependency:resolve", it will download all dependencies used in later stages for running the tests
-        ./mvnw install dependency:resolve -V -e -DskipTests -DskipExamples -DexcludeGroupIds=org.keycloak -Dsilent=true -DcommitProtoLockChanges=true
+        # By using "dependency:resolve", it will download all dependencies used in later stages for running the tests.
+        # "dependency:resolve-plugins" pre-downloads declared plugin runtime dependencies so test jobs
+        # don't need to fetch them from Maven Central (avoiding transient 403 rate-limit failures).
+        ./mvnw install dependency:resolve dependency:resolve-plugins -V -e -DskipTests -DskipExamples -DexcludeGroupIds=org.keycloak -Dsilent=true -DcommitProtoLockChanges=true
+        # Surefire auto-detects its JUnit Platform provider at test runtime, so it is not a declared
+        # plugin dependency and won't be fetched by dependency:resolve-plugins. Pre-download it
+        # explicitly so it is cached and test jobs don't hit Maven Central for it.
+        SUREFIRE_VER=$(./mvnw help:evaluate -Dexpression=version.surefire.plugin -q -DforceStdout)
+        ./mvnw dependency:get -Dartifact=org.apache.maven.surefire:surefire-junit-platform:${SUREFIRE_VER}
 
     - id: compress-keycloak-maven-repository
       name: Compress Keycloak Maven artifacts


### PR DESCRIPTION
Closes #52327

## Summary

Pre-downloads `surefire-junit-platform` and all declared plugin dependencies during the CI build step so they are cached and available for test jobs.

## Problem

CI test jobs intermittently fail downloading `surefire-junit-platform` from Maven Central (HTTP 403 / rate limiting). This happens because the artifact is never cached:

- **`-DskipTests` in the build step:** Surefire's `execute()` returns immediately without resolving its provider JARs. The JUnit Platform provider (`surefire-junit-platform`) is auto-detected and downloaded dynamically only when tests actually run.
- **`dependency:resolve` doesn't cover plugin deps:** It only resolves project dependencies declared in `<dependencies>`, not Maven plugin runtime dependencies.
- **`dependency:resolve-plugins` doesn't cover auto-detected providers:** It resolves declared plugin `<dependencies>`, but `surefire-junit-platform` is not declared — Surefire discovers it at runtime via service-loader auto-detection.

As a result, every test job downloads `surefire-junit-platform` fresh from Maven Central, making it vulnerable to transient failures.

## What didn't work

Declaring `surefire-junit-platform` as an explicit `<dependency>` of the Surefire plugin in the root POM's `<pluginManagement>` caused a **JUnit Platform version conflict**. The provider (Surefire 3.5.6) transitively pulls in `junit-platform-launcher:1.12.2`, which conflicts with the Arquillian integration test suite's pinned `junit-platform-commons:1.10.3` and `junit-platform-engine:1.10.3`. When declared as a plugin dependency, the provider's classloader isolation is lost, mixing incompatible JUnit Platform versions and causing `NoClassDefFoundError` at test startup. See [failed run](https://github.com/keycloak/keycloak/actions/runs/33643142457/job/100343845090?pr=52328).

## How the fix works

Changes are in `.github/actions/build-keycloak/action.yml` only (no POM changes):

1. **`dependency:resolve-plugins`** added to the main build command — pre-downloads all declared plugin runtime dependencies (general hardening against transient Maven Central failures for any plugin).
2. **`dependency:get`** for `surefire-junit-platform` — reads the surefire version from the POM via `help:evaluate` (so it stays in sync when the version is bumped), then pre-downloads the provider artifact and its transitive dependencies into `~/.m2/repository`. This is the only way to cache an auto-detected provider that neither `dependency:resolve` nor `dependency:resolve-plugins` can reach.

These artifacts then land in the weekly Maven cache and are restored by test jobs, eliminating the fresh download from Maven Central.

## Example failure (original)

https://github.com/keycloak/keycloak/actions/runs/33638121717/job/100277213415?pr=52313