### PR TITLE
Stabilizing tests like FlowTest.testRemoveExecutionSubflow

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEvents.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEvents.java
@@ -115,9 +115,9 @@ public abstract class AbstractEvents<R> {
     }
 
     void testStarted() {
-        testStarted = getCurrentTime();
+        // Discard events from the previous test's cleanup to avoid them leaking into this test's poll() window
+        skipAll();
         timeOffset = getCurrentTimeOffset();
-        lastFetch = -1;
     }
 
     protected abstract List<R> getEvents(long from, long to);


### PR DESCRIPTION
Closes #52329

Changes `AbstractEvents.testStarted()` to delegate to `skipAll()`, which includes a `Thread.sleep(1)` and `events.clear()` before recording the new event window timestamp.

### Why this fixes the flakiness

The test framework lifecycle runs in this order between tests:

1. `afterEach()` → `ManagedRealm.cleanup()` → e.g. `deleteFlow()` → generates admin events
2. `beforeEach()` → `testStarted()` → records `testStarted = System.currentTimeMillis()`
3. Next test's `poll()` fetches events with timestamp >= `testStarted`

The old `testStarted()` recorded the timestamp immediately, without any guard against same-millisecond overlap. When cleanup and `testStarted()` executed within the same millisecond, the cleanup DELETE event's timestamp equaled `testStarted`, causing it to leak into the next test's event window.

`skipAll()` already solved this exact problem with `Thread.sleep(1)` to ensure time advances past any prior events — it just wasn't being used by `testStarted()`.

A follow-up enhancement to also exclude `@BeforeEach` events automatically is tracked in #52426.