### PR TITLE
Stabilizing SCIM filter test

### DIFF
--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -827,12 +827,12 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
-    public void testFilterByMetaTimestamps() {
+    public void testFilterByMetaTimestamps() throws InterruptedException {
         Instant before = Instant.now();
-
+        Thread.sleep(1); // Ensure createdTimestamp is strictly after 'before' to satisfy the gt filter
         User user = createUser("bob");
         final String userName = user.getUserName();
-
+        Thread.sleep(1); // Ensure 'after' is strictly after createdTimestamp to satisfy the lt filter
         Instant after = Instant.now();
 
         // filter by meta.created gt <before> — should include the user
@@ -872,15 +872,15 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
-    public void testFilterGroupsByMetaTimestamps() {
+    public void testFilterGroupsByMetaTimestamps() throws InterruptedException {
         Instant before = Instant.now();
-
+        Thread.sleep(1); // Ensure createdTimestamp is strictly after 'before' to satisfy the gt filter
         Group group = new Group();
         group.setDisplayName(KeycloakModelUtils.generateId());
         group = client.groups().create(group);
         groupIdsToRemove.add(group.getId());
         String displayName = group.getDisplayName();
-
+        Thread.sleep(1); // Ensure 'after' is strictly after createdTimestamp to satisfy the lt filter
         Instant after = Instant.now();
 
         // filter by meta.created gt <before> — should include the group

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -827,13 +827,13 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
-    public void testFilterByMetaTimestamps() throws InterruptedException {
-        Instant before = Instant.now();
-        Thread.sleep(1); // Ensure createdTimestamp is strictly after 'before' to satisfy the gt filter
+    public void testFilterByMetaTimestamps() {
         User user = createUser("bob");
         final String userName = user.getUserName();
-        Thread.sleep(1); // Ensure 'after' is strictly after createdTimestamp to satisfy the lt filter
-        Instant after = Instant.now();
+
+        Instant created = Instant.parse(user.getMeta().getCreated());
+        Instant before = created.minusMillis(1);
+        Instant after = created.plusMillis(1);
 
         // filter by meta.created gt <before> — should include the user
         String filter = ResourceFilter.filter()
@@ -872,16 +872,16 @@ public class FilterTest extends AbstractScimTest {
     }
 
     @Test
-    public void testFilterGroupsByMetaTimestamps() throws InterruptedException {
-        Instant before = Instant.now();
-        Thread.sleep(1); // Ensure createdTimestamp is strictly after 'before' to satisfy the gt filter
+    public void testFilterGroupsByMetaTimestamps() {
         Group group = new Group();
         group.setDisplayName(KeycloakModelUtils.generateId());
         group = client.groups().create(group);
         groupIdsToRemove.add(group.getId());
         String displayName = group.getDisplayName();
-        Thread.sleep(1); // Ensure 'after' is strictly after createdTimestamp to satisfy the lt filter
-        Instant after = Instant.now();
+
+        Instant created = Instant.parse(group.getMeta().getCreated());
+        Instant before = created.minusMillis(1);
+        Instant after = created.plusMillis(1);
 
         // filter by meta.created gt <before> — should include the group
         String filter = ResourceFilter.filter()


### PR DESCRIPTION
Closes #52331

This uses deterministic before/after timestamps to based on the creation time of the entity in the test, thereby removing the timing dependency. 
