### PR TITLE
Add an Amazon SES email sender using the SES v2 API and IAM credentials

### DIFF
--- a/docs/documentation/release_notes/topics/26_8_0.adoc
+++ b/docs/documentation/release_notes/topics/26_8_0.adoc
@@ -36,6 +36,12 @@ When upgrading {project_name} with large database tables, index creation was pre
 
 For installation instructions, see the link:{operatorguide_link}[{operatorguide_name}].
 
+== Amazon SES email sender
+
+{project_name} can now send its email through the Amazon SES API instead of the SES SMTP interface. The SMTP route requires a dedicated SES SMTP username and password derived from a long-lived IAM user secret, stored in the realm; the API route signs the request with the AWS credentials the server already has, including an assumed role on EKS, ECS or EC2.
+
+Enable it with `--spi-email-sender--provider=aws-ses`. The realm's existing email settings — sender, display name, reply-to — keep their meaning, and the message sent is the one {project_name} already composed. For details, see the link:{adminguide_link}#amazon-ses-api[{adminguide_name}].
+
 = Themes
 
 == Redesigned identity provider buttons on the login page

--- a/docs/documentation/server_admin/topics/realms/email.adoc
+++ b/docs/documentation/server_admin/topics/realms/email.adoc
@@ -143,4 +143,67 @@ This feature is not yet supported by {project_name}, because Google does not all
 XOAUTH2 is not supported by the AWS-SMTP service.
 The AWS-service requires the use of a password.
 
+If {project_name} runs on AWS, <<amazon-ses-api,sending through the Amazon SES API>> avoids that password entirely.
+
+[[amazon-ses-api]]
+== Sending email through the Amazon SES API
+
+Amazon SES also exposes an HTTPS API, and {project_name} ships an email sender that uses it. Compared with the SMTP interface, it authenticates with ordinary AWS credentials — an IAM role where the deployment has one — instead of a dedicated SES SMTP username and password stored in the realm.
+
+The message itself is unchanged: it is composed exactly as the SMTP sender composes it, from the same realm email settings, and handed to SES as a raw MIME message.
+
+NOTE: This section has been contributed by the Keycloak community. As the Keycloak core team does not have means to test third-party providers, it is provided as-is. If you find this documentation outdated or incomplete, please contribute to improve it.
+
+=== Enabling it
+
+[source,bash]
+----
+bin/kc.sh start --spi-email-sender--provider=aws-ses --spi-email-sender--aws-ses--region=eu-central-1
+----
+
+The provider selection is a build-time option, so it takes effect through {project_name}'s build step, not through a restart alone. The corresponding environment variables are `KC_SPI_EMAIL_SENDER__PROVIDER` and `KC_SPI_EMAIL_SENDER__AWS_SES__REGION`.
+
+The legacy single-dash spelling (`--spi-email-sender-provider`, `KC_SPI_EMAIL_SENDER_PROVIDER`) is still accepted and is the only form older servers understand, which is why it is the spelling the provider's own error messages use.
+
+=== Configuration
+
+|===
+|Option |Environment fallback |Default |Description
+
+|`--spi-email-sender--aws-ses--region`
+|`AWS_REGION`, `AWS_DEFAULT_REGION`
+|_required_
+|Region of the verified SES identity. SES identities are per region, and a send from a different region is denied rather than redirected.
+
+|`--spi-email-sender--aws-ses--endpoint`
+|`AWS_ENDPOINT_URL_SESV2`, `AWS_ENDPOINT_URL`
+|`https://email.<region>.amazonaws.com`
+|Overrides the endpoint, for a VPC endpoint or a FIPS endpoint.
+
+|`--spi-email-sender--aws-ses--configuration-set`
+|
+|
+|SES configuration set to send through, which is how bounce, complaint and open events are published.
+
+|`--spi-email-sender--aws-ses--connect-timeout`
+|
+|`10000`
+|Milliseconds. The realm's own connection timeout, when set, takes precedence.
+
+|`--spi-email-sender--aws-ses--read-timeout`
+|
+|`10000`
+|Milliseconds. The realm's own timeout, when set, takes precedence.
+|===
+
+There is no option for credentials. They are resolved in the order the AWS SDKs use — JVM system properties, environment variables, a web identity token (EKS IRSA), the shared AWS config files, container credentials (ECS and EKS Pod Identity), and finally the EC2 instance metadata service. Shared profiles are read for static keys only: a profile that delegates through `role_arn`, `credential_process` or SSO is skipped rather than resolved. Temporary credentials are refreshed before they expire. On a server that is not on AWS, set `AWS_EC2_METADATA_DISABLED=true` to skip the metadata probe.
+
+The sending principal needs `ses:SendEmail` on the sending identity. A policy written for the SMTP interface grants `ses:SendRawEmail`, which is the action for the v1 API and does not authorize the v2 `SendEmail` operation — such a policy has to be updated, and keeping the old action alongside the new one is what preserves the ability to switch back to SMTP. Because {project_name} only ever sends from the realm's configured *From* address, the policy can be narrowed with a `ses:FromAddress` condition.
+
+=== What the realm still controls
+
+*From*, *From Display Name*, *Reply To*, *Reply To Display Name* and the two timeouts keep their meaning. *Envelope From* is mapped to the SES feedback-forwarding address, which routes bounces and complaints; the SMTP envelope sender itself is fixed by the sending identity's MAIL FROM domain and cannot be set per message over the API. The SMTP host, port and credentials are ignored, since no SMTP connection is made.
+
+An internationalised domain is converted to its ASCII form, as the SMTP sender does. A non-ASCII local part needs the SMTPUTF8 extension, which Amazon SES does not implement, and is rejected before the message is sent.
+
 endif::[]

--- a/services/src/main/java/org/keycloak/email/aws/AwsHttpRequest.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsHttpRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * One outbound HTTP call, described in full before it is executed.
+ * <p>
+ * The request is a value object on purpose: SigV4 signs a byte-exact rendering of method, URI,
+ * headers and body, so the bytes that are signed and the bytes that reach the socket must come from
+ * the same immutable object. Anything that lets a layer below add or rewrite a signed header
+ * invalidates the signature.
+ *
+ * @param method               HTTP method, uppercase
+ * @param uri                  absolute request URI; must carry no query string for SES
+ * @param headers              headers to place on the request, insertion-ordered
+ * @param body                 request body, empty (never {@code null}) for bodyless requests
+ * @param connectTimeoutMillis TCP connect timeout
+ * @param readTimeoutMillis    socket read timeout
+ */
+public record AwsHttpRequest(String method, URI uri, Map<String, String> headers, byte[] body,
+                             int connectTimeoutMillis, int readTimeoutMillis) {
+
+    public static final byte[] NO_BODY = new byte[0];
+
+    public AwsHttpRequest {
+        headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
+        body = body == null ? NO_BODY : body.clone();
+    }
+
+    public static AwsHttpRequest get(URI uri, Map<String, String> headers, int connectTimeoutMillis, int readTimeoutMillis) {
+        return new AwsHttpRequest("GET", uri, headers, NO_BODY, connectTimeoutMillis, readTimeoutMillis);
+    }
+
+    @Override
+    public byte[] body() {
+        return body.clone();
+    }
+
+    /** The body as text, for the JSON/XML responses of the credential endpoints. */
+    public String bodyAsString() {
+        return new String(body, StandardCharsets.UTF_8);
+    }
+
+    public AwsHttpRequest withHeaders(Map<String, String> additional) {
+        Map<String, String> merged = new LinkedHashMap<>(headers);
+        merged.putAll(additional);
+        return new AwsHttpRequest(method, uri, merged, body, connectTimeoutMillis, readTimeoutMillis);
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsHttpResponse.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsHttpResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The response of an {@link AwsHttpTransport} exchange.
+ *
+ * @param status  HTTP status code
+ * @param headers response headers; look them up through {@link #header(String)}, never directly —
+ *                AWS documents {@code x-amzn-ErrorType} in one casing and sends another
+ * @param body    response body, empty when there is none
+ */
+public record AwsHttpResponse(int status, Map<String, String> headers, byte[] body) {
+
+    public AwsHttpResponse {
+        headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
+        body = body == null ? new byte[0] : body.clone();
+    }
+
+    @Override
+    public byte[] body() {
+        return body.clone();
+    }
+
+    public String bodyAsString() {
+        return new String(body, StandardCharsets.UTF_8);
+    }
+
+    public boolean isSuccessful() {
+        return status >= 200 && status < 300;
+    }
+
+    /** Case-insensitive header lookup, as HTTP requires and AWS's own casing demands. */
+    public String header(String name) {
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(name)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsHttpTransport.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsHttpTransport.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+
+/**
+ * Executes an {@link AwsHttpRequest} exactly as described.
+ * <p>
+ * "Exactly" is the whole contract. An implementation must not add, remove, reorder or rewrite any
+ * header the caller set, must not follow redirects, and must not itself retry a request whose bytes
+ * already reached the wire: the first two would break the SigV4 signature, the third would send a
+ * transactional email twice, because SES {@code SendEmail} has no idempotency token.
+ * <p>
+ * The last one is only as strong as the client underneath. {@code KeycloakHttpTransport} runs on the
+ * server's shared Apache client, which installs a retry handler of its own and turns it into a
+ * resend-after-send when {@code spi-connections-http-client-default-max-retries} is set; that cannot
+ * be opted out of per request, so the factory warns at startup when it sees it.
+ */
+public interface AwsHttpTransport {
+
+    AwsHttpResponse exchange(AwsHttpRequest request) throws IOException;
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsRegion.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsRegion.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.util.regex.Pattern;
+
+/**
+ * The two things this provider needs to know about an AWS region name: whether it is one, and which
+ * DNS suffix its partition uses.
+ * <p>
+ * Validation is not defensive programming for its own sake. A region name is interpolated into the
+ * hostname of the SES and STS endpoints, and both of those requests carry credentials — the STS one
+ * carries a service-account token in its body. A region read from the environment as
+ * {@code attacker.example/collect} would otherwise build
+ * {@code https://sts.attacker.example/collect.amazonaws.com/} and post that token to a host of
+ * someone else's choosing.
+ */
+public final class AwsRegion {
+
+    /** {@code eu-central-1}, {@code us-gov-west-1}, {@code cn-north-1} — and nothing that could smuggle a host or a path. */
+    private static final Pattern VALID = Pattern.compile("[a-z0-9]+(-[a-z0-9]+)+");
+
+    private static final String DEFAULT_DNS_SUFFIX = "amazonaws.com";
+    private static final String CHINA_DNS_SUFFIX = "amazonaws.com.cn";
+
+    private AwsRegion() {
+    }
+
+    public static boolean isValid(String region) {
+        return region != null && VALID.matcher(region).matches();
+    }
+
+    /**
+     * The DNS suffix of the region's partition. China is the partition that differs for the endpoints
+     * this provider builds; the AWS GovCloud and the standard partition share {@code amazonaws.com},
+     * and the isolated partitions are not reachable from a server that could run this code anyway.
+     */
+    public static String dnsSuffix(String region) {
+        return region != null && region.startsWith("cn-") ? CHINA_DNS_SUFFIX : DEFAULT_DNS_SUFFIX;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsSesConfig.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsSesConfig.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.keycloak.Config;
+import org.keycloak.email.aws.credentials.AwsEnvironment;
+
+/**
+ * Server-wide configuration of the SES sender, resolved once at boot.
+ * <p>
+ * Everything here is an SPI option ({@code --spi-email-sender-aws-ses-<key>}) with an AWS-standard
+ * environment variable as a fallback, so a server already configured the way every other AWS tool on
+ * the box is configured needs no Keycloak-specific settings at all.
+ * <p>
+ * What is deliberately <em>not</em> here is credentials. There is no {@code access-key} option: the
+ * secret would then live in Keycloak's configuration, where {@code kc.sh show-config} prints
+ * unregistered SPI options unmasked. Credentials come from the standard AWS chain — an IAM role
+ * where one exists, {@code AWS_ACCESS_KEY_ID}/{@code AWS_SECRET_ACCESS_KEY} in the process
+ * environment where it does not.
+ * <p>
+ * Per-realm settings are not here either. The email sender is resolved once for the whole server, so
+ * a per-realm region or endpoint would be a setting Keycloak has no way to honour. The realm keeps
+ * what is genuinely per-realm — sender address, display name, reply-to — in its existing SMTP block.
+ */
+public final class AwsSesConfig {
+
+    /**
+     * SES answers on {@code email.<region>.amazonaws.com} but signs as {@code ses}. The two are not
+     * interchangeable and the hostname is not the source of the signing name.
+     */
+    static final String SIGNING_SERVICE = "ses";
+
+    static final String SEND_EMAIL_PATH = "/v2/email/outbound-emails";
+
+    static final int DEFAULT_TIMEOUT_MILLIS = 10_000;
+
+    private final String region;
+    private final URI sendEmailUri;
+    private final String hostHeader;
+    private final String configurationSetName;
+    private final int connectTimeoutMillis;
+    private final int readTimeoutMillis;
+
+    private AwsSesConfig(String region, URI sendEmailUri, String configurationSetName,
+                         int connectTimeoutMillis, int readTimeoutMillis) {
+        this.region = region;
+        this.sendEmailUri = sendEmailUri;
+        this.hostHeader = hostHeader(sendEmailUri);
+        this.configurationSetName = configurationSetName;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
+    }
+
+    public static AwsSesConfig from(Config.Scope scope, AwsEnvironment environment) {
+        String region = firstPresent(scope.get("region"), environment.value("AWS_REGION"), environment.value("AWS_DEFAULT_REGION"));
+        if (region == null) {
+            throw new AwsSesConfigurationException("No AWS region configured for the Amazon SES email sender."
+                    + " Set --spi-email-sender-aws-ses-region, or AWS_REGION in the server environment."
+                    + " SES identities are per region: a verified domain in one region does not exist in another.");
+        }
+        if (!AwsRegion.isValid(region)) {
+            throw new AwsSesConfigurationException("'" + region + "' is not a valid AWS region name");
+        }
+
+        String endpoint = firstPresent(scope.get("endpoint"),
+                environment.value("AWS_ENDPOINT_URL_SESV2"), environment.value("AWS_ENDPOINT_URL"));
+        URI sendEmailUri = sendEmailUri(endpoint, region);
+
+        int connectTimeout = timeout(scope, "connect-timeout");
+        int readTimeout = timeout(scope, "read-timeout");
+
+        return new AwsSesConfig(region, sendEmailUri, blankToNull(scope.get("configuration-set")),
+                connectTimeout, readTimeout);
+    }
+
+    /**
+     * Reads a timeout option, converting a malformed value into a configuration error rather than
+     * letting it escape.
+     * <p>
+     * {@code Config.Scope.getInt} throws a bare {@link NumberFormatException}, which is not an
+     * {@link AwsSesConfigurationException} — so a typo here would escape the factory's "this provider
+     * is not the one in use" branch and stop a server that sends over SMTP from booting at all. The
+     * typo is an easy one to make: most Keycloak duration options are written {@code 10s}.
+     */
+    private static int timeout(Config.Scope scope, String key) {
+        String value = scope.get(key);
+        if (value == null || value.isBlank()) {
+            return DEFAULT_TIMEOUT_MILLIS;
+        }
+        int millis;
+        try {
+            millis = Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new AwsSesConfigurationException("spi-email-sender-aws-ses-" + key + " must be a whole number of"
+                    + " milliseconds, but is '" + value + "'");
+        }
+        if (millis <= 0) {
+            throw new AwsSesConfigurationException("spi-email-sender-aws-ses-" + key + " must be positive; an"
+                    + " unbounded timeout would hold a Keycloak transaction open for as long as the network takes"
+                    + " to give up");
+        }
+        return millis;
+    }
+
+    private static URI sendEmailUri(String endpoint, String region) {
+        // The suffix comes from the region's partition: hard-coding amazonaws.com would build an
+        // endpoint that does not resolve in the China partition, where cn-north-1 answers on
+        // amazonaws.com.cn.
+        String base = endpoint != null ? stripTrailingSlashes(endpoint)
+                : "https://email." + region + "." + AwsRegion.dnsSuffix(region);
+        try {
+            URI parsed = new URI(base);
+            if (parsed.getScheme() == null || parsed.getHost() == null) {
+                throw new AwsSesConfigurationException("'" + endpoint + "' is not a usable Amazon SES endpoint URL:"
+                        + " it must be absolute, for example https://email.eu-central-1.amazonaws.com");
+            }
+            if (!"https".equalsIgnoreCase(parsed.getScheme()) && !"http".equalsIgnoreCase(parsed.getScheme())) {
+                // The transport speaks HTTP only, so any other scheme parses happily at boot and then
+                // fails on every single send.
+                throw new AwsSesConfigurationException("The Amazon SES endpoint URL must be http or https,"
+                        + " but is '" + endpoint + "'");
+            }
+            if (parsed.getRawQuery() != null || parsed.getRawFragment() != null) {
+                // Appending the operation path to a URL that already has a query string would bury it
+                // inside that query — the request would be posted to "/" and SES would answer 404,
+                // a long way from the typo that caused it.
+                throw new AwsSesConfigurationException("The Amazon SES endpoint URL must carry no query string or"
+                        + " fragment, but is '" + endpoint + "'");
+            }
+            return new URI(base + SEND_EMAIL_PATH);
+        } catch (URISyntaxException e) {
+            throw new AwsSesConfigurationException("'" + endpoint + "' is not a valid Amazon SES endpoint URL", e);
+        }
+    }
+
+    /**
+     * The {@code Host} header value, computed here rather than left to the HTTP client because it is
+     * signed: if the client renders it differently — appending an explicit {@code :443} the signature
+     * did not cover, for instance — AWS answers 403 with nothing to explain why.
+     */
+    private static String hostHeader(URI uri) {
+        return uri.getPort() == -1 ? uri.getHost() : uri.getHost() + ":" + uri.getPort();
+    }
+
+    /**
+     * Removes every trailing slash, not just one: the operation path is appended to what this
+     * returns, so an endpoint written {@code https://host//} would otherwise post to
+     * {@code //v2/email/outbound-emails}.
+     */
+    private static String stripTrailingSlashes(String value) {
+        int end = value.length();
+        while (end > 0 && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return value.substring(0, end);
+    }
+
+    private static String firstPresent(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    public String region() {
+        return region;
+    }
+
+    public URI sendEmailUri() {
+        return sendEmailUri;
+    }
+
+    public String hostHeader() {
+        return hostHeader;
+    }
+
+    public String configurationSetName() {
+        return configurationSetName;
+    }
+
+    public int connectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    public int readTimeoutMillis() {
+        return readTimeoutMillis;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsSesConfigurationException.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsSesConfigurationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+/**
+ * The SES sender is misconfigured.
+ * <p>
+ * Unchecked on purpose: when this provider is the server's selected email sender the condition is
+ * fatal at boot — a Keycloak that cannot send email cannot verify an address or reset a password,
+ * and discovering that at the first password reset instead of at startup is strictly worse. When the
+ * provider is merely present on the classpath and another sender is selected, the factory catches it
+ * and the server starts normally.
+ */
+public class AwsSesConfigurationException extends RuntimeException {
+
+    public AwsSesConfigurationException(String message) {
+        super(message);
+    }
+
+    public AwsSesConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsSesEmailSenderProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsSesEmailSenderProvider.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.keycloak.email.EmailException;
+import org.keycloak.email.EmailSenderProvider;
+import org.keycloak.models.UserModel;
+
+import org.jboss.logging.Logger;
+
+import static org.keycloak.utils.StringUtil.isNotBlank;
+
+/**
+ * Sends Keycloak's transactional email through the Amazon SES v2 API, authenticated with AWS SigV4.
+ * <p>
+ * The reason this exists is authentication, not transport. Keycloak's SMTP sender can already reach
+ * SES — through the SMTP interface, which requires a dedicated, long-lived SMTP username and password
+ * derived from an IAM user's secret key. That credential cannot be an assumed role, cannot be rotated
+ * by AWS, and has to be stored somewhere in the identity provider that is meant to hold no static
+ * secrets. Signing the API call instead lets the server use whatever credential its platform already
+ * gives it: an EKS service account, an ECS task role, an EC2 instance profile, or — where there is no
+ * role to assume — an IAM user's key pair supplied through the standard AWS environment variables.
+ * <p>
+ * Everything a recipient can observe is unchanged from the SMTP sender: the same
+ * {@code multipart/alternative} message, the same headers, built from the same realm SMTP settings.
+ * Only the transport differs.
+ */
+public class AwsSesEmailSenderProvider implements EmailSenderProvider {
+
+    private static final Logger logger = Logger.getLogger(AwsSesEmailSenderProvider.class);
+
+    /**
+     * {@code envelopeFrom} maps only partially onto SES; warning about it on every send would be
+     * noise, and warning never would leave the gap undiscovered, so it is said once per server.
+     */
+    private static final AtomicBoolean ENVELOPE_FROM_WARNING_EMITTED = new AtomicBoolean();
+
+    private final AwsSesConfig sesConfig;
+    private final SesClient client;
+    private final AwsHttpTransport transport;
+    private final Clock clock;
+
+    AwsSesEmailSenderProvider(AwsSesConfig sesConfig, SesClient client, AwsHttpTransport transport, Clock clock) {
+        this.sesConfig = sesConfig;
+        this.client = client;
+        this.transport = transport;
+        this.clock = clock;
+    }
+
+    @Override
+    public void send(Map<String, String> config, UserModel user, String subject, String textBody, String htmlBody)
+            throws EmailException {
+        String address = user.getEmail();
+        if (address == null) {
+            throw new EmailException("No email address configured for the user");
+        }
+        send(config, address, subject, textBody, htmlBody);
+    }
+
+    @Override
+    public void send(Map<String, String> config, String address, String subject, String textBody, String htmlBody)
+            throws EmailException {
+        SesRawMessage message = SesRawMessage.compose(config, address, subject, textBody, htmlBody);
+
+        String messageId = client.sendEmail(transport, message, feedbackForwardingAddress(config),
+                timeout(config.get("connectionTimeout"), sesConfig.connectTimeoutMillis()),
+                timeout(config.get("timeout"), sesConfig.readTimeoutMillis()),
+                clock.instant());
+
+        // No recipient address in the log line: a Keycloak server logs at DEBUG in plenty of
+        // deployments, and who was sent a password reset is exactly the sort of thing that should not
+        // accumulate there. "Accepted", not "delivered" — SES can accept a message it never delivers.
+        logger.debugf("Amazon SES accepted an email for delivery (messageId=%s)", messageId);
+    }
+
+    /**
+     * Static validation of the realm's email settings, called by newer servers when an administrator
+     * saves or imports a realm.
+     * <p>
+     * Declared without {@code @Override} on purpose. {@code EmailSenderProvider.validate} was added
+     * to the SPI after 26.0 and — because it was backported — is present in 26.2.8+ and 26.3.3+ but
+     * absent from 26.0.x, 26.1.x and 26.3.0–26.3.2. Annotating it would make this class refuse to
+     * compile against the older SPI; declaring it plainly satisfies the newer servers, which call it,
+     * and is dead weight on the older ones, which do not. A class that omitted it would instead fail
+     * with an {@code AbstractMethodError} the first time an administrator saved a realm.
+     * <p>
+     * Only addresses are checked, and nothing here touches the network: this runs on the realm-update
+     * request path, and an SES deployment legitimately has no host, port, user or password to verify.
+     */
+    public void validate(Map<String, String> config) throws EmailException {
+        SesRawMessage.requireSendableAddress(config.get("from"), "sender");
+        if (isNotBlank(config.get("replyTo"))) {
+            SesRawMessage.requireSendableAddress(config.get("replyTo"), "reply-to");
+        }
+        if (isNotBlank(config.get("envelopeFrom"))) {
+            SesRawMessage.requireSendableAddress(config.get("envelopeFrom"), "envelope-from");
+        }
+    }
+
+    @Override
+    public void close() {
+        // The HTTP client belongs to Keycloak's HttpClientProvider and must outlive this provider.
+    }
+
+    private String feedbackForwardingAddress(Map<String, String> config) throws EmailException {
+        String envelopeFrom = config.get("envelopeFrom");
+        if (!isNotBlank(envelopeFrom)) {
+            return null;
+        }
+        // Validated and converted like every other address rather than passed through: validate() is
+        // not called at all on servers older than 26.2.8, so this is the only check an internationalised
+        // or malformed envelope-from gets before it reaches AWS.
+        String sendable = SesRawMessage.requireSendableAddress(envelopeFrom, "envelope-from");
+        if (ENVELOPE_FROM_WARNING_EMITTED.compareAndSet(false, true)) {
+            logger.warn("The realm sets an envelope-from address, which Amazon SES honours only for bounce and"
+                    + " complaint routing: the SMTP envelope sender is fixed by the sending identity's MAIL FROM"
+                    + " domain, so SPF alignment cannot be driven from the realm over the SES API. The address must"
+                    + " itself be a verified SES identity or SES will refuse the message.");
+        }
+        return sendable;
+    }
+
+    /**
+     * Realm-level timeouts win over the server-wide ones, mirroring the SMTP sender, so an
+     * administrator who has already tuned the realm's mail timeouts keeps them after the switch.
+     */
+    private static int timeout(String realmValue, int fallback) {
+        if (realmValue == null || realmValue.isBlank()) {
+            return fallback;
+        }
+        try {
+            int parsed = Integer.parseInt(realmValue.trim());
+            return parsed > 0 ? parsed : fallback;
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsSesEmailSenderProviderFactory.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsSesEmailSenderProviderFactory.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.time.Clock;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.email.EmailSenderProvider;
+import org.keycloak.email.EmailSenderProviderFactory;
+import org.keycloak.email.aws.credentials.AwsCredentialsProviderChain;
+import org.keycloak.email.aws.credentials.AwsEnvironment;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Registers the Amazon SES email sender under the id {@code aws-ses}.
+ * <p>
+ * Selecting it is an explicit act: {@code --spi-email-sender-provider=aws-ses} (or
+ * {@code KC_SPI_EMAIL_SENDER_PROVIDER=aws-ses}). Merely dropping the jar into {@code providers/}
+ * changes nothing, which is deliberate — the factory keeps the inherited {@code order()} of 0, since
+ * any positive order would make SES win Keycloak's default-provider resolution and quietly take over
+ * every realm's transactional email the moment the jar landed.
+ * <p>
+ * Configuration is read in {@link #init(Config.Scope)} rather than in the constructor because the
+ * constructor also runs during {@code kc.sh build}, inside an image that has none of the runtime
+ * environment: anything read there would capture build-time values and look, at runtime, like a
+ * configuration that was never applied.
+ */
+public class AwsSesEmailSenderProviderFactory implements EmailSenderProviderFactory {
+
+    public static final String PROVIDER_ID = "aws-ses";
+
+    /**
+     * The name of the SPI this factory belongs to. Used to ask whether this provider is the one the
+     * server was told to use, which decides whether a broken configuration is fatal.
+     */
+    private static final String EMAIL_SENDER_SPI = "emailSender";
+
+    private static final Logger logger = Logger.getLogger(AwsSesEmailSenderProviderFactory.class);
+
+    private final Clock clock;
+
+    private AwsSesConfig config;
+    private SesClient client;
+    private AwsSesConfigurationException configurationError;
+
+    public AwsSesEmailSenderProviderFactory() {
+        this(Clock.systemUTC());
+    }
+
+    AwsSesEmailSenderProviderFactory(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public EmailSenderProvider create(KeycloakSession session) {
+        if (config == null) {
+            // configurationError is null only if create() ran before init(), which Keycloak does not
+            // do — but "throw null" would then surface as a NullPointerException with nothing in it,
+            // and a provider that cannot be built should say why.
+            throw configurationError != null ? configurationError
+                    : new AwsSesConfigurationException("The Amazon SES email sender was not initialised");
+        }
+        HttpClientProvider httpClientProvider = session.getProvider(HttpClientProvider.class);
+        return new AwsSesEmailSenderProvider(config, client,
+                new KeycloakHttpTransport(httpClientProvider.getHttpClient()), clock);
+    }
+
+    @Override
+    public void init(Config.Scope scope) {
+        AwsEnvironment environment = AwsEnvironment.SYSTEM;
+        try {
+            config = AwsSesConfig.from(scope, environment);
+            client = new SesClient(config, AwsCredentialsProviderChain.defaultChain(environment));
+            if (isSelectedEmailSender()) {
+                logger.infof("Amazon SES email sender configured for region %s (endpoint %s)",
+                        config.region(), config.sendEmailUri());
+                if (!"https".equalsIgnoreCase(config.sendEmailUri().getScheme())) {
+                    // AWS_ENDPOINT_URL is a cross-service variable: an environment that sets it for a
+                    // local emulator, and shares that environment with Keycloak, would silently send
+                    // activation links and their tokens over plaintext to whatever answers there.
+                    logger.warnf("The Amazon SES endpoint %s is not HTTPS; email, including action"
+                            + " tokens, will be sent in clear text", config.sendEmailUri());
+                }
+            } else {
+                // Keycloak initialises every factory of an SPI, not only the selected one, so an
+                // INFO line here would tell every server in the world that SES is "configured".
+                logger.debugf("Amazon SES email sender is available for region %s but the server uses the '%s' sender",
+                        config.region(), configuredEmailSender());
+            }
+        } catch (AwsSesConfigurationException e) {
+            configurationError = e;
+            if (isSelectedEmailSender()) {
+                // Fail the boot rather than start an identity provider that cannot send an
+                // activation link, a password reset or an invitation, and would only reveal it the
+                // first time a user needed one.
+                throw e;
+            }
+            // The jar is on the classpath but another sender is in use: nothing is wrong.
+            logger.debugf("Amazon SES email sender is present but not configured (%s); the server is using the '%s' sender",
+                    e.getMessage(), configuredEmailSender());
+        }
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        if (config == null || !isSelectedEmailSender()) {
+            // A region in the ambient environment is enough to build a configuration, so without this
+            // guard every AWS-hosted Keycloak would be warned about duplicate emails from a provider
+            // it does not use.
+            return;
+        }
+        int httpRetries = Config.scope("connectionsHttpClient", "default").getInt("max-retries", 0);
+        if (httpRetries > 0) {
+            // Keycloak's shared HTTP client retries a request whose bytes already reached the wire
+            // when this is set. SES SendEmail has no idempotency token, so a retried send is a second
+            // email in a real person's inbox — and it cannot be opted out of per request.
+            logger.warnf("spi-connections-http-client-default-max-retries is set to %d: a retried Amazon SES request"
+                    + " can deliver the same email twice, because the SES API has no idempotency token", httpRetries);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name("region")
+                .type("string")
+                .helpText("AWS region hosting the verified SES identity, for example eu-central-1."
+                        + " Defaults to the AWS_REGION or AWS_DEFAULT_REGION environment variable."
+                        + " SES identities are per region: a domain verified in one region does not exist in another.")
+                .add()
+                .property()
+                .name("endpoint")
+                .type("string")
+                .helpText("Overrides the SES endpoint URL, which defaults to https://email.<region>.amazonaws.com."
+                        + " Set it for a VPC endpoint, a FIPS endpoint, or a local stub in tests."
+                        + " Defaults to the AWS_ENDPOINT_URL_SESV2 or AWS_ENDPOINT_URL environment variable.")
+                .add()
+                .property()
+                .name("configuration-set")
+                .type("string")
+                .helpText("Name of the SES configuration set to send through, which is how open, bounce and"
+                        + " complaint events are published to CloudWatch, SNS or EventBridge. Optional.")
+                .add()
+                .property()
+                .name("connect-timeout")
+                .type("int")
+                .defaultValue(AwsSesConfig.DEFAULT_TIMEOUT_MILLIS)
+                .helpText("Milliseconds to wait for the TCP connection to SES. The realm's own connection timeout,"
+                        + " when set, takes precedence.")
+                .add()
+                .property()
+                .name("read-timeout")
+                .type("int")
+                .defaultValue(AwsSesConfig.DEFAULT_TIMEOUT_MILLIS)
+                .helpText("Milliseconds to wait for the SES response. Kept short on purpose: the send happens inside"
+                        + " a Keycloak transaction. The realm's own timeout, when set, takes precedence.")
+                .add()
+                .build();
+    }
+
+    private boolean isSelectedEmailSender() {
+        return PROVIDER_ID.equals(configuredEmailSender());
+    }
+
+    /**
+     * Which email sender the server was told to use, resolved the way Keycloak's own session factory
+     * resolves it: {@code --spi-email-sender-provider} wins, and only when it is unset does
+     * {@code --spi-email-sender-provider-default} apply. Both spellings select a provider, so a
+     * check that knew about only one would fail open for operators who used the other.
+     */
+    private String configuredEmailSender() {
+        String provider = Config.getProvider(EMAIL_SENDER_SPI);
+        return provider != null ? provider : Config.getDefaultProvider(EMAIL_SENDER_SPI);
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/AwsV4Signer.java
+++ b/services/src/main/java/org/keycloak/email/aws/AwsV4Signer.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.TreeMap;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.keycloak.email.aws.credentials.AwsCredentials;
+
+/**
+ * AWS Signature Version 4 (the {@code AWS4-HMAC-SHA256} scheme) for JSON/REST services.
+ * <p>
+ * Implemented directly rather than pulled in with an SDK so that the provider adds no runtime
+ * dependency to the server. The algorithm is fully specified by AWS and is verified here against
+ * AWS's own published test vectors (see {@code AwsV4SignerTest}), which is what makes hand-rolling
+ * it defensible: the vectors are a byte-level oracle for every step — canonical request, string to
+ * sign and signature — so an error cannot hide behind a passing "it returns something" assertion.
+ * <p>
+ * Two details are worth knowing before touching this class:
+ * <ul>
+ * <li>The signing <em>service</em> name is not the hostname prefix. SES answers on
+ * {@code email.<region>.amazonaws.com} but signs as {@code ses}; deriving one from the other
+ * produces a 403 on every request.</li>
+ * <li>Only the headers passed in are signed. Whatever the HTTP client adds afterwards (Host when
+ * unset, Content-Length, User-Agent, Accept-Encoding, Connection) must stay out of the signature,
+ * so the caller sets every signed header explicitly and this class leaves the hop-by-hop ones out of
+ * the signature.</li>
+ * </ul>
+ */
+public final class AwsV4Signer {
+
+    public static final String X_AMZ_DATE = "X-Amz-Date";
+    public static final String X_AMZ_SECURITY_TOKEN = "X-Amz-Security-Token";
+    public static final String AUTHORIZATION = "Authorization";
+
+    private static final String ALGORITHM = "AWS4-HMAC-SHA256";
+    private static final String TERMINATOR = "aws4_request";
+    private static final String HMAC_SHA256 = "HmacSHA256";
+
+    private static final DateTimeFormatter AMZ_DATE_TIME =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+
+    /**
+     * Headers a client is entitled to add, rewrite or drop between signing and transmission. Signing
+     * any of them makes the signature depend on state this class does not control; AWS lists them as
+     * headers that must not be signed.
+     */
+    private static final Set<String> UNSIGNABLE_HEADERS = Set.of(
+            "authorization", "connection", "content-length", "expect", "keep-alive", "proxy-authorization",
+            "te", "trailer", "transfer-encoding", "upgrade", "user-agent", "accept-encoding", "x-amzn-trace-id");
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private final String region;
+    private final String service;
+
+    public AwsV4Signer(String region, String service) {
+        this.region = region;
+        this.service = service;
+    }
+
+    /**
+     * Signs {@code request} and returns the headers that must be added to it: {@code X-Amz-Date},
+     * {@code X-Amz-Security-Token} when the credentials are temporary, and {@code Authorization}.
+     * <p>
+     * {@code signingTime} is a parameter rather than a {@code now()} call inside the method for two
+     * reasons: the tests need a fixed clock to compare against AWS's vectors, and the date must be
+     * read exactly once — computing the {@code X-Amz-Date} header and the credential-scope date from
+     * two separate reads mismatches them for the requests that straddle midnight UTC.
+     */
+    public Map<String, String> sign(AwsHttpRequest request, AwsCredentials credentials, Instant signingTime) {
+        String amzDateTime = AMZ_DATE_TIME.format(signingTime);
+        String date = amzDateTime.substring(0, 8);
+
+        Map<String, String> headersToSign = new TreeMap<>();
+        for (Map.Entry<String, String> header : request.headers().entrySet()) {
+            String name = header.getKey().toLowerCase(Locale.ROOT);
+            if (!UNSIGNABLE_HEADERS.contains(name)) {
+                headersToSign.put(name, normalizeHeaderValue(header.getValue()));
+            }
+        }
+        headersToSign.put("x-amz-date", amzDateTime);
+        if (credentials.isTemporary()) {
+            // Must be signed, not merely sent: AWS rejects a request whose session token is outside
+            // SignedHeaders, and the signature differs from the one computed without it.
+            headersToSign.put("x-amz-security-token", normalizeHeaderValue(credentials.sessionToken()));
+        }
+
+        String signedHeaders = String.join(";", headersToSign.keySet());
+        String canonicalRequest = canonicalRequest(request, headersToSign, signedHeaders);
+        String credentialScope = date + "/" + region + "/" + service + "/" + TERMINATOR;
+        String stringToSign = ALGORITHM + "\n" + amzDateTime + "\n" + credentialScope + "\n" + hexSha256(canonicalRequest.getBytes(StandardCharsets.UTF_8));
+
+        byte[] signingKey = signingKey(credentials.secretAccessKey(), date);
+        String signature = hex(hmacSha256(signingKey, stringToSign.getBytes(StandardCharsets.UTF_8)));
+
+        Map<String, String> signedRequestHeaders = new LinkedHashMap<>();
+        signedRequestHeaders.put(X_AMZ_DATE, amzDateTime);
+        if (credentials.isTemporary()) {
+            signedRequestHeaders.put(X_AMZ_SECURITY_TOKEN, credentials.sessionToken());
+        }
+        signedRequestHeaders.put(AUTHORIZATION, ALGORITHM
+                + " Credential=" + credentials.accessKeyId() + "/" + credentialScope
+                + ", SignedHeaders=" + signedHeaders
+                + ", Signature=" + signature);
+        return signedRequestHeaders;
+    }
+
+    String canonicalRequest(AwsHttpRequest request, Map<String, String> sortedHeadersToSign, String signedHeaders) {
+        StringBuilder canonicalHeaders = new StringBuilder();
+        for (Map.Entry<String, String> header : sortedHeadersToSign.entrySet()) {
+            canonicalHeaders.append(header.getKey()).append(':').append(header.getValue()).append('\n');
+        }
+        // The blank line between the headers block and SignedHeaders is required: every header line
+        // ends with \n and the block itself is then followed by another \n.
+        return request.method().toUpperCase(Locale.ROOT) + "\n"
+                + canonicalUri(request) + "\n"
+                + canonicalQueryString(request) + "\n"
+                + canonicalHeaders + "\n"
+                + signedHeaders + "\n"
+                + hexSha256(request.body());
+    }
+
+    private static String canonicalUri(AwsHttpRequest request) {
+        // The RAW path, not the decoded one: URI#getPath turns a %2F inside a segment back into a
+        // slash, which then reads as a segment separator and changes the canonical request — and so
+        // the signature — for a path the caller never wrote.
+        String path = request.uri().getRawPath();
+        if (path == null || path.isEmpty()) {
+            return "/";
+        }
+        StringBuilder canonical = new StringBuilder();
+        // Split on '/' keeping empty segments: an empty segment is a genuine "//" in the path and
+        // must survive into the canonical form, which is why the -1 limit is not optional.
+        String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length; i++) {
+            if (i > 0) {
+                canonical.append('/');
+            }
+            canonical.append(uriEncode(percentDecode(segments[i])));
+        }
+        return canonical.toString();
+    }
+
+    private static String canonicalQueryString(AwsHttpRequest request) {
+        String rawQuery = request.uri().getRawQuery();
+        if (rawQuery == null || rawQuery.isEmpty()) {
+            return "";
+        }
+        List<String[]> parameters = new ArrayList<>();
+        for (String parameter : rawQuery.split("&", -1)) {
+            int separator = parameter.indexOf('=');
+            String name = separator < 0 ? parameter : parameter.substring(0, separator);
+            String value = separator < 0 ? "" : parameter.substring(separator + 1);
+            parameters.add(new String[]{uriEncode(percentDecode(name)), uriEncode(percentDecode(value))});
+        }
+        // Sorted by name and then by value, which is not the same as sorting the joined
+        // "name=value" strings: '=' (0x3D) sorts above '-', '.' and the digits, so "a-c=3" would
+        // come before "a=1" under a plain lexicographic sort and produce a different signature.
+        parameters.sort(Comparator.<String[], String>comparing(parameter -> parameter[0])
+                .thenComparing(parameter -> parameter[1]));
+
+        StringJoiner canonical = new StringJoiner("&");
+        for (String[] parameter : parameters) {
+            canonical.add(parameter[0] + "=" + parameter[1]);
+        }
+        return canonical.toString();
+    }
+
+    /**
+     * Percent-encodes per RFC 3986 as AWS requires: unreserved characters pass through, everything
+     * else becomes uppercase-hex triplets of its UTF-8 bytes.
+     * <p>
+     * {@link java.net.URLEncoder} cannot be used here — it is {@code application/x-www-form-urlencoded},
+     * so it emits {@code +} for a space and escapes {@code ~}, both of which produce a wrong
+     * signature. AWS's signing documentation says so explicitly.
+     */
+    static String uriEncode(String value) {
+        StringBuilder encoded = new StringBuilder(value.length());
+        for (byte b : value.getBytes(StandardCharsets.UTF_8)) {
+            int unsigned = b & 0xFF;
+            if ((unsigned >= 'A' && unsigned <= 'Z') || (unsigned >= 'a' && unsigned <= 'z')
+                    || (unsigned >= '0' && unsigned <= '9')
+                    || unsigned == '-' || unsigned == '_' || unsigned == '.' || unsigned == '~') {
+                encoded.append((char) unsigned);
+            } else {
+                encoded.append('%')
+                        .append(Character.toUpperCase(HEX[unsigned >> 4]))
+                        .append(Character.toUpperCase(HEX[unsigned & 0x0F]));
+            }
+        }
+        return encoded.toString();
+    }
+
+    /**
+     * Percent-decodes a URI component.
+     * <p>
+     * {@link java.net.URLDecoder} cannot be used: it decodes {@code application/x-www-form-urlencoded},
+     * where {@code +} means a space. In a URI a {@code +} is a literal plus, so decoding it as a space
+     * and re-encoding would emit {@code %20} where the request carried {@code %2B} — a valid-looking
+     * canonical string that signs something the server never received.
+     * <p>
+     * Works on the UTF-8 bytes rather than the characters so that a multi-byte sequence split across
+     * percent triplets reassembles correctly.
+     */
+    static String percentDecode(String value) {
+        if (value.indexOf('%') < 0) {
+            return value;
+        }
+        byte[] source = value.getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream decoded = new ByteArrayOutputStream(source.length);
+        for (int i = 0; i < source.length; i++) {
+            if (source[i] == '%' && i + 2 < source.length) {
+                int high = Character.digit((char) source[i + 1], 16);
+                int low = Character.digit((char) source[i + 2], 16);
+                if (high >= 0 && low >= 0) {
+                    decoded.write((high << 4) + low);
+                    i += 2;
+                    continue;
+                }
+            }
+            decoded.write(source[i]);
+        }
+        return decoded.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Trims the value and collapses every run of whitespace into a single space, as the canonical
+     * form requires. {@code String.trim()} alone is not enough: {@code "a   b"} and {@code "a b"}
+     * must canonicalise to the same bytes.
+     */
+    static String normalizeHeaderValue(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder normalized = new StringBuilder(value.length());
+        boolean pendingSpace = false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == ' ' || c == '\t') {
+                pendingSpace = normalized.length() > 0;
+            } else {
+                if (pendingSpace) {
+                    normalized.append(' ');
+                    pendingSpace = false;
+                }
+                normalized.append(c);
+            }
+        }
+        return normalized.toString();
+    }
+
+    /**
+     * Derives the request-scoped signing key: HMAC chained over date, region, service and the
+     * {@code aws4_request} terminator, so the key that signs a request is useless for any other
+     * date, region or service.
+     */
+    private byte[] signingKey(String secretAccessKey, String date) {
+        byte[] initial = ("AWS4" + secretAccessKey).getBytes(StandardCharsets.UTF_8);
+        byte[] dateKey = hmacSha256(initial, date.getBytes(StandardCharsets.UTF_8));
+        byte[] regionKey = hmacSha256(dateKey, region.getBytes(StandardCharsets.UTF_8));
+        byte[] serviceKey = hmacSha256(regionKey, service.getBytes(StandardCharsets.UTF_8));
+        return hmacSha256(serviceKey, TERMINATOR.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static byte[] hmacSha256(byte[] key, byte[] data) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            mac.init(new SecretKeySpec(key, HMAC_SHA256));
+            return mac.doFinal(data);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("HmacSHA256 is not available in this JVM", e);
+        }
+    }
+
+    static String hexSha256(byte[] payload) {
+        try {
+            return hex(MessageDigest.getInstance("SHA-256").digest(payload));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available in this JVM", e);
+        }
+    }
+
+    static String hex(byte[] bytes) {
+        StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            hex.append(HEX[(b >> 4) & 0x0F]).append(HEX[b & 0x0F]);
+        }
+        return hex.toString();
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/CrlfNormalizingOutputStream.java
+++ b/services/src/main/java/org/keycloak/email/aws/CrlfNormalizingOutputStream.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Rewrites bare {@code LF} into {@code CRLF} on the way out, leaving existing {@code CRLF} pairs
+ * untouched.
+ * <p>
+ * This is not cosmetic. {@link jakarta.mail.internet.MimeMessage#writeTo} copies the bytes of a
+ * {@code 7bit} body part verbatim, so the line endings of a Keycloak FreeMarker template survive as
+ * bare LF. Over SMTP that never mattered, because the mail implementation wraps the socket in a
+ * CRLF-translating stream before the message reaches the server; when the same bytes are base64'd
+ * into an SES {@code Content.Raw} payload nothing performs that translation, and the result is a
+ * message that violates RFC 5322 line-ending rules — with DKIM signing computed over it.
+ */
+final class CrlfNormalizingOutputStream extends FilterOutputStream {
+
+    private int previousByte = -1;
+
+    CrlfNormalizingOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        // The same translation the mail implementation applies on the SMTP socket: a bare CR, a bare
+        // LF and a CRLF pair all end the line as CRLF. Reproducing it exactly is the point — the
+        // bytes SES receives have to be the bytes the SMTP transport would have sent.
+        if (b == '\r') {
+            writeLineEnding();
+        } else if (b == '\n') {
+            if (previousByte != '\r') {
+                writeLineEnding();
+            }
+        } else {
+            out.write(b);
+        }
+        previousByte = b;
+    }
+
+    private void writeLineEnding() throws IOException {
+        out.write('\r');
+        out.write('\n');
+    }
+
+    @Override
+    public void write(byte[] buffer, int offset, int length) throws IOException {
+        // FilterOutputStream's inherited implementation is byte-at-a-time through write(int), which
+        // is what this class needs; it is spelled out here so a future "optimisation" that forwards
+        // the array straight to the delegate cannot silently bypass the translation.
+        for (int i = 0; i < length; i++) {
+            write(buffer[offset + i]);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/DirectHttpTransport.java
+++ b/services/src/main/java/org/keycloak/email/aws/DirectHttpTransport.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Talks to the credential endpoints on the local machine, never through a proxy.
+ * <p>
+ * The ECS/EKS container endpoint and the instance metadata service answer on loopback and link-local
+ * addresses, and the request carries a bearer token. If the server is configured with
+ * {@code HTTP_PROXY} and no matching {@code no_proxy}, Keycloak's shared client sends everything
+ * through that proxy — which would hand the token to it, and would also make the address checks in
+ * front of these calls meaningless, because the host being validated is no longer the host being
+ * spoken to. This transport is built with {@link HttpClient.Builder#NO_PROXY} so the route is direct
+ * by construction.
+ * <p>
+ * Only those two sources use it. The STS call of the web-identity flow goes to a real internet
+ * endpoint and keeps the server's own outbound configuration, proxy included.
+ */
+final class DirectHttpTransport implements AwsHttpTransport {
+
+    /**
+     * A JDK client cannot change its connect timeout per request, so one is kept per timeout value
+     * asked for. In practice the map holds a single entry — both callers ask for a second — but the
+     * transport contract says the request is executed as described, and a cache is cheaper than
+     * either breaking that or building a client, and its threads, on every credential lookup.
+     */
+    private final Map<Integer, HttpClient> clients = new ConcurrentHashMap<>();
+
+    private final HttpClient fixedClient;
+
+    DirectHttpTransport() {
+        this.fixedClient = null;
+    }
+
+    DirectHttpTransport(HttpClient httpClient) {
+        this.fixedClient = httpClient;
+    }
+
+    /** Package-private so a test can assert the one property this class exists for. */
+    static HttpClient directClient(int connectTimeoutMillis) {
+        return HttpClient.newBuilder()
+                .proxy(HttpClient.Builder.NO_PROXY)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(Duration.ofMillis(connectTimeoutMillis))
+                .build();
+    }
+
+    private HttpClient clientFor(AwsHttpRequest request) {
+        return fixedClient != null ? fixedClient
+                : clients.computeIfAbsent(request.connectTimeoutMillis(), DirectHttpTransport::directClient);
+    }
+
+    @Override
+    public AwsHttpResponse exchange(AwsHttpRequest request) throws IOException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(request.uri())
+                .timeout(Duration.ofMillis(request.readTimeoutMillis()))
+                .method(request.method(), bodyOf(request));
+        request.headers().forEach(builder::header);
+
+        // Sent asynchronously and waited on with a deadline, because none of the JDK's body
+        // handlers is bounded by HttpRequest#timeout: that timeout covers the headers, and a peer
+        // that answers and then stalls holds the body read open for as long as it likes. Verified,
+        // not assumed — with ofInputStream, ofByteArray and ofByteArrayConsumer alike, a handler
+        // that stops writing after the headers keeps the caller blocked. This runs on a request
+        // thread inside a Keycloak transaction, so the wait has to end whatever the peer does.
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        CompletableFuture<HttpResponse<Void>> exchange = clientFor(request).sendAsync(builder.build(),
+                responseInfo -> HttpResponse.BodySubscribers.ofByteArrayConsumer(
+                        chunk -> chunk.ifPresent(bytes -> append(body, bytes))));
+        try {
+            HttpResponse<Void> response = exchange.get(request.readTimeoutMillis(), TimeUnit.MILLISECONDS);
+            return new AwsHttpResponse(response.statusCode(), headersOf(response), body.toByteArray());
+        } catch (TimeoutException e) {
+            exchange.cancel(true);
+            throw new IOException("No complete response from " + request.uri().getHost() + " within "
+                    + request.readTimeoutMillis() + "ms", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof UncheckedIOException unchecked) {
+                throw unchecked.getCause();
+            }
+            throw cause instanceof IOException io ? io : new IOException(cause);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while reading " + request.uri().getHost(), e);
+        }
+    }
+
+    private static void append(ByteArrayOutputStream body, byte[] chunk) {
+        if (body.size() + chunk.length > HttpBodies.MAX_RESPONSE_BYTES) {
+            // Unchecked because the consumer cannot declare one; unwrapped by the caller.
+            throw new UncheckedIOException(
+                    new IOException("Response body exceeded " + HttpBodies.MAX_RESPONSE_BYTES + " bytes"));
+        }
+        body.write(chunk, 0, chunk.length);
+    }
+
+    private static HttpRequest.BodyPublisher bodyOf(AwsHttpRequest request) {
+        byte[] body = request.body();
+        return body.length == 0
+                ? HttpRequest.BodyPublishers.noBody()
+                : HttpRequest.BodyPublishers.ofByteArray(body);
+    }
+
+    private static Map<String, String> headersOf(HttpResponse<?> response) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        response.headers().map().forEach((name, values) -> {
+            if (!values.isEmpty()) {
+                headers.put(name, values.get(0));
+            }
+        });
+        return headers;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/HttpBodies.java
+++ b/services/src/main/java/org/keycloak/email/aws/HttpBodies.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reads a response body without letting the peer decide how much memory to take.
+ * <p>
+ * Shared by both transports rather than written twice: the bound is not about SES, whose answers are
+ * a few hundred bytes, but about the credential endpoints — a peer that announces an enormous
+ * {@code Content-Length}, or streams a body that never ends, would otherwise pin a request thread and
+ * its heap inside a Keycloak transaction.
+ */
+final class HttpBodies {
+
+    /** Four orders of magnitude above any answer these endpoints legitimately return. */
+    static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+
+    private HttpBodies() {
+    }
+
+    static byte[] readBounded(InputStream content) throws IOException {
+        if (content == null) {
+            return new byte[0];
+        }
+        try (InputStream in = content) {
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            byte[] chunk = new byte[8192];
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                if (body.size() + read > MAX_RESPONSE_BYTES) {
+                    throw new IOException("Response body exceeded " + MAX_RESPONSE_BYTES + " bytes");
+                }
+                body.write(chunk, 0, read);
+            }
+            return body.toByteArray();
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/KeycloakHttpTransport.java
+++ b/services/src/main/java/org/keycloak/email/aws/KeycloakHttpTransport.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+/**
+ * Runs an {@link AwsHttpRequest} on Keycloak's shared HTTP client, so SES and the AWS credential
+ * endpoints inherit the server's outbound HTTP configuration — truststore, proxy mappings,
+ * connection pool — instead of opening a second, differently-configured stack alongside it.
+ * <p>
+ * Two things are overridden per request, and both matter. Timeouts: the shared client's defaults
+ * leave connect and connection-request unbounded, which on a blackholed route would hold a Keycloak
+ * transaction open until the operating system gives up on the TCP handshake. And redirects: a
+ * redirect would replay a SigV4-signed request against a host the signature does not cover, so the
+ * only useful outcome is a clear failure.
+ * <p>
+ * Note that Apache's per-request configuration <em>replaces</em> the client's rather than merging
+ * with it, which is why all three timeouts are set together — setting one alone silently reverts the
+ * other two to "infinite".
+ */
+final class KeycloakHttpTransport implements AwsHttpTransport {
+
+    private final CloseableHttpClient httpClient;
+
+    KeycloakHttpTransport(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public AwsHttpResponse exchange(AwsHttpRequest request) throws IOException {
+        HttpRequestBase httpRequest = build(request);
+        httpRequest.setConfig(RequestConfig.custom()
+                .setConnectTimeout(request.connectTimeoutMillis())
+                .setConnectionRequestTimeout(request.connectTimeoutMillis())
+                .setSocketTimeout(request.readTimeoutMillis())
+                .setRedirectsEnabled(false)
+                .build());
+
+        for (Map.Entry<String, String> header : request.headers().entrySet()) {
+            httpRequest.setHeader(header.getKey(), header.getValue());
+        }
+
+        try (CloseableHttpResponse response = httpClient.execute(httpRequest)) {
+            HttpEntity entity = response.getEntity();
+            return new AwsHttpResponse(response.getStatusLine().getStatusCode(), headersOf(response),
+                    HttpBodies.readBounded(entity == null ? null : entity.getContent()));
+        } finally {
+            // Releases the pooled connection if the exchange was abandoned mid-flight; a no-op on the
+            // normal path, and the difference between a leaked connection and a returned one on the
+            // path where the caller's read timed out.
+            httpRequest.reset();
+        }
+    }
+
+    private static HttpRequestBase build(AwsHttpRequest request) {
+        String uri = request.uri().toString();
+        switch (request.method()) {
+            case "GET":
+                return new HttpGet(uri);
+            case "POST":
+                return withBody(new HttpPost(uri), request);
+            case "PUT":
+                return withBody(new HttpPut(uri), request);
+            default:
+                throw new IllegalArgumentException("Unsupported HTTP method " + request.method());
+        }
+    }
+
+    private static HttpRequestBase withBody(HttpEntityEnclosingRequestBase httpRequest, AwsHttpRequest request) {
+        byte[] body = request.body();
+        if (body.length > 0) {
+            // The single-argument constructor attaches no Content-Type of its own, leaving the one
+            // the caller set — and signed — untouched. Content-Length is left to Apache, which
+            // derives it from these exact bytes; setting it here makes httpcore reject the request.
+            httpRequest.setEntity(new ByteArrayEntity(body));
+        }
+        return httpRequest;
+    }
+
+    private static Map<String, String> headersOf(CloseableHttpResponse response) {
+        Map<String, String> headers = new LinkedHashMap<>();
+        for (Header header : response.getAllHeaders()) {
+            headers.put(header.getName(), header.getValue());
+        }
+        return headers;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/SesClient.java
+++ b/services/src/main/java/org/keycloak/email/aws/SesClient.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.email.EmailException;
+import org.keycloak.email.aws.credentials.AwsCredentials;
+import org.keycloak.email.aws.credentials.AwsCredentialsException;
+import org.keycloak.email.aws.credentials.AwsCredentialsProviderChain;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
+
+/**
+ * The SES v2 {@code SendEmail} call: resolve credentials, build the JSON body, sign it, post it,
+ * turn the answer into a message id or an {@link EmailException}.
+ * <p>
+ * The message is always sent as {@code Content.Raw}. SES could compose the MIME itself from a
+ * {@code Content.Simple} subject and body, but then the message a recipient receives would be
+ * SES's rendering rather than Keycloak's, and every difference from the SMTP sender — header order,
+ * encodings, the {@code Reply-To} Keycloak sets — would be invisible until someone noticed it in
+ * production. Sending the same bytes Keycloak's SMTP transport would have sent keeps the two
+ * transports interchangeable.
+ */
+final class SesClient {
+
+    private static final Logger logger = Logger.getLogger(SesClient.class);
+
+    private final AwsSesConfig config;
+    private final AwsCredentialsProviderChain credentialsChain;
+    private final AwsHttpTransport directTransport;
+    private final AwsV4Signer signer;
+
+    SesClient(AwsSesConfig config, AwsCredentialsProviderChain credentialsChain) {
+        this(config, credentialsChain, new DirectHttpTransport());
+    }
+
+    SesClient(AwsSesConfig config, AwsCredentialsProviderChain credentialsChain, AwsHttpTransport directTransport) {
+        this.config = config;
+        this.credentialsChain = credentialsChain;
+        this.directTransport = directTransport;
+        this.signer = new AwsV4Signer(config.region(), AwsSesConfig.SIGNING_SERVICE);
+    }
+
+    /**
+     * @param feedbackForwardingAddress the realm's {@code envelopeFrom}, or {@code null}
+     * @return the SES message id — an acknowledgement that SES accepted the message for sending,
+     *         which is not the same thing as delivery
+     */
+    String sendEmail(AwsHttpTransport transport, SesRawMessage message, String feedbackForwardingAddress,
+                     int connectTimeoutMillis, int readTimeoutMillis, Instant now) throws EmailException {
+        byte[] body = requestBody(message, feedbackForwardingAddress);
+
+        AwsCredentials credentials;
+        try {
+            credentials = credentialsChain.resolve(transport, directTransport, now);
+        } catch (AwsCredentialsException e) {
+            throw new EmailException(e.getMessage(), e);
+        }
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Host", config.hostHeader());
+        headers.put("Content-Type", "application/json");
+
+        AwsHttpRequest request = new AwsHttpRequest("POST", config.sendEmailUri(), headers, body,
+                connectTimeoutMillis, readTimeoutMillis);
+        request = request.withHeaders(signer.sign(request, credentials, now));
+
+        AwsHttpResponse response;
+        try {
+            response = transport.exchange(request);
+        } catch (IOException e) {
+            // Deliberately not retried: SES SendEmail has no idempotency token, so a request that
+            // failed after reaching AWS cannot be distinguished from one that never arrived, and
+            // resending it would deliver the same activation email twice. Keycloak's SMTP sender
+            // does not retry either.
+            throw new EmailException("Could not reach Amazon SES at " + config.hostHeader() + ": " + e.getMessage(), e);
+        }
+
+        if (!response.isSuccessful()) {
+            SesErrorResponse error = SesErrorResponse.parse(response);
+            logger.warnf("Amazon SES refused an email: %s", error.describeForLog());
+            throw new EmailException(error.describe());
+        }
+        return messageId(response);
+    }
+
+    private byte[] requestBody(SesRawMessage message, String feedbackForwardingAddress) throws EmailException {
+        Map<String, Object> destination = new LinkedHashMap<>();
+        destination.put("ToAddresses", List.of(message.recipient()));
+
+        Map<String, Object> raw = new LinkedHashMap<>();
+        // Base64 is the caller's job on the plain HTTPS API — only the AWS SDKs encode it for you.
+        raw.put("Data", Base64.getEncoder().encodeToString(message.mime()));
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("FromEmailAddress", message.fromHeaderValue());
+        payload.put("Destination", destination);
+        payload.put("Content", Map.of("Raw", raw));
+        if (feedbackForwardingAddress != null && !feedbackForwardingAddress.isBlank()) {
+            // The realm's envelopeFrom is Keycloak's bounce address, and this is the SES parameter
+            // with that meaning. Note the mapping is partial: SES fixes the SMTP envelope sender to
+            // the identity's MAIL FROM domain, so the SPF-alignment half of envelopeFrom cannot be
+            // honoured over the API — only the bounce routing.
+            payload.put("FeedbackForwardingEmailAddress", feedbackForwardingAddress);
+        }
+        if (config.configurationSetName() != null) {
+            payload.put("ConfigurationSetName", config.configurationSetName());
+        }
+        // ReplyToAddresses is deliberately absent: Keycloak already writes a Reply-To header into the
+        // MIME, and AWS documents no interaction between the parameter and a raw message's headers.
+
+        try {
+            return JsonSerialization.writeValueAsBytes(payload);
+        } catch (IOException e) {
+            throw new EmailException("Failed to serialise the Amazon SES request", e);
+        }
+    }
+
+    private String messageId(AwsHttpResponse response) throws EmailException {
+        try {
+            JsonNode body = JsonSerialization.mapper.readTree(response.body());
+            // The null check is defensive rather than reachable: Jackson answers an empty document
+            // with MissingNode, not null. It is here so this class does not depend on that.
+            String messageId = body == null ? null : body.path("MessageId").asText(null);
+            if (messageId == null || messageId.isBlank()) {
+                throw new EmailException("Amazon SES accepted the message but returned no message id");
+            }
+            return messageId;
+        } catch (IOException e) {
+            throw new EmailException("Could not read the Amazon SES response", e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/SesErrorResponse.java
+++ b/services/src/main/java/org/keycloak/email/aws/SesErrorResponse.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * An error answer from SES, reduced to the three things worth acting on: what AWS called it, what it
+ * said, and the request id AWS support needs to trace it.
+ *
+ * @param status    HTTP status code
+ * @param errorCode the AWS exception name ({@code MessageRejected}, {@code TooManyRequestsException}…),
+ *                  or {@code null} when the response carried none
+ * @param message   the human-readable text AWS returned, or {@code null}
+ * @param requestId the value of {@code x-amzn-RequestId} — the only handle AWS support can follow
+ */
+record SesErrorResponse(int status, String errorCode, String message, String requestId) {
+
+    private static final Pattern ADDRESS = Pattern.compile("[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}");
+
+    /**
+     * Extracts the error from a non-2xx response.
+     * <p>
+     * Three quirks of the SES wire format are handled here rather than at the call site. The
+     * exception name arrives in the {@code x-amzn-ErrorType} header, decorated: AWS appends
+     * {@code :} plus a request id, or prefixes a {@code #}-separated namespace, and both have to be
+     * stripped. When the header is absent the same name may appear in the body as {@code __type},
+     * {@code code} or {@code Code}. And the message itself is under {@code message} <em>or</em>
+     * {@code Message} depending on the operation — reading only one casing yields empty error text
+     * exactly when an operator most needs it.
+     */
+    static SesErrorResponse parse(AwsHttpResponse response) {
+        String errorCode = sanitizeErrorType(response.header("x-amzn-ErrorType"));
+        String message = null;
+
+        if (response.body().length > 0) {
+            try {
+                // A null document is defensive rather than reachable — Jackson answers an empty body
+                // with MissingNode — and lands in the same place as a body that is not JSON at all:
+                // the status and the request id still carry the diagnosis.
+                JsonNode body = JsonSerialization.mapper.readTree(response.body());
+                if (body != null) {
+                    if (errorCode == null) {
+                        errorCode = sanitizeErrorType(firstText(body, "__type", "code", "Code"));
+                    }
+                    message = firstText(body, "message", "Message");
+                }
+            } catch (IOException e) {
+                // A body that is not JSON is itself unremarkable — a proxy or a load balancer in
+                // front of SES answers in HTML. The status code and the request id still carry the
+                // diagnosis, so this is not worth failing over.
+                message = null;
+            }
+        }
+        return new SesErrorResponse(response.status(), errorCode, message, response.header("x-amzn-RequestId"));
+    }
+
+    private static String firstText(JsonNode body, String... fields) {
+        for (String field : fields) {
+            JsonNode value = body.get(field);
+            if (value != null && value.isTextual() && !value.asText().isBlank()) {
+                return value.asText();
+            }
+        }
+        return null;
+    }
+
+    private static String sanitizeErrorType(String errorType) {
+        if (errorType == null || errorType.isBlank()) {
+            return null;
+        }
+        String sanitized = errorType;
+        int colon = sanitized.indexOf(':');
+        if (colon >= 0) {
+            sanitized = sanitized.substring(0, colon);
+        }
+        int hash = sanitized.lastIndexOf('#');
+        if (hash >= 0) {
+            sanitized = sanitized.substring(hash + 1);
+        }
+        return sanitized.isBlank() ? null : sanitized.trim();
+    }
+
+    /**
+     * Whether SES is asking for the send to slow down rather than refusing it.
+     * <p>
+     * Nothing retries on it — see {@code AwsSesEmailSenderProvider} for why — but the distinction is
+     * what tells an administrator staring at a failed invitation whether to fix a configuration or
+     * to ask AWS for a higher sending rate.
+     */
+    boolean isThrottling() {
+        return status == 429
+                || "TooManyRequestsException".equals(errorCode)
+                || "ThrottlingException".equals(errorCode)
+                || "LimitExceededException".equals(errorCode);
+    }
+
+    /** Admin-facing summary. Carries no credential material: AWS error text never contains any. */
+    String describe() {
+        StringBuilder description = new StringBuilder("Amazon SES rejected the message (HTTP ").append(status);
+        if (errorCode != null) {
+            description.append(", ").append(errorCode);
+        }
+        description.append(')');
+        if (message != null) {
+            description.append(": ").append(redactAddresses(message));
+        }
+        if (isThrottling()) {
+            description.append(" [the account's SES sending rate or quota was exceeded]");
+        }
+        if (requestId != null) {
+            description.append(" [aws-request-id: ").append(requestId).append(']');
+        }
+        return description.toString();
+    }
+
+    /**
+     * Removes anything address-shaped from AWS's text.
+     * <p>
+     * The text itself is what makes a failure actionable — "Email address is not verified" tells an
+     * administrator exactly what to fix — but it names the recipient, and this message does not stay
+     * in the administrator's browser: the callers of the email SPI log the whole exception, so
+     * without this the address ends up in the server log for every failed send.
+     */
+    private static String redactAddresses(String message) {
+        return ADDRESS.matcher(message).replaceAll("<address redacted>");
+    }
+
+    /** Log-facing summary: status, error name and request id only — never the message, which can name a recipient. */
+    String describeForLog() {
+        return "status=" + status + " error=" + (errorCode == null ? "unknown" : errorCode)
+                + " awsRequestId=" + (requestId == null ? "none" : requestId);
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/SesRawMessage.java
+++ b/services/src/main/java/org/keycloak/email/aws/SesRawMessage.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.IDN;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Multipart;
+import jakarta.mail.Session;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.internet.MimeUtility;
+
+import org.keycloak.email.EmailException;
+import org.keycloak.utils.EmailValidationUtil;
+
+import static org.keycloak.utils.StringUtil.isNotBlank;
+
+/**
+ * The MIME message handed to SES as {@code Content.Raw}, together with the two envelope values that
+ * must agree with its headers.
+ * <p>
+ * Everything about the message construction mirrors Keycloak's SMTP sender
+ * ({@code DefaultEmailSenderProvider}) deliberately: same {@code multipart/alternative} with the
+ * text part first, same RFC 2047 subject encoding, same rule that {@code Reply-To} defaults to the
+ * {@code From} address, same raw {@code To} header. Switching a realm from SMTP to SES must change
+ * the transport and nothing a recipient can see.
+ */
+final class SesRawMessage {
+
+    private final InternetAddress from;
+    private final String recipient;
+    private final byte[] mime;
+
+    private SesRawMessage(InternetAddress from, String recipient, byte[] mime) {
+        this.from = from;
+        this.recipient = recipient;
+        this.mime = mime;
+    }
+
+    /**
+     * The exact string used as the MIME {@code From} header, to be sent as SES's
+     * {@code FromEmailAddress}.
+     * <p>
+     * Both come from this one object rather than from two separate renderings of the configuration:
+     * AWS documents the parameter as the envelope sender and the header as the message header, but
+     * never documents what happens when the two disagree — nor which identity IAM authorises then.
+     * Deriving both from a single {@link InternetAddress} removes the question instead of betting on
+     * an answer.
+     */
+    String fromHeaderValue() {
+        return from.toString();
+    }
+
+    /** The single envelope recipient, identical to the {@code To} header. */
+    String recipient() {
+        return recipient;
+    }
+
+    byte[] mime() {
+        return mime;
+    }
+
+    static SesRawMessage compose(Map<String, String> config, String address, String subject,
+                                 String textBody, String htmlBody) throws EmailException {
+        String fromAddress = requireSendableAddress(config.get("from"), "sender");
+        String recipient = requireSendableAddress(address, "recipient");
+
+        Properties properties = new Properties();
+        // Without mail.from, saveChanges() builds the Message-ID from
+        // InetAddress.getLocalHost().getHostName(): a blocking reverse lookup on every email whose
+        // result — the container's internal hostname — then travels to the recipient. SES replaces
+        // the Message-ID anyway, so there is nothing to lose and a hostname leak to avoid.
+        properties.setProperty("mail.from", fromAddress);
+        Session session = Session.getInstance(properties);
+
+        try {
+            InternetAddress from = toInternetAddress(fromAddress, config.get("fromDisplayName"));
+
+            MimeMessage message = new MimeMessage(session);
+            message.setFrom(from);
+            message.setReplyTo(new Address[]{from});
+
+            String replyTo = config.get("replyTo");
+            if (isNotBlank(replyTo)) {
+                String replyToAddress = requireSendableAddress(replyTo, "reply-to");
+                message.setReplyTo(new Address[]{toInternetAddress(replyToAddress, config.get("replyToDisplayName"))});
+            }
+
+            message.setHeader("To", recipient);
+            message.setSubject(MimeUtility.encodeText(subject, StandardCharsets.UTF_8.name(), null));
+            message.setContent(multipartBody(textBody, htmlBody));
+            message.saveChanges();
+            message.setSentDate(new Date());
+
+            return new SesRawMessage(from, recipient, serialize(message));
+        } catch (UnsupportedEncodingException e) {
+            throw new EmailException("Failed to encode email address", e);
+        } catch (AddressException e) {
+            throw new EmailException("Invalid email address format", e);
+        } catch (MessagingException | IOException e) {
+            throw new EmailException("Failed to compose the email message", e);
+        }
+    }
+
+    private static byte[] serialize(Message message) throws IOException, MessagingException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try (OutputStream out = new CrlfNormalizingOutputStream(buffer)) {
+            message.writeTo(out);
+        }
+        return buffer.toByteArray();
+    }
+
+    private static Multipart multipartBody(String textBody, String htmlBody) throws MessagingException {
+        Multipart multipart = new MimeMultipart("alternative");
+        if (textBody != null) {
+            MimeBodyPart textPart = new MimeBodyPart();
+            textPart.setText(textBody, StandardCharsets.UTF_8.name());
+            multipart.addBodyPart(textPart);
+        }
+        if (htmlBody != null) {
+            MimeBodyPart htmlPart = new MimeBodyPart();
+            htmlPart.setContent(htmlBody, "text/html; charset=UTF-8");
+            multipart.addBodyPart(htmlPart);
+        }
+        return multipart;
+    }
+
+    private static InternetAddress toInternetAddress(String email, String displayName)
+            throws UnsupportedEncodingException, AddressException {
+        if (displayName == null || displayName.trim().isEmpty()) {
+            return new InternetAddress(email);
+        }
+        return new InternetAddress(email, displayName, StandardCharsets.UTF_8.name());
+    }
+
+    /**
+     * Renders a rejected address for an error message.
+     * <p>
+     * The address is only ever quoted back when it has already failed validation, which is exactly
+     * the case where it may contain line breaks: this message reaches the server log, and a raw CR or
+     * LF in it would let the offending value forge a log line of its own.
+     */
+    private static String forMessage(String address) {
+        String sanitized = address.length() > 120 ? address.substring(0, 120) + "…" : address;
+        return sanitized.replaceAll("[\\p{Cntrl}]", "?");
+    }
+
+    /**
+     * Validates an address and returns the form that can actually be sent.
+     * <p>
+     * An internationalised domain is converted to its ASCII (punycode) equivalent, which is what
+     * Keycloak's own SMTP sender does — {@code utente@società.it} is delivered as
+     * {@code utente@xn--societ-nta.it} rather than rejected. A non-ASCII <em>local</em> part cannot be
+     * rescued that way: it needs the SMTPUTF8 extension, which Amazon SES does not implement ("the
+     * email address string must be 7-bit ASCII"), so it is refused here with a message that says why
+     * instead of coming back later as an opaque {@code MessageRejected}.
+     */
+    static String requireSendableAddress(String address, String role) throws EmailException {
+        if (address == null || address.isBlank()) {
+            throw new EmailException("No " + role + " address configured");
+        }
+        if (!EmailValidationUtil.isValidEmail(address)) {
+            throw new EmailException("Invalid " + role + " address '" + forMessage(address) + "'");
+        }
+        String asciiAddress = toAsciiDomain(address);
+        if (asciiAddress == null || !StandardCharsets.US_ASCII.newEncoder().canEncode(asciiAddress)) {
+            throw new EmailException("Amazon SES does not support internationalised (non 7-bit ASCII) "
+                    + role + " addresses, but '" + forMessage(address) + "' has a local part or a domain"
+                    + " that cannot be expressed in ASCII");
+        }
+        return asciiAddress;
+    }
+
+    /**
+     * Punycodes the domain part, leaving the local part alone. Returns {@code null} when the domain
+     * cannot be converted, which {@link IDN#toASCII} signals by throwing.
+     */
+    private static String toAsciiDomain(String address) {
+        int at = address.lastIndexOf('@');
+        if (at < 0) {
+            return address;
+        }
+        try {
+            return address.substring(0, at + 1) + IDN.toASCII(address.substring(at + 1));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentials.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentials.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * An AWS access key pair, optionally temporary.
+ *
+ * @param accessKeyId     the {@code AKIA…}/{@code ASIA…} identifier; the only part of a credential
+ *                        that may be logged
+ * @param secretAccessKey the signing secret — never log, never put in an exception message
+ * @param sessionToken    the STS session token for temporary credentials, {@code null} for a long
+ *                        lived IAM user key pair
+ * @param expiration      when the credentials stop being valid, {@code null} when they do not expire
+ */
+public record AwsCredentials(String accessKeyId, String secretAccessKey, String sessionToken, Instant expiration) {
+
+    public AwsCredentials {
+        Objects.requireNonNull(accessKeyId, "accessKeyId");
+        Objects.requireNonNull(secretAccessKey, "secretAccessKey");
+    }
+
+    public static AwsCredentials of(String accessKeyId, String secretAccessKey) {
+        return new AwsCredentials(accessKeyId, secretAccessKey, null, null);
+    }
+
+    public boolean isTemporary() {
+        return sessionToken != null && !sessionToken.isBlank();
+    }
+
+    /**
+     * Whether these credentials should be replaced. Mirrors what the AWS SDKs do: refresh a few
+     * minutes <em>before</em> the stated expiry, so a request signed at the edge of the window is
+     * still valid when it reaches AWS.
+     */
+    public boolean isExpired(Instant now, Duration refreshWindow) {
+        return expiration != null && !now.plus(refreshWindow).isBefore(expiration);
+    }
+
+    /**
+     * Redacted rendering. {@code toString()} on a record prints every component, which would put the
+     * secret access key into any log line or exception that happens to interpolate the object.
+     */
+    @Override
+    public String toString() {
+        return "AwsCredentials[accessKeyId=" + accessKeyId + ", temporary=" + isTemporary()
+                + ", expiration=" + expiration + "]";
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentialsException.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentialsException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+/**
+ * A credential source was configured but could not produce credentials.
+ * <p>
+ * Messages of this exception reach the Keycloak server log and, through {@code EmailException}, an
+ * administrator's browser. They must therefore name the <em>source</em> and the failure, never the
+ * material: an access key id is the only part of a credential that may appear here.
+ */
+public class AwsCredentialsException extends Exception {
+
+    public AwsCredentialsException(String message) {
+        super(message);
+    }
+
+    public AwsCredentialsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentialsProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import org.keycloak.email.aws.AwsHttpTransport;
+
+/**
+ * One source of AWS credentials — an environment variable pair, a role attached to the compute the
+ * server runs on, a profile file.
+ * <p>
+ * A provider reports "not configured" by returning {@code null}, and reports "configured but broken"
+ * by throwing. The distinction is what makes {@link AwsCredentialsProviderChain} usable: a missing
+ * environment variable must fall through to the next source, while an unreadable web-identity token
+ * file must not be silently swallowed into an unrelated later failure.
+ */
+public interface AwsCredentialsProvider {
+
+    /**
+     * @param transport used by the sources that have to call an HTTP endpoint (STS, the container
+     *                  credential endpoint, the instance metadata service); ignored by the others
+     * @return the credentials, or {@code null} when this source is not configured in this environment
+     * @throws AwsCredentialsException when the source is configured but cannot be used
+     */
+    AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException;
+
+    /** Short human-readable name, used in log lines and in the "no credentials" error message. */
+    String name();
+
+    /**
+     * Whether this source must be reached without a proxy.
+     * <p>
+     * True for the sources that answer on this machine — the container credential endpoint and the
+     * instance metadata service. Their requests carry a bearer token, and a proxy in the path would
+     * both receive that token and become the peer the address checks were meant to pin down. The
+     * sources that talk to a real AWS endpoint say false and keep the server's outbound configuration.
+     */
+    default boolean requiresDirectConnection() {
+        return false;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentialsProviderChain.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/AwsCredentialsProviderChain.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringJoiner;
+
+import org.keycloak.email.aws.AwsHttpTransport;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Resolves credentials from the first configured source, in the order the AWS SDK for Java v2 uses:
+ * JVM system properties, environment variables, web identity token (EKS IRSA), profile files,
+ * container credentials (ECS / EKS Pod Identity), then the EC2 instance metadata service.
+ * <p>
+ * The order is not arbitrary and is not the place to be creative: an operator who exports
+ * {@code AWS_ACCESS_KEY_ID} on a machine that also has {@code ~/.aws/credentials} expects the
+ * environment to win, exactly as every other AWS tool on that machine behaves.
+ * <p>
+ * Resolved credentials are cached until shortly before they expire. Long-lived IAM user keys never
+ * expire and are resolved once; the role-based sources return short-lived credentials and are
+ * refreshed {@value #REFRESH_WINDOW_MINUTES} minutes ahead of expiry, so a message signed at the
+ * edge of the window is still valid when it reaches AWS.
+ */
+public final class AwsCredentialsProviderChain {
+
+    static final int REFRESH_WINDOW_MINUTES = 5;
+
+    private static final Logger logger = Logger.getLogger(AwsCredentialsProviderChain.class);
+    private static final Duration REFRESH_WINDOW = Duration.ofMinutes(REFRESH_WINDOW_MINUTES);
+
+    private final List<AwsCredentialsProvider> providers;
+    private final Object refreshLock = new Object();
+
+    private volatile AwsCredentials cached;
+
+    public AwsCredentialsProviderChain(List<AwsCredentialsProvider> providers) {
+        this.providers = List.copyOf(providers);
+    }
+
+    /**
+     * The default chain. {@code environment} is injected rather than read from {@link System} so the
+     * whole chain is exercisable from a test without mutating the JVM's real environment.
+     */
+    public static AwsCredentialsProviderChain defaultChain(AwsEnvironment environment) {
+        List<AwsCredentialsProvider> providers = new ArrayList<>();
+        providers.add(new SystemPropertiesCredentialsProvider(environment));
+        providers.add(new EnvironmentVariableCredentialsProvider(environment));
+        providers.add(new WebIdentityTokenCredentialsProvider(environment));
+        providers.add(new ProfileCredentialsProvider(environment));
+        providers.add(new ContainerCredentialsProvider(environment));
+        providers.add(new InstanceMetadataCredentialsProvider(environment));
+        return new AwsCredentialsProviderChain(providers);
+    }
+
+    /**
+     * @param transport       the server's own HTTP client, used for the sources that talk to AWS
+     * @param directTransport a proxy-free client, used for the sources that answer on this machine
+     */
+    public AwsCredentials resolve(AwsHttpTransport transport, AwsHttpTransport directTransport, Instant now)
+            throws AwsCredentialsException {
+        AwsCredentials current = cached;
+        if (current != null && !current.isExpired(now, REFRESH_WINDOW)) {
+            return current;
+        }
+        synchronized (refreshLock) {
+            // Re-read under the lock: while this thread waited, another one may have refreshed. The
+            // sources that cost an HTTP round trip are the ones that expire, so letting every
+            // concurrent send re-fetch would multiply calls to the metadata service under load.
+            current = cached;
+            if (current != null && !current.isExpired(now, REFRESH_WINDOW)) {
+                return current;
+            }
+            AwsCredentials resolved = resolveFromSources(transport, directTransport);
+            // Temporary credentials with no stated expiry are not cached. They come from a profile
+            // file or the process environment, where a session token can be pasted in by hand; once
+            // it expires there is nothing here that could notice, and caching it would keep every
+            // email broken even after an operator refreshed the file.
+            cached = resolved.isTemporary() && resolved.expiration() == null ? null : resolved;
+            return resolved;
+        }
+    }
+
+    private AwsCredentials resolveFromSources(AwsHttpTransport transport, AwsHttpTransport directTransport)
+            throws AwsCredentialsException {
+        StringJoiner attempted = new StringJoiner(", ");
+        for (AwsCredentialsProvider provider : providers) {
+            attempted.add(provider.name());
+            AwsCredentials credentials =
+                    provider.resolve(provider.requiresDirectConnection() ? directTransport : transport);
+            if (credentials != null) {
+                logger.debugf("Resolved AWS credentials from %s (access key id %s)", provider.name(),
+                        credentials.accessKeyId());
+                return credentials;
+            }
+        }
+        throw new AwsCredentialsException("No AWS credentials found. Sources tried, in order: " + attempted
+                + ". Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the Keycloak environment, or run the"
+                + " server with an IAM role attached.");
+    }
+
+    /** Visible for testing: drops the cache so the next resolve re-runs the chain. */
+    void invalidate() {
+        cached = null;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/AwsEnvironment.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/AwsEnvironment.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * The ambient process state the AWS credential chain reads: environment variables, JVM system
+ * properties and the user's home directory.
+ * <p>
+ * It exists as an interface for one reason: {@link System#getenv(String)} cannot be set from a test,
+ * so without this indirection the environment-variable, container and instance-profile branches of
+ * the chain would only be exercisable by mutating the JVM's real environment. Production code uses
+ * {@link #SYSTEM}.
+ */
+public interface AwsEnvironment {
+
+    AwsEnvironment SYSTEM = new AwsEnvironment() {
+
+        @Override
+        public String getenv(String name) {
+            return System.getenv(name);
+        }
+
+        @Override
+        public String getProperty(String name) {
+            return System.getProperty(name);
+        }
+
+        @Override
+        public Path userHome() {
+            return Paths.get(System.getProperty("user.home", ""));
+        }
+    };
+
+    String getenv(String name);
+
+    String getProperty(String name);
+
+    Path userHome();
+
+    /**
+     * Reads {@code name} and returns {@code null} when it is unset <em>or blank</em>.
+     * <p>
+     * Blank has to collapse into unset: docker compose's {@code KEY: ${VAR:-}} form injects an empty
+     * string rather than omitting the variable, so a chain link that only checked for {@code null}
+     * would accept empty credentials and fail later with an opaque SES {@code SignatureDoesNotMatch}
+     * instead of falling through to the next link.
+     */
+    default String value(String name) {
+        String value = getenv(name);
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /** {@link #value(String)} for a JVM system property. */
+    default String property(String name) {
+        String value = getProperty(name);
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /**
+     * A setting the AWS SDKs expose both ways, read in their order: the JVM system property wins over
+     * the environment variable.
+     * <p>
+     * Reading only the variable would make this provider disagree with every other AWS client in the
+     * same JVM — a server started with {@code -Daws.profile=…} would send email as one identity while
+     * everything else used another.
+     */
+    default String setting(String systemProperty, String environmentVariable) {
+        String property = property(systemProperty);
+        return property != null ? property : value(environmentVariable);
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/ContainerCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/ContainerCredentialsProvider.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.email.aws.AwsHttpRequest;
+import org.keycloak.email.aws.AwsHttpResponse;
+import org.keycloak.email.aws.AwsHttpTransport;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
+
+/**
+ * Credentials handed out by a container credential endpoint — an ECS task role, or the EKS Pod
+ * Identity agent.
+ * <p>
+ * The runtime that starts the container exports one of two variables:
+ * {@code AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}, a path resolved against the fixed ECS endpoint
+ * {@code http://169.254.170.2}, or {@code AWS_CONTAINER_CREDENTIALS_FULL_URI}, an absolute URI.
+ * Neither one set means the server is not running under such a runtime, and the chain moves on.
+ * <p>
+ * Two details of this endpoint differ from the STS ones and are both asserted in the tests: the
+ * session token arrives in a field named {@code Token} rather than {@code SessionToken}, and the
+ * request may carry a bearer token of its own, which is what makes the full-URI validation below a
+ * security control rather than an input check.
+ */
+public final class ContainerCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final Logger logger = Logger.getLogger(ContainerCredentialsProvider.class);
+
+    private static final String RELATIVE_URI_VARIABLE = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+    private static final String FULL_URI_VARIABLE = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+    private static final String AUTHORIZATION_TOKEN_VARIABLE = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+    private static final String AUTHORIZATION_TOKEN_FILE_VARIABLE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+
+    /** The ECS task metadata endpoint. Fixed by the agent, never configurable. */
+    private static final String ECS_ENDPOINT = "http://169.254.170.2";
+
+    /**
+     * The link-local addresses AWS's own credential agents listen on: the ECS task metadata endpoint
+     * and the EKS Pod Identity agent, in its IPv4 and IPv6 form. A list, not a set, so the order in
+     * the rejection message is the same on every JVM.
+     */
+    private static final List<String> ALLOWED_LINK_LOCAL_HOSTS =
+            List.of("169.254.170.2", "169.254.170.23", "fd00:ec2::23");
+
+    /**
+     * One second either way. The endpoint answers from the local link or from a loopback socket, so
+     * anything slower than this is down rather than busy — and this lookup runs inside the
+     * transaction that sends the mail, where a hang is worse than a failure.
+     */
+    private static final int TIMEOUT_MILLIS = 1000;
+
+    private final AwsEnvironment environment;
+
+    public ContainerCredentialsProvider(AwsEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public boolean requiresDirectConnection() {
+        return true;
+    }
+
+    @Override
+    public String name() {
+        return "container credentials (ECS task role / EKS Pod Identity)";
+    }
+
+    @Override
+    public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+        URI endpoint = endpoint();
+        if (endpoint == null) {
+            return null;
+        }
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Accept", "application/json");
+        String token = authorizationToken();
+        if (token != null) {
+            // Verbatim, without a scheme prefix: both the ECS and the Pod Identity agent compare the
+            // header against the value they generated. Never logged, at any level.
+            headers.put("Authorization", token);
+        }
+
+        logger.debugf("Fetching AWS credentials from the container credential endpoint at %s", endpoint.getHost());
+
+        AwsHttpResponse response;
+        try {
+            response = transport.exchange(AwsHttpRequest.get(endpoint, headers, TIMEOUT_MILLIS, TIMEOUT_MILLIS));
+        } catch (IOException e) {
+            throw new AwsCredentialsException("Container credential endpoint " + endpoint.getHost()
+                    + " is not reachable", e);
+        }
+        if (!response.isSuccessful()) {
+            // The status and nothing else: the body of a failed credential response is undocumented,
+            // and an endpoint that is not the one we think it is could echo the authorization token
+            // straight back into the server log.
+            throw new AwsCredentialsException("Container credential endpoint " + endpoint.getHost()
+                    + " returned HTTP " + response.status());
+        }
+        return parse(response, endpoint.getHost());
+    }
+
+    /**
+     * The URI to call, or {@code null} when neither variable is set. The relative form wins when both
+     * are, as it does in the AWS SDKs.
+     */
+    private URI endpoint() throws AwsCredentialsException {
+        String relative = environment.value(RELATIVE_URI_VARIABLE);
+        if (relative != null) {
+            String path = relative.startsWith("/") ? relative : "/" + relative;
+            return uri(ECS_ENDPOINT + path, RELATIVE_URI_VARIABLE);
+        }
+        String full = environment.value(FULL_URI_VARIABLE);
+        return full == null ? null : validated(uri(full, FULL_URI_VARIABLE));
+    }
+
+    private static URI uri(String value, String variable) throws AwsCredentialsException {
+        try {
+            return new URI(value);
+        } catch (URISyntaxException e) {
+            // The variable name, not its value: a full URI is operator-supplied and may carry
+            // anything in its query string.
+            throw new AwsCredentialsException(variable + " is not a valid URI", e);
+        }
+    }
+
+    /**
+     * Rejects a full URI that is neither HTTPS nor local.
+     * <p>
+     * This is a deliberate SSRF guard rather than a tidy input check: the request about to be made
+     * carries the container authorization token, and {@code AWS_CONTAINER_CREDENTIALS_FULL_URI} is a
+     * plain environment variable. Without this, whoever can set that variable — an edited deployment
+     * manifest, an injected env entry — turns Keycloak into a credential-forwarding proxy that hands
+     * the token to a host of their choosing, in cleartext.
+     * <p>
+     * The check is lexical on purpose. Resolving the host to decide whether it is really loopback
+     * would put an untimed DNS lookup inside the mail transaction and would leave a rebinding window
+     * between the decision and the connection.
+     */
+    private static URI validated(URI uri) throws AwsCredentialsException {
+        String scheme = uri.getScheme();
+        String host = uri.getHost();
+        if (scheme == null || host == null) {
+            throw new AwsCredentialsException(FULL_URI_VARIABLE + " must be an absolute http or https URI");
+        }
+        if ("https".equalsIgnoreCase(scheme)) {
+            return uri;
+        }
+        if ("http".equalsIgnoreCase(scheme) && isLocal(host)) {
+            return uri;
+        }
+        throw new AwsCredentialsException(FULL_URI_VARIABLE + " points at " + host + ", which is refused: without"
+                + " https the container authorization token may only be sent to a loopback address or to one of the"
+                + " AWS credential endpoints " + String.join(", ", ALLOWED_LINK_LOCAL_HOSTS) + ".");
+    }
+
+    private static boolean isLocal(String host) {
+        if ("localhost".equalsIgnoreCase(host)) {
+            return true;
+        }
+        if (LocalAddress.isLoopback(host)) {
+            return true;
+        }
+        return ALLOWED_LINK_LOCAL_HOSTS.stream().anyMatch(allowed -> LocalAddress.is(host, allowed));
+    }
+
+    /**
+     * The value for the {@code Authorization} header, or {@code null} when the runtime uses none — a
+     * bare ECS task role does not.
+     * <p>
+     * The file form takes precedence, as in the AWS SDKs: EKS Pod Identity rotates the token on disk,
+     * so a copy captured in the environment at startup must never win over the file the agent keeps
+     * current.
+     */
+    private String authorizationToken() throws AwsCredentialsException {
+        String file = environment.value(AUTHORIZATION_TOKEN_FILE_VARIABLE);
+        if (file == null) {
+            return environment.value(AUTHORIZATION_TOKEN_VARIABLE);
+        }
+        String token;
+        try {
+            // Trimmed: the file ends with a newline the agent never meant as part of the value, and a
+            // header carrying CR or LF is at best rejected by the client, at worst a splitting vector.
+            token = Files.readString(Paths.get(file), StandardCharsets.UTF_8).trim();
+        } catch (IOException | InvalidPathException e) {
+            throw new AwsCredentialsException(AUTHORIZATION_TOKEN_FILE_VARIABLE + " (" + file + ") cannot be read", e);
+        }
+        if (token.isEmpty()) {
+            throw new AwsCredentialsException(AUTHORIZATION_TOKEN_FILE_VARIABLE + " (" + file + ") is empty");
+        }
+        return token;
+    }
+
+    private static AwsCredentials parse(AwsHttpResponse response, String host) throws AwsCredentialsException {
+        JsonNode body;
+        try {
+            body = JsonSerialization.mapper.readTree(response.body());
+        } catch (IOException e) {
+            // The cause is dropped on purpose: Jackson quotes the offending source in its message,
+            // and that source is the credential document.
+            throw new AwsCredentialsException("Container credential endpoint " + host
+                    + " returned a body that is not JSON");
+        }
+
+        if (body == null) {
+            // Defensive rather than reachable: Jackson answers an empty body with MissingNode. Kept
+            // so a change of parser cannot turn an empty 200 into a NullPointerException here.
+            throw new AwsCredentialsException("Container credential endpoint " + host + " returned an empty body");
+        }
+
+        String accessKeyId = text(body, "AccessKeyId");
+        String secretAccessKey = text(body, "SecretAccessKey");
+        if (accessKeyId == null || secretAccessKey == null) {
+            throw new AwsCredentialsException("Container credential endpoint " + host
+                    + " returned a response without AccessKeyId or SecretAccessKey");
+        }
+        // "Token", not "SessionToken": this endpoint and STS name the same value differently, and
+        // reading the STS name here yields credentials that sign happily and are rejected by AWS.
+        String sessionToken = text(body, "Token");
+        if (sessionToken == null) {
+            throw new AwsCredentialsException("Container credential endpoint " + host
+                    + " returned a response without a Token; container role credentials are always temporary");
+        }
+        return new AwsCredentials(accessKeyId, secretAccessKey, sessionToken, expiration(body, host));
+    }
+
+    private static Instant expiration(JsonNode body, String host) throws AwsCredentialsException {
+        String expiration = text(body, "Expiration");
+        if (expiration == null) {
+            // These credentials always expire, so a document without an Expiration is incomplete
+            // rather than perpetual — treating it as perpetual would cache it past its life.
+            throw new AwsCredentialsException("Container credential endpoint " + host
+                    + " returned a response without an Expiration");
+        }
+        try {
+            return Instant.parse(expiration);
+        } catch (DateTimeParseException e) {
+            // Not "treat it as non-expiring": that would turn one unreadable timestamp into
+            // credentials the chain caches forever and keeps signing with long after AWS stopped
+            // honouring them.
+            throw new AwsCredentialsException("Container credential endpoint " + host
+                    + " returned an Expiration that is not an ISO-8601 instant: " + expiration, e);
+        }
+    }
+
+    /** {@code null} for a field that is absent, null, non-textual or blank — all of them "not supplied". */
+    private static String text(JsonNode body, String field) {
+        JsonNode value = body.path(field);
+        return value.isTextual() && !value.asText().isBlank() ? value.asText() : null;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/EnvironmentVariableCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/EnvironmentVariableCredentialsProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import org.keycloak.email.aws.AwsHttpTransport;
+
+/**
+ * Credentials from {@code AWS_ACCESS_KEY_ID}, {@code AWS_SECRET_ACCESS_KEY} and the optional
+ * {@code AWS_SESSION_TOKEN} — the form docker compose files, systemd units and Kubernetes secrets
+ * all speak, and the one an operator reaches for first.
+ * <p>
+ * The source is process-local: it never uses the transport and cannot block. Variables are read
+ * through {@link AwsEnvironment#value(String)}, so a variable that exists but is empty counts as
+ * unset and the chain moves on — the difference between falling through to the instance role and
+ * signing every message with an empty secret.
+ * <p>
+ * A pair found here is reported as non-expiring even when it carries a session token: the process
+ * environment is fixed at exec time, so re-resolving would only read the same value back.
+ */
+public final class EnvironmentVariableCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final String ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+    private static final String SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
+    private static final String SESSION_TOKEN = "AWS_SESSION_TOKEN";
+
+    private final AwsEnvironment environment;
+
+    public EnvironmentVariableCredentialsProvider(AwsEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+        String accessKeyId = environment.value(ACCESS_KEY_ID);
+        String secretAccessKey = environment.value(SECRET_ACCESS_KEY);
+        if (accessKeyId == null && secretAccessKey == null) {
+            return null;
+        }
+        // Half of a key pair is a typo, not an unconfigured source: falling through would hide the
+        // mistake behind whatever the next source happens to find, or behind "no credentials found".
+        if (accessKeyId == null) {
+            throw new AwsCredentialsException("Environment variable " + SECRET_ACCESS_KEY + " is set but "
+                    + ACCESS_KEY_ID + " is not. Set both, or neither.");
+        }
+        if (secretAccessKey == null) {
+            throw new AwsCredentialsException("Environment variable " + ACCESS_KEY_ID + " is set but "
+                    + SECRET_ACCESS_KEY + " is not. Set both, or neither.");
+        }
+        return new AwsCredentials(accessKeyId, secretAccessKey, environment.value(SESSION_TOKEN), null);
+    }
+
+    @Override
+    public String name() {
+        return "environment variables";
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/InstanceMetadataCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/InstanceMetadataCredentialsProvider.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+
+import org.keycloak.email.aws.AwsHttpRequest;
+import org.keycloak.email.aws.AwsHttpResponse;
+import org.keycloak.email.aws.AwsHttpTransport;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
+
+/**
+ * The credentials of the IAM role attached to an EC2 instance, read from the instance metadata
+ * service (IMDS) on the link-local address.
+ * <p>
+ * <strong>IMDSv2 only.</strong> Every read here is authenticated with a session token obtained by a
+ * {@code PUT}, which a browser-driven request cannot issue cross-origin and whose response AWS
+ * returns with an IP hop limit of 1 so it cannot be relayed off the instance. IMDSv1 — the
+ * unauthenticated {@code GET http://169.254.169.254/latest/meta-data/…} that AWS itself now
+ * discourages and that new instances disable by default — is deliberately not implemented: it is
+ * the SSRF-amplifier variant, and a Keycloak that never speaks it cannot be tricked, by a
+ * server-side request forgery anywhere else in the server, into handing out the instance's role
+ * credentials through a single forged GET. The price is that this source stays silent on an
+ * instance that only offers IMDSv1, which is the right way round.
+ * <p>
+ * Finding nothing is the normal case, not an error: this provider sits last in the chain, so on
+ * every machine that is not an EC2 instance — a laptop, a container on someone else's cloud, a
+ * plain VPS — the token call fails and {@link #resolve} returns {@code null} quietly. Logging that
+ * at anything above {@code DEBUG} would put a stack trace in the server log on every email sent.
+ */
+public final class InstanceMetadataCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final Logger logger = Logger.getLogger(InstanceMetadataCredentialsProvider.class);
+
+    private static final String METADATA_DISABLED_ENV = "AWS_EC2_METADATA_DISABLED";
+    /** The spelling the AWS SDK for Java v2 uses; it is not the camel case of the variable above. */
+    private static final String METADATA_DISABLED_PROPERTY = "aws.disableEc2Metadata";
+    private static final String ENDPOINT_ENV = "AWS_EC2_METADATA_SERVICE_ENDPOINT";
+
+    private static final String METADATA_IPV4 = "169.254.169.254";
+    /** The one IPv6 address AWS documents for the instance metadata service, not the range around it. */
+    private static final String METADATA_IPV6 = "fd00:ec2::254";
+    private static final String DEFAULT_ENDPOINT = "http://" + METADATA_IPV4;
+
+    private static final String TOKEN_PATH = "/latest/api/token";
+    private static final String SECURITY_CREDENTIALS_PATH = "/latest/meta-data/iam/security-credentials/";
+    private static final String TOKEN_HEADER = "X-aws-ec2-metadata-token";
+    private static final String TOKEN_TTL_HEADER = "X-aws-ec2-metadata-token-ttl-seconds";
+    private static final String TOKEN_TTL_SECONDS = "21600";
+
+    /**
+     * A credential lookup runs inside the transaction that is sending a mail, on the link-local
+     * address of the host itself. A second is already generous; anything longer would turn a
+     * black-holed 169.254.0.0/16 route into a hung Keycloak thread.
+     */
+    private static final int TIMEOUT_MILLIS = 1000;
+
+    private final AwsEnvironment environment;
+
+    public InstanceMetadataCredentialsProvider(AwsEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+        if (isDisabled()) {
+            return null;
+        }
+        URI endpoint = endpoint();
+        String token = fetchToken(transport, endpoint);
+        if (token == null) {
+            return null;
+        }
+        String role = fetchRoleName(transport, endpoint, token);
+        if (role == null) {
+            return null;
+        }
+        return fetchCredentials(transport, endpoint, token, role);
+    }
+
+    @Override
+    public boolean requiresDirectConnection() {
+        return true;
+    }
+
+    @Override
+    public String name() {
+        return "EC2 instance metadata (IMDSv2)";
+    }
+
+    private boolean isDisabled() {
+        return "true".equalsIgnoreCase(environment.value(METADATA_DISABLED_ENV))
+                || "true".equalsIgnoreCase(environment.property(METADATA_DISABLED_PROPERTY));
+    }
+
+    private URI endpoint() throws AwsCredentialsException {
+        String configured = environment.value(ENDPOINT_ENV);
+        String raw = configured == null ? DEFAULT_ENDPOINT : configured;
+        URI endpoint;
+        try {
+            endpoint = new URI(raw.replaceAll("/+$", ""));
+        } catch (URISyntaxException e) {
+            throw new AwsCredentialsException(ENDPOINT_ENV + " is not a valid URI: " + raw, e);
+        }
+        if (!isAllowedEndpoint(endpoint)) {
+            throw new AwsCredentialsException(ENDPOINT_ENV + " is set to " + raw + ", which is neither the EC2"
+                    + " instance metadata service nor a loopback address. Over plain HTTP only " + METADATA_IPV4
+                    + ", " + METADATA_IPV6 + " and loopback are accepted; use https for anything else.");
+        }
+        return endpoint;
+    }
+
+    /**
+     * Confines the un-encrypted, un-authenticated leg of this exchange to the addresses that can
+     * only be the host itself. Without it, an operator-supplied (or, worse, injected) endpoint would
+     * make Keycloak fetch an attacker's URL and hand whatever came back to the signer as
+     * credentials. Over TLS the peer is authenticated by its certificate, so any host is fine there.
+     */
+    private static boolean isAllowedEndpoint(URI endpoint) {
+        if ("https".equalsIgnoreCase(endpoint.getScheme())) {
+            return true;
+        }
+        String host = endpoint.getHost();
+        if (host == null) {
+            return false;
+        }
+        if (host.equalsIgnoreCase("localhost")) {
+            return true;
+        }
+        // A name is refused rather than resolved: resolving it is the request forgery being guarded
+        // against, and a DNS answer of 127.0.0.1 today says nothing about the next lookup.
+        return LocalAddress.is(host, METADATA_IPV4)
+                || LocalAddress.is(host, METADATA_IPV6)
+                || LocalAddress.isLoopback(host);
+    }
+
+    /**
+     * @return the IMDSv2 session token, or {@code null} when there is no metadata service to talk
+     *         to — which is what every non-EC2 host answers, and is not a failure
+     */
+    private String fetchToken(AwsHttpTransport transport, URI endpoint) {
+        AwsHttpRequest request = new AwsHttpRequest("PUT", URI.create(endpoint + TOKEN_PATH),
+                Map.of(TOKEN_TTL_HEADER, TOKEN_TTL_SECONDS), AwsHttpRequest.NO_BODY,
+                TIMEOUT_MILLIS, TIMEOUT_MILLIS);
+        AwsHttpResponse response;
+        try {
+            response = transport.exchange(request);
+        } catch (IOException e) {
+            logger.debugf(e, "No EC2 instance metadata service at %s, this server is not an EC2 instance", endpoint);
+            return null;
+        }
+        if (!response.isSuccessful()) {
+            logger.debugf("EC2 instance metadata service at %s refused an IMDSv2 token with HTTP %d", endpoint,
+                    response.status());
+            return null;
+        }
+        String token = response.bodyAsString().trim();
+        return token.isEmpty() ? null : token;
+    }
+
+    /**
+     * @return the first role in the instance profile, or {@code null} when no role is attached; from
+     *         here on a failure is loud, because the successful token call proved this is an EC2
+     *         instance and therefore that this source <em>is</em> configured
+     */
+    private String fetchRoleName(AwsHttpTransport transport, URI endpoint, String token) throws AwsCredentialsException {
+        URI uri = URI.create(endpoint + SECURITY_CREDENTIALS_PATH);
+        AwsHttpResponse response = get(transport, uri, token);
+        if (response.status() == 404) {
+            return null;
+        }
+        if (!response.isSuccessful()) {
+            throw new AwsCredentialsException("EC2 instance metadata service answered HTTP " + response.status()
+                    + " for " + uri);
+        }
+        for (String line : response.bodyAsString().split("\n")) {
+            String role = line.trim();
+            if (!role.isEmpty()) {
+                return role;
+            }
+        }
+        // An empty list says the same thing as the 404 above: no role is attached to this instance.
+        return null;
+    }
+
+    private AwsCredentials fetchCredentials(AwsHttpTransport transport, URI endpoint, String token, String role)
+            throws AwsCredentialsException {
+        URI uri = URI.create(endpoint + SECURITY_CREDENTIALS_PATH + encodePathSegment(role));
+        AwsHttpResponse response = get(transport, uri, token);
+        if (!response.isSuccessful()) {
+            throw new AwsCredentialsException("EC2 instance metadata service answered HTTP " + response.status()
+                    + " for the credentials of role " + role);
+        }
+
+        JsonNode document;
+        try {
+            document = JsonSerialization.mapper.readTree(response.body());
+        } catch (IOException e) {
+            // The cause is dropped on purpose: Jackson quotes the offending source in its message,
+            // and that source is the credential document itself.
+            throw new AwsCredentialsException("EC2 instance metadata service returned an unreadable credential"
+                    + " document for role " + role);
+        }
+
+        if (document == null) {
+            // Defensive rather than reachable: Jackson answers an empty body with MissingNode. Kept
+            // so a change of parser cannot turn an empty 200 into a NullPointerException here.
+            throw new AwsCredentialsException("EC2 instance metadata service returned an empty credential"
+                    + " document for role " + role);
+        }
+
+        String code = text(document, "Code");
+        if (!"Success".equals(code)) {
+            throw new AwsCredentialsException("EC2 instance metadata service reported Code=" + code
+                    + " for role " + role);
+        }
+        String accessKeyId = text(document, "AccessKeyId");
+        String secretAccessKey = text(document, "SecretAccessKey");
+        // Required rather than optional: an instance role is always temporary, and credentials used
+        // without their session token come back from SES as a bare SignatureDoesNotMatch.
+        String sessionToken = text(document, "Token");
+        if (accessKeyId == null || secretAccessKey == null || sessionToken == null) {
+            throw new AwsCredentialsException("EC2 instance metadata service returned an incomplete credential"
+                    + " document for role " + role + ": AccessKeyId, SecretAccessKey or Token is missing");
+        }
+        return new AwsCredentials(accessKeyId, secretAccessKey, sessionToken,
+                expiration(text(document, "Expiration"), role, accessKeyId));
+    }
+
+    private AwsHttpResponse get(AwsHttpTransport transport, URI uri, String token) throws AwsCredentialsException {
+        try {
+            return transport.exchange(AwsHttpRequest.get(uri, Map.of(TOKEN_HEADER, token),
+                    TIMEOUT_MILLIS, TIMEOUT_MILLIS));
+        } catch (IOException e) {
+            // Only the URI goes into the message; rendering the request would print the token header.
+            throw new AwsCredentialsException("EC2 instance metadata service call to " + uri + " failed", e);
+        }
+    }
+
+    /**
+     * Role credentials always expire, so an {@code Expiration} that cannot be read is treated as an
+     * error rather than as "never expires": the latter would cache a credential past its life and
+     * turn the whole realm's email into 403s an hour later, with nothing in the log to explain it.
+     */
+    private static Instant expiration(String value, String role, String accessKeyId) throws AwsCredentialsException {
+        if (value == null) {
+            // Absent counts the same as unparseable. Instance-profile credentials always expire, so
+            // "no expiry" is not a document this endpoint can legitimately produce, and accepting it
+            // would cache a credential for the life of the process.
+            throw new AwsCredentialsException("EC2 instance metadata service returned credentials without an"
+                    + " Expiration for role " + role + " (access key id " + accessKeyId + ")");
+        }
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new AwsCredentialsException("EC2 instance metadata service returned an unparseable Expiration \""
+                    + value + "\" for role " + role + " (access key id " + accessKeyId + ")", e);
+        }
+    }
+
+    /**
+     * Reads a string field, collapsing absent, null and blank alike into {@code null}. Blank has to
+     * count as missing: an empty {@code SecretAccessKey} would sign every message with the empty
+     * string and surface, much later and somewhere else, as an opaque SES SignatureDoesNotMatch.
+     */
+    private static String text(JsonNode document, String field) {
+        String value = document.path(field).asText(null);
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /**
+     * The role name is read off the wire and then spliced into a URL path, so it is encoded, not
+     * trusted. {@link URLEncoder} is form encoding rather than path encoding — the one difference
+     * that matters is the space, which it renders as {@code +}; a literal {@code +} has already
+     * become {@code %2B} by then, so rewriting what is left is safe.
+     */
+    private static String encodePathSegment(String segment) {
+        return URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/LocalAddress.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/LocalAddress.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.regex.Pattern;
+
+/**
+ * The address checks that decide whether a credential endpoint from the environment may be spoken to
+ * over plain HTTP, with a bearer token attached.
+ * <p>
+ * They live in one place because they were written twice and the two copies disagreed: one validated
+ * IPv4 octets and the other accepted {@code 127.999.999.999}, which is not an address at all but is a
+ * legal DNS name — and a name is exactly what these checks exist to keep out.
+ * <p>
+ * Nothing here resolves a name. {@link InetAddress#getByName} parses a literal without touching DNS,
+ * and every method refuses anything that is not one: a lookup that answers {@code 127.0.0.1} today
+ * says nothing about where the next one will point.
+ */
+final class LocalAddress {
+
+    private static final String IPV4_OCTET = "(25[0-5]|2[0-4]\\d|[01]?\\d?\\d)";
+    private static final Pattern IPV4_LITERAL = Pattern.compile(IPV4_OCTET + "(\\." + IPV4_OCTET + "){3}");
+
+    private LocalAddress() {
+    }
+
+    /** Strips the brackets {@code URI#getHost} keeps around an IPv6 literal. */
+    static String unbracket(String host) {
+        return host.length() > 1 && host.startsWith("[") && host.endsWith("]")
+                ? host.substring(1, host.length() - 1)
+                : host;
+    }
+
+    /** Whether {@code host} is a literal address on the loopback interface. Names are refused. */
+    static boolean isLoopback(String host) {
+        InetAddress address = literal(host);
+        return address != null && address.isLoopbackAddress();
+    }
+
+    /**
+     * Whether {@code host} is the same address as {@code expected}, both read as literals.
+     * <p>
+     * Compared as addresses rather than as strings: {@code fd00:ec2::254} has a dozen legal spellings,
+     * and a string comparison would accept only the one that happens to be written here — while a
+     * prefix comparison, which is what this replaced, would accept the whole {@code fd00:ec2::/32}
+     * range instead of the one endpoint AWS documents.
+     */
+    static boolean is(String host, String expected) {
+        InetAddress address = literal(host);
+        InetAddress target = literal(expected);
+        return address != null && target != null && address.equals(target);
+    }
+
+    private static InetAddress literal(String host) {
+        if (host == null) {
+            return null;
+        }
+        String bare = unbracket(host);
+        // A colon means IPv6, which getByName always parses rather than resolves; anything else has
+        // to look exactly like a dotted quad before it is handed over.
+        if (!bare.contains(":") && !IPV4_LITERAL.matcher(bare).matches()) {
+            return null;
+        }
+        try {
+            return InetAddress.getByName(bare);
+        } catch (UnknownHostException e) {
+            return null;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/ProfileCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/ProfileCredentialsProvider.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.keycloak.email.aws.AwsHttpTransport;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Credentials from the shared AWS profile files — {@code ~/.aws/credentials} and {@code ~/.aws/config},
+ * the pair every AWS tool on a developer machine or a hand-configured VM reads.
+ * <p>
+ * Only a static key pair is understood here: {@code aws_access_key_id}, {@code aws_secret_access_key}
+ * and an optional {@code aws_session_token}, which do not expire on their own. A profile that instead
+ * points at a role or at SSO carries none of those keys, and is reported as "not configured" so the
+ * chain moves on to a source that can actually produce credentials.
+ * <p>
+ * Two things about the file format are easy to get wrong and are the reason this class parses the
+ * files itself rather than reaching for a generic INI reader:
+ * <ul>
+ * <li>The two files spell a section differently. The credentials file names a profile
+ * {@code [myprofile]}, the config file names the same profile {@code [profile myprofile]} — except
+ * {@code default}, which is {@code [default]} in both.</li>
+ * <li>{@code #} and {@code ;} start a comment only at the start of a line. Both are legal characters
+ * in a secret access key, and a parser that strips "trailing comments" truncates the secret into a
+ * SES {@code SignatureDoesNotMatch} that says nothing about the file it came from.</li>
+ * </ul>
+ * Where both files set the same key, the credentials file wins, key by key, as in the AWS SDKs.
+ */
+public final class ProfileCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final Logger logger = Logger.getLogger(ProfileCredentialsProvider.class);
+
+    private static final String DEFAULT_PROFILE = "default";
+    private static final String ACCESS_KEY_ID = "aws_access_key_id";
+    private static final String SECRET_ACCESS_KEY = "aws_secret_access_key";
+    private static final String SESSION_TOKEN = "aws_session_token";
+
+    private final AwsEnvironment environment;
+
+    public ProfileCredentialsProvider(AwsEnvironment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * @param transport unused: a profile is read from disk, this source never leaves the machine
+     * @return the profile's key pair, or {@code null} when no file names the profile or the profile
+     *         holds no static key material at all
+     * @throws AwsCredentialsException when a file exists but cannot be read, or when the profile sets
+     *         one half of the key pair and not the other — a typo that must not be mistaken for an
+     *         unconfigured machine
+     */
+    @Override
+    public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+        String profile = environment.setting("aws.profile", "AWS_PROFILE");
+        if (profile == null) {
+            profile = DEFAULT_PROFILE;
+        }
+        Path credentialsFile = fileLocation("aws.sharedCredentialsFile", "AWS_SHARED_CREDENTIALS_FILE", "credentials");
+        Path configFile = fileLocation("aws.configFile", "AWS_CONFIG_FILE", "config");
+
+        Map<String, String> settings = new HashMap<>(readProfile(credentialsFile, profile));
+        readProfile(configFile, configSection(profile)).forEach(settings::putIfAbsent);
+
+        String accessKeyId = setting(settings, ACCESS_KEY_ID);
+        String secretAccessKey = setting(settings, SECRET_ACCESS_KEY);
+        if (accessKeyId == null && secretAccessKey == null) {
+            logger.debugf("No AWS profile credentials for profile '%s' in %s or %s", profile, credentialsFile, configFile);
+            return null;
+        }
+        if (accessKeyId == null || secretAccessKey == null) {
+            throw new AwsCredentialsException("The AWS profile '" + profile + "' is incomplete: "
+                    + (accessKeyId == null ? ACCESS_KEY_ID : SECRET_ACCESS_KEY) + " is not set in "
+                    + credentialsFile + " or " + configFile);
+        }
+        return new AwsCredentials(accessKeyId, secretAccessKey, setting(settings, SESSION_TOKEN), null);
+    }
+
+    @Override
+    public String name() {
+        return "profile file";
+    }
+
+    private Path fileLocation(String systemProperty, String variable, String defaultFileName) {
+        String override = environment.setting(systemProperty, variable);
+        return override != null ? Paths.get(override) : environment.userHome().resolve(".aws").resolve(defaultFileName);
+    }
+
+    /** The config file spells every profile but {@code default} as {@code [profile <name>]}. */
+    private static String configSection(String profile) {
+        return DEFAULT_PROFILE.equals(profile) ? DEFAULT_PROFILE : "profile " + profile;
+    }
+
+    private static Map<String, String> readProfile(Path file, String section) throws AwsCredentialsException {
+        String content;
+        try {
+            content = Files.readString(file);
+        } catch (NoSuchFileException e) {
+            return Map.of();
+        } catch (IOException e) {
+            // Read first, then classify the failure. An existence check up front would file a
+            // present-but-unreadable profile under "not configured", and the chain would move on to
+            // another source instead of naming the file the operator has to fix.
+            throw new AwsCredentialsException("The AWS profile file " + file + " exists but cannot be read", e);
+        }
+        return parseSection(content, section);
+    }
+
+    /**
+     * Returns the keys of {@code section}, empty when the section is not in {@code content}.
+     * <p>
+     * Strict on purpose, and narrow on purpose: keys are lowercased, values keep every character
+     * after the first {@code =} (secrets contain {@code =}, {@code #} and {@code ;}), a later
+     * duplicate within a section overwrites an earlier one, and everything else — unknown keys,
+     * other sections, lines without a {@code =} — is ignored rather than rejected, because this
+     * file is shared with tools that write keys this provider knows nothing about.
+     */
+    private static Map<String, String> parseSection(String content, String section) {
+        Map<String, String> settings = new HashMap<>();
+        boolean inSection = false;
+        for (String rawLine : content.split("\\R")) {
+            String line = rawLine.trim();
+            if (line.isEmpty() || line.charAt(0) == '#' || line.charAt(0) == ';') {
+                continue;
+            }
+            if (line.charAt(0) == '[') {
+                int end = line.indexOf(']');
+                inSection = end > 0 && section.equals(line.substring(1, end).trim());
+                continue;
+            }
+            int separator = inSection ? line.indexOf('=') : -1;
+            if (separator > 0) {
+                settings.put(line.substring(0, separator).trim().toLowerCase(Locale.ROOT),
+                        line.substring(separator + 1).trim());
+            }
+        }
+        return settings;
+    }
+
+    /**
+     * A key present with an empty value counts as unset, for the reason
+     * {@link AwsEnvironment#value(String)} gives: empty credentials fail far from here, with a
+     * signature error that points at nothing.
+     */
+    private static String setting(Map<String, String> settings, String key) {
+        String value = settings.get(key);
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/SystemPropertiesCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/SystemPropertiesCredentialsProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import org.keycloak.email.aws.AwsHttpTransport;
+
+/**
+ * Credentials from the JVM system properties {@code aws.accessKeyId}, {@code aws.secretAccessKey}
+ * and the optional {@code aws.sessionToken}, the same three properties every AWS SDK reads.
+ * <p>
+ * The source is process-local: it never uses the transport and cannot block, which is also why it
+ * is cheap enough to sit first in the chain. It is the only source an operator can set per server
+ * process — through {@code JAVA_OPTS_APPEND} — without touching the environment of the whole
+ * machine, so it has to win over the variables that machine may already export for other tools.
+ * <p>
+ * A pair found here is reported as non-expiring even when it carries a session token: nothing
+ * rewrites a system property while the JVM runs, so re-resolving would only read the same value
+ * back, and an expiry would buy an endless refresh loop instead of a refreshed credential.
+ */
+public final class SystemPropertiesCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final String ACCESS_KEY_ID = "aws.accessKeyId";
+    private static final String SECRET_ACCESS_KEY = "aws.secretAccessKey";
+    private static final String SESSION_TOKEN = "aws.sessionToken";
+
+    private final AwsEnvironment environment;
+
+    public SystemPropertiesCredentialsProvider(AwsEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+        String accessKeyId = environment.property(ACCESS_KEY_ID);
+        String secretAccessKey = environment.property(SECRET_ACCESS_KEY);
+        if (accessKeyId == null && secretAccessKey == null) {
+            return null;
+        }
+        // Half of a key pair is a typo, not an unconfigured source: falling through would hide the
+        // mistake behind whatever the next source happens to find, or behind "no credentials found".
+        if (accessKeyId == null) {
+            throw new AwsCredentialsException("System property " + SECRET_ACCESS_KEY + " is set but "
+                    + ACCESS_KEY_ID + " is not. Set both, or neither.");
+        }
+        if (secretAccessKey == null) {
+            throw new AwsCredentialsException("System property " + ACCESS_KEY_ID + " is set but "
+                    + SECRET_ACCESS_KEY + " is not. Set both, or neither.");
+        }
+        return new AwsCredentials(accessKeyId, secretAccessKey, environment.property(SESSION_TOKEN), null);
+    }
+
+    @Override
+    public String name() {
+        return "JVM system properties";
+    }
+}

--- a/services/src/main/java/org/keycloak/email/aws/credentials/WebIdentityTokenCredentialsProvider.java
+++ b/services/src/main/java/org/keycloak/email/aws/credentials/WebIdentityTokenCredentialsProvider.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.keycloak.email.aws.AwsHttpRequest;
+import org.keycloak.email.aws.AwsHttpResponse;
+import org.keycloak.email.aws.AwsHttpTransport;
+import org.keycloak.email.aws.AwsRegion;
+
+import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Credentials for a Kubernetes service account — EKS IRSA and anything else that projects an OIDC
+ * token into the pod: the token on disk is exchanged at STS, through {@code AssumeRoleWithWebIdentity},
+ * for the temporary credentials of {@code AWS_ROLE_ARN}.
+ * <p>
+ * The exchange is deliberately <em>unsigned</em>, and that is the whole point of the flow rather than
+ * an omission: the signed OIDC token is itself the proof of identity, and this is the source that
+ * exists precisely because the process holds no AWS key to sign with.
+ * <p>
+ * STS speaks the AWS query protocol, which has no JSON rendering, so this is the only place in the
+ * provider that parses XML. The parser is hardened before it touches a byte: an answer that arrives
+ * here is only as trustworthy as the DNS and TLS path to {@code sts.amazonaws.com}, and a
+ * {@link DocumentBuilderFactory} at its defaults turns a spoofed answer into arbitrary file reads and
+ * outbound requests from the Keycloak process.
+ */
+public final class WebIdentityTokenCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final Logger logger = Logger.getLogger(WebIdentityTokenCredentialsProvider.class);
+
+    private static final String TOKEN_FILE_VARIABLE = "AWS_WEB_IDENTITY_TOKEN_FILE";
+    private static final String ROLE_ARN_VARIABLE = "AWS_ROLE_ARN";
+    private static final String SESSION_NAME_VARIABLE = "AWS_ROLE_SESSION_NAME";
+
+    /** The same three settings as JVM system properties, which the AWS SDKs read first. */
+    private static final String TOKEN_FILE_PROPERTY = "aws.webIdentityTokenFile";
+    private static final String ROLE_ARN_PROPERTY = "aws.roleArn";
+    private static final String SESSION_NAME_PROPERTY = "aws.roleSessionName";
+    private static final String REGION_VARIABLE = "AWS_REGION";
+    private static final String DEFAULT_REGION_VARIABLE = "AWS_DEFAULT_REGION";
+
+    /**
+     * The session name ends up in CloudTrail and in the assumed-role ARN, so it is a fixed, telling
+     * string rather than something random: every Keycloak-sent email is then attributable to this
+     * provider without correlating anything.
+     */
+    private static final String DEFAULT_SESSION_NAME = "keycloak-email-aws-ses";
+
+    private static final String GLOBAL_STS_ENDPOINT = "https://sts.amazonaws.com/";
+    private static final String STS_API_VERSION = "2011-06-15";
+    private static final String DISALLOW_DOCTYPE_DECLARATION = "http://apache.org/xml/features/disallow-doctype-decl";
+
+    /**
+     * STS is a public-internet service rather than a link-local endpoint, so it gets a wider budget
+     * than the metadata sources — but a credential lookup runs inside a Keycloak transaction and may
+     * never hang: five seconds each way, then fail.
+     */
+    private static final int CONNECT_TIMEOUT_MILLIS = 5000;
+    private static final int READ_TIMEOUT_MILLIS = 5000;
+
+    /**
+     * Rethrows rather than letting the parser's default handler print to {@code System.err}: that
+     * bypasses the server log, and prints in the JVM's locale. The failure is not lost — it becomes
+     * the cause of the {@link AwsCredentialsException} thrown below.
+     */
+    private static final ErrorHandler STRICT_ERROR_HANDLER = new ErrorHandler() {
+
+        @Override
+        public void warning(SAXParseException exception) {
+            logger.debugf("Ignoring a warning while parsing the STS response: %s", exception.getMessage());
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            throw exception;
+        }
+    };
+
+    private final AwsEnvironment environment;
+
+    public WebIdentityTokenCredentialsProvider(AwsEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+        String tokenFile = environment.setting(TOKEN_FILE_PROPERTY, TOKEN_FILE_VARIABLE);
+        String roleArn = environment.setting(ROLE_ARN_PROPERTY, ROLE_ARN_VARIABLE);
+        if (tokenFile == null || roleArn == null) {
+            return null;
+        }
+
+        // Read on every refresh rather than once: the kubelet rotates the projected token well
+        // before it expires, and STS stops accepting the content this process read at boot.
+        String token = readToken(tokenFile);
+        String sessionName = environment.setting(SESSION_NAME_PROPERTY, SESSION_NAME_VARIABLE);
+        String body = "Action=AssumeRoleWithWebIdentity"
+                + "&Version=" + STS_API_VERSION
+                + "&RoleArn=" + formEncode(roleArn)
+                + "&RoleSessionName=" + formEncode(sessionName == null ? DEFAULT_SESSION_NAME : sessionName)
+                + "&WebIdentityToken=" + formEncode(token);
+
+        URI endpoint = stsEndpoint();
+        AwsHttpRequest request = new AwsHttpRequest("POST", endpoint,
+                Map.of("Content-Type", "application/x-www-form-urlencoded; charset=utf-8"),
+                body.getBytes(StandardCharsets.UTF_8), CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS);
+
+        logger.debugf("Assuming %s at %s with the web identity token from %s", roleArn, endpoint, tokenFile);
+        AwsHttpResponse response;
+        try {
+            response = transport.exchange(request);
+        } catch (IOException e) {
+            throw new AwsCredentialsException("STS AssumeRoleWithWebIdentity call to " + endpoint + " failed", e);
+        }
+        if (!response.isSuccessful()) {
+            throw new AwsCredentialsException(failureMessage(roleArn, response));
+        }
+        return credentials(parse(response.body()));
+    }
+
+    @Override
+    public String name() {
+        return "web identity token (" + TOKEN_FILE_VARIABLE + ")";
+    }
+
+    /**
+     * Reads and trims the projected token. Every failure here is fatal rather than a fall-through:
+     * the variables say this pod was given a service account identity, so an unreadable or empty
+     * token is a broken deployment, not an absent source.
+     */
+    private static String readToken(String tokenFile) throws AwsCredentialsException {
+        String token;
+        try {
+            // Trimmed because the projected file ends with a newline, and STS rejects the token
+            // with an opaque InvalidIdentityToken if that newline is sent along.
+            token = Files.readString(Paths.get(tokenFile)).trim();
+        } catch (IOException | InvalidPathException e) {
+            throw new AwsCredentialsException(TOKEN_FILE_VARIABLE + " points at " + tokenFile
+                    + ", which cannot be read", e);
+        }
+        if (token.isEmpty()) {
+            throw new AwsCredentialsException(TOKEN_FILE_VARIABLE + " points at " + tokenFile + ", which is empty");
+        }
+        return token;
+    }
+
+    private URI stsEndpoint() throws AwsCredentialsException {
+        String region = environment.value(REGION_VARIABLE);
+        if (region == null) {
+            region = environment.value(DEFAULT_REGION_VARIABLE);
+        }
+        if (region != null && !AwsRegion.isValid(region)) {
+            // This value is interpolated into the hostname of a request whose body carries the
+            // service-account token. A region of "attacker.example/collect" would otherwise build
+            // https://sts.attacker.example/collect.amazonaws.com/ and post the token there.
+            throw new AwsCredentialsException(REGION_VARIABLE + " is not a valid AWS region name: " + region);
+        }
+        // The regional endpoint is preferred over the global one for the reason AWS gives: it keeps
+        // the call inside the region, so an STS outage elsewhere cannot stop this server sending mail.
+        String endpoint = region == null ? GLOBAL_STS_ENDPOINT
+                : "https://sts." + region + "." + AwsRegion.dnsSuffix(region) + "/";
+        try {
+            return new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new AwsCredentialsException("Cannot build an STS endpoint for region " + region
+                    + ", configured in " + REGION_VARIABLE + " or " + DEFAULT_REGION_VARIABLE, e);
+        }
+    }
+
+    /**
+     * Encodes one form parameter value. {@link URLEncoder} is correct here and
+     * {@code AwsV4Signer.uriEncode} is not — the two solve mirror-image problems. The STS body is
+     * {@code application/x-www-form-urlencoded}, where a space is {@code +} and {@code ~} is escaped;
+     * those exact two rules are what makes {@code URLEncoder} wrong for a SigV4 canonical request,
+     * which is RFC 3986. Do not "unify" them.
+     */
+    private static String formEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * The HTTP status and the STS error code, and deliberately nothing more: an AWS error body can
+     * quote the request that produced it back at you, and that request carries the web identity token.
+     */
+    private static String failureMessage(String roleArn, AwsHttpResponse response) {
+        String code = errorCode(response.body());
+        return "STS refused AssumeRoleWithWebIdentity for " + roleArn + " with HTTP " + response.status()
+                + (code == null ? "" : " (" + code + ")");
+    }
+
+    /** Best effort: an error body that does not parse must not mask the status being reported. */
+    private static String errorCode(byte[] body) {
+        try {
+            Element code = firstElement(parse(body), "Code");
+            return code == null ? null : code.getTextContent().trim();
+        } catch (AwsCredentialsException e) {
+            return null;
+        }
+    }
+
+    private static AwsCredentials credentials(Document response) throws AwsCredentialsException {
+        Element credentials = firstElement(response, "Credentials");
+        if (credentials == null) {
+            throw new AwsCredentialsException("STS returned no <Credentials> in its"
+                    + " AssumeRoleWithWebIdentity response");
+        }
+        return new AwsCredentials(
+                required(credentials, "AccessKeyId"),
+                required(credentials, "SecretAccessKey"),
+                required(credentials, "SessionToken"),
+                expiration(required(credentials, "Expiration")));
+    }
+
+    /**
+     * An unparseable expiry is an error, not a credential that never expires: treating it as
+     * non-expiring would cache these credentials forever and start failing every email an hour later,
+     * far away from the cause.
+     */
+    private static Instant expiration(String value) throws AwsCredentialsException {
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new AwsCredentialsException("STS returned an Expiration that is not an ISO-8601 instant", e);
+        }
+    }
+
+    private static String required(Element parent, String tagName) throws AwsCredentialsException {
+        Element element = (Element) parent.getElementsByTagName(tagName).item(0);
+        String value = element == null ? "" : element.getTextContent().trim();
+        if (value.isEmpty()) {
+            throw new AwsCredentialsException("STS returned no <" + tagName + "> in its"
+                    + " AssumeRoleWithWebIdentity response");
+        }
+        return value;
+    }
+
+    private static Element firstElement(Document document, String tagName) {
+        return (Element) document.getElementsByTagName(tagName).item(0);
+    }
+
+    /**
+     * Parses an STS response with external entities, DTDs and XInclude all switched off. Every one of
+     * these settings is load-bearing, and removing any of them is what {@code refusesAnXxePayload…}
+     * in the test exists to catch: whoever can answer for the STS endpoint would otherwise read files
+     * off this host, or make it issue requests of their choosing, through a declared entity.
+     */
+    private static Document parse(byte[] xml) throws AwsCredentialsException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(DISALLOW_DOCTYPE_DECLARATION, true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            builder.setErrorHandler(STRICT_ERROR_HANDLER);
+            return builder.parse(new ByteArrayInputStream(xml));
+        } catch (ParserConfigurationException | SAXException | IOException | IllegalArgumentException e) {
+            // IllegalArgumentException because setAttribute is allowed to refuse an attribute it does
+            // not recognise: on a JAXP implementation other than the JDK's it would otherwise escape
+            // unchecked, out of a method whose callers are promised an AwsCredentialsException.
+            // The message stays out of the exception: it is the untrusted document talking.
+            throw new AwsCredentialsException("STS returned a response that is not parseable XML", e);
+        }
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.email.EmailSenderProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.email.EmailSenderProviderFactory
@@ -16,3 +16,4 @@
 #
 
 org.keycloak.email.DefaultEmailSenderProviderFactory
+org.keycloak.email.aws.AwsSesEmailSenderProviderFactory

--- a/services/src/test/java/org/keycloak/email/aws/AwsSesConfigTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/AwsSesConfigTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.keycloak.Config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The configuration read once at boot, and the only place where an operator's typo can still be
+ * turned into a message instead of into a 403.
+ * <p>
+ * Two of these values are not merely settings: the region is interpolated into a hostname and into
+ * the SigV4 credential scope, and the host header is signed. A region that is not a region, or a
+ * host header that disagrees by a port with what the signature covered, produces an AWS rejection
+ * that says nothing about its cause — so both are pinned here rather than discovered in production.
+ * <p>
+ * The {@link Config.Scope} is a real one: {@link Config.SystemPropertiesConfigProvider} backed by
+ * JVM system properties, the same implementation Keycloak itself falls back to. A hand-written test
+ * double would compile against today's {@code Config.Scope} and break upstream the next time the
+ * interface gains a method.
+ */
+class AwsSesConfigTest {
+
+    /** {@code Config.scope("emailSender", "aws-ses").get("x")} reads {@code <this>x}. */
+    private static final String OPTION_PREFIX = "keycloak.emailSender.aws-ses.";
+
+    private final Set<String> setProperties = new HashSet<>();
+
+    @BeforeEach
+    void useSystemPropertiesAsTheServerConfiguration() {
+        Config.init(new Config.SystemPropertiesConfigProvider());
+    }
+
+    @AfterEach
+    void clearOptions() {
+        setProperties.forEach(System::clearProperty);
+        setProperties.clear();
+    }
+
+    @Test
+    void readsTheRegionFromTheSpiOption() {
+        option("region", "eu-central-1");
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.region(), is("eu-central-1"));
+    }
+
+    @Test
+    void fallsBackToAwsRegionWhenTheSpiOptionIsUnset() {
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty().with("AWS_REGION", "us-east-2"));
+
+        assertThat(config.region(), is("us-east-2"));
+    }
+
+    @Test
+    void fallsBackToAwsDefaultRegionWhenAwsRegionIsUnset() {
+        AwsSesConfig config =
+                AwsSesConfig.from(options(), TestEnvironment.empty().with("AWS_DEFAULT_REGION", "ap-southeast-2"));
+
+        assertThat(config.region(), is("ap-southeast-2"));
+    }
+
+    /**
+     * The SPI option is the explicit instruction and outranks the ambient environment; between the
+     * two variables, {@code AWS_REGION} wins, which is the order every other AWS tool on the box
+     * uses. Getting this backwards sends mail from the wrong region, where the verified identity
+     * does not exist, and the failure names neither variable.
+     */
+    @Test
+    void prefersTheSpiOptionThenAwsRegionThenAwsDefaultRegion() {
+        TestEnvironment bothVariables = TestEnvironment.empty()
+                .with("AWS_REGION", "us-east-1")
+                .with("AWS_DEFAULT_REGION", "ap-south-1");
+
+        assertThat(AwsSesConfig.from(options(), bothVariables).region(), is("us-east-1"));
+
+        option("region", "eu-central-1");
+        assertThat(AwsSesConfig.from(options(), bothVariables).region(), is("eu-central-1"));
+    }
+
+    @Test
+    void explainsWhatToSetWhenNoRegionIsConfiguredAnywhere() {
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), containsString("--spi-email-sender-aws-ses-region"));
+        assertThat(thrown.getMessage(), containsString("AWS_REGION"));
+    }
+
+    /**
+     * The region ends up in {@code email.<region>.amazonaws.com} and in the credential scope, so a
+     * value that is not a region is refused rather than concatenated: {@code eu-central-1.example.com}
+     * would otherwise send a signed request, credentials and all, to a host of someone else's
+     * choosing.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"eu_central_1", "EU-CENTRAL-1", "a/b", "evil.example.com/",
+            "eu-central-1.attacker.example.com", "eu-central-1 "})
+    void rejectsARegionThatIsNotARegionName(String region) {
+        option("region", region);
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), is("'" + region + "' is not a valid AWS region name"));
+    }
+
+    /**
+     * Blank has to collapse into unset. Docker compose's {@code AWS_REGION: ${AWS_REGION:-}} form
+     * injects an empty string rather than omitting the variable; accepting it would build the host
+     * {@code email..amazonaws.com} and report a DNS failure instead of a missing setting.
+     */
+    @Test
+    void treatsABlankRegionAsNoRegionAtAll() {
+        option("region", "   ");
+
+        AwsSesConfigurationException fromOption = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+        AwsSesConfigurationException fromEnvironment = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty().with("AWS_REGION", "")));
+
+        assertThat(fromOption.getMessage(), containsString("No AWS region configured"));
+        assertThat(fromEnvironment.getMessage(), containsString("No AWS region configured"));
+    }
+
+    /**
+     * The default endpoint is asserted whole, including the path: SES v2 answers on
+     * {@code /v2/email/outbound-emails} and on the older {@code /v1/email/outbound-emails} with a
+     * different payload shape, and the region-less {@code email.amazonaws.com} is a different
+     * (classic SES) API altogether.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"eu-central-1", "us-gov-west-1"})
+    void buildsTheDefaultSesEndpointFromTheRegion(String region) {
+        option("region", region);
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.sendEmailUri().toString(),
+                is("https://email." + region + ".amazonaws.com/v2/email/outbound-emails"));
+    }
+
+    @Test
+    void usesTheEndpointOverrideFromTheSpiOption() {
+        option("region", "eu-central-1");
+        option("endpoint", "https://vpce-0123.email.eu-central-1.vpce.amazonaws.com");
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.sendEmailUri().toString(),
+                is("https://vpce-0123.email.eu-central-1.vpce.amazonaws.com/v2/email/outbound-emails"));
+    }
+
+    /**
+     * {@code AWS_ENDPOINT_URL_SESV2} is the service-specific variable and outranks the blanket
+     * {@code AWS_ENDPOINT_URL}; the SPI option outranks both. A box running LocalStack exports the
+     * blanket one for every service, and a deliberate per-service override that lost to it would
+     * silently keep sending mail to the stub.
+     */
+    @Test
+    void prefersTheSpiOptionThenTheSesv2EndpointVariableThenTheGenericOne() {
+        option("region", "eu-central-1");
+        TestEnvironment bothVariables = TestEnvironment.empty()
+                .with("AWS_ENDPOINT_URL_SESV2", "http://ses.localhost:4566")
+                .with("AWS_ENDPOINT_URL", "http://localstack:4566");
+
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()
+                        .with("AWS_ENDPOINT_URL", "http://localstack:4566")).sendEmailUri().toString(),
+                is("http://localstack:4566/v2/email/outbound-emails"));
+        assertThat(AwsSesConfig.from(options(), bothVariables).sendEmailUri().toString(),
+                is("http://ses.localhost:4566/v2/email/outbound-emails"));
+
+        option("endpoint", "http://stub:9999");
+        assertThat(AwsSesConfig.from(options(), bothVariables).sendEmailUri().toString(),
+                is("http://stub:9999/v2/email/outbound-emails"));
+    }
+
+    /**
+     * An operator copying an endpoint out of the AWS console brings the trailing slash with it. The
+     * resulting {@code //v2/email/outbound-emails} is a different path, and it is the canonical
+     * request's path that gets signed, so SES would answer 404 or 403 rather than normalise it.
+     */
+    @Test
+    void stripsATrailingSlashFromAnEndpointOverride() {
+        option("region", "eu-central-1");
+        option("endpoint", "http://localhost:4566/");
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.sendEmailUri().toString(), is("http://localhost:4566/v2/email/outbound-emails"));
+    }
+
+    /**
+     * The {@code Host} header is signed and sent verbatim, so it must be spelled the way the URL
+     * spells it: an implicit port stays out, an explicit one stays in. Add a {@code :443} the
+     * signature did not cover and AWS answers 403 with no indication of which header disagreed.
+     */
+    @Test
+    void keepsTheHostHeaderSpelledTheWayTheEndpointUrlSpellsIt() {
+        option("region", "eu-central-1");
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).hostHeader(),
+                is("email.eu-central-1.amazonaws.com"));
+
+        option("endpoint", "http://localhost:8123");
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).hostHeader(), is("localhost:8123"));
+
+        option("endpoint", "https://email.eu-central-1.amazonaws.com:443");
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).hostHeader(),
+                is("email.eu-central-1.amazonaws.com:443"));
+    }
+
+    @Test
+    void rejectsAnEndpointWithNoScheme() {
+        option("region", "eu-central-1");
+        option("endpoint", "localhost:4566");
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), containsString("'localhost:4566' is not a usable Amazon SES endpoint URL"));
+    }
+
+    @Test
+    void rejectsAnEndpointThatIsNotAUrlAtAll() {
+        option("region", "eu-central-1");
+        option("endpoint", "https://exa mple.com");
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), is("'https://exa mple.com' is not a valid Amazon SES endpoint URL"));
+        assertThat(thrown.getCause(), is(instanceOf(URISyntaxException.class)));
+    }
+
+    @Test
+    void defaultsBothTimeoutsToTenSeconds() {
+        option("region", "eu-central-1");
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.connectTimeoutMillis(), is(10_000));
+        assertThat(config.readTimeoutMillis(), is(10_000));
+    }
+
+    @Test
+    void readsBothTimeoutOverrides() {
+        option("region", "eu-central-1");
+        option("connect-timeout", "2500");
+        option("read-timeout", "7000");
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.connectTimeoutMillis(), is(2500));
+        assertThat(config.readTimeoutMillis(), is(7000));
+    }
+
+    /**
+     * Apache HttpClient reads 0 and any negative value as "wait forever". The send happens inside a
+     * Keycloak transaction, so an unbounded timeout on a blackholed route holds that transaction —
+     * and its database connection — open until the operating system gives up on the handshake.
+     */
+    @ParameterizedTest
+    @CsvSource({"connect-timeout,0", "connect-timeout,-1", "read-timeout,0", "read-timeout,-1"})
+    void rejectsATimeoutThatMeansWaitForever(String timeoutOption, String value) {
+        option("region", "eu-central-1");
+        option(timeoutOption, value);
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), containsString("must be positive"));
+        // The option is named in the message: an operator reading a boot failure should not have to
+        // guess which of the two timeouts they mistyped.
+        assertThat(thrown.getMessage(), containsString("spi-email-sender-aws-ses-" + timeoutOption));
+    }
+
+    /**
+     * The operation path is appended to the configured endpoint, so every trailing slash has to go,
+     * not just the last one: {@code https://host//} would otherwise post to {@code //v2/...}.
+     */
+    @ParameterizedTest
+    @CsvSource({"https://stub.example.com", "https://stub.example.com/", "https://stub.example.com///"})
+    void appendsTheOperationPathToAnEndpointHoweverItIsWritten(String endpoint) {
+        option("region", "eu-central-1");
+        option("endpoint", endpoint);
+
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).sendEmailUri().toString(),
+                is("https://stub.example.com/v2/email/outbound-emails"));
+    }
+
+    /**
+     * An IPv6 endpoint keeps its brackets in the Host header. {@code URI#getHost} returns the
+     * bracketed form, so concatenating the port is already correct — pinned because the header is
+     * signed, and a Host that renders differently from what was signed is a 403 with no diagnosis.
+     */
+    @Test
+    void bracketsAnIpv6EndpointInTheHostHeader() {
+        option("region", "eu-central-1");
+        option("endpoint", "http://[::1]:8500");
+
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).hostHeader(), is("[::1]:8500"));
+    }
+
+    /**
+     * The endpoint host is built from the region's partition. Hard-coding {@code amazonaws.com} makes
+     * the default endpoint fail to resolve in the China partition, where the suffix differs.
+     */
+    @Test
+    void usesThePartitionSuffixWhenBuildingTheDefaultEndpoint() {
+        option("region", "cn-north-1");
+
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).sendEmailUri().toString(),
+                is("https://email.cn-north-1.amazonaws.com.cn/v2/email/outbound-emails"));
+    }
+
+    /**
+     * The transport speaks HTTP only, so any other scheme parses happily at boot and then fails on
+     * every single send.
+     */
+    @ParameterizedTest
+    @CsvSource({"ftp://stub.example.com", "file://stub.example.com"})
+    void rejectsAnEndpointThatIsNotHttp(String endpoint) {
+        option("region", "eu-central-1");
+        option("endpoint", endpoint);
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), containsString("must be http or https"));
+    }
+
+    /**
+     * A malformed timeout must be a configuration error, not a raw {@link NumberFormatException}.
+     * <p>
+     * The factory catches {@link AwsSesConfigurationException} to stay silent when another email
+     * sender is in use; anything else escapes that branch, so a typo in an option belonging to a
+     * provider the server does not even use would stop it from booting. And the typo is easy: most
+     * Keycloak duration options are written {@code 10s}.
+     */
+    @ParameterizedTest
+    @CsvSource({"connect-timeout,10s", "read-timeout,thirty", "connect-timeout,1_000"})
+    void rejectsATimeoutThatIsNotANumberOfMilliseconds(String timeoutOption, String value) {
+        option("region", "eu-central-1");
+        option(timeoutOption, value);
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), containsString("spi-email-sender-aws-ses-" + timeoutOption));
+        assertThat(thrown.getMessage(), containsString(value));
+    }
+
+    /**
+     * The operation path is appended to the configured endpoint. If the endpoint already carries a
+     * query string the path lands inside it, and the request goes to {@code /} — an SES 404 a long
+     * way from the typo that caused it.
+     */
+    @ParameterizedTest
+    @CsvSource({"https://stub.example.com/?x=1", "https://stub.example.com/#frag"})
+    void rejectsAnEndpointCarryingAQueryStringOrFragment(String endpoint) {
+        option("region", "eu-central-1");
+        option("endpoint", endpoint);
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> AwsSesConfig.from(options(), TestEnvironment.empty()));
+
+        assertThat(thrown.getMessage(), containsString("no query string or fragment"));
+    }
+
+    /**
+     * The configuration set is optional and reaches the SES request only when non-null, so a blank
+     * one has to arrive as null: SES rejects {@code ConfigurationSetName: ""} with a 400 on every
+     * single send.
+     */
+    @Test
+    void leavesTheConfigurationSetUnsetWhenItIsAbsentOrBlank() {
+        option("region", "eu-central-1");
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).configurationSetName(), is(nullValue()));
+
+        option("configuration-set", "   ");
+        assertThat(AwsSesConfig.from(options(), TestEnvironment.empty()).configurationSetName(), is(nullValue()));
+    }
+
+    @Test
+    void readsTheConfigurationSetName() {
+        option("region", "eu-central-1");
+        option("configuration-set", "keycloak-transactional");
+
+        AwsSesConfig config = AwsSesConfig.from(options(), TestEnvironment.empty());
+
+        assertThat(config.configurationSetName(), is("keycloak-transactional"));
+    }
+
+    private void option(String key, String value) {
+        String property = OPTION_PREFIX + key;
+        System.setProperty(property, value);
+        setProperties.add(property);
+    }
+
+    private static Config.Scope options() {
+        return Config.scope("emailSender", "aws-ses");
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/AwsSesEmailSenderProviderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/AwsSesEmailSenderProviderFactoryTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Locale;
+
+import org.keycloak.Config;
+import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The opt-in and fail-closed contract, which is the whole safety story of this extension.
+ * <p>
+ * Dropping the jar into {@code providers/} must change nothing on a server that sends over SMTP, and
+ * selecting it without configuring it must stop the boot rather than surface at the first password
+ * reset. Both are decided in {@link AwsSesEmailSenderProviderFactory#init(Config.Scope)} and in
+ * {@link AwsSesEmailSenderProviderFactory#order()}, and both are the kind of thing a well-meant
+ * one-line change quietly inverts.
+ * <p>
+ * The server configuration is a real {@link Config.SystemPropertiesConfigProvider} over JVM system
+ * properties rather than a test double, because {@code Config.Scope} has gained methods since 26.0
+ * and a hand-written implementation would stop compiling on the next server that does.
+ */
+class AwsSesEmailSenderProviderFactoryTest {
+
+    private static final String REGION_OPTION = "keycloak.emailSender.aws-ses.region";
+
+    /** What {@code --spi-email-sender-provider} / {@code KC_SPI_EMAIL_SENDER_PROVIDER} lands in. */
+    private static final String SELECTED_EMAIL_SENDER = "keycloak.emailSender.provider";
+
+    /**
+     * What {@code --spi-email-sender-provider-default} lands in. Keycloak's own resolution falls back
+     * to it when {@code provider} is unset, so it selects this sender just as effectively.
+     */
+    private static final String DEFAULT_EMAIL_SENDER = "keycloak.emailSender.provider.default";
+
+    /**
+     * A configuration the provider cannot use, expressed as a region that is not a region name
+     * rather than as no region at all.
+     * <p>
+     * The distinction matters for the test, not for the provider: both raise the same
+     * {@link AwsSesConfigurationException} out of {@link AwsSesConfig#from}, and it is that exception
+     * that decides whether the boot survives. But {@code init} reads the process environment through
+     * {@link org.keycloak.email.aws.credentials.AwsEnvironment#SYSTEM}, and a test cannot unset
+     * {@code AWS_REGION} — so "no region anywhere" is only reproducible on a machine that exports
+     * none, while an SPI option that outranks the environment is reproducible everywhere. What the
+     * missing-region message tells the operator is pinned in {@code AwsSesConfigTest} instead.
+     */
+    private static final String UNUSABLE_REGION = "Frankfurt";
+
+    private final AwsSesEmailSenderProviderFactory factory = new AwsSesEmailSenderProviderFactory();
+
+    @BeforeEach
+    void useSystemPropertiesAsTheServerConfiguration() {
+        Config.init(new Config.SystemPropertiesConfigProvider());
+        clearProperties();
+    }
+
+    @AfterEach
+    void clearProperties() {
+        System.clearProperty(REGION_OPTION);
+        System.clearProperty(SELECTED_EMAIL_SENDER);
+        System.clearProperty(DEFAULT_EMAIL_SENDER);
+    }
+
+    @Test
+    void registersItselfUnderTheIdOperatorsSelectItBy() {
+        assertThat(factory.getId(), is("aws-ses"));
+    }
+
+    /**
+     * Keycloak prefers any factory whose {@code order()} is greater than zero over the one called
+     * "default". A non-zero order here would therefore make SES the email sender of every realm on
+     * the server the moment the jar landed in {@code providers/}, with no setting changed and
+     * nothing in the log to say so. This assertion is the guard against someone helpfully raising it.
+     */
+    @Test
+    void neverOutranksTheDefaultEmailSender() {
+        assertThat(factory.order(), is(0));
+    }
+
+    /**
+     * A successful init leaves no return value to assert on, so it is asserted through what
+     * {@code create} then produces: a real sender. Asserting instead that {@code create} throws
+     * would assert nothing at all — a factory whose {@code init} never ran throws there too, from
+     * {@code throw configurationError} with a null field — so the provider that comes back is the
+     * only observation that tells the initialised state from the broken one.
+     */
+    @Test
+    void initialisesTheSenderWhenARegionIsConfigured() {
+        System.setProperty(REGION_OPTION, "eu-central-1");
+
+        factory.init(Config.scope("emailSender", "aws-ses"));
+
+        assertThat(factory.create(sessionOfferingKeycloaksHttpClient()),
+                is(instanceOf(AwsSesEmailSenderProvider.class)));
+    }
+
+    /**
+     * The jar being present must never break a server that sends over SMTP: an unconfigured SES
+     * sender that nobody selected is not an error, and throwing here would take down every Keycloak
+     * that merely has the provider on its classpath. The error is remembered rather than discarded,
+     * so a later {@code create} still refuses to hand back a half-built provider — asserting that is
+     * also how this test proves {@code init} returned normally instead of throwing.
+     */
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"default"})
+    void startsQuietlyWhenTheServerUsesAnotherEmailSender(String selectedSender) {
+        System.setProperty(REGION_OPTION, UNUSABLE_REGION);
+        if (selectedSender != null) {
+            System.setProperty(SELECTED_EMAIL_SENDER, selectedSender);
+        }
+
+        factory.init(Config.scope("emailSender", "aws-ses"));
+
+        AwsSesConfigurationException thrown =
+                assertThrows(AwsSesConfigurationException.class, () -> factory.create(null));
+        assertThat(thrown.getMessage(), containsString(UNUSABLE_REGION));
+    }
+
+    /**
+     * The same quiet start when the <em>default</em> provider names someone else. A check that read
+     * only {@code --spi-email-sender-provider} gets this branch right by accident;
+     * {@link #failsTheBootWhenItIsTheDefaultSenderAndCannotBeConfigured()} is where the same check
+     * gets it wrong in the direction that matters.
+     */
+    @Test
+    void startsQuietlyWhenTheDefaultEmailSenderIsAnotherProvider() {
+        System.setProperty(REGION_OPTION, UNUSABLE_REGION);
+        System.setProperty(DEFAULT_EMAIL_SENDER, "default");
+
+        factory.init(Config.scope("emailSender", "aws-ses"));
+
+        assertThrows(AwsSesConfigurationException.class, () -> factory.create(null));
+    }
+
+    /**
+     * The mirror image: once the server has been told to send through SES, a configuration it cannot
+     * use is fatal at boot. A Keycloak that starts but cannot send an activation link, a password
+     * reset or an invitation reports the problem for the first time to a locked-out user.
+     */
+    @Test
+    void failsTheBootWhenItIsTheSelectedSenderAndCannotBeConfigured() {
+        System.setProperty(REGION_OPTION, UNUSABLE_REGION);
+        System.setProperty(SELECTED_EMAIL_SENDER, "aws-ses");
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> factory.init(Config.scope("emailSender", "aws-ses")));
+
+        assertThat(thrown.getMessage(), containsString(UNUSABLE_REGION));
+    }
+
+    /**
+     * {@code --spi-email-sender-provider-default=aws-ses} selects this sender exactly as
+     * {@code --spi-email-sender-provider=aws-ses} does: Keycloak's session factory resolves the
+     * default provider whenever the explicit one is unset. A fail-closed check that read only the
+     * explicit setting would let such a server boot with a broken SES configuration and report it,
+     * for the first time, to a user waiting for a password-reset mail.
+     */
+    @Test
+    void failsTheBootWhenItIsTheDefaultSenderAndCannotBeConfigured() {
+        System.setProperty(REGION_OPTION, UNUSABLE_REGION);
+        System.setProperty(DEFAULT_EMAIL_SENDER, "aws-ses");
+
+        AwsSesConfigurationException thrown = assertThrows(AwsSesConfigurationException.class,
+                () -> factory.init(Config.scope("emailSender", "aws-ses")));
+
+        assertThat(thrown.getMessage(), containsString(UNUSABLE_REGION));
+    }
+
+    /**
+     * With both set, only {@code provider} decides — which is what Keycloak's own resolution does,
+     * and the reason it has to be mirrored here rather than approximated. Taking the union of the
+     * two instead would stop the boot of a server that deliberately overrode an inherited
+     * {@code provider-default=aws-ses} back to SMTP; taking only the default would let a server that
+     * asked for SES boot without it.
+     */
+    @Test
+    void letsTheExplicitProviderOutrankTheDefaultProvider() {
+        System.setProperty(REGION_OPTION, UNUSABLE_REGION);
+        System.setProperty(DEFAULT_EMAIL_SENDER, "aws-ses");
+        System.setProperty(SELECTED_EMAIL_SENDER, "default");
+
+        // The explicit setting says SMTP, so the broken SES configuration is not fatal.
+        factory.init(Config.scope("emailSender", "aws-ses"));
+        assertThrows(AwsSesConfigurationException.class, () -> factory.create(null));
+
+        // Swapped, and a fresh factory because init() is a once-per-boot call: now the explicit
+        // setting says SES, and the same configuration must stop the boot.
+        System.setProperty(DEFAULT_EMAIL_SENDER, "default");
+        System.setProperty(SELECTED_EMAIL_SENDER, "aws-ses");
+
+        assertThrows(AwsSesConfigurationException.class,
+                () -> new AwsSesEmailSenderProviderFactory().init(Config.scope("emailSender", "aws-ses")));
+    }
+
+    /**
+     * This list is what upstream renders into the all-config guide, so an option added to
+     * {@link AwsSesConfig} and forgotten here is an option nobody can discover. The order is asserted
+     * too: it is the order the guide prints, and region before endpoint before the optional rest is
+     * the order an operator configures them in.
+     */
+    @Test
+    void documentsEveryOptionAnOperatorCanSet() {
+        List<ProviderConfigProperty> metadata = factory.getConfigMetadata();
+
+        assertThat(metadata.stream().map(ProviderConfigProperty::getName).toList(),
+                contains("region", "endpoint", "configuration-set", "connect-timeout", "read-timeout"));
+        for (ProviderConfigProperty property : metadata) {
+            assertThat("help text for " + property.getName(), property.getHelpText(), is(not(blankOrNullString())));
+        }
+    }
+
+    /**
+     * Credentials deliberately do not come from Keycloak configuration, and this is the assertion
+     * that keeps it that way: {@code kc.sh show-config} prints SPI options unmasked, so an
+     * {@code access-key} option added here for convenience would print the secret to the console and
+     * into whatever collects it. Credentials belong to the AWS chain — an IAM role, or the process
+     * environment.
+     */
+    @Test
+    void exposesNoOptionThatCouldHoldACredential() {
+        for (ProviderConfigProperty property : factory.getConfigMetadata()) {
+            String name = property.getName().toLowerCase(Locale.ROOT);
+            for (String secretish : List.of("key", "secret", "password", "token")) {
+                assertThat(name, not(containsString(secretish)));
+            }
+        }
+    }
+
+    /**
+     * A session that answers {@code getProvider} with an {@link HttpClientProvider} and does nothing
+     * else. Both interfaces are JDK proxies rather than hand-written classes for the same reason this
+     * test drives a real {@link Config.Scope}: both gain methods between server versions, and an
+     * implementation of either would stop compiling on the next one. There is no mocking framework on
+     * this classpath by design. The HTTP client itself is never touched — {@code create} only stores
+     * it — so the provider proxy may answer {@code null}.
+     */
+    private static KeycloakSession sessionOfferingKeycloaksHttpClient() {
+        Object httpClientProvider = Proxy.newProxyInstance(HttpClientProvider.class.getClassLoader(),
+                new Class<?>[]{HttpClientProvider.class}, (proxy, method, arguments) -> null);
+        return (KeycloakSession) Proxy.newProxyInstance(KeycloakSession.class.getClassLoader(),
+                new Class<?>[]{KeycloakSession.class}, (proxy, method, arguments) ->
+                        "getProvider".equals(method.getName()) ? httpClientProvider : null);
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/AwsSesEmailSenderProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/AwsSesEmailSenderProviderTest.java
@@ -1,0 +1,509 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+
+import org.keycloak.Config;
+import org.keycloak.email.EmailException;
+import org.keycloak.email.aws.credentials.AwsCredentials;
+import org.keycloak.email.aws.credentials.AwsCredentialsProvider;
+import org.keycloak.email.aws.credentials.AwsCredentialsProviderChain;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.UserModelDelegate;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The sender as a Keycloak server sees it: a realm's SMTP settings in, one signed SES request out.
+ * <p>
+ * The pieces below it each have their own test — the signature, the credential chain, the error
+ * parsing. What only this test can catch is the wiring between them: a realm setting read under the
+ * wrong key, a timeout passed in the wrong argument position, an envelope value that never reaches
+ * the JSON. Every assertion here is made on the bytes that would have gone to AWS.
+ */
+class AwsSesEmailSenderProviderTest {
+
+    private static final String ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+    private static final String SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    /** Frozen so the credential scope date in the {@code Authorization} header is a known value. */
+    private static final Instant SEND_TIME = Instant.parse("2026-09-03T10:15:30Z");
+
+    private static final int SPI_CONNECT_TIMEOUT_MILLIS = 2500;
+    private static final int SPI_READ_TIMEOUT_MILLIS = 7500;
+
+    /** The shape of a real SES v2 {@code SendEmail} 200, trimmed to the field the client reads. */
+    private static final String ACCEPTED = "{\"MessageId\":\"010f0192a8f4b1d2-4b0f4a2c-0e5b-4a1f-9d3c-000000000000-000000\"}";
+
+    private final FakeTransport transport = new FakeTransport();
+
+    private AwsSesEmailSenderProvider provider;
+
+    @BeforeEach
+    void configureTheServerWideSender() {
+        System.setProperty("keycloak.emailSender.aws-ses.region", "eu-central-1");
+        System.setProperty("keycloak.emailSender.aws-ses.connect-timeout", String.valueOf(SPI_CONNECT_TIMEOUT_MILLIS));
+        System.setProperty("keycloak.emailSender.aws-ses.read-timeout", String.valueOf(SPI_READ_TIMEOUT_MILLIS));
+        Config.init(new Config.SystemPropertiesConfigProvider());
+
+        AwsSesConfig sesConfig = AwsSesConfig.from(Config.scope("emailSender", "aws-ses"), TestEnvironment.empty());
+        SesClient client = new SesClient(sesConfig, new AwsCredentialsProviderChain(List.of(new FixedCredentials())));
+        provider = new AwsSesEmailSenderProvider(sesConfig, client, transport, Clock.fixed(SEND_TIME, ZoneOffset.UTC));
+    }
+
+    @AfterEach
+    void restoreTheServerWideSender() {
+        System.clearProperty("keycloak.emailSender.aws-ses.region");
+        System.clearProperty("keycloak.emailSender.aws-ses.connect-timeout");
+        System.clearProperty("keycloak.emailSender.aws-ses.read-timeout");
+    }
+
+    /**
+     * The end-to-end proof. One realm configuration produces one request, addressed and signed for
+     * SES, whose base64 payload is a MIME message carrying exactly what the caller passed in. A
+     * sender that got any single hand-off wrong — the {@code from} key, the multipart order, the
+     * base64, the signing service name — fails here rather than in an operator's inbox.
+     */
+    @Test
+    void deliversTheComposedMessageToSesAsOneSignedRequest() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+        Map<String, String> config = realmWithSender();
+        config.put("replyTo", "support@example.com");
+        config.put("replyToDisplayName", "Example Support");
+
+        provider.send(config, "user@example.com", "Reset your password",
+                "Open the link to reset your password.", "<html><body><a href=\"#\">Reset</a></body></html>");
+
+        assertThat(transport.requestCount(), is(1));
+        AwsHttpRequest request = transport.lastRequest();
+        assertThat(request.method(), is("POST"));
+        assertThat(request.uri(), is(URI.create("https://email.eu-central-1.amazonaws.com/v2/email/outbound-emails")));
+        assertThat(request.headers().get("Host"), is("email.eu-central-1.amazonaws.com"));
+        assertThat(request.headers().get("Content-Type"), is("application/json"));
+        assertThat(request.headers().get("X-Amz-Date"), is("20260903T101530Z"));
+        // The credential scope, not the signature: the MIME carries a Date header and a generated
+        // multipart boundary, so the signed bytes are not reproducible. AwsV4SignerTest pins the
+        // signature itself against AWS's published vectors; what matters here is that the region and
+        // the service name reaching the signer are the SES ones.
+        assertThat(request.headers().get("Authorization"), startsWith(
+                "AWS4-HMAC-SHA256 Credential=" + ACCESS_KEY_ID + "/20260903/eu-central-1/ses/aws4_request,"));
+
+        JsonNode payload = payloadOf(request);
+        assertThat(payload.get("FromEmailAddress").asText(), is("Example <noreply@example.com>"));
+        assertThat(payload.get("Destination").get("ToAddresses").size(), is(1));
+        assertThat(payload.get("Destination").get("ToAddresses").get(0).asText(), is("user@example.com"));
+
+        MimeMessage message = mimeOf(request);
+        assertThat(message.getHeader("To", null), is("user@example.com"));
+        assertThat(message.getHeader("From", null), is("Example <noreply@example.com>"));
+        assertThat(message.getHeader("Reply-To", null), is("Example Support <support@example.com>"));
+        assertThat(message.getSubject(), is("Reset your password"));
+
+        MimeMultipart body = (MimeMultipart) message.getContent();
+        assertThat(body.getContentType(), startsWith("multipart/alternative"));
+        assertThat(body.getCount(), is(2));
+        // Text first: RFC 2046 says the last alternative is the richest, so a client that renders
+        // HTML must find it after the plain text, not before it.
+        assertThat(body.getBodyPart(0).getContentType(), startsWith("text/plain"));
+        assertThat(body.getBodyPart(0).getContent(), is("Open the link to reset your password."));
+        assertThat(body.getBodyPart(1).getContentType(), startsWith("text/html"));
+        assertThat(body.getBodyPart(1).getContent(), is("<html><body><a href=\"#\">Reset</a></body></html>"));
+    }
+
+    /**
+     * {@code MimeMessage.writeTo()} emits a bare LF inside a 7bit part. SES accepts the raw message
+     * anyway and then delivers something no MTA agrees on — most visibly, a body whose lines run
+     * together or a part boundary that is not recognised. The normalisation has to survive the trip
+     * through base64, which is why it is asserted on the decoded bytes rather than on the stream.
+     */
+    @Test
+    void emitsTheRawMimeWithNoBareLineFeeds() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+
+        provider.send(realmWithSender(), "user@example.com", "Your account",
+                "first line\nsecond line\nthird line", "<p>one</p>\n<p>two</p>");
+
+        byte[] raw = rawMimeOf(transport.lastRequest());
+        for (int i = 0; i < raw.length; i++) {
+            if (raw[i] == '\n') {
+                assertThat("bare LF at offset " + i, i > 0 && raw[i - 1] == '\r', is(true));
+            }
+        }
+        assertThat(new String(raw, StandardCharsets.UTF_8), containsString("first line\r\nsecond line\r\nthird line"));
+    }
+
+    /**
+     * Keycloak's subjects are localised: "Verifica dell'indirizzo email" and worse. The subject is
+     * RFC 2047 encoded on the way out, and a double encoding — easy to introduce, since
+     * {@code MimeMessage.setSubject} encodes too — would put a literal {@code =?UTF-8?Q?…?=} in front
+     * of every non-English recipient.
+     */
+    @Test
+    void keepsANonAsciiSubjectReadableAfterRfc2047Encoding() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+
+        provider.send(realmWithSender(), "user@example.com", "Verifica dell'indirizzo email — è urgente",
+                "Testo", null);
+
+        MimeMessage message = mimeOf(transport.lastRequest());
+        assertThat(message.getSubject(), is("Verifica dell'indirizzo email — è urgente"));
+        assertThat(message.getHeader("Subject", null), startsWith("=?UTF-8?"));
+    }
+
+    /**
+     * The overload Keycloak's own flows call. It must read the address off the user and nothing else:
+     * the double below throws on every other {@link UserModel} method, so any extra access — a
+     * locale lookup, an attribute read — fails the test instead of reaching a real user store from a
+     * code path that has no session.
+     */
+    @Test
+    void sendsToTheAddressCarriedByTheUserModel() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+
+        provider.send(realmWithSender(), userWithEmail("user@example.com"), "Your account", "Testo", null);
+
+        assertThat(transport.requestCount(), is(1));
+        assertThat(mimeOf(transport.lastRequest()).getHeader("To", null), is("user@example.com"));
+    }
+
+    /**
+     * A user with no email is an administrator's data problem, not an AWS one: it has to be named as
+     * such before anything is signed or sent, or the operator gets an opaque SES rejection instead.
+     */
+    @Test
+    void refusesToSendToAUserThatHasNoEmailAddress() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> provider.send(realmWithSender(), userWithEmail(null), "Your account", "Testo", null));
+
+        assertThat(failure.getMessage(), is("No email address configured for the user"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void refusesANullRecipientAddress() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> provider.send(realmWithSender(), (String) null, "Your account", "Testo", null));
+
+        assertThat(failure.getMessage(), is("No recipient address configured"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /**
+     * An administrator who tuned the realm's mail timeouts under the SMTP sender keeps them after the
+     * switch to SES. Getting this backwards would silently double or halve the time a login request
+     * can block while an email is being sent.
+     */
+    @Test
+    void prefersTheRealmTimeoutsOverTheServerWideOnes() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+        Map<String, String> config = realmWithSender();
+        config.put("connectionTimeout", "1500");
+        config.put("timeout", "4000");
+
+        provider.send(config, "user@example.com", "Your account", "Testo", null);
+
+        assertThat(transport.lastRequest().connectTimeoutMillis(), is(1500));
+        assertThat(transport.lastRequest().readTimeoutMillis(), is(4000));
+    }
+
+    @Test
+    void usesTheServerWideTimeoutsWhenTheRealmConfiguresNone() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+
+        provider.send(realmWithSender(), "user@example.com", "Your account", "Testo", null);
+
+        assertThat(transport.lastRequest().connectTimeoutMillis(), is(SPI_CONNECT_TIMEOUT_MILLIS));
+        assertThat(transport.lastRequest().readTimeoutMillis(), is(SPI_READ_TIMEOUT_MILLIS));
+    }
+
+    /**
+     * The admin console writes an empty string for a cleared timeout field, and a realm imported from
+     * JSON can carry anything at all. None of those may become the effective timeout: {@code 0} and a
+     * negative value mean "wait forever" to an HTTP client, which would pin a Keycloak transaction
+     * open for as long as the network takes to give up.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "not-a-number", "-1", "0"})
+    void fallsBackToTheServerWideTimeoutsWhenTheRealmValueIsUnusable(String realmValue) throws Exception {
+        transport.respondWith(200, ACCEPTED);
+        Map<String, String> config = realmWithSender();
+        config.put("connectionTimeout", realmValue);
+        config.put("timeout", realmValue);
+
+        provider.send(config, "user@example.com", "Your account", "Testo", null);
+
+        assertThat(transport.lastRequest().connectTimeoutMillis(), is(SPI_CONNECT_TIMEOUT_MILLIS));
+        assertThat(transport.lastRequest().readTimeoutMillis(), is(SPI_READ_TIMEOUT_MILLIS));
+    }
+
+    /**
+     * The realm's {@code envelopeFrom} is its bounce address. {@code FeedbackForwardingEmailAddress}
+     * is the SES parameter with that meaning; dropping it would send bounces and complaints to the
+     * sending identity instead of to the mailbox the realm nominates.
+     */
+    @Test
+    void passesTheRealmEnvelopeFromAsTheSesFeedbackForwardingAddress() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+        Map<String, String> config = realmWithSender();
+        config.put("envelopeFrom", "bounces@example.com");
+
+        provider.send(config, "user@example.com", "Your account", "Testo", null);
+
+        assertThat(payloadOf(transport.lastRequest()).get("FeedbackForwardingEmailAddress").asText(),
+                is("bounces@example.com"));
+    }
+
+    /**
+     * Absent, not null and not empty: SES validates the parameter when it is present, so sending
+     * {@code ""} for a realm that never set an envelope-from turns every email into a rejection.
+     */
+    @Test
+    void omitsTheFeedbackForwardingAddressWhenTheRealmSetsNoEnvelopeFrom() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+        Map<String, String> config = realmWithSender();
+        config.put("envelopeFrom", "");
+
+        provider.send(config, "user@example.com", "Your account", "Testo", null);
+
+        assertThat(payloadOf(transport.lastRequest()).has("FeedbackForwardingEmailAddress"), is(false));
+    }
+
+    /**
+     * The envelope-from is validated on the send path, not only in {@code validate(Map)}: servers
+     * older than 26.2.8 never call that method, so this is the only check a malformed bounce address
+     * gets before it reaches AWS as an opaque rejection.
+     */
+    @Test
+    void refusesAMalformedEnvelopeFromBeforeSending() {
+        Map<String, String> config = realmWithSender();
+        config.put("envelopeFrom", "not-an-address");
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> provider.send(config, "user@example.com", "Your account", "Testo", null));
+
+        assertThat(failure.getMessage(), containsString("Invalid envelope-from address"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /** And it is converted like every other address, rather than sent to SES with a non-ASCII domain. */
+    @Test
+    void punycodesTheEnvelopeFromDomain() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+        Map<String, String> config = realmWithSender();
+        config.put("envelopeFrom", "bounces@società.it");
+
+        provider.send(config, "user@example.com", "Your account", "Testo", null);
+
+        assertThat(payloadOf(transport.lastRequest()).get("FeedbackForwardingEmailAddress").asText(),
+                is("bounces@xn--societ-nta.it"));
+    }
+
+    /**
+     * What an administrator sees when SES refuses. The three things that make the failure actionable
+     * — the AWS exception name, AWS's own text and the request id AWS support traces — all have to
+     * survive into the {@link EmailException}, because that message is the whole of what the admin
+     * console shows.
+     */
+    @Test
+    void reportsASesRefusalAsAnActionableEmailException() {
+        transport.respondWith(400,
+                Map.of("x-amzn-ErrorType", "MessageRejected:8f9e1c0a-1b2c-4d3e-9f8a-0123456789ab",
+                        "x-amzn-RequestId", "8f9e1c0a-1b2c-4d3e-9f8a-0123456789ab"),
+                "{\"message\":\"Email address is not verified.\"}");
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> provider.send(realmWithSender(), "user@example.com", "Your account", "Testo", null));
+
+        assertThat(failure.getMessage(), is("Amazon SES rejected the message (HTTP 400, MessageRejected):"
+                + " Email address is not verified. [aws-request-id: 8f9e1c0a-1b2c-4d3e-9f8a-0123456789ab]"));
+    }
+
+    /**
+     * A send that died on the wire must not be replayed. SES {@code SendEmail} has no idempotency
+     * token, so a retry of a request AWS may already have accepted is a second activation link in a
+     * real person's inbox.
+     */
+    @Test
+    void doesNotRetryASendThatFailedOnTheWire() {
+        transport.failWith(new IOException("Connection reset"));
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> provider.send(realmWithSender(), "user@example.com", "Your account", "Testo", null));
+
+        assertThat(failure.getMessage(),
+                is("Could not reach Amazon SES at email.eu-central-1.amazonaws.com: Connection reset"));
+        assertThat(transport.requestCount(), is(1));
+    }
+
+    /**
+     * An SES realm has no host, port, user or password — those fields are meaningless over the API
+     * and an administrator leaves them empty. If {@code validate} demanded them, the admin console
+     * would refuse to save every legitimate SES realm.
+     */
+    @Test
+    void acceptsARealmThatConfiguresNothingButTheSenderAddress() throws Exception {
+        provider.validate(Map.of("from", "noreply@example.com", "fromDisplayName", "Example"));
+
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /**
+     * {@code validate} runs on the realm-update request path, where an administrator is waiting for a
+     * save to return. A network call there would make saving a realm depend on SES being reachable —
+     * and on the server holding usable AWS credentials, which a validation has no business needing.
+     */
+    @Test
+    void validatesWithoutTouchingTheNetwork() throws Exception {
+        Map<String, String> config = realmWithSender();
+        config.put("replyTo", "support@example.com");
+        config.put("envelopeFrom", "bounces@example.com");
+
+        provider.validate(config);
+
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void rejectsARealmWithNoSenderAddress() {
+        EmailException failure = assertThrows(EmailException.class, () -> provider.validate(Map.of()));
+
+        assertThat(failure.getMessage(), is("No sender address configured"));
+    }
+
+    @Test
+    void rejectsARealmWhoseSenderAddressIsMalformed() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> provider.validate(Map.of("from", "noreply@")));
+
+        assertThat(failure.getMessage(), is("Invalid sender address 'noreply@'"));
+    }
+
+    @Test
+    void rejectsARealmWhoseReplyToAddressIsMalformed() {
+        Map<String, String> config = realmWithSender();
+        config.put("replyTo", "support at example.com");
+
+        EmailException failure = assertThrows(EmailException.class, () -> provider.validate(config));
+
+        assertThat(failure.getMessage(), is("Invalid reply-to address 'support at example.com'"));
+    }
+
+    @Test
+    void rejectsARealmWhoseEnvelopeFromAddressIsMalformed() {
+        Map<String, String> config = realmWithSender();
+        config.put("envelopeFrom", "bounces@@example.com");
+
+        EmailException failure = assertThrows(EmailException.class, () -> provider.validate(config));
+
+        assertThat(failure.getMessage(), is("Invalid envelope-from address 'bounces@@example.com'"));
+    }
+
+    /**
+     * The HTTP client is Keycloak's, shared with everything else the server calls out to. Closing it
+     * when a per-request provider is closed would break the first email and every outbound call after
+     * it; sending again after {@code close()} is the observable form of "nothing was shut down".
+     */
+    @Test
+    void keepsSendingAfterCloseBecauseTheHttpClientIsNotItsToClose() throws Exception {
+        transport.respondWith(200, ACCEPTED);
+
+        provider.close();
+        provider.send(realmWithSender(), "user@example.com", "Your account", "Testo", null);
+
+        assertThat(transport.requestCount(), is(1));
+    }
+
+    private static Map<String, String> realmWithSender() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("from", "noreply@example.com");
+        config.put("fromDisplayName", "Example");
+        return config;
+    }
+
+    /**
+     * A {@link UserModel} that answers {@code getEmail()} and refuses everything else: the inherited
+     * delegate is {@code null}, so any other call throws. That is the assertion — no mocking library
+     * is on this classpath, and none is needed to state "only the address is read".
+     */
+    private static UserModel userWithEmail(String email) {
+        return new UserModelDelegate(null) {
+            @Override
+            public String getEmail() {
+                return email;
+            }
+        };
+    }
+
+    private static JsonNode payloadOf(AwsHttpRequest request) throws IOException {
+        return JsonSerialization.mapper.readTree(request.body());
+    }
+
+    private static byte[] rawMimeOf(AwsHttpRequest request) throws IOException {
+        return Base64.getDecoder().decode(payloadOf(request).get("Content").get("Raw").get("Data").asText());
+    }
+
+    private static MimeMessage mimeOf(AwsHttpRequest request) throws Exception {
+        return new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(rawMimeOf(request)));
+    }
+
+    /**
+     * Credentials fixed in the test rather than resolved from the chain: the real chain reads the
+     * process environment and the filesystem, neither of which a build machine may be assumed to have
+     * — or to lack.
+     */
+    private static final class FixedCredentials implements AwsCredentialsProvider {
+
+        @Override
+        public AwsCredentials resolve(AwsHttpTransport transport) {
+            return AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY);
+        }
+
+        @Override
+        public String name() {
+            return "test credentials";
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/AwsV4SignerTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/AwsV4SignerTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.keycloak.email.aws.credentials.AwsCredentials;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Pins the signer against AWS's own published signing example.
+ * <p>
+ * A signature is all-or-nothing: any deviation anywhere in the canonical request — a missing
+ * newline, a header left unsorted, a payload hashed as Latin-1 — produces a different hex string.
+ * Asserting the final {@code Authorization} value against AWS's expected output therefore verifies
+ * every step at once, which is why these constants are worth more than a suite of assertions on the
+ * intermediate strings.
+ */
+class AwsV4SignerTest {
+
+    private static final String ACCESS_KEY_ID = "AKIDEXAMPLE";
+    private static final String SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+    private static final Instant SIGNING_TIME = Instant.parse("2015-08-30T12:36:00Z");
+
+    @Test
+    void signsAwsPublishedGetVanillaExample() {
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/"),
+                Map.of("Host", "example.amazonaws.com"), new byte[0]);
+
+        Map<String, String> signed = new AwsV4Signer("us-east-1", "service")
+                .sign(request, AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY), SIGNING_TIME);
+
+        assertThat(signed.get("X-Amz-Date"), is("20150830T123600Z"));
+        assertThat(signed.get("X-Amz-Security-Token"), is(nullValue()));
+        assertThat(signed.get("Authorization"), is("AWS4-HMAC-SHA256 "
+                + "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+                + "SignedHeaders=host;x-amz-date, "
+                + "Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"));
+    }
+
+    /**
+     * AWS's {@code get-header-value-trim} case. The header arrives with leading, trailing and
+     * repeated internal whitespace and must canonicalise to {@code value1 value2 value3};
+     * {@code String.trim()} alone would leave the internal runs and sign something else.
+     */
+    @Test
+    void collapsesWhitespaceInsideHeaderValues() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Host", "example.amazonaws.com");
+        headers.put("My-Header1", " value1  value2     value3");
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/"), headers, new byte[0]);
+
+        Map<String, String> signed = new AwsV4Signer("us-east-1", "service")
+                .sign(request, AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY), SIGNING_TIME);
+
+        assertThat(signed.get("Authorization"), is("AWS4-HMAC-SHA256 "
+                + "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+                + "SignedHeaders=host;my-header1;x-amz-date, "
+                + "Signature=cfd34249e4b1c8d6b91ef74165d41a32e5fab3306300901bb65a51a73575eefd"));
+    }
+
+    /**
+     * The shape this provider actually sends: a JSON POST to the SES endpoint with temporary
+     * credentials. The session token has to be part of the signature and of {@code SignedHeaders},
+     * not merely sent alongside — AWS rejects the request otherwise.
+     */
+    @Test
+    void signsSesSendEmailRequestWithTemporaryCredentials() {
+        byte[] body = ("{\"FromEmailAddress\":\"AldoTime <noreply@aldotime.it>\","
+                + "\"Destination\":{\"ToAddresses\":[\"user@example.com\"]},"
+                + "\"Content\":{\"Raw\":{\"Data\":\"UkFX\"}}}").getBytes(StandardCharsets.UTF_8);
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Host", "email.eu-central-1.amazonaws.com");
+        headers.put("Content-Type", "application/json");
+        AwsHttpRequest request = request("POST",
+                URI.create("https://email.eu-central-1.amazonaws.com/v2/email/outbound-emails"), headers, body);
+        AwsCredentials credentials = new AwsCredentials("ASIAEXAMPLE123456789", SECRET_ACCESS_KEY,
+                "FwoGZXIvYXdzEExampleSessionToken==", Instant.parse("2026-09-03T11:00:00Z"));
+
+        Map<String, String> signed = new AwsV4Signer("eu-central-1", "ses")
+                .sign(request, credentials, Instant.parse("2026-09-03T10:15:30Z"));
+
+        assertThat(signed.get("X-Amz-Security-Token"), is("FwoGZXIvYXdzEExampleSessionToken=="));
+        assertThat(signed.get("Authorization"), is("AWS4-HMAC-SHA256 "
+                + "Credential=ASIAEXAMPLE123456789/20260903/eu-central-1/ses/aws4_request, "
+                + "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, "
+                + "Signature=c747cbbba89b046b0741cea3b4886af64a0ad60e548e920ea0c9e5d730d547a9"));
+    }
+
+    /**
+     * Headers an HTTP client is free to add or rewrite between signing and transmission must not
+     * enter the signature — if they did, the request would be rejected whenever Apache HttpClient
+     * decided to spell one differently. Asserting the signature is byte-identical to the vanilla case
+     * proves they were excluded rather than merely tolerated.
+     */
+    @Test
+    void ignoresHeadersTheHttpClientIsAllowedToRewrite() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Host", "example.amazonaws.com");
+        headers.put("User-Agent", "Apache-HttpClient/4.5.14");
+        headers.put("Content-Length", "0");
+        headers.put("Connection", "keep-alive");
+        headers.put("Accept-Encoding", "gzip,deflate");
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/"), headers, new byte[0]);
+
+        Map<String, String> signed = new AwsV4Signer("us-east-1", "service")
+                .sign(request, AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY), SIGNING_TIME);
+
+        assertThat(signed.get("Authorization"), is("AWS4-HMAC-SHA256 "
+                + "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+                + "SignedHeaders=host;x-amz-date, "
+                + "Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"));
+    }
+
+    @Test
+    void bindsTheSignatureToRegionAndService() {
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/"),
+                Map.of("Host", "example.amazonaws.com"), new byte[0]);
+        AwsCredentials credentials = AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY);
+
+        String signature = signatureOf(new AwsV4Signer("us-east-1", "service").sign(request, credentials, SIGNING_TIME));
+
+        assertThat(signatureOf(new AwsV4Signer("eu-central-1", "service").sign(request, credentials, SIGNING_TIME)),
+                is(not(signature)));
+        // The one that bites in practice: SES answers on email.<region>.amazonaws.com but signs as
+        // "ses". Deriving the signing name from the hostname yields "email" and a 403 on every send.
+        assertThat(signatureOf(new AwsV4Signer("us-east-1", "email").sign(request, credentials, SIGNING_TIME)),
+                is(not(signature)));
+    }
+
+    /**
+     * The credential scope date and the {@code X-Amz-Date} header must come from the same instant.
+     * Reading the clock twice makes them disagree for requests that straddle midnight UTC, which
+     * fails roughly one send a day and is close to impossible to reproduce.
+     */
+    @Test
+    void takesTheScopeDateFromTheSameInstantAsTheDateHeader() {
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/"),
+                Map.of("Host", "example.amazonaws.com"), new byte[0]);
+
+        Map<String, String> signed = new AwsV4Signer("us-east-1", "service").sign(request,
+                AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY), Instant.parse("2026-12-31T23:59:59.999Z"));
+
+        assertThat(signed.get("X-Amz-Date"), is("20261231T235959Z"));
+        assertThat(signed.get("Authorization"), startsWith(
+                "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20261231/us-east-1/service/aws4_request,"));
+    }
+
+    /**
+     * Query parameters are ordered by name and then by value, which is not the same as ordering the
+     * joined {@code name=value} strings: {@code =} (0x3D) sorts above {@code -} and {@code .}, so
+     * {@code a-c=3} would come first under a plain lexicographic sort and the signature would differ.
+     * <p>
+     * The SES call carries no query string, so nothing in this provider exercises the path today —
+     * which is exactly why it is pinned here rather than left to be discovered by the first caller
+     * that does.
+     */
+    @Test
+    void ordersQueryParametersByNameThenValue() {
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/?a=1&a-c=3&a.b=2"),
+                Map.of("Host", "example.amazonaws.com"), new byte[0]);
+
+        Map<String, String> signed = new AwsV4Signer("us-east-1", "service")
+                .sign(request, AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY), SIGNING_TIME);
+
+        assertThat(signed.get("Authorization"), is("AWS4-HMAC-SHA256 "
+                + "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+                + "SignedHeaders=host;x-amz-date, "
+                + "Signature=f139a4ac0cd3b1b7d6490a97b1ce73519a87bf38f10bad6298ccadc4b9dfcc2c"));
+    }
+
+    /**
+     * A {@code +} in a query is a literal plus, not a space. Decoding it as a space — which is what
+     * {@code URLDecoder} does, because it decodes form bodies — and re-encoding would emit
+     * {@code %20} where the request carried {@code %2B}, signing something the server never received.
+     */
+    @Test
+    void treatsAPlusInTheQueryAsALiteralPlus() {
+        AwsHttpRequest request = request("GET", URI.create("https://example.amazonaws.com/?a=1%2B2&b=x%2By"),
+                Map.of("Host", "example.amazonaws.com"), new byte[0]);
+
+        Map<String, String> signed = new AwsV4Signer("us-east-1", "service")
+                .sign(request, AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY), SIGNING_TIME);
+
+        assertThat(signed.get("Authorization"), is("AWS4-HMAC-SHA256 "
+                + "Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+                + "SignedHeaders=host;x-amz-date, "
+                + "Signature=f586138b3e5d10112110b90d6de1e2bed89e271ddcd6115cbd69a376dd399eae"));
+    }
+
+    /**
+     * An encoded slash is part of a path segment, not a separator. Canonicalising from the decoded
+     * path would collapse {@code /v2/a%2Fb} onto {@code /v2/a/b} and sign a path the caller never
+     * wrote — so the two must produce different signatures.
+     */
+    @Test
+    void keepsAnEncodedSlashInsideItsPathSegment() {
+        AwsCredentials credentials = AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY);
+        AwsV4Signer signer = new AwsV4Signer("us-east-1", "service");
+        Map<String, String> headers = Map.of("Host", "example.amazonaws.com");
+
+        String encoded = signer.sign(request("GET", URI.create("https://example.amazonaws.com/v2/a%2Fb"),
+                headers, new byte[0]), credentials, SIGNING_TIME).get("Authorization");
+        String separated = signer.sign(request("GET", URI.create("https://example.amazonaws.com/v2/a/b"),
+                headers, new byte[0]), credentials, SIGNING_TIME).get("Authorization");
+
+        assertThat(encoded, is(not(separated)));
+    }
+
+    @Test
+    void percentDecodesWithoutTheFormBodyRules() {
+        assertThat(AwsV4Signer.percentDecode("a+b"), is("a+b"));
+        assertThat(AwsV4Signer.percentDecode("a%2Bb"), is("a+b"));
+        assertThat(AwsV4Signer.percentDecode("caf%C3%A9"), is("café"));
+        assertThat(AwsV4Signer.percentDecode("nothing to decode"), is("nothing to decode"));
+        assertThat(AwsV4Signer.percentDecode("100%"), is("100%"));
+    }
+
+    @Test
+    void percentEncodesPerRfc3986RatherThanAsAFormBody() {
+        // java.net.URLEncoder would give "a+b" for the space and escape the tilde: both produce a
+        // wrong signature, and both are what a reviewer's first instinct would reach for.
+        assertThat(AwsV4Signer.uriEncode("a b"), is("a%20b"));
+        assertThat(AwsV4Signer.uriEncode("~-_."), is("~-_."));
+        assertThat(AwsV4Signer.uriEncode("*"), is("%2A"));
+        assertThat(AwsV4Signer.uriEncode("/"), is("%2F"));
+        assertThat(AwsV4Signer.uriEncode("ሴ"), is("%E1%88%B4"));
+        assertThat(AwsV4Signer.uriEncode("café"), is("caf%C3%A9"));
+    }
+
+    @Test
+    void normalisesHeaderValuesForCanonicalisation() {
+        assertThat(AwsV4Signer.normalizeHeaderValue("  a   b  "), is("a b"));
+        assertThat(AwsV4Signer.normalizeHeaderValue("\ta\tb\t"), is("a b"));
+        assertThat(AwsV4Signer.normalizeHeaderValue(""), is(""));
+        assertThat(AwsV4Signer.normalizeHeaderValue(null), is(""));
+    }
+
+    @Test
+    void hashesTheEmptyPayloadToTheKnownSha256() {
+        assertThat(AwsV4Signer.hexSha256(new byte[0]),
+                equalTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    }
+
+    private static String signatureOf(Map<String, String> signedHeaders) {
+        String authorization = signedHeaders.get("Authorization");
+        return authorization.substring(authorization.indexOf("Signature=") + "Signature=".length());
+    }
+
+    private static AwsHttpRequest request(String method, URI uri, Map<String, String> headers, byte[] body) {
+        return new AwsHttpRequest(method, uri, headers, body, 1000, 1000);
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/CrlfNormalizingOutputStreamTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/CrlfNormalizingOutputStreamTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * The line-ending rewrite that stands between a Keycloak template and a DKIM-signed SES payload.
+ * <p>
+ * Every case here is one jakarta.mail actually produces while serialising a message: bare LFs inside
+ * a {@code 7bit} body part, CRLF pairs in the headers it writes itself, and both arriving in
+ * arbitrary chunks because the body is copied through a buffer whose boundaries nobody controls.
+ * Getting any of them wrong corrupts the message in a way SES accepts and only the recipient sees.
+ */
+class CrlfNormalizingOutputStreamTest {
+
+    @Test
+    void turnsABareLineFeedIntoCrlf() throws Exception {
+        assertThat(normalized("first\nsecond\n"), is("first\r\nsecond\r\n"));
+    }
+
+    /** Doubling the CR here would put a blank line between every pair of header lines. */
+    @Test
+    void leavesAnExistingCrlfPairUntouched() throws Exception {
+        assertThat(normalized("Subject: hello\r\nTo: user@example.com\r\n"),
+                is("Subject: hello\r\nTo: user@example.com\r\n"));
+    }
+
+    /**
+     * A bare CR ends a line too, and becomes CRLF — which is what the mail implementation's own
+     * CRLF stream does on the SMTP socket. Parity with that stream is the whole contract here: the
+     * bytes handed to SES must be the bytes the SMTP transport would have put on the wire.
+     */
+    @Test
+    void turnsABareCarriageReturnIntoCrlf() throws Exception {
+        assertThat(normalized("before\rafter"), is("before\r\nafter"));
+    }
+
+    /**
+     * The chunk boundary case. jakarta.mail streams a body through a buffer, so a CRLF pair can be
+     * split across two writes; a stream that only looked at the current buffer would emit CRCRLF and
+     * break every message longer than the buffer.
+     */
+    @Test
+    void doesNotDoubleTheCarriageReturnWhenCrlfIsSplitAcrossTwoWrites() throws Exception {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        try (OutputStream out = new CrlfNormalizingOutputStream(sink)) {
+            out.write("line\r".getBytes(StandardCharsets.UTF_8));
+            out.write("\nnext".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertThat(sink.toString(StandardCharsets.UTF_8), is("line\r\nnext"));
+    }
+
+    /**
+     * {@code FilterOutputStream} is free to forward an array write straight to the delegate, and a
+     * subclass that let it would translate byte-at-a-time writes only — which is precisely the path
+     * jakarta.mail does not take for message bodies.
+     */
+    @Test
+    void translatesArrayWritesExactlyAsItTranslatesSingleBytes() throws Exception {
+        String input = "a\nb\r\nc\rd\n\n";
+
+        ByteArrayOutputStream oneByteAtATime = new ByteArrayOutputStream();
+        try (OutputStream out = new CrlfNormalizingOutputStream(oneByteAtATime)) {
+            for (byte b : input.getBytes(StandardCharsets.UTF_8)) {
+                out.write(b);
+            }
+        }
+
+        assertThat(normalized(input), is("a\r\nb\r\nc\r\nd\r\n\r\n"));
+        assertThat(oneByteAtATime.toString(StandardCharsets.UTF_8), is("a\r\nb\r\nc\r\nd\r\n\r\n"));
+    }
+
+    /** Only the requested window may be written: the surrounding bytes are another part's. */
+    @Test
+    void writesOnlyTheRequestedWindowOfTheArray() throws Exception {
+        byte[] buffer = "XXline\nYY".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+
+        try (OutputStream out = new CrlfNormalizingOutputStream(sink)) {
+            out.write(buffer, 2, 5);
+        }
+
+        assertThat(sink.toString(StandardCharsets.UTF_8), is("line\r\n"));
+    }
+
+    @Test
+    void writesNothingForEmptyInput() throws Exception {
+        assertThat(normalized(""), is(""));
+    }
+
+    private static String normalized(String input) throws IOException {
+        ByteArrayOutputStream sink = new ByteArrayOutputStream();
+        try (OutputStream out = new CrlfNormalizingOutputStream(sink)) {
+            out.write(input.getBytes(StandardCharsets.UTF_8));
+        }
+        return sink.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/DirectHttpTransportTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/DirectHttpTransportTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * The transport used for the credential endpoints that answer on this machine.
+ * <p>
+ * Its reason to exist is the proxy: the container and instance-metadata calls carry a bearer token,
+ * and a server configured with {@code HTTP_PROXY} and no matching {@code no_proxy} would otherwise
+ * send that token through the proxy — and make the address checks in front of those calls
+ * meaningless, since the host being validated would no longer be the host being spoken to.
+ */
+class DirectHttpTransportTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    /** The whole point of the class: no proxy can be interposed, whatever the server is configured with. */
+    @Test
+    void buildsItsClientWithoutAProxy() {
+        ProxySelector selector = DirectHttpTransport.directClient(1000).proxy().orElseThrow();
+        assertThat(selector.select(URI.create("http://169.254.170.2/v1/credentials")),
+                is(List.of(Proxy.NO_PROXY)));
+        assertThat(DirectHttpTransport.directClient(2500).connectTimeout().orElseThrow().toMillis(), is(2500L));
+    }
+
+    @Test
+    void sendsTheRequestAsDescribedAndReturnsTheAnswer() throws Exception {
+        Map<String, String> received = new LinkedHashMap<>();
+        server.createContext("/v2/credentials", exchange -> {
+            exchange.getRequestHeaders().forEach((name, values) -> received.put(name, values.get(0)));
+            received.put(":method", exchange.getRequestMethod());
+            byte[] body = "{\"AccessKeyId\":\"ASIA\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("X-Answer", "yes");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+
+        AwsHttpResponse response = new DirectHttpTransport().exchange(AwsHttpRequest.get(
+                URI.create(baseUrl + "/v2/credentials"), Map.of("Authorization", "Bearer secret"), 1000, 1000));
+
+        assertThat(received.get(":method"), is("GET"));
+        assertThat(received.get("Authorization"), is("Bearer secret"));
+        assertThat(response.status(), is(200));
+        assertThat(response.header("x-answer"), is("yes"));
+        assertThat(response.bodyAsString(), is("{\"AccessKeyId\":\"ASIA\"}"));
+    }
+
+    /** The IMDSv2 token call: a PUT that carries a header and no body. */
+    @Test
+    void sendsABodylessPut() throws Exception {
+        Map<String, String> received = new LinkedHashMap<>();
+        server.createContext("/latest/api/token", exchange -> {
+            received.put(":method", exchange.getRequestMethod());
+            received.put("ttl", exchange.getRequestHeaders().getFirst("X-aws-ec2-metadata-token-ttl-seconds"));
+            byte[] body = "AQAE-token".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+
+        AwsHttpResponse response = new DirectHttpTransport().exchange(new AwsHttpRequest("PUT",
+                URI.create(baseUrl + "/latest/api/token"),
+                Map.of("X-aws-ec2-metadata-token-ttl-seconds", "21600"), AwsHttpRequest.NO_BODY, 1000, 1000));
+
+        assertThat(received.get(":method"), is("PUT"));
+        assertThat(received.get("ttl"), is("21600"));
+        assertThat(response.bodyAsString(), is("AQAE-token"));
+    }
+
+    /**
+     * A redirect is returned rather than followed. Following one would send the bearer token to
+     * whatever the endpoint nominated, which is the redirection the address checks exist to prevent.
+     */
+    @Test
+    void doesNotFollowARedirect() throws Exception {
+        server.createContext("/moved", exchange -> {
+            exchange.getResponseHeaders().add("Location", "http://example.com/elsewhere");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+
+        AwsHttpResponse response = new DirectHttpTransport()
+                .exchange(AwsHttpRequest.get(URI.create(baseUrl + "/moved"), Map.of(), 1000, 1000));
+
+        assertThat(response.status(), is(302));
+        assertThat(response.header("Location"), is("http://example.com/elsewhere"));
+    }
+
+    @Test
+    void refusesAResponseBodyLargerThanTheBound() {
+        server.createContext("/flood", exchange -> {
+            exchange.sendResponseHeaders(200, 0);
+            try (OutputStream out = exchange.getResponseBody()) {
+                byte[] chunk = new byte[64 * 1024];
+                for (int i = 0; i < 32; i++) {
+                    out.write(chunk);
+                }
+            } catch (IOException ignored) {
+                // The client aborts once the bound is passed; that is the behaviour under test.
+            }
+        });
+
+        IOException failure = org.junit.jupiter.api.Assertions.assertThrows(IOException.class,
+                () -> new DirectHttpTransport()
+                        .exchange(AwsHttpRequest.get(URI.create(baseUrl + "/flood"), Map.of(), 1000, 5000)));
+
+        assertThat(failure.getMessage(), containsString("Response body exceeded 1048576 bytes"));
+    }
+
+    /**
+     * A peer that sends the headers and then stalls must not pin the thread. With a streaming body
+     * handler the request timeout stops applying the moment the headers arrive, so the read would
+     * block for as long as the peer liked — on a request thread, inside a Keycloak transaction.
+     */
+    @Test
+    void givesUpOnAPeerThatSendsHeadersAndThenStalls() {
+        server.createContext("/stall", exchange -> {
+            exchange.sendResponseHeaders(200, 1024);
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            exchange.close();
+        });
+
+        long startedAt = System.nanoTime();
+        org.junit.jupiter.api.Assertions.assertThrows(IOException.class,
+                () -> new DirectHttpTransport()
+                        .exchange(AwsHttpRequest.get(URI.create(baseUrl + "/stall"), Map.of(), 1000, 500)));
+
+        assertThat(Duration.ofNanos(System.nanoTime() - startedAt).toMillis() < 2500, is(true));
+    }
+
+    @Test
+    void returnsAnEmptyBodyRatherThanNull() throws Exception {
+        server.createContext("/empty", exchange -> {
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+        });
+
+        AwsHttpResponse response = new DirectHttpTransport()
+                .exchange(AwsHttpRequest.get(URI.create(baseUrl + "/empty"), Map.of(), 1000, 1000));
+
+        assertThat(response.status(), is(204));
+        assertThat(response.bodyAsString(), is(""));
+        assertThat(response.header("nope"), is(nullValue()));
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/FakeTransport.java
+++ b/services/src/test/java/org/keycloak/email/aws/FakeTransport.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An {@link AwsHttpTransport} that answers from a queue of canned responses and records every
+ * request it was given, so a test can assert on the exact bytes that would have reached the wire.
+ */
+public final class FakeTransport implements AwsHttpTransport {
+
+    private final Deque<Object> responses = new ArrayDeque<>();
+    private final List<AwsHttpRequest> requests = new ArrayList<>();
+
+    public FakeTransport respondWith(int status, String body) {
+        return respondWith(status, Map.of(), body);
+    }
+
+    public FakeTransport respondWith(int status, Map<String, String> headers, String body) {
+        responses.add(new AwsHttpResponse(status, headers, body.getBytes(StandardCharsets.UTF_8)));
+        return this;
+    }
+
+    public FakeTransport failWith(IOException failure) {
+        responses.add(failure);
+        return this;
+    }
+
+    @Override
+    public AwsHttpResponse exchange(AwsHttpRequest request) throws IOException {
+        requests.add(request);
+        Object response = responses.poll();
+        if (response == null) {
+            throw new AssertionError("Unexpected request, no response queued: " + request.method() + " " + request.uri());
+        }
+        if (response instanceof IOException failure) {
+            throw failure;
+        }
+        return (AwsHttpResponse) response;
+    }
+
+    public List<AwsHttpRequest> requests() {
+        return List.copyOf(requests);
+    }
+
+    public AwsHttpRequest lastRequest() {
+        if (requests.isEmpty()) {
+            throw new AssertionError("No request was made");
+        }
+        return requests.get(requests.size() - 1);
+    }
+
+    public AwsHttpRequest request(int index) {
+        return requests.get(index);
+    }
+
+    public int requestCount() {
+        return requests.size();
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/KeycloakHttpTransportTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/KeycloakHttpTransportTest.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Drives the real Apache HttpClient Keycloak hands out against a real local HTTP server, because
+ * this class exists for one reason only: to guarantee what leaves the socket. A fake client would
+ * assert the code we wrote, not the bytes Apache actually puts on the wire, and every failure this
+ * adapter can cause — a re-encoded body, a rewritten header, a followed redirect — is invisible
+ * until it reaches AWS, where it comes back as an unexplainable {@code SignatureDoesNotMatch}.
+ */
+class KeycloakHttpTransportTest {
+
+    private static final String SES_PATH = "/v2/email/outbound-emails";
+    private static final String METADATA_TOKEN_PATH = "/latest/api/token";
+    private static final String SIGNED_HOST = "email.eu-central-1.amazonaws.com";
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 2000;
+    private static final int READ_TIMEOUT_MILLIS = 2000;
+
+    /** Mirrors the transport's own {@code MAX_RESPONSE_BYTES}, which is private and has to stay so. */
+    private static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+
+    private HttpServer server;
+    private ExecutorService serverExecutor;
+    private CloseableHttpClient httpClient;
+    private KeycloakHttpTransport transport;
+
+    private final List<RecordedRequest> received = new CopyOnWriteArrayList<>();
+    private final AtomicInteger redirectTargetHits = new AtomicInteger();
+
+    /** Released in teardown so a deliberately slow handler can never outlive its test. */
+    private final CountDownLatch slowHandlerRelease = new CountDownLatch(1);
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        serverExecutor = Executors.newCachedThreadPool();
+        server.setExecutor(serverExecutor);
+        server.start();
+        httpClient = HttpClients.createDefault();
+        transport = new KeycloakHttpTransport(httpClient);
+    }
+
+    @AfterEach
+    void stopServer() throws IOException {
+        slowHandlerRelease.countDown();
+        httpClient.close();
+        server.stop(0);
+        serverExecutor.shutdownNow();
+    }
+
+    /**
+     * A UTF-8 body must arrive as UTF-8. The obvious {@code new StringEntity(json, ...)}
+     * implementation re-encodes to ISO-8859-1 by default, which changes the bytes AWS hashes: every
+     * accented subject line would then fail signature verification while an ASCII one worked.
+     */
+    @Test
+    void putsTheExactBodyBytesOnTheWireIncludingNonAsciiCharacters() throws Exception {
+        String json = "{\"Subject\":\"Attivazione dell'account \u00e8 gi\u00e0 pronta \u2014 conferma\"}";
+        byte[] utf8 = json.getBytes(StandardCharsets.UTF_8);
+        stub(SES_PATH, 200, Map.of(), "{\"MessageId\":\"0100018f\"}");
+
+        transport.exchange(post(uri(SES_PATH), Map.of("Content-Type", "application/json"), utf8));
+
+        RecordedRequest request = onlyRequest();
+        assertThat(request.method(), is("POST"));
+        assertThat(request.path(), is(SES_PATH));
+        assertThat(request.body(), is(equalTo(utf8)));
+        assertThat(request.body(), is(not(equalTo(json.getBytes(StandardCharsets.ISO_8859_1)))));
+    }
+
+    /**
+     * SigV4 signs the header values verbatim, so anything the transport rewrites, drops or adds a
+     * second copy of invalidates the signature. {@code Host} is the sharp case: it is signed with
+     * the SES endpoint's name while the socket goes somewhere else entirely (here 127.0.0.1, in
+     * production a proxy), and a client that overwrote it with the connection's authority would
+     * make every send fail with a 403 no log could explain.
+     */
+    @Test
+    void sendsEveryHeaderTheCallerSetWithItsExactValue() throws Exception {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Host", SIGNED_HOST);
+        headers.put("Content-Type", "application/json");
+        headers.put("X-Amz-Date", "20260903T101530Z");
+        headers.put("X-Amz-Security-Token", "FwoGZXIvYXdzEExampleSessionToken==");
+        headers.put("Authorization", "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260903/eu-central-1/ses/aws4_request, "
+                + "SignedHeaders=content-type;host;x-amz-date;x-amz-security-token, "
+                + "Signature=c747cbbba89b046b0741cea3b4886af64a0ad60e548e920ea0c9e5d730d547a9");
+        stub(SES_PATH, 200, Map.of(), "{}");
+
+        transport.exchange(post(uri(SES_PATH), headers, "{}".getBytes(StandardCharsets.UTF_8)));
+
+        RecordedRequest request = onlyRequest();
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            assertThat("header " + header.getKey(), request.headerValues(header.getKey()), contains(header.getValue()));
+        }
+    }
+
+    /**
+     * The caller signs one {@code content-type}; a second one added by the entity would leave AWS
+     * canonicalising a value the signature never covered.
+     */
+    @Test
+    void leavesTheCallersContentTypeAsTheOnlyOne() throws Exception {
+        stub(SES_PATH, 200, Map.of(), "{}");
+
+        transport.exchange(post(uri(SES_PATH), Map.of("Content-Type", "application/json"),
+                "{}".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(onlyRequest().headerValues("Content-Type"), contains("application/json"));
+    }
+
+    /** An unsigned header the transport invents is a header AWS sees and the signature does not. */
+    @Test
+    void sendsNoContentTypeWhenTheCallerSetNone() throws Exception {
+        stub(SES_PATH, 200, Map.of(), "{}");
+
+        transport.exchange(post(uri(SES_PATH), Map.of("Host", SIGNED_HOST),
+                "{}".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(onlyRequest().headerValues("Content-Type"), is(empty()));
+    }
+
+    /** The shape of every instance-metadata read: a GET carrying the IMDSv2 token and no body. */
+    @Test
+    void sendsAGetWithNoBody() throws Exception {
+        stub("/latest/meta-data/iam/security-credentials/", 200, Map.of(), "keycloak-ses-role");
+
+        AwsHttpResponse response = transport.exchange(AwsHttpRequest.get(
+                uri("/latest/meta-data/iam/security-credentials/"),
+                Map.of("X-aws-ec2-metadata-token", "imds-session-token"),
+                CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS));
+
+        RecordedRequest request = onlyRequest();
+        assertThat(request.method(), is("GET"));
+        assertThat(request.body(), is(equalTo(new byte[0])));
+        assertThat(request.headerValues("X-aws-ec2-metadata-token"), contains("imds-session-token"));
+        assertThat(response.bodyAsString(), is("keycloak-ses-role"));
+    }
+
+    /**
+     * The IMDSv2 token call is a PUT with an empty body — the one place the provider sends a body
+     * method without a body. An entity-less PUT that Apache refused to send would silently
+     * downgrade every EC2 deployment to "no credentials found".
+     */
+    @Test
+    void sendsAPutWithNoBody() throws Exception {
+        stub(METADATA_TOKEN_PATH, 200, Map.of(), "AQAEAExampleTokenValue==");
+
+        AwsHttpResponse response = transport.exchange(new AwsHttpRequest("PUT", uri(METADATA_TOKEN_PATH),
+                Map.of("X-aws-ec2-metadata-token-ttl-seconds", "21600"), AwsHttpRequest.NO_BODY,
+                CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS));
+
+        RecordedRequest request = onlyRequest();
+        assertThat(request.method(), is("PUT"));
+        assertThat(request.body(), is(equalTo(new byte[0])));
+        assertThat(request.headerValues("X-aws-ec2-metadata-token-ttl-seconds"), contains("21600"));
+        assertThat(response.status(), is(200));
+        assertThat(response.bodyAsString(), is("AQAEAExampleTokenValue=="));
+    }
+
+    @Test
+    void returnsTheStatusHeadersAndBodyOfTheResponse() throws Exception {
+        String body = "{\"MessageId\":\"0100018f-\u00e8\"}";
+        stub(SES_PATH, 200, Map.of("Content-Type", "application/json"), body);
+
+        AwsHttpResponse response = transport.exchange(post(uri(SES_PATH), Map.of(), "{}".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(response.status(), is(200));
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.body(), is(equalTo(body.getBytes(StandardCharsets.UTF_8))));
+        assertThat(response.header("Content-Type"), is("application/json"));
+    }
+
+    /**
+     * The only handle on a failed send is the request id AWS returns, and it arrives in whatever
+     * casing the responding server chose. Looking the header up by the documented spelling must
+     * still find it, or every SES failure is reported without the id support asks for.
+     */
+    @Test
+    void findsAResponseHeaderWhateverCasingTheServerUsed() throws Exception {
+        stub(SES_PATH, 400, Map.of("x-amzn-requestid", "4c9f5d1e-0d2a-4d3f-9d2a-4d3f9d2a4d3f"), "{}");
+
+        AwsHttpResponse response = transport.exchange(post(uri(SES_PATH), Map.of(), "{}".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(response.header("X-Amzn-RequestId"), is("4c9f5d1e-0d2a-4d3f-9d2a-4d3f9d2a4d3f"));
+        // No HTTP stack produces this spelling on its own, so the lookup above cannot have matched
+        // the map key literally: it went through the case-insensitive path.
+        assertThat(response.headers(), not(hasKey("X-Amzn-RequestId")));
+    }
+
+    /**
+     * A followed redirect replays a signed request against a host the signature does not cover: at
+     * best a 403, at worst the credential-endpoint token handed to whatever host answered. The
+     * verb here is a GET on purpose — Apache's default strategy declines to redirect a POST, so
+     * only a GET proves redirects are off rather than merely unreachable for the SES call.
+     */
+    @Test
+    void doesNotFollowARedirect() throws Exception {
+        stub(METADATA_TOKEN_PATH, 302, Map.of("Location", uri("/elsewhere").toString()), "");
+        server.createContext("/elsewhere", exchange -> {
+            redirectTargetHits.incrementAndGet();
+            respond(exchange, 200, Map.of(), "should never be reached".getBytes(StandardCharsets.UTF_8));
+        });
+
+        AwsHttpResponse response = transport.exchange(AwsHttpRequest.get(uri(METADATA_TOKEN_PATH), Map.of(),
+                CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS));
+
+        assertThat(response.status(), is(302));
+        assertThat(response.header("Location"), is(uri("/elsewhere").toString()));
+        assertThat(redirectTargetHits.get(), is(0));
+    }
+
+    /**
+     * SES puts the reason for a rejection in the body of a 4xx. A transport that threw on a non-2xx
+     * would leave the caller with "HTTP 400" and no way to tell a throttle from an unverified
+     * sender address.
+     */
+    @Test
+    void returnsTheBodyOfAnErrorResponseInsteadOfThrowing() throws Exception {
+        String error = "{\"__type\":\"MessageRejected\",\"message\":\"Email address is not verified.\"}";
+        stub(SES_PATH, 400, Map.of("x-amzn-ErrorType", "MessageRejected:1a2b3c"), error);
+
+        AwsHttpResponse response = transport.exchange(post(uri(SES_PATH), Map.of(), "{}".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(response.status(), is(400));
+        assertThat(response.isSuccessful(), is(false));
+        assertThat(response.bodyAsString(), is(error));
+        assertThat(response.header("x-amzn-errortype"), is("MessageRejected:1a2b3c"));
+    }
+
+    /**
+     * A silent SES endpoint must not pin the Keycloak thread that is sending the email: without the
+     * per-request socket timeout the shared client's default of "wait forever" applies, and a
+     * blackholed route holds the transaction open until the OS gives up.
+     */
+    @Test
+    void failsWhenTheServerStaysSilentPastTheReadTimeout() {
+        server.createContext("/slow", exchange -> {
+            awaitTeardown();
+            respondQuietly(exchange);
+        });
+        AwsHttpRequest request = new AwsHttpRequest("POST", uri("/slow"), Map.of(),
+                "{}".getBytes(StandardCharsets.UTF_8), 300, 300);
+
+        assertThrows(SocketTimeoutException.class, () -> transport.exchange(request));
+    }
+
+    /**
+     * The signature is computed over the method, so sending a request as anything other than what
+     * the caller named would fail at AWS with no local trace. Failing here names the mistake.
+     */
+    @Test
+    void rejectsAMethodItCannotSendRatherThanSendingSomethingElse() {
+        stub(SES_PATH, 200, Map.of(), "{}");
+        AwsHttpRequest request = new AwsHttpRequest("DELETE", uri(SES_PATH), Map.of(),
+                AwsHttpRequest.NO_BODY, CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS);
+
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> transport.exchange(request));
+
+        assertThat(failure.getMessage(), containsString("DELETE"));
+        assertThat(received, is(empty()));
+    }
+
+    /**
+     * Apache's per-request {@link RequestConfig} <em>replaces</em> the client's rather than merging
+     * with it, so the three timeouts have to be set in the same object: a change that set only the
+     * socket timeout would silently return connect and connection-request to "infinite". Neither of
+     * those two can be observed from a passing exchange — a connect timeout needs a blackholed
+     * route, a connection-request timeout an exhausted pool — so the configuration Apache resolved
+     * for the request is read back instead, out of the client's own execution context.
+     */
+    @Test
+    void boundsTheConnectAndConnectionRequestTimeoutsAlongsideTheReadTimeout() throws Exception {
+        stub(SES_PATH, 200, Map.of(), "{}");
+        AtomicReference<RequestConfig> applied = new AtomicReference<>();
+        HttpRequestInterceptor captureAppliedConfig =
+                (request, context) -> applied.set(HttpClientContext.adapt(context).getRequestConfig());
+
+        try (CloseableHttpClient client = HttpClients.custom().addInterceptorFirst(captureAppliedConfig).build()) {
+            new KeycloakHttpTransport(client).exchange(new AwsHttpRequest("POST", uri(SES_PATH), Map.of(),
+                    "{}".getBytes(StandardCharsets.UTF_8), 1500, 2500));
+        }
+
+        RequestConfig config = applied.get();
+        assertThat(config.getConnectTimeout(), is(1500));
+        assertThat(config.getConnectionRequestTimeout(), is(1500));
+        assertThat(config.getSocketTimeout(), is(2500));
+    }
+
+    /**
+     * The response is read on a request thread inside a Keycloak transaction, and the same transport
+     * talks to the container credential endpoint and the instance metadata service — neither of them
+     * an endpoint whose size is guaranteed by AWS. A peer that streams without end must therefore be
+     * cut off: buffering it would pin the thread and exhaust the heap, and the heap is shared with
+     * every other session on the server.
+     */
+    @Test
+    void refusesAResponseBodyLargerThanTheBound() {
+        stubOversizedBody(SES_PATH, 4 * MAX_RESPONSE_BYTES);
+
+        IOException failure = assertThrows(IOException.class,
+                () -> transport.exchange(post(uri(SES_PATH), Map.of(), "{}".getBytes(StandardCharsets.UTF_8))));
+
+        assertThat(failure.getMessage(), containsString(String.valueOf(MAX_RESPONSE_BYTES)));
+    }
+
+    /**
+     * The other side of the bound. Written as an exact fit because that is where an off-by-one lives:
+     * a {@code >=} in place of the {@code >} would reject a legitimate answer, and the failure would
+     * look like an SES outage rather than like a bug here.
+     */
+    @Test
+    void returnsABodyThatExactlyFillsTheBound() throws Exception {
+        stub(SES_PATH, 200, Map.of(), "x".repeat(MAX_RESPONSE_BYTES));
+
+        AwsHttpResponse response = transport.exchange(post(uri(SES_PATH), Map.of(),
+                "{}".getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(response.body().length, is(MAX_RESPONSE_BYTES));
+    }
+
+    private AwsHttpRequest post(URI uri, Map<String, String> headers, byte[] body) {
+        return new AwsHttpRequest("POST", uri, headers, body, CONNECT_TIMEOUT_MILLIS, READ_TIMEOUT_MILLIS);
+    }
+
+    private URI uri(String path) {
+        return URI.create("http://127.0.0.1:" + server.getAddress().getPort() + path);
+    }
+
+    /** Answers {@code path} with a canned response, recording the request exactly as it arrived. */
+    private void stub(String path, int status, Map<String, String> responseHeaders, String responseBody) {
+        server.createContext(path, exchange -> {
+            received.add(RecordedRequest.of(exchange));
+            respond(exchange, status, responseHeaders, responseBody.getBytes(StandardCharsets.UTF_8));
+        });
+    }
+
+    /**
+     * Answers {@code path} with a chunked body of {@code totalBytes}, which is more than the caller
+     * is willing to read. The write fails as soon as the transport gives up and closes the socket,
+     * which is the expected outcome rather than a problem.
+     */
+    private void stubOversizedBody(String path, int totalBytes) {
+        server.createContext(path, exchange -> {
+            byte[] chunk = new byte[8192];
+            try (exchange) {
+                exchange.sendResponseHeaders(200, 0);
+                try (OutputStream out = exchange.getResponseBody()) {
+                    for (int written = 0; written < totalBytes; written += chunk.length) {
+                        out.write(chunk);
+                    }
+                }
+            } catch (IOException expected) {
+                // The transport hung up mid-body. That is the assertion under test, client-side.
+            }
+        });
+    }
+
+    private RecordedRequest onlyRequest() {
+        assertThat("requests the server received", received.size(), is(1));
+        return received.get(0);
+    }
+
+    private static void respond(HttpExchange exchange, int status, Map<String, String> headers, byte[] body)
+            throws IOException {
+        headers.forEach((name, value) -> exchange.getResponseHeaders().add(name, value));
+        try (exchange) {
+            exchange.sendResponseHeaders(status, body.length == 0 ? -1 : body.length);
+            if (body.length > 0) {
+                try (OutputStream out = exchange.getResponseBody()) {
+                    out.write(body);
+                }
+            }
+        }
+    }
+
+    private void awaitTeardown() {
+        try {
+            slowHandlerRelease.await(2, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /** The client has long since timed out and closed the socket; writing back is best-effort. */
+    private static void respondQuietly(HttpExchange exchange) {
+        try {
+            respond(exchange, 200, Map.of(), "too late".getBytes(StandardCharsets.UTF_8));
+        } catch (IOException expected) {
+            // The connection is gone. Nothing to report: the assertion under test is client-side.
+        }
+    }
+
+    private record RecordedRequest(String method, String path, Map<String, List<String>> headers, byte[] body) {
+
+        static RecordedRequest of(HttpExchange exchange) throws IOException {
+            byte[] body = exchange.getRequestBody().readAllBytes();
+            return new RecordedRequest(exchange.getRequestMethod(), exchange.getRequestURI().toString(),
+                    new LinkedHashMap<>(exchange.getRequestHeaders()), body);
+        }
+
+        /** Every value sent under {@code name}, so a duplicated header is visible, not merged away. */
+        List<String> headerValues(String name) {
+            for (Map.Entry<String, List<String>> header : headers.entrySet()) {
+                if (header.getKey().equalsIgnoreCase(name)) {
+                    return header.getValue();
+                }
+            }
+            return List.of();
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/SesClientTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/SesClientTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.Config;
+import org.keycloak.email.EmailException;
+import org.keycloak.email.aws.credentials.AwsCredentials;
+import org.keycloak.email.aws.credentials.AwsCredentialsProvider;
+import org.keycloak.email.aws.credentials.AwsCredentialsProviderChain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The exact HTTP call this provider makes to SES, asserted on the captured request rather than on a
+ * live account.
+ * <p>
+ * Every value pinned here is one AWS validates and nobody else does: a wrong signing service, a
+ * {@code Host} carrying a port, a {@code Data} field that is not base64 of the MIME, all come back
+ * as an opaque 403 or {@code BadRequestException} the first time a user asks for a password reset.
+ */
+class SesClientTest {
+
+    private static final String REGION = "eu-central-1";
+    private static final String SPI_PREFIX = "keycloak.emailSender.aws-ses.";
+
+    private static final String ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+    private static final String SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    private static final String SESSION_TOKEN = "FwoGZXIvYXdzEExampleSessionToken==";
+
+    private static final String RECIPIENT = "user@example.com";
+    private static final Instant SEND_TIME = Instant.parse("2026-09-03T10:15:30Z");
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final FakeTransport transport = new FakeTransport();
+
+    /** SPI options are JVM-wide system properties here; leaving one set would leak into the next test. */
+    @AfterEach
+    void clearSpiOptions() {
+        System.getProperties().stringPropertyNames().stream()
+                .filter(name -> name.startsWith(SPI_PREFIX))
+                .forEach(System::clearProperty);
+    }
+
+    /**
+     * A 200 whose MessageId is present but empty is as useless as one without it: the id is the only
+     * handle AWS support can trace, so accepting "" would log a successful send that cannot be
+     * followed up.
+     */
+    @Test
+    void refusesAnAcceptanceWithABlankMessageId() {
+        transport.respondWith(200, "{\"MessageId\":\"   \"}");
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME));
+
+        assertThat(failure.getMessage(), containsString("returned no message id"));
+    }
+
+    @Test
+    void postsTheSendEmailRequestToTheRegionalSesEndpoint() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+
+        client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+
+        AwsHttpRequest request = transport.lastRequest();
+        assertThat(request.method(), is("POST"));
+        assertThat(request.uri().toString(), is("https://email.eu-central-1.amazonaws.com/v2/email/outbound-emails"));
+        // Signed, so it must be the bare hostname: an explicit ":443" the signature did not cover is
+        // a 403 with nothing in the response explaining why.
+        assertThat(request.headers().get("Host"), is("email.eu-central-1.amazonaws.com"));
+        assertThat(request.headers().get("Content-Type"), is("application/json"));
+    }
+
+    /**
+     * SES answers on {@code email.<region>.amazonaws.com} but signs as {@code ses}. Signing as
+     * "email" is the classic mistake and it is silent: every send comes back 403 with no hint that
+     * the credential scope is what AWS objected to.
+     */
+    @Test
+    void signsWithTheSesServiceNameAndTheDateOfTheSendingInstant() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+
+        client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+
+        AwsHttpRequest request = transport.lastRequest();
+        assertThat(request.headers().get("X-Amz-Date"), is("20260903T101530Z"));
+        assertThat(request.headers().get("Authorization"), startsWith("AWS4-HMAC-SHA256 Credential="
+                + ACCESS_KEY_ID + "/20260903/" + REGION + "/ses/aws4_request"));
+    }
+
+    /**
+     * The body is the whole API contract. {@code Data} is base64 of the MIME on the plain HTTPS API
+     * — only the AWS SDKs encode it for the caller — and {@code FromEmailAddress} must be the very
+     * string in the {@code From} header, since AWS documents no behaviour for the two disagreeing.
+     */
+    @Test
+    void sendsTheComposedMimeBytesAsBase64RawContent() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+        SesRawMessage message = message();
+
+        client().sendEmail(transport, message, null, 10_000, 10_000, SEND_TIME);
+
+        JsonNode body = bodyOf(transport.lastRequest());
+        assertThat(body.get("FromEmailAddress").asText(), is("AldoTime <noreply@aldotime.it>"));
+        assertThat(body.get("FromEmailAddress").asText(), is(headerValue(message.mime(), "From")));
+
+        JsonNode toAddresses = body.get("Destination").get("ToAddresses");
+        assertThat(toAddresses.size(), is(1));
+        assertThat(toAddresses.get(0).asText(), is(RECIPIENT));
+
+        byte[] decoded = Base64.getDecoder().decode(body.get("Content").get("Raw").get("Data").asText());
+        assertThat(decoded, is(equalTo(message.mime())));
+        assertThat(new String(decoded, StandardCharsets.UTF_8), containsString("To: " + RECIPIENT + "\r\n"));
+    }
+
+    /**
+     * {@code ReplyToAddresses} stays out of the request on purpose: Keycloak already wrote the
+     * {@code Reply-To} header into the MIME and AWS documents no interaction between the parameter
+     * and a raw message's own headers. Sending both would be betting on undocumented behaviour.
+     */
+    @Test
+    void omitsReplyToAddressesAndLeavesReplyToInTheMime() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+        Map<String, String> realm = realmConfig();
+        realm.put("replyTo", "support@aldotime.it");
+        SesRawMessage message = SesRawMessage.compose(realm, RECIPIENT, "Reset your password", "text", "<p>html</p>");
+
+        client().sendEmail(transport, message, null, 10_000, 10_000, SEND_TIME);
+
+        assertThat(headerValue(message.mime(), "Reply-To"), is("support@aldotime.it"));
+        assertThat(bodyOf(transport.lastRequest()).has("ReplyToAddresses"), is(false));
+    }
+
+    /** The realm's envelopeFrom is its bounce address, and this is the SES parameter with that meaning. */
+    @Test
+    void mapsTheRealmEnvelopeFromToFeedbackForwardingEmailAddress() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+
+        client().sendEmail(transport, message(), "bounces@aldotime.it", 10_000, 10_000, SEND_TIME);
+
+        assertThat(bodyOf(transport.lastRequest()).get("FeedbackForwardingEmailAddress").asText(),
+                is("bounces@aldotime.it"));
+    }
+
+    /**
+     * Absent, not present-and-empty: SES rejects {@code FeedbackForwardingEmailAddress: ""} with a
+     * validation error, so a realm that simply never set an envelopeFrom — or set it to whitespace —
+     * must produce a body without the field at all.
+     */
+    @Test
+    void omitsFeedbackForwardingEmailAddressWhenTheRealmSetNoEnvelopeFrom() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"1\"}").respondWith(200, "{\"MessageId\":\"2\"}");
+        SesClient client = client();
+
+        client.sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+        client.sendEmail(transport, message(), "   ", 10_000, 10_000, SEND_TIME);
+
+        assertThat(bodyOf(transport.request(0)).has("FeedbackForwardingEmailAddress"), is(false));
+        assertThat(bodyOf(transport.request(1)).has("FeedbackForwardingEmailAddress"), is(false));
+    }
+
+    /**
+     * A configuration set is how open, bounce and complaint events are published. Naming one that
+     * does not exist fails the send, so an unconfigured server must not send the field at all.
+     */
+    @Test
+    void includesTheConfigurationSetOnlyWhenOneIsConfigured() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"1\"}");
+        new SesClient(config(Map.of("configuration-set", "keycloak-events")), chain(longLivedCredentials()))
+                .sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+        assertThat(bodyOf(transport.lastRequest()).get("ConfigurationSetName").asText(), is("keycloak-events"));
+
+        clearSpiOptions();
+        transport.respondWith(200, "{\"MessageId\":\"2\"}");
+        client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+        assertThat(bodyOf(transport.lastRequest()).has("ConfigurationSetName"), is(false));
+    }
+
+    /**
+     * With an IAM role — the way the provider is meant to run — the credentials are temporary. The
+     * session token has to be a signed header as well as a sent one: AWS rejects a request whose
+     * token is outside {@code SignedHeaders}, and a token sent but unsigned looks like a valid
+     * request until it reaches AWS.
+     */
+    @Test
+    void signsAndSendsTheSessionTokenOfTemporaryCredentials() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+        AwsCredentials temporary = new AwsCredentials("ASIAIOSFODNN7EXAMPLE", SECRET_ACCESS_KEY, SESSION_TOKEN,
+                SEND_TIME.plusSeconds(3600));
+
+        new SesClient(config(Map.of()), chain(temporary))
+                .sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+
+        AwsHttpRequest request = transport.lastRequest();
+        assertThat(request.headers().get("X-Amz-Security-Token"), is(SESSION_TOKEN));
+        assertThat(request.headers().get("Authorization"),
+                containsString("SignedHeaders=content-type;host;x-amz-date;x-amz-security-token,"));
+    }
+
+    @Test
+    void returnsTheMessageIdSesAcknowledgedTheSendWith() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"010f0192a9b4c5d6-11112222-3333-4444-5555-666677778888-000000\"}");
+
+        String messageId = client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+
+        assertThat(messageId, is("010f0192a9b4c5d6-11112222-3333-4444-5555-666677778888-000000"));
+    }
+
+    /**
+     * A 2xx with no message id is not a successful send: it is a proxy, a stub or a captive portal
+     * answering in SES's place. Returning null from here would be recorded as a delivered email.
+     */
+    @Test
+    void refusesASuccessResponseThatCarriesNoMessageId() {
+        transport.respondWith(200, "{\"ResponseMetadata\":{}}");
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME));
+
+        assertThat(failure.getMessage(), is("Amazon SES accepted the message but returned no message id"));
+    }
+
+    /**
+     * What an administrator sees when SES refuses the message. It must carry the AWS error name and
+     * the AWS request id — the only handle AWS support can follow — and it must not carry the
+     * signing secret, the Authorization header or the session token, because this string reaches the
+     * admin console and the server log.
+     */
+    @Test
+    void reportsASesRejectionWithTheAwsErrorNameAndRequestIdButNoCredentials() {
+        transport.respondWith(400,
+                Map.of("x-amzn-ErrorType", "MessageRejected:8c3f", "x-amzn-RequestId", "b7e6a1d2-0b6f-4c2e-9c3a-2b1f"),
+                "{\"message\":\"Email address is not verified in region EU-CENTRAL-1\"}");
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME));
+
+        assertThat(failure.getMessage(), containsString("400"));
+        assertThat(failure.getMessage(), containsString("MessageRejected"));
+        assertThat(failure.getMessage(), containsString("Email address is not verified in region EU-CENTRAL-1"));
+        assertThat(failure.getMessage(), containsString("b7e6a1d2-0b6f-4c2e-9c3a-2b1f"));
+        assertThat(failure.getMessage(), not(containsString(SECRET_ACCESS_KEY)));
+        assertThat(failure.getMessage(), not(containsString(SESSION_TOKEN)));
+        assertThat(failure.getMessage(), not(containsString("AWS4-HMAC-SHA256")));
+    }
+
+    /**
+     * The request is attempted exactly once, deliberately. SES {@code SendEmail} takes no idempotency
+     * token, so a call that failed after its bytes reached AWS cannot be told apart from one that
+     * never arrived — and a retry of the former puts a second activation email in a real person's
+     * inbox. If someone ever adds a retry loop here, this is the assertion that stops it.
+     */
+    @Test
+    void doesNotRetryWhenTheTransportFails() {
+        transport.failWith(new IOException("Connection reset"));
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME));
+
+        assertThat(failure.getMessage(), containsString("email.eu-central-1.amazonaws.com"));
+        assertThat(failure.getMessage(), containsString("Connection reset"));
+        assertThat(transport.requestCount(), is(1));
+    }
+
+    /**
+     * The send happens inside a Keycloak transaction, so the timeouts the caller resolved — realm
+     * settings first, SPI options second — have to reach the request the transport executes.
+     */
+    @Test
+    void putsTheCallerSuppliedTimeoutsOnTheRequest() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+
+        client().sendEmail(transport, message(), null, 1_234, 5_678, SEND_TIME);
+
+        assertThat(transport.lastRequest().connectTimeoutMillis(), is(1_234));
+        assertThat(transport.lastRequest().readTimeoutMillis(), is(5_678));
+    }
+
+    /** No credential source reaches the network here, so the only request captured is the SES send itself. */
+    @Test
+    void resolvesCredentialsWithoutIssuingAnyAdditionalRequest() throws Exception {
+        transport.respondWith(200, "{\"MessageId\":\"0100019\"}");
+
+        client().sendEmail(transport, message(), null, 10_000, 10_000, SEND_TIME);
+
+        assertThat(transport.requestCount(), is(1));
+        assertThat(transport.lastRequest().headers().get("X-Amz-Security-Token"), is(nullValue()));
+    }
+
+    private SesClient client() {
+        return new SesClient(config(Map.of()), chain(longLivedCredentials()));
+    }
+
+    private static AwsCredentials longLivedCredentials() {
+        return AwsCredentials.of(ACCESS_KEY_ID, SECRET_ACCESS_KEY);
+    }
+
+    /**
+     * A real {@code Config.Scope}: Keycloak's own {@code SystemPropertiesScope} reading
+     * {@code keycloak.emailSender.aws-ses.*}. Hand-writing a {@code Config.Scope} would compile here
+     * and stop compiling on the first server release that adds a method to the interface.
+     */
+    private static AwsSesConfig config(Map<String, String> options) {
+        Config.init(new Config.SystemPropertiesConfigProvider());
+        System.setProperty(SPI_PREFIX + "region", REGION);
+        options.forEach((key, value) -> System.setProperty(SPI_PREFIX + key, value));
+        return AwsSesConfig.from(Config.scope("emailSender", "aws-ses"), TestEnvironment.empty());
+    }
+
+    private static AwsCredentialsProviderChain chain(AwsCredentials credentials) {
+        return new AwsCredentialsProviderChain(List.of(new FixedCredentialsProvider(credentials)));
+    }
+
+    private static SesRawMessage message() throws EmailException {
+        return SesRawMessage.compose(realmConfig(), RECIPIENT, "Reset your password", "text", "<p>html</p>");
+    }
+
+    private static Map<String, String> realmConfig() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("from", "noreply@aldotime.it");
+        config.put("fromDisplayName", "AldoTime");
+        return config;
+    }
+
+    private static JsonNode bodyOf(AwsHttpRequest request) throws IOException {
+        return JSON.readTree(request.body());
+    }
+
+    /** Reads a header out of the serialised MIME, which is CRLF-normalised and not folded here. */
+    private static String headerValue(byte[] mime, String name) {
+        for (String line : new String(mime, StandardCharsets.UTF_8).split("\r\n")) {
+            if (line.isEmpty()) {
+                break;
+            }
+            if (line.startsWith(name + ": ")) {
+                return line.substring(name.length() + 2);
+            }
+        }
+        throw new AssertionError("No " + name + " header in the MIME message");
+    }
+
+    private record FixedCredentialsProvider(AwsCredentials credentials) implements AwsCredentialsProvider {
+
+        @Override
+        public AwsCredentials resolve(AwsHttpTransport transport) {
+            return credentials;
+        }
+
+        @Override
+        public String name() {
+            return "fixed test credentials";
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/SesErrorResponseTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/SesErrorResponseTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * How an SES refusal is read off the wire.
+ * <p>
+ * SES states the same three facts — what it called the error, what it means, which request it was —
+ * in several different places depending on the operation and on whatever sits between Keycloak and
+ * AWS. Everything asserted here is a shape AWS actually sends; missing one of them turns an
+ * actionable "Email address is not verified" into "Amazon SES rejected the message (HTTP 400)".
+ */
+class SesErrorResponseTest {
+
+    @Test
+    void readsTheErrorNameFromTheAmznErrorTypeHeader() {
+        SesErrorResponse error = SesErrorResponse.parse(
+                response(400, Map.of("x-amzn-ErrorType", "MessageRejected"), "{}"));
+
+        assertThat(error.status(), is(400));
+        assertThat(error.errorCode(), is("MessageRejected"));
+    }
+
+    /**
+     * AWS decorates {@code x-amzn-ErrorType} two different ways — a trailing {@code :requestId} and a
+     * leading {@code namespace#} — and which one arrives is not something the caller controls. An
+     * unstripped value never matches a comparison such as the throttling check below.
+     */
+    @Test
+    void stripsTheRequestIdAndTheNamespaceAwsDecoratesTheErrorTypeHeaderWith() {
+        assertThat(SesErrorResponse.parse(response(400, Map.of("x-amzn-ErrorType", "MessageRejected:1234"), "{}"))
+                .errorCode(), is("MessageRejected"));
+        assertThat(SesErrorResponse.parse(
+                response(429, Map.of("x-amzn-ErrorType", "com.amazonaws.ses#TooManyRequestsException"), "{}"))
+                .errorCode(), is("TooManyRequestsException"));
+    }
+
+    /**
+     * Without the header the name is in the body, under a field name that varies with the protocol
+     * SES answered in: {@code __type} for JSON, {@code code}/{@code Code} for the query and REST-XML
+     * shapes a proxy may still return.
+     */
+    @Test
+    void fallsBackToTheErrorNameCarriedInTheBody() {
+        assertThat(SesErrorResponse.parse(response(400, Map.of(), "{\"__type\":\"com.amazonaws.ses#MessageRejected\"}"))
+                .errorCode(), is("MessageRejected"));
+        assertThat(SesErrorResponse.parse(response(400, Map.of(), "{\"code\":\"AccountSuspendedException\"}"))
+                .errorCode(), is("AccountSuspendedException"));
+        assertThat(SesErrorResponse.parse(response(400, Map.of(), "{\"Code\":\"SendingPausedException\"}"))
+                .errorCode(), is("SendingPausedException"));
+    }
+
+    /**
+     * SES writes the human text under {@code message} for some operations and {@code Message} for
+     * others. Reading a single casing yields an empty error text exactly when an administrator needs
+     * it, since the sentence AWS puts there is usually the whole diagnosis.
+     */
+    @Test
+    void readsTheHumanMessageInEitherCasing() {
+        assertThat(SesErrorResponse.parse(response(400, Map.of(), "{\"message\":\"Email address is not verified\"}"))
+                .message(), is("Email address is not verified"));
+        assertThat(SesErrorResponse.parse(response(400, Map.of(), "{\"Message\":\"Email address is not verified\"}"))
+                .message(), is("Email address is not verified"));
+    }
+
+    /** The request id is the only handle AWS support can follow, and AWS does not send it in a fixed casing. */
+    @Test
+    void findsTheRequestIdWhateverCasingAwsSendsItIn() {
+        SesErrorResponse error = SesErrorResponse.parse(
+                response(400, Map.of("X-Amzn-Requestid", "7b0c2f4e-2f1a-4c86-9f4d-1a2b3c4d5e6f"), "{}"));
+
+        assertThat(error.requestId(), is("7b0c2f4e-2f1a-4c86-9f4d-1a2b3c4d5e6f"));
+    }
+
+    /**
+     * A load balancer or a corporate proxy in front of SES answers in HTML, not JSON. Parsing must
+     * not throw there: the status and the request id are still the diagnosis, and an exception raised
+     * while reporting an error would replace it with an unrelated stack trace.
+     */
+    @Test
+    void survivesAnHtmlErrorPageFromAProxy() {
+        SesErrorResponse error = SesErrorResponse.parse(response(503,
+                Map.of("x-amzn-RequestId", "proxy-1"),
+                "<html><head><title>503 Service Unavailable</title></head><body></body></html>"));
+
+        assertThat(error.status(), is(503));
+        assertThat(error.errorCode(), is(nullValue()));
+        assertThat(error.message(), is(nullValue()));
+        assertThat(error.requestId(), is("proxy-1"));
+        assertThat(error.describeForLog(), is("status=503 error=unknown awsRequestId=proxy-1"));
+    }
+
+    /**
+     * Throttling has to be recognised by error name, not by status: SES returns
+     * {@code LimitExceededException} with HTTP 400, so classifying on the status alone tells an
+     * administrator to fix a configuration when the account has simply hit its sending quota.
+     */
+    @Test
+    void classifiesThrottlingByErrorNameAndNotOnlyByStatus() {
+        assertThat(throttling(429, "{}"), is(true));
+        assertThat(throttling(400, "{\"__type\":\"TooManyRequestsException\"}"), is(true));
+        assertThat(throttling(400, "{\"__type\":\"ThrottlingException\"}"), is(true));
+        assertThat(throttling(400, "{\"__type\":\"LimitExceededException\"}"), is(true));
+        assertThat(throttling(400, "{\"__type\":\"MessageRejected\"}"), is(false));
+    }
+
+    /** The admin-facing string: everything needed to act, including the id to quote to AWS support. */
+    @Test
+    void describeCarriesStatusErrorNameMessageAndRequestId() {
+        SesErrorResponse error = SesErrorResponse.parse(response(400,
+                Map.of("x-amzn-ErrorType", "MessageRejected:9f2", "x-amzn-RequestId", "1a2b3c"),
+                "{\"message\":\"Email address is not verified in region EU-CENTRAL-1\"}"));
+
+        String description = error.describe();
+
+        assertThat(description, containsString("400"));
+        assertThat(description, containsString("MessageRejected"));
+        assertThat(description, containsString("Email address is not verified in region EU-CENTRAL-1"));
+        assertThat(description, containsString("1a2b3c"));
+    }
+
+    /**
+     * The log line deliberately drops the human message: AWS quotes the rejected address in it, and
+     * the server log is not where a user's email address should end up. Status, error name and
+     * request id are what a log reader needs anyway.
+     */
+    @Test
+    void describeForLogLeavesTheHumanMessageOut() {
+        SesErrorResponse error = SesErrorResponse.parse(response(400,
+                Map.of("x-amzn-ErrorType", "MessageRejected", "x-amzn-RequestId", "1a2b3c"),
+                "{\"message\":\"Email address is not verified: alice@example.com\"}"));
+
+        String logLine = error.describeForLog();
+
+        assertThat(logLine, is("status=400 error=MessageRejected awsRequestId=1a2b3c"));
+        assertThat(logLine, not(containsString("alice@example.com")));
+    }
+
+    private static boolean throttling(int status, String body) {
+        return SesErrorResponse.parse(response(status, Map.of(), body)).isThrottling();
+    }
+
+    /**
+     * AWS names the recipient in its rejection text, and this message does not stay in the
+     * administrator's browser: the callers of the email SPI log the whole exception, so the address
+     * would land in the server log on every failed send.
+     */
+    @Test
+    void redactsAddressesFromTheAwsText() {
+        SesErrorResponse error = SesErrorResponse.parse(new AwsHttpResponse(400,
+                Map.of("x-amzn-ErrorType", "MessageRejected", "x-amzn-RequestId", "req-42"),
+                ("{\"message\":\"Email address is not verified. The following identities failed the check"
+                        + " in region EU-CENTRAL-1: utente@example.com\"}").getBytes(StandardCharsets.UTF_8)));
+
+        String described = error.describe();
+
+        assertThat(described, not(containsString("utente@example.com")));
+        assertThat(described, containsString("<address redacted>"));
+        assertThat(described, containsString("Email address is not verified"));
+        assertThat(described, containsString("MessageRejected"));
+        assertThat(described, containsString("req-42"));
+    }
+
+    private static AwsHttpResponse response(int status, Map<String, String> headers, String body) {
+        return new AwsHttpResponse(status, headers, body.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/SesRawMessageTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/SesRawMessageTest.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.internet.MimeUtility;
+
+import org.keycloak.email.EmailException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Pins what a recipient can see, because that is exactly what must not change when a realm is moved
+ * from SMTP to SES.
+ * <p>
+ * The produced bytes are parsed back with {@link MimeMessage} and asserted on the parsed message
+ * rather than matched as text: it is a stronger check than string matching — a boundary, a folded
+ * header or a transfer encoding cannot be got wrong and still parse — and it proves the bytes are
+ * parseable at all, which is the one property SES will not tell us about until a real recipient
+ * complains.
+ */
+class SesRawMessageTest {
+
+    private static final String FROM_ADDRESS = "noreply@aldotime.it";
+    private static final String RECIPIENT = "utente@example.com";
+
+    /**
+     * Several lines of plain ASCII: the case that makes jakarta.mail pick {@code 7bit} and copy the
+     * body verbatim, bare line feeds and all.
+     */
+    private static final String ASCII_BODY = "Ciao,\nprima riga\nseconda riga\nterza riga\nSaluti\n";
+
+    private final Map<String, String> config = new LinkedHashMap<>(Map.of(
+            "from", FROM_ADDRESS,
+            "fromDisplayName", "AldoTime"));
+
+    @Test
+    void buildsAMultipartAlternativeWithThePlainTextPartBeforeTheHtmlPart() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password",
+                "Reset your password: https://aldotime.it/reset\n", "<p>Reset your password</p>");
+
+        MimeMessage parsed = parse(message.mime());
+        assertThat(parsed.isMimeType("multipart/alternative"), is(true));
+        MimeMultipart parts = (MimeMultipart) parsed.getContent();
+        assertThat(parts.getCount(), is(2));
+        // The order is the whole point of multipart/alternative: the client shows the LAST part it
+        // can render, so text first, html second. Swapped, every recipient sees plain text.
+        assertThat(parts.getBodyPart(0).getContentType(), is("text/plain; charset=UTF-8"));
+        // CRLF, not LF: the body reaches the recipient with MIME line endings, which is what
+        // serialisesEveryLineEndingAsCrlfBecauseSesGetsTheBytesVerbatim() pins byte by byte.
+        assertThat(parts.getBodyPart(0).getContent(), is("Reset your password: https://aldotime.it/reset\r\n"));
+        assertThat(parts.getBodyPart(1).getContentType(), is("text/html; charset=UTF-8"));
+        assertThat(parts.getBodyPart(1).getContent(), is("<p>Reset your password</p>"));
+    }
+
+    @Test
+    void keepsASinglePlainTextPartWhenTheRealmHasNoHtmlTemplate() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        MimeMultipart parts = (MimeMultipart) parse(message.mime()).getContent();
+        assertThat(parts.getCount(), is(1));
+        assertThat(parts.getBodyPart(0).getContentType(), is("text/plain; charset=UTF-8"));
+        assertThat(parts.getBodyPart(0).getContent(),
+                is("Ciao,\r\nprima riga\r\nseconda riga\r\nterza riga\r\nSaluti\r\n"));
+    }
+
+    @Test
+    void keepsASingleHtmlPartWhenThereIsNoTextBody() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password",
+                null, "<p>Reset your password</p>");
+
+        MimeMultipart parts = (MimeMultipart) parse(message.mime()).getContent();
+        assertThat(parts.getCount(), is(1));
+        assertThat(parts.getBodyPart(0).getContentType(), is("text/html; charset=UTF-8"));
+        assertThat(parts.getBodyPart(0).getContent(), is("<p>Reset your password</p>"));
+    }
+
+    /**
+     * A template that renders neither body is a bug further up in Keycloak, and it must surface as an
+     * {@link EmailException} the caller reports — never as an accepted, empty email that SES bills
+     * for and the recipient cannot read. jakarta.mail refuses to serialise a multipart with no parts,
+     * which is the same thing that would happen on the SMTP path.
+     */
+    @Test
+    void refusesToComposeAMessageWithNoBodyAtAll() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, RECIPIENT, "Reset your password", null, null));
+
+        assertThat(failure.getMessage(), is("Failed to compose the email message"));
+    }
+
+    /**
+     * The header the recipient sees and the {@code FromEmailAddress} SES is asked to authorise come
+     * from the same value. If they could drift, IAM would be authorising one identity while the
+     * message claimed another.
+     */
+    @Test
+    void sendsTheSameFromAddressInTheHeaderAsItSendsToSes() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(message.fromHeaderValue(), is("AldoTime <noreply@aldotime.it>"));
+        MimeMessage parsed = parse(message.mime());
+        // equals() on InternetAddress compares the address only, so the display name is asserted
+        // separately rather than through raw string equality on a header jakarta.mail may fold.
+        assertThat(new InternetAddress(MimeUtility.unfold(parsed.getHeader("From", null))),
+                is(new InternetAddress(message.fromHeaderValue())));
+        assertThat(((InternetAddress) parsed.getFrom()[0]).getPersonal(), is("AldoTime"));
+    }
+
+    @Test
+    void omitsTheDisplayNameWhenTheRealmConfiguresNone() throws Exception {
+        config.remove("fromDisplayName");
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(message.fromHeaderValue(), is("noreply@aldotime.it"));
+        assertThat(((InternetAddress) parse(message.mime()).getFrom()[0]).getPersonal(), is(nullValue()));
+    }
+
+    /**
+     * The admin console posts a cleared field as an empty string rather than omitting the key, so
+     * "blank" — not "absent" — is the shape a realm that never set a display name actually has. Taken
+     * literally it becomes a quoted run of spaces in front of the sender address, on every email the
+     * realm sends.
+     */
+    @Test
+    void treatsABlankDisplayNameAsNoDisplayName() throws Exception {
+        config.put("fromDisplayName", "   ");
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(message.fromHeaderValue(), is("noreply@aldotime.it"));
+        assertThat(((InternetAddress) parse(message.mime()).getFrom()[0]).getPersonal(), is(nullValue()));
+    }
+
+    /**
+     * A display name long enough to fold, in the alphabet an Italian or German realm actually uses.
+     * The header then spans two lines and no longer equals {@code fromHeaderValue()} byte for byte —
+     * the address and the name still have to survive, which a naive string comparison would miss and
+     * a naive implementation (concatenating the name without RFC 2047 encoding) would corrupt.
+     */
+    @Test
+    void foldsALongNonAsciiDisplayNameWithoutLosingTheNameOrTheAddress() throws Exception {
+        String displayName = "AldoTime — Gestione presenze e ferie del personale";
+        config.put("fromDisplayName", displayName);
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(message.fromHeaderValue(), is("=?UTF-8?Q?AldoTime_=E2=80=94_Gestione_presenze_e_ferie_del_"
+                + "personale?= <noreply@aldotime.it>"));
+        MimeMessage parsed = parse(message.mime());
+        assertThat(parsed.getHeader("From", null), containsString("\r\n"));
+        assertThat(new InternetAddress(MimeUtility.unfold(parsed.getHeader("From", null))),
+                is(new InternetAddress(message.fromHeaderValue())));
+        assertThat(((InternetAddress) parsed.getFrom()[0]).getPersonal(), is(displayName));
+    }
+
+    /**
+     * Keycloak's SMTP sender always writes a {@code Reply-To}, defaulting it to the sender. Dropping
+     * it when the realm configures none would be a visible change: replies would go wherever the
+     * client decided instead of to the address the realm publishes.
+     */
+    @Test
+    void defaultsReplyToToTheFromAddressWhenTheRealmSetsNone() throws Exception {
+        config.put("replyTo", "  ");
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        MimeMessage parsed = parse(message.mime());
+        assertThat(parsed.getReplyTo().length, is(1));
+        assertThat(((InternetAddress) parsed.getReplyTo()[0]).getAddress(), is(FROM_ADDRESS));
+        assertThat(((InternetAddress) parsed.getReplyTo()[0]).getPersonal(), is("AldoTime"));
+    }
+
+    @Test
+    void usesTheConfiguredReplyToAddressAndDisplayName() throws Exception {
+        config.put("replyTo", "supporto@aldotime.it");
+        config.put("replyToDisplayName", "Supporto AldoTime");
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        MimeMessage parsed = parse(message.mime());
+        assertThat(parsed.getReplyTo().length, is(1));
+        assertThat(((InternetAddress) parsed.getReplyTo()[0]).getAddress(), is("supporto@aldotime.it"));
+        assertThat(((InternetAddress) parsed.getReplyTo()[0]).getPersonal(), is("Supporto AldoTime"));
+        // The From address is not the reply address, and must not have been overwritten by it.
+        assertThat(((InternetAddress) parsed.getFrom()[0]).getAddress(), is(FROM_ADDRESS));
+    }
+
+    /**
+     * SES takes the envelope recipient from {@code Destination.ToAddresses} and does not read the
+     * {@code To} header. A mismatch delivers the message to one address while showing another.
+     */
+    @Test
+    void sendsTheSameRecipientInTheToHeaderAsInTheEnvelope() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(message.recipient(), is(RECIPIENT));
+        assertThat(parse(message.mime()).getHeader("To", null), is(RECIPIENT));
+    }
+
+    /**
+     * A header is an ASCII byte stream: an accented subject has to be RFC 2047 encoded, not written
+     * as UTF-8 bytes. SES accepts the raw message either way, and the recipient sees mojibake.
+     */
+    @Test
+    void encodesANonAsciiSubjectAsRfc2047AndDecodesBackToTheOriginal() throws Exception {
+        String subject = "Reimposta la password – AldoTime";
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, subject, ASCII_BODY, null);
+
+        String rawBytes = new String(message.mime(), StandardCharsets.ISO_8859_1);
+        assertThat(rawBytes, containsString("=?UTF-8?"));
+        assertThat(rawBytes, not(containsString(latin1View("–"))));
+        assertThat(parse(message.mime()).getSubject(), is(subject));
+    }
+
+    /**
+     * A subject is interpolated from realm settings and message-bundle parameters, so a CR LF can
+     * reach it. It must come out as a folded header, never as a second header: the raw bytes go to
+     * SES as they are, and an injected {@code Bcc} would be delivered.
+     */
+    @Test
+    void foldsCarriageReturnsInsideASubjectInsteadOfStartingANewHeader() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT,
+                "Reimposta la password\r\nBcc: attaccante@example.com", ASCII_BODY, null);
+
+        MimeMessage parsed = parse(message.mime());
+        assertThat(parsed.getHeader("Bcc"), is(nullValue()));
+        assertThat(parsed.getAllRecipients().length, is(1));
+        assertThat(parsed.getSubject(), is("Reimposta la password Bcc: attaccante@example.com"));
+    }
+
+    @Test
+    void carriesNonAsciiBodiesThroughTheRoundTripUnchanged() throws Exception {
+        String text = "Buongiorno Loré,\npuò reimpostare la password qui: → https://aldotime.it/reset\n";
+        String html = "<p>Buongiorno Loré, può reimpostare la password <a href=\"#\">qui →</a></p>";
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", text, html);
+
+        MimeMultipart parts = (MimeMultipart) parse(message.mime()).getContent();
+        assertThat(parts.getBodyPart(0).getContent(),
+                is("Buongiorno Loré,\r\npuò reimpostare la password qui: → https://aldotime.it/reset\r\n"));
+        assertThat(parts.getBodyPart(1).getContent(), is(html));
+    }
+
+    /**
+     * The one thing SMTP was silently doing for us. jakarta.mail copies a {@code 7bit} part verbatim,
+     * so a template's bare LFs stay bare; over SMTP the mail implementation wraps the socket in a
+     * CRLF-translating stream, while an SES {@code Content.Raw} payload is base64'd and delivered
+     * exactly as given. The result would be a message that breaks RFC 5322 line endings, with DKIM
+     * signed over it — and the second assertion is the proof that this body really is the case that
+     * produces bare LFs, so the first one cannot pass by accident.
+     */
+    @Test
+    void serialisesEveryLineEndingAsCrlfBecauseSesGetsTheBytesVerbatim() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        MimeMultipart parts = (MimeMultipart) parse(message.mime()).getContent();
+        assertThat(parts.getBodyPart(0).getHeader("Content-Transfer-Encoding")[0], is("7bit"));
+        assertThat(bareLineFeeds(message.mime()), is(0));
+        assertThat(bareLineFeeds(sameBodyPartWrittenWithoutNormalisation()), is(5)); // one per body line
+    }
+
+    /**
+     * Without {@code mail.from}, jakarta.mail builds the {@code Message-ID} from
+     * {@code InetAddress.getLocalHost().getHostName()}: a blocking reverse lookup whose result — a
+     * container id such as {@code keycloak-7d9f8c4b6-x2k9p} — would then be published to every
+     * recipient. The domain on the right of the {@code @} has to be the sender's.
+     */
+    @Test
+    void buildsTheMessageIdFromTheSenderDomainRatherThanTheLocalHostname() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(parse(message.mime()).getHeader("Message-ID", null), endsWith("@aldotime.it>"));
+    }
+
+    @Test
+    void rejectsAMissingOrBlankSenderAddress() {
+        config.remove("from");
+        assertThat(composeFailure().getMessage(), is("No sender address configured"));
+
+        config.put("from", "   ");
+        assertThat(composeFailure().getMessage(), is("No sender address configured"));
+    }
+
+    @Test
+    void rejectsASyntacticallyInvalidSenderAddress() {
+        config.put("from", "noreply.aldotime.it");
+
+        assertThat(composeFailure().getMessage(), is("Invalid sender address 'noreply.aldotime.it'"));
+    }
+
+    @Test
+    void rejectsASyntacticallyInvalidRecipientAddress() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, "utente.example.com", "Reset your password", ASCII_BODY, null));
+
+        assertThat(failure.getMessage(), is("Invalid recipient address 'utente.example.com'"));
+    }
+
+    @Test
+    void rejectsASyntacticallyInvalidReplyToAddress() {
+        config.put("replyTo", "supporto.aldotime.it");
+
+        assertThat(composeFailure().getMessage(), is("Invalid reply-to address 'supporto.aldotime.it'"));
+    }
+
+    /**
+     * The {@code To} header is written from the address verbatim, so an address carrying a line break
+     * would append headers of the attacker's choosing to a message SES sends without further parsing.
+     * The address validation is what stops it, and this test is here so a future relaxation of that
+     * validation cannot pass unnoticed.
+     */
+    @Test
+    void rejectsARecipientAddressThatCarriesAnInjectedHeader() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, "utente@example.com\r\nBcc: attaccante@example.com",
+                        "Reset your password", ASCII_BODY, null));
+
+        assertThat(failure.getMessage(), containsString("Invalid recipient address"));
+    }
+
+    /**
+     * An internationalised DOMAIN is punycoded rather than refused, which is what Keycloak's SMTP
+     * sender does: refusing it would make the switch to SES a visible regression for any realm
+     * whose users have an IDN address.
+     */
+    @Test
+    void punycodesAnInternationalisedRecipientDomain() throws Exception {
+        SesRawMessage message = SesRawMessage.compose(config, "utente@società.it", "Reset your password",
+                ASCII_BODY, null);
+
+        assertThat(message.recipient(), is("utente@xn--societ-nta.it"));
+        assertThat(parse(message.mime()).getHeader("To", null), is("utente@xn--societ-nta.it"));
+    }
+
+    @Test
+    void punycodesAnInternationalisedSenderDomain() throws Exception {
+        config.put("from", "noreply@münchen.example");
+
+        SesRawMessage message = SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null);
+
+        assertThat(message.fromHeaderValue(), containsString("noreply@xn--mnchen-3ya.example"));
+    }
+
+    /**
+     * A non-ASCII LOCAL part cannot be punycoded — it needs the SMTPUTF8 extension, which Amazon SES
+     * does not implement. Rejecting it here produces a message an administrator can act on; letting
+     * it through produces an opaque {@code MessageRejected} from AWS.
+     */
+    @Test
+    void rejectsAnInternationalisedSenderLocalPartUpFront() {
+        config.put("from", "nöreply@aldotime.it");
+
+        assertThat(composeFailure().getMessage(),
+                is("Amazon SES does not support internationalised (non 7-bit ASCII) sender addresses,"
+                        + " but 'nöreply@aldotime.it' has a local part or a domain that cannot be expressed in ASCII"));
+    }
+
+    @Test
+    void rejectsAnInternationalisedRecipientLocalPartUpFront() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, "ütente@example.com", "Reset your password", ASCII_BODY, null));
+
+        assertThat(failure.getMessage(),
+                is("Amazon SES does not support internationalised (non 7-bit ASCII) recipient addresses,"
+                        + " but 'ütente@example.com' has a local part or a domain that cannot be expressed in ASCII"));
+    }
+
+    /**
+     * The rejected address is quoted back into a message that goes straight to the server log, and a
+     * rejected address is precisely the kind that contains a line break. Left raw, the value writes
+     * log lines of its own — a forged "WARN ... authentication succeeded" underneath the real entry —
+     * which is why this asserts the shape of the whole message and not merely that the address was
+     * mentioned: one line, no CR, no LF.
+     */
+    @Test
+    void keepsARejectedAddressOnASingleLogLine() {
+        EmailException failure = assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, "utente@example.com\r\nWARN  [org.keycloak] login succeeded",
+                        "Reset your password", ASCII_BODY, null));
+
+        String message = failure.getMessage();
+        assertThat(message, not(containsString("\r")));
+        assertThat(message, not(containsString("\n")));
+        assertThat(message.lines().count(), is(1L));
+        // The control characters are replaced rather than dropped, so nothing is silently glued
+        // together and the operator can still see what was sent.
+        assertThat(message, containsString("'utente@example.com??WARN  [org.keycloak] login succeeded'"));
+    }
+
+    /**
+     * An address is attacker-supplied on the self-registration path, and the whole of it is quoted
+     * back. Without the cap, a megabyte of junk in the registration form becomes a megabyte of log —
+     * the cheapest way there is to push the entries that matter out of a retention window.
+     */
+    @Test
+    void truncatesAnAbsurdlyLongRejectedAddress() {
+        String longAddress = "u".repeat(5000) + ".example.com";
+
+        EmailException failure = assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, longAddress, "Reset your password", ASCII_BODY, null));
+
+        String quoted = failure.getMessage().split("'")[1];
+        assertThat(quoted, startsWith("u".repeat(120)));
+        // 120 characters and the ellipsis that says there were more.
+        assertThat(quoted, hasLength(121));
+        assertThat(quoted, endsWith("…"));
+    }
+
+    private EmailException composeFailure() {
+        return assertThrows(EmailException.class,
+                () -> SesRawMessage.compose(config, RECIPIENT, "Reset your password", ASCII_BODY, null));
+    }
+
+    private static byte[] sameBodyPartWrittenWithoutNormalisation() throws MessagingException, IOException {
+        MimeBodyPart part = new MimeBodyPart();
+        part.setText(ASCII_BODY, StandardCharsets.UTF_8.name());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        part.writeTo(out);
+        return out.toByteArray();
+    }
+
+    private static int bareLineFeeds(byte[] bytes) {
+        int count = 0;
+        for (int i = 0; i < bytes.length; i++) {
+            if (bytes[i] == '\n' && (i == 0 || bytes[i - 1] != '\r')) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** The UTF-8 bytes of {@code text} seen as Latin-1, i.e. how they would look in the raw message. */
+    private static String latin1View(String text) {
+        return new String(text.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
+    }
+
+    private static MimeMessage parse(byte[] mime) throws MessagingException {
+        return new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(mime));
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/TestEnvironment.java
+++ b/services/src/test/java/org/keycloak/email/aws/TestEnvironment.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.email.aws.credentials.AwsEnvironment;
+
+/** An {@link AwsEnvironment} backed by plain maps, so tests never touch the real process state. */
+public final class TestEnvironment implements AwsEnvironment {
+
+    private final Map<String, String> variables = new HashMap<>();
+    private final Map<String, String> properties = new HashMap<>();
+
+    private Path userHome = Paths.get("/nonexistent-home");
+
+    public static TestEnvironment empty() {
+        return new TestEnvironment();
+    }
+
+    public TestEnvironment with(String name, String value) {
+        variables.put(name, value);
+        return this;
+    }
+
+    public TestEnvironment withProperty(String name, String value) {
+        properties.put(name, value);
+        return this;
+    }
+
+    public TestEnvironment withUserHome(Path home) {
+        this.userHome = home;
+        return this;
+    }
+
+    @Override
+    public String getenv(String name) {
+        return variables.get(name);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        return properties.get(name);
+    }
+
+    @Override
+    public Path userHome() {
+        return userHome;
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/credentials/AwsCredentialsProviderChainTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/credentials/AwsCredentialsProviderChainTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.keycloak.email.aws.AwsHttpTransport;
+import org.keycloak.email.aws.FakeTransport;
+import org.keycloak.email.aws.TestEnvironment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The chain's own behaviour — precedence, failure propagation and caching — pinned down against
+ * hand-written sources, so none of it depends on which real source happens to be reachable from the
+ * machine running the build.
+ */
+class AwsCredentialsProviderChainTest {
+
+    private static final Instant NOW = Instant.parse("2026-09-03T12:00:00Z");
+    private static final AwsCredentials LONG_LIVED =
+            AwsCredentials.of("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+    private final FakeTransport noNetwork = new FakeTransport();
+
+    @Test
+    void takesTheFirstConfiguredSourceAndStopsThere() throws Exception {
+        StubSource unconfigured = StubSource.unconfigured("first source");
+        StubSource configured = new StubSource("second source", LONG_LIVED);
+        StubSource neverReached = new StubSource("third source", AwsCredentials.of("AKIAOTHER", "other"));
+        AwsCredentialsProviderChain chain =
+                new AwsCredentialsProviderChain(List.of(unconfigured, configured, neverReached));
+
+        AwsCredentials resolved = chain.resolve(noNetwork, noNetwork, NOW);
+
+        assertThat(resolved, is(sameInstance(LONG_LIVED)));
+        assertThat(unconfigured.resolveCount(), is(1));
+        assertThat(neverReached.resolveCount(), is(0));
+    }
+
+    /**
+     * A source that is configured but broken is an operator error that must surface as itself. If the
+     * chain swallowed it and carried on, a typo in the profile file would be reported as "no AWS
+     * credentials found" — or, worse, silently replaced by the instance role's identity.
+     */
+    @Test
+    void stopsAtTheFirstBrokenSource() {
+        BrokenSource broken = new BrokenSource("broken source");
+        StubSource neverReached = new StubSource("later source", LONG_LIVED);
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(List.of(broken, neverReached));
+
+        AwsCredentialsException failure =
+                assertThrows(AwsCredentialsException.class, () -> chain.resolve(noNetwork, noNetwork, NOW));
+
+        assertThat(failure.getMessage(), containsString("broken source"));
+        assertThat(neverReached.resolveCount(), is(0));
+    }
+
+    @Test
+    void listsEverySourceItTriedWhenNoneIsConfigured() {
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(
+                List.of(StubSource.unconfigured("first source"), StubSource.unconfigured("second source")));
+
+        AwsCredentialsException failure =
+                assertThrows(AwsCredentialsException.class, () -> chain.resolve(noNetwork, noNetwork, NOW));
+
+        assertThat(failure.getMessage(), containsString("No AWS credentials found"));
+        assertThat(failure.getMessage(), containsString("first source"));
+        assertThat(failure.getMessage(), containsString("second source"));
+    }
+
+    @Test
+    void resolvesCredentialsWithoutAnExpiryOnlyOnce() throws Exception {
+        StubSource source = new StubSource("static source", LONG_LIVED);
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(List.of(source));
+
+        chain.resolve(noNetwork, noNetwork, NOW);
+        AwsCredentials second = chain.resolve(noNetwork, noNetwork, NOW.plus(Duration.ofDays(30)));
+
+        assertThat(second, is(sameInstance(LONG_LIVED)));
+        assertThat(source.resolveCount(), is(1));
+    }
+
+    @Test
+    void invalidateDropsTheCache() throws Exception {
+        StubSource source = new StubSource("static source", LONG_LIVED);
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(List.of(source));
+
+        chain.resolve(noNetwork, noNetwork, NOW);
+        chain.invalidate();
+        chain.resolve(noNetwork, noNetwork, NOW);
+
+        assertThat(source.resolveCount(), is(2));
+    }
+
+    /**
+     * Two minutes of validity left is inside the {@value AwsCredentialsProviderChain#REFRESH_WINDOW_MINUTES}
+     * minute window: the credentials are still valid now, but a message signed with them may not be by
+     * the time SES checks the signature, so the chain must fetch a fresh pair.
+     */
+    @Test
+    void refreshesCredentialsThatExpireInsideTheRefreshWindow() throws Exception {
+        StubSource source = new StubSource("temporary source", temporary(NOW.plus(Duration.ofMinutes(2))));
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(List.of(source));
+
+        chain.resolve(noNetwork, noNetwork, NOW);
+        chain.resolve(noNetwork, noNetwork, NOW);
+
+        assertThat(source.resolveCount(), is(2));
+    }
+
+    @Test
+    void keepsCredentialsThatExpireAfterTheRefreshWindow() throws Exception {
+        StubSource source = new StubSource("temporary source", temporary(NOW.plus(Duration.ofMinutes(30))));
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(List.of(source));
+
+        chain.resolve(noNetwork, noNetwork, NOW);
+        chain.resolve(noNetwork, noNetwork, NOW);
+
+        assertThat(source.resolveCount(), is(1));
+    }
+
+    /**
+     * Temporary credentials with no stated expiry — a session token pasted into a profile file or
+     * exported into the environment — must not be cached. Nothing here can notice when they stop
+     * working, so caching them would keep every email failing even after an operator refreshed the
+     * file, until someone restarted the server.
+     */
+    @Test
+    void doesNotCacheTemporaryCredentialsWithNoKnownExpiry() throws Exception {
+        StubSource source = new StubSource("profile file",
+                new AwsCredentials("ASIAEXAMPLE", "secret", "session-token", null));
+        AwsCredentialsProviderChain chain = new AwsCredentialsProviderChain(List.of(source));
+
+        chain.resolve(noNetwork, noNetwork, NOW);
+        chain.resolve(noNetwork, noNetwork, NOW);
+
+        assertThat(source.resolveCount(), is(2));
+    }
+
+    /**
+     * The sources that answer on this machine — the container endpoint and the metadata service —
+     * are reached through the proxy-free transport, and the ones that talk to AWS through the
+     * server's own client. Sending a bearer token to the first group through a configured proxy
+     * would hand it to the proxy, and would make the address checks in front of those calls
+     * meaningless, since the host being validated would no longer be the host being spoken to.
+     */
+    @Test
+    void routesLocalCredentialSourcesThroughTheDirectTransport() throws Exception {
+        FakeTransport shared = new FakeTransport();
+        FakeTransport direct = new FakeTransport();
+        RecordingSource local = new RecordingSource("container", true);
+        RecordingSource remote = new RecordingSource("web identity", false);
+
+        new AwsCredentialsProviderChain(List.of(local)).resolve(shared, direct, NOW);
+        new AwsCredentialsProviderChain(List.of(remote)).resolve(shared, direct, NOW);
+
+        assertThat(local.transportSeen, is(sameInstance(direct)));
+        assertThat(remote.transportSeen, is(sameInstance(shared)));
+    }
+
+    /** Records which transport the chain handed it, and answers with fixed credentials. */
+    private static final class RecordingSource implements AwsCredentialsProvider {
+
+        private final String name;
+        private final boolean direct;
+
+        private AwsHttpTransport transportSeen;
+
+        private RecordingSource(String name, boolean direct) {
+            this.name = name;
+            this.direct = direct;
+        }
+
+        @Override
+        public AwsCredentials resolve(AwsHttpTransport transport) {
+            transportSeen = transport;
+            return AwsCredentials.of("AKIAEXAMPLE", "secret");
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public boolean requiresDirectConnection() {
+            return direct;
+        }
+    }
+
+    /**
+     * On a machine with no AWS configuration at all the default chain ends where every AWS SDK ends:
+     * probing the instance metadata service, because "am I running on EC2?" cannot be answered any
+     * other way. That probe is expected to fail here, and failing is the point — the chain must then
+     * report that it found nothing, rather than surfacing the metadata service's own error.
+     */
+    @Test
+    void defaultChainOnAnEmptyEnvironmentProbesInstanceMetadataAndThenGivesUp() {
+        FakeTransport transport = new FakeTransport().failWith(new IOException("no route to 169.254.169.254"));
+        AwsCredentialsProviderChain chain = AwsCredentialsProviderChain.defaultChain(TestEnvironment.empty());
+
+        AwsCredentialsException failure =
+                assertThrows(AwsCredentialsException.class, () -> chain.resolve(transport, transport, NOW));
+
+        assertThat(failure.getMessage(), containsString("No AWS credentials found"));
+        assertThat(failure.getMessage(), containsString("environment variables"));
+        assertThat(transport.requestCount(), is(1));
+    }
+
+    /**
+     * The posture for a server that is not on AWS at all — this product ships on plain docker compose
+     * — where the metadata probe is a guaranteed-useless round trip on the path of every email.
+     */
+    @Test
+    void skipsTheNetworkEntirelyWhenInstanceMetadataIsDisabled() {
+        AwsCredentialsProviderChain chain = AwsCredentialsProviderChain.defaultChain(
+                TestEnvironment.empty().with("AWS_EC2_METADATA_DISABLED", "true"));
+
+        AwsCredentialsException failure =
+                assertThrows(AwsCredentialsException.class, () -> chain.resolve(noNetwork, noNetwork, NOW));
+
+        assertThat(failure.getMessage(), containsString("No AWS credentials found"));
+        assertThat(noNetwork.requestCount(), is(0));
+    }
+
+    /**
+     * The chain logs the source and the access key id of whatever it resolved, and credentials travel
+     * on from here into exception messages. A record's generated {@code toString()} would print the
+     * secret access key in all of them.
+     */
+    @Test
+    void credentialsDoNotPrintTheSecret() {
+        AwsCredentials credentials = temporary(NOW.plus(Duration.ofMinutes(30)));
+
+        assertThat(credentials.toString(), not(containsString(credentials.secretAccessKey())));
+        assertThat(credentials.toString(), not(containsString(credentials.sessionToken())));
+        assertThat(credentials.toString(), containsString(credentials.accessKeyId()));
+    }
+
+    private static AwsCredentials temporary(Instant expiration) {
+        return new AwsCredentials("ASIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "FwoGZXIvYXdzEExampleToken", expiration);
+    }
+
+    /** A source that always answers the same thing and counts how often it was asked. */
+    private static final class StubSource implements AwsCredentialsProvider {
+
+        private final String name;
+        private final AwsCredentials credentials;
+
+        private int resolveCount;
+
+        StubSource(String name, AwsCredentials credentials) {
+            this.name = name;
+            this.credentials = credentials;
+        }
+
+        static StubSource unconfigured(String name) {
+            return new StubSource(name, null);
+        }
+
+        @Override
+        public AwsCredentials resolve(AwsHttpTransport transport) {
+            resolveCount++;
+            return credentials;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        int resolveCount() {
+            return resolveCount;
+        }
+    }
+
+    /** A source that is configured but cannot produce credentials. */
+    private static final class BrokenSource implements AwsCredentialsProvider {
+
+        private final String name;
+
+        BrokenSource(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public AwsCredentials resolve(AwsHttpTransport transport) throws AwsCredentialsException {
+            throw new AwsCredentialsException(name + " is configured but unreadable");
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/credentials/ContainerCredentialsProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/credentials/ContainerCredentialsProviderTest.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import org.keycloak.email.aws.FakeTransport;
+import org.keycloak.email.aws.TestEnvironment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ContainerCredentialsProviderTest {
+
+    private static final String RELATIVE_URI_VARIABLE = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+    private static final String FULL_URI_VARIABLE = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+    private static final String TOKEN_VARIABLE = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+    private static final String TOKEN_FILE_VARIABLE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+
+    private static final String CREDENTIALS_PATH = "/v2/credentials/7f3d9c";
+
+    private static final String CREDENTIALS_JSON = """
+            {
+              "AccessKeyId": "ASIACONTAINEREXAMPLE",
+              "SecretAccessKey": "container-secret",
+              "Token": "container-session-token",
+              "Expiration": "2026-09-03T12:34:56Z"
+            }""";
+
+    /** Held apart from the header value below so that a leak of the secret half alone still fails. */
+    private static final String TOKEN_SECRET = "container-authorization-token-value";
+    private static final String AUTHORIZATION_TOKEN = "Bearer " + TOKEN_SECRET;
+
+    private final FakeTransport transport = new FakeTransport();
+
+    @Test
+    void returnsNullWhenNoContainerVariableIsSet() throws Exception {
+        AwsCredentials credentials = new ContainerCredentialsProvider(TestEnvironment.empty()).resolve(transport);
+
+        assertThat(credentials, is(nullValue()));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void resolvesARelativeUriAgainstTheEcsEndpoint() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        AwsCredentials credentials = new ContainerCredentialsProvider(withRelativeUri()).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("ASIACONTAINEREXAMPLE"));
+        assertThat(transport.lastRequest().method(), is("GET"));
+        assertThat(transport.lastRequest().uri().toString(), is("http://169.254.170.2/v2/credentials/7f3d9c"));
+        assertThat(transport.lastRequest().connectTimeoutMillis(), is(1000));
+        assertThat(transport.lastRequest().readTimeoutMillis(), is(1000));
+    }
+
+    @Test
+    void joinsARelativeUriThatHasNoLeadingSlash() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+        TestEnvironment environment = TestEnvironment.empty().with(RELATIVE_URI_VARIABLE, "v2/credentials/7f3d9c");
+
+        new ContainerCredentialsProvider(environment).resolve(transport);
+
+        assertThat(transport.lastRequest().uri().toString(), is("http://169.254.170.2/v2/credentials/7f3d9c"));
+    }
+
+    @Test
+    void acceptsAFullUriOverHttps() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        AwsCredentials credentials =
+                new ContainerCredentialsProvider(withFullUri("https://pod-identity.example.com/creds")).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("ASIACONTAINEREXAMPLE"));
+        assertThat(transport.lastRequest().uri().toString(), is("https://pod-identity.example.com/creds"));
+    }
+
+    @Test
+    void acceptsAFullUriOnLoopbackOverHttp() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        new ContainerCredentialsProvider(withFullUri("http://localhost:8080/creds")).resolve(transport);
+
+        assertThat(transport.lastRequest().uri().toString(), is("http://localhost:8080/creds"));
+    }
+
+    /**
+     * The three addresses AWS's own agents listen on, all of them plain HTTP: the ECS task metadata
+     * endpoint and the EKS Pod Identity agent in both of its forms. Missing one of them refuses
+     * credentials the platform is offering, and the chain then falls through to "no credentials
+     * found" on a pod that has a perfectly good role.
+     * <p>
+     * The IPv6 case is the one that breaks in production rather than in review: {@link java.net.URI}
+     * keeps the brackets of a literal, so {@code getHost()} returns {@code [fd00:ec2::23]} while the
+     * allow list is written bare — an implementation that compared the two directly would reject
+     * every EKS Pod Identity pod configured over IPv6, and only those.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://169.254.170.2/v2/credentials/7f3d9c",
+            "http://169.254.170.23/v1/credentials",
+            "http://[fd00:ec2::23]/v1/credentials"})
+    void acceptsAFullUriOnAnAwsCredentialEndpointOverHttp(String endpoint) throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        AwsCredentials credentials = new ContainerCredentialsProvider(withFullUri(endpoint)).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("ASIACONTAINEREXAMPLE"));
+        assertThat(transport.lastRequest().uri().toString(), is(endpoint));
+    }
+
+    @Test
+    void refusesAFullUriOnAnArbitraryHost() {
+        assertRefuses("http://evil.example.com/creds", "evil.example.com");
+    }
+
+    @Test
+    void refusesAFullUriOnTheInstanceMetadataService() {
+        assertRefuses("http://169.254.169.254/latest/meta-data/iam/security-credentials/", "169.254.169.254");
+    }
+
+    /**
+     * The first gate of the SSRF guard. A bare path in {@code AWS_CONTAINER_CREDENTIALS_FULL_URI} —
+     * the shape an operator produces by copying the value of the <em>relative</em> variable into the
+     * full one — has no scheme and no host to validate, so there is nothing to decide the request is
+     * safe on, and it must be refused rather than resolved against something.
+     */
+    @Test
+    void refusesAFullUriThatIsNotAbsolute() {
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(withFullUri("/v2/credentials/7f3d9c")).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(FULL_URI_VARIABLE));
+        // The message has to name what is wrong with it: falling through to the "points at <host>"
+        // rejection below would report the host as "null", which describes nothing an operator set.
+        assertThat(failure.getMessage(), containsString("must be an absolute http or https URI"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /**
+     * A full URI is operator-supplied and may carry credentials of its own in a query string, so the
+     * rejection names the variable and never quotes its value: this message goes to the server log,
+     * where the whole point of the guard is that nothing secret arrives.
+     */
+    @Test
+    void namesTheVariableWithoutQuotingItWhenTheFullUriCannotBeParsed() {
+        String malformed = "http://pod identity.example.com/creds?token=" + TOKEN_SECRET;
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(withFullUri(malformed)).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(FULL_URI_VARIABLE));
+        assertThat(failure.getMessage(), not(containsString(TOKEN_SECRET)));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void sendsTheAuthorizationTokenFromTheEnvironment() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+        TestEnvironment environment = withRelativeUri().with(TOKEN_VARIABLE, AUTHORIZATION_TOKEN);
+
+        new ContainerCredentialsProvider(environment).resolve(transport);
+
+        assertThat(transport.lastRequest().headers().get("Authorization"), is(AUTHORIZATION_TOKEN));
+    }
+
+    @Test
+    void sendsTheAuthorizationTokenFromTheTokenFile(@TempDir Path directory) throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+        Path tokenFile = Files.writeString(directory.resolve("token"), AUTHORIZATION_TOKEN + "\n", StandardCharsets.UTF_8);
+        TestEnvironment environment = withRelativeUri().with(TOKEN_FILE_VARIABLE, tokenFile.toString());
+
+        new ContainerCredentialsProvider(environment).resolve(transport);
+
+        assertThat(transport.lastRequest().headers().get("Authorization"), is(AUTHORIZATION_TOKEN));
+    }
+
+    /**
+     * The file wins over the variable, which is the difference between a pod that keeps working and
+     * one that stops. EKS Pod Identity rotates the token on disk while the environment keeps the copy
+     * the process was started with: preferring the variable would sign credential fetches with a
+     * value that was valid at boot and is stale hours later, and the failure — an HTTP 401 from the
+     * agent — says nothing about which of the two was used.
+     */
+    @Test
+    void prefersTheRotatingTokenFileOverTheTokenCapturedInTheEnvironment(@TempDir Path directory) throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+        String rotated = "Bearer container-authorization-token-after-rotation";
+        Path tokenFile = Files.writeString(directory.resolve("token"), rotated + "\n", StandardCharsets.UTF_8);
+        TestEnvironment environment = withRelativeUri()
+                .with(TOKEN_VARIABLE, AUTHORIZATION_TOKEN)
+                .with(TOKEN_FILE_VARIABLE, tokenFile.toString());
+
+        new ContainerCredentialsProvider(environment).resolve(transport);
+
+        assertThat(transport.lastRequest().headers().get("Authorization"), is(rotated));
+    }
+
+    /**
+     * An empty token file is what a read caught mid-rotation looks like. Sending the empty
+     * {@code Authorization} header it would produce turns a retryable local race into an
+     * indistinguishable 401 from the agent; failing here names the file instead.
+     */
+    @Test
+    void failsWhenTheTokenFileIsEmpty(@TempDir Path directory) throws Exception {
+        Path tokenFile = Files.writeString(directory.resolve("token"), "\n", StandardCharsets.UTF_8);
+        TestEnvironment environment = withRelativeUri().with(TOKEN_FILE_VARIABLE, tokenFile.toString());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(environment).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(TOKEN_FILE_VARIABLE));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void sendsNoAuthorizationHeaderWhenNeitherTokenVariableIsSet() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        new ContainerCredentialsProvider(withRelativeUri()).resolve(transport);
+
+        assertThat(transport.lastRequest().headers().containsKey("Authorization"), is(false));
+    }
+
+    @Test
+    void failsWhenTheTokenFileCannotBeRead(@TempDir Path directory) {
+        TestEnvironment environment = withRelativeUri().with(TOKEN_FILE_VARIABLE, directory.resolve("absent").toString());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(environment).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(TOKEN_FILE_VARIABLE));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void mapsTheTokenFieldToTheSessionTokenAndParsesTheExpiration() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        AwsCredentials credentials = new ContainerCredentialsProvider(withRelativeUri()).resolve(transport);
+
+        assertThat(credentials.secretAccessKey(), is("container-secret"));
+        assertThat(credentials.sessionToken(), is("container-session-token"));
+        assertThat(credentials.isTemporary(), is(true));
+        assertThat(credentials.expiration(), is(Instant.parse("2026-09-03T12:34:56Z")));
+    }
+
+    @Test
+    void failsOnAnErrorStatusWithoutRevealingTheAuthorizationToken() {
+        transport.respondWith(500, "{\"message\":\"" + AUTHORIZATION_TOKEN + "\"}");
+        TestEnvironment environment = withRelativeUri().with(TOKEN_VARIABLE, AUTHORIZATION_TOKEN);
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(environment).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("500"));
+        assertThat(failure.getMessage(), not(containsString(TOKEN_SECRET)));
+    }
+
+    @Test
+    void failsOnAMalformedJsonResponse() {
+        transport.respondWith(200, "{\"AccessKeyId\": ");
+
+        assertThrows(AwsCredentialsException.class, this::resolveWithRelativeUri);
+    }
+
+    @Test
+    void failsWhenTheResponseHasNoSecretAccessKey() {
+        transport.respondWith(200, "{\"AccessKeyId\":\"ASIACONTAINEREXAMPLE\",\"Token\":\"container-session-token\"}");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, this::resolveWithRelativeUri);
+
+        assertThat(failure.getMessage(), containsString("SecretAccessKey"));
+    }
+
+    @Test
+    void failsOnAnExpirationThatIsNotAnInstant() {
+        transport.respondWith(200, """
+                {
+                  "AccessKeyId": "ASIACONTAINEREXAMPLE",
+                  "SecretAccessKey": "container-secret",
+                  "Token": "container-session-token",
+                  "Expiration": "2026-09-03 12:34:56"
+                }""");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, this::resolveWithRelativeUri);
+
+        assertThat(failure.getMessage(), containsString("Expiration"));
+    }
+
+    /**
+     * Container role credentials are always temporary. A document without a {@code Token} would be
+     * accepted as a long-lived key pair and every signed request would then be rejected by AWS, far
+     * away from the endpoint that produced it.
+     */
+    @Test
+    void refusesACredentialDocumentWithoutAToken() {
+        transport.respondWith(200, """
+                {
+                  "AccessKeyId": "ASIACONTAINEREXAMPLE",
+                  "SecretAccessKey": "container-secret",
+                  "Expiration": "2026-09-03T12:34:56Z"
+                }""");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, this::resolveWithRelativeUri);
+
+        assertThat(failure.getMessage(), containsString("without a Token"));
+    }
+
+    /** Same reasoning for the expiry: absent is incomplete, not perpetual. */
+    @Test
+    void refusesACredentialDocumentWithoutAnExpiration() {
+        transport.respondWith(200, """
+                {
+                  "AccessKeyId": "ASIACONTAINEREXAMPLE",
+                  "SecretAccessKey": "container-secret",
+                  "Token": "container-session-token"
+                }""");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, this::resolveWithRelativeUri);
+
+        assertThat(failure.getMessage(), containsString("without an Expiration"));
+    }
+
+    /**
+     * {@code 127.999.999.999} is not an address, and the loopback check used to accept anything
+     * shaped like a dotted quad. It never actually got that far — {@link java.net.URI} refuses an
+     * authority that looks like an IPv4 address and is not one, so the endpoint is rejected before
+     * the guard sees it — but "rejected by accident, one layer earlier" is not a property to rely on,
+     * so both layers are pinned here.
+     */
+    @Test
+    void refusesAnAddressShapedNameThatIsNotAnAddress() {
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(withFullUri("http://127.999.999.999/v1/credentials"))
+                        .resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(FULL_URI_VARIABLE));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /** The same shape written so that URI does parse it: the guard itself has to refuse it. */
+    @Test
+    void refusesALoopbackLookalikeThatUriAccepts() {
+        assertRefuses("http://127.0.0.1.example.com/v1/credentials", "127.0.0.1.example.com");
+    }
+
+    /**
+     * The allowed endpoints are compared as addresses, not as strings: an IPv6 address has many legal
+     * spellings, and accepting only the one written in the allow list would refuse a perfectly
+     * ordinary way of writing the EKS Pod Identity endpoint.
+     */
+    @Test
+    void acceptsAnAllowedEndpointHoweverItsAddressIsSpelled() throws Exception {
+        transport.respondWith(200, CREDENTIALS_JSON);
+
+        AwsCredentials credentials = new ContainerCredentialsProvider(
+                withFullUri("http://[fd00:0ec2:0000:0000:0000:0000:0000:0023]/v1/credentials")).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("ASIACONTAINEREXAMPLE"));
+    }
+
+    private static TestEnvironment withRelativeUri() {
+        return TestEnvironment.empty().with(RELATIVE_URI_VARIABLE, CREDENTIALS_PATH);
+    }
+
+    private static TestEnvironment withFullUri(String uri) {
+        return TestEnvironment.empty().with(FULL_URI_VARIABLE, uri);
+    }
+
+    private AwsCredentials resolveWithRelativeUri() throws AwsCredentialsException {
+        return new ContainerCredentialsProvider(withRelativeUri()).resolve(transport);
+    }
+
+    /** A refused endpoint must fail before the exchange: the authorization token may not leave the process. */
+    private void assertRefuses(String fullUri, String host) {
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new ContainerCredentialsProvider(withFullUri(fullUri)).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(host));
+        assertThat(transport.requestCount(), is(0));
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/credentials/InstanceMetadataCredentialsProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/credentials/InstanceMetadataCredentialsProviderTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.ConnectException;
+import java.time.Instant;
+
+import org.keycloak.email.aws.AwsHttpRequest;
+import org.keycloak.email.aws.FakeTransport;
+import org.keycloak.email.aws.TestEnvironment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The wire contract of the instance metadata service, pinned end to end: the exact URLs, the IMDSv2
+ * token dance, and — the part that is easy to get wrong — which failures mean "this is not an EC2
+ * instance, try the next source" and which mean "this is an EC2 instance and something is broken".
+ */
+class InstanceMetadataCredentialsProviderTest {
+
+    /**
+     * AWS documents exactly one IPv6 address for the metadata service. The guard used to accept the
+     * whole {@code fd00:ec2::/32} range around it, so a configured endpoint anywhere in that range
+     * could have supplied credentials over plain HTTP.
+     */
+    @Test
+    void refusesAnotherAddressInTheMetadataServicesRange() {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_EC2_METADATA_SERVICE_ENDPOINT", "http://[fd00:ec2::dead]");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(environment).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("fd00:ec2::dead"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /** The documented address itself is accepted, in either spelling. */
+    @Test
+    void acceptsTheDocumentedIpv6MetadataAddress() throws Exception {
+        transport.respondWith(200, METADATA_TOKEN).respondWith(200, ROLE).respondWith(200, CREDENTIALS_JSON);
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_EC2_METADATA_SERVICE_ENDPOINT", "http://[fd00:0ec2:0:0:0:0:0:0254]");
+
+        assertThat(new InstanceMetadataCredentialsProvider(environment).resolve(transport).accessKeyId(),
+                is("ASIAIOSFODNN7EXAMPLE"));
+    }
+
+    /**
+     * Instance-profile credentials always expire, so a document without an {@code Expiration} is
+     * incomplete rather than perpetual. Accepting it would let the chain cache the credentials for
+     * the life of the process and keep signing with them long after AWS stopped honouring them.
+     */
+    @Test
+    void refusesACredentialDocumentWithoutAnExpiration() {
+        transport.respondWith(200, METADATA_TOKEN).respondWith(200, ROLE).respondWith(200, """
+                {
+                  "Code": "Success",
+                  "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+                  "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                  "Token": "IQoJb3JpZ2luX2VjEXAMPLESESSIONTOKEN"
+                }
+                """);
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("without an Expiration"));
+    }
+
+    private static final String TOKEN_URL = "http://169.254.169.254/latest/api/token";
+    private static final String ROLES_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/";
+    private static final String METADATA_TOKEN = "AQAEAP1Nz1AbCdEfGhIjKlMnOpQrStUvWxYz0123456789==";
+    private static final String ROLE = "keycloak-ses-role";
+
+    private static final String CREDENTIALS_JSON = """
+            {
+              "Code": "Success",
+              "LastUpdated": "2026-09-03T11:00:00Z",
+              "Type": "AWS-HMAC",
+              "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+              "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+              "Token": "IQoJb3JpZ2luX2VjEXAMPLESESSIONTOKEN",
+              "Expiration": "2026-09-03T17:00:00Z"
+            }
+            """;
+
+    private final FakeTransport transport = new FakeTransport();
+
+    @Test
+    void makesNoHttpCallAtAllWhenDisabledByEnvironmentVariable() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty().with("AWS_EC2_METADATA_DISABLED", "TRUE");
+
+        assertThat(new InstanceMetadataCredentialsProvider(environment).resolve(transport), is(nullValue()));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void makesNoHttpCallAtAllWhenDisabledBySystemProperty() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty().withProperty("aws.disableEc2Metadata", "true");
+
+        assertThat(new InstanceMetadataCredentialsProvider(environment).resolve(transport), is(nullValue()));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void resolvesTheCredentialsOfTheAttachedRole() throws Exception {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, "\n" + ROLE + "\nsecond-role\n")
+                .respondWith(200, CREDENTIALS_JSON);
+
+        AwsCredentials credentials = new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("ASIAIOSFODNN7EXAMPLE"));
+        assertThat(credentials.secretAccessKey(), is("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        assertThat(credentials.sessionToken(), is("IQoJb3JpZ2luX2VjEXAMPLESESSIONTOKEN"));
+        assertThat(credentials.expiration(), is(Instant.parse("2026-09-03T17:00:00Z")));
+        assertThat(credentials.isTemporary(), is(true));
+
+        assertThat(transport.requestCount(), is(3));
+
+        AwsHttpRequest tokenRequest = transport.request(0);
+        assertThat(tokenRequest.method(), is("PUT"));
+        assertThat(tokenRequest.uri().toString(), is(TOKEN_URL));
+        assertThat(tokenRequest.headers(), hasEntry("X-aws-ec2-metadata-token-ttl-seconds", "21600"));
+        assertThat(tokenRequest.headers(), not(hasKey("X-aws-ec2-metadata-token")));
+        assertThat(tokenRequest.connectTimeoutMillis(), is(1000));
+        assertThat(tokenRequest.readTimeoutMillis(), is(1000));
+
+        AwsHttpRequest roleListRequest = transport.request(1);
+        assertThat(roleListRequest.method(), is("GET"));
+        assertThat(roleListRequest.uri().toString(), is(ROLES_URL));
+        assertThat(roleListRequest.headers(), hasEntry("X-aws-ec2-metadata-token", METADATA_TOKEN));
+
+        AwsHttpRequest credentialsRequest = transport.request(2);
+        assertThat(credentialsRequest.method(), is("GET"));
+        assertThat(credentialsRequest.uri().toString(), is(ROLES_URL + ROLE));
+        assertThat(credentialsRequest.headers(), hasEntry("X-aws-ec2-metadata-token", METADATA_TOKEN));
+        assertThat(credentialsRequest.readTimeoutMillis(), is(1000));
+    }
+
+    @Test
+    void fallsThroughWhenThereIsNoMetadataServiceToAnswerTheToken() throws Exception {
+        transport.failWith(new ConnectException("Connection refused"));
+
+        assertThat(new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport), is(nullValue()));
+        assertThat(transport.requestCount(), is(1));
+    }
+
+    @Test
+    void fallsThroughWhenTheTokenIsRefused() throws Exception {
+        transport.respondWith(403, "");
+
+        assertThat(new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport), is(nullValue()));
+        assertThat(transport.requestCount(), is(1));
+    }
+
+    @Test
+    void fallsThroughWhenNoRoleIsAttachedToTheInstance() throws Exception {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(404, "");
+
+        assertThat(new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport), is(nullValue()));
+        assertThat(transport.requestCount(), is(2));
+    }
+
+    @Test
+    void failsWhenTheCredentialDocumentIsNotSuccessful() {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, ROLE)
+                .respondWith(200, "{\"Code\":\"AssumeRoleUnauthorizedAccess\",\"Message\":\"instance profile\"}");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("AssumeRoleUnauthorizedAccess"));
+        assertThat(failure.getMessage(), containsString(ROLE));
+    }
+
+    @Test
+    void failsWhenTheCredentialDocumentIsIncomplete() {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, ROLE)
+                .respondWith(200, "{\"Code\":\"Success\",\"AccessKeyId\":\"ASIAIOSFODNN7EXAMPLE\"}");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("SecretAccessKey"));
+    }
+
+    @Test
+    void failsWhenTheExpirationCannotBeParsed() {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, ROLE)
+                .respondWith(200, CREDENTIALS_JSON.replace("2026-09-03T17:00:00Z", "in about an hour"));
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("Expiration"));
+    }
+
+    @Test
+    void urlEncodesTheRoleNameIntoThePath() throws Exception {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, "my role/../evil")
+                .respondWith(200, CREDENTIALS_JSON);
+
+        new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport);
+
+        assertThat(transport.lastRequest().uri().toString(), is(ROLES_URL + "my%20role%2F..%2Fevil"));
+    }
+
+    @Test
+    void failsWhenTheCredentialsCallIsRejected() {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, ROLE)
+                .respondWith(500, "");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("500"));
+        assertThat(failure.getMessage(), containsString(ROLE));
+    }
+
+    /**
+     * The whole rendered exception, not just its message: the tempting way to write the failure of
+     * an HTTP call is to interpolate the request, and {@link AwsHttpRequest} is a record whose
+     * {@code toString} would print the metadata token header into the server log.
+     */
+    @Test
+    void neverPutsTheMetadataTokenInAFailure() {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, ROLE)
+                .failWith(new IOException("connection reset by peer"));
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        StringWriter rendered = new StringWriter();
+        failure.printStackTrace(new PrintWriter(rendered));
+        assertThat(rendered.toString(), not(containsString(METADATA_TOKEN)));
+    }
+
+    @Test
+    void neverEchoesTheCredentialDocumentThatCouldNotBeParsed() {
+        transport.respondWith(200, METADATA_TOKEN)
+                .respondWith(200, ROLE)
+                .respondWith(200, "{\"SecretAccessKey\": \"wJalrXUtnFEMI-not-json");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(TestEnvironment.empty()).resolve(transport));
+
+        assertThat(failure.getMessage(), not(containsString("wJalrXUtnFEMI")));
+        assertThat(failure.getCause(), is(nullValue()));
+    }
+
+    @Test
+    void refusesAnEndpointThatIsNotTheMetadataServiceOverPlainHttp() {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_EC2_METADATA_SERVICE_ENDPOINT", "http://metadata.attacker.example");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new InstanceMetadataCredentialsProvider(environment).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("AWS_EC2_METADATA_SERVICE_ENDPOINT"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void honoursALoopbackEndpointForAMetadataProxy() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_EC2_METADATA_SERVICE_ENDPOINT", "http://127.0.0.1:8169/");
+        transport.failWith(new IOException("nothing listening"));
+
+        assertThat(new InstanceMetadataCredentialsProvider(environment).resolve(transport), is(nullValue()));
+        assertThat(transport.lastRequest().uri().toString(), is("http://127.0.0.1:8169/latest/api/token"));
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/credentials/ProfileCredentialsProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/credentials/ProfileCredentialsProviderTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.keycloak.email.aws.FakeTransport;
+import org.keycloak.email.aws.TestEnvironment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Exercises the provider against real files under a temporary home, which is the only way to cover
+ * what actually breaks here: the two spellings of a section header, the precedence between the two
+ * files, and a secret that contains the characters a naive INI parser eats.
+ */
+class ProfileCredentialsProviderTest {
+
+    /**
+     * A transport that fails the test if it is called at all: reading a profile must never touch the
+     * network, and a provider that fell through to an HTTP endpoint would otherwise pass unnoticed.
+     */
+    private final FakeTransport transport = new FakeTransport();
+
+    @TempDir
+    Path home;
+
+    @Test
+    void returnsNullWhenNoProfileFileExists() throws Exception {
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()).resolve(transport);
+
+        assertThat(credentials, nullValue());
+    }
+
+    @Test
+    void readsTheDefaultProfileFromTheCredentialsFile() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIADEFAULT
+                aws_secret_access_key = default-secret
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()).resolve(transport);
+
+        assertThat(credentials, notNullValue());
+        assertThat(credentials.accessKeyId(), is("AKIADEFAULT"));
+        assertThat(credentials.secretAccessKey(), is("default-secret"));
+        assertThat(credentials.isTemporary(), is(false));
+        assertThat(credentials.expiration(), nullValue());
+    }
+
+    /**
+     * The named-profile case and the section-naming rule in one file pair: {@code [profile staging]}
+     * is the config file's spelling only, so the identically named section in the credentials file
+     * must not be picked up — if it were, the wrong key would come back.
+     */
+    @Test
+    void readsTheProfileNamedByAwsProfileAndAcceptsTheProfilePrefixOnlyInTheConfigFile() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIADEFAULT
+                aws_secret_access_key = default-secret
+
+                [profile staging]
+                aws_access_key_id = AKIAMISSPELLED
+                aws_secret_access_key = misspelled-secret
+                """);
+        writeHomeFile("config", """
+                [profile staging]
+                aws_access_key_id = AKIASTAGING
+                aws_secret_access_key = staging-secret
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment().with("AWS_PROFILE", "staging"))
+                .resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("AKIASTAGING"));
+        assertThat(credentials.secretAccessKey(), is("staging-secret"));
+    }
+
+    @Test
+    void honoursTheFileLocationOverridesAndMergesTheTwoFiles() throws Exception {
+        Path credentialsFile = writeFile(home.resolve("elsewhere/creds.ini"),
+                "[default]\naws_access_key_id = AKIAELSEWHERE\n");
+        Path configFile = writeFile(home.resolve("elsewhere/conf.ini"),
+                "[default]\naws_secret_access_key = elsewhere-secret\n");
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIAHOME
+                aws_secret_access_key = home-secret
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()
+                .with("AWS_SHARED_CREDENTIALS_FILE", credentialsFile.toString())
+                .with("AWS_CONFIG_FILE", configFile.toString()))
+                .resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("AKIAELSEWHERE"));
+        assertThat(credentials.secretAccessKey(), is("elsewhere-secret"));
+    }
+
+    @Test
+    void reportsAProfileWithASessionTokenAsTemporaryButNotExpiring() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = ASIATEMPORARY
+                aws_secret_access_key = temporary-secret
+                aws_session_token = FwoGZXIvYXdzEJr//////////wEaDExAMPLE=
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()).resolve(transport);
+
+        assertThat(credentials.sessionToken(), is("FwoGZXIvYXdzEJr//////////wEaDExAMPLE="));
+        assertThat(credentials.isTemporary(), is(true));
+        assertThat(credentials.expiration(), nullValue());
+    }
+
+    /**
+     * The {@code #} inside the secret is the point: it is a legal character in an AWS secret access
+     * key, so it must survive the parser rather than be read as the start of a trailing comment.
+     */
+    @Test
+    void parsesCommentsBlankLinesWhitespaceCrlfAndASecretContainingHashAndEquals() throws Exception {
+        String secret = "wJal#rXUtnFEMI/K7MDENG=bPxRfi#CYEXAMPLEKEY";
+        writeHomeFile("credentials", String.join("\r\n",
+                "# a comment before any section",
+                "; and the other comment character",
+                "",
+                "[default]",
+                "    aws_access_key_id   =   AKIASUPERSEDED   ",
+                "   # an indented comment inside the section",
+                "aws_secret_access_key = " + secret,
+                "region = eu-south-1",
+                "aws_access_key_id = AKIALAST",
+                "",
+                "[other]",
+                "aws_access_key_id = AKIAOTHER",
+                ""));
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("AKIALAST"));
+        assertThat(credentials.secretAccessKey(), is(secret));
+    }
+
+    @Test
+    void failsWhenTheProfileHasTheKeyIdButNoSecret() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIAHALFCONFIGURED
+                """);
+        ProfileCredentialsProvider provider = new ProfileCredentialsProvider(environment());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("aws_secret_access_key"));
+        assertThat(failure.getMessage(), containsString("default"));
+    }
+
+    @Test
+    void treatsAKeyWithAnEmptyValueAsUnset() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id =
+                aws_secret_access_key =
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()).resolve(transport);
+
+        assertThat(credentials, nullValue());
+    }
+
+    @Test
+    void returnsNullWhenTheRequestedProfileIsAbsentFromAFileThatExists() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIADEFAULT
+                aws_secret_access_key = default-secret
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment().with("AWS_PROFILE", "absent"))
+                .resolve(transport);
+
+        assertThat(credentials, nullValue());
+    }
+
+    @Test
+    void prefersTheCredentialsFileOverTheConfigFileKeyByKey() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIAFROMCREDENTIALS
+                aws_secret_access_key = credentials-secret
+                """);
+        writeHomeFile("config", """
+                [default]
+                aws_access_key_id = AKIAFROMCONFIG
+                aws_secret_access_key = config-secret
+                aws_session_token = token-only-in-config
+                """);
+
+        AwsCredentials credentials = new ProfileCredentialsProvider(environment()).resolve(transport);
+
+        assertThat(credentials.accessKeyId(), is("AKIAFROMCREDENTIALS"));
+        assertThat(credentials.secretAccessKey(), is("credentials-secret"));
+        assertThat(credentials.sessionToken(), is("token-only-in-config"));
+    }
+
+    private TestEnvironment environment() {
+        return TestEnvironment.empty().withUserHome(home);
+    }
+
+    private void writeHomeFile(String name, String content) throws IOException {
+        writeFile(home.resolve(".aws").resolve(name), content);
+    }
+
+    /**
+     * The AWS SDKs read {@code aws.profile} before {@code AWS_PROFILE}. Reading only the variable
+     * would make this provider send email as one identity while every other AWS client in the same
+     * JVM used another.
+     */
+    @Test
+    void prefersTheProfileSystemPropertyOverTheEnvironmentVariable() throws Exception {
+        writeHomeFile("credentials", """
+                [default]
+                aws_access_key_id = AKIADEFAULT
+                aws_secret_access_key = default-secret
+
+                [chosen]
+                aws_access_key_id = AKIACHOSEN
+                aws_secret_access_key = chosen-secret
+                """);
+        TestEnvironment environment = environment()
+                .with("AWS_PROFILE", "default")
+                .withProperty("aws.profile", "chosen");
+
+        assertThat(new ProfileCredentialsProvider(environment).resolve(null).accessKeyId(), is("AKIACHOSEN"));
+    }
+
+    /** Same rule for the file locations. */
+    @Test
+    void prefersTheCredentialsFileSystemPropertyOverTheEnvironmentVariable() throws Exception {
+        Path chosen = home.resolve("chosen-credentials");
+        writeFile(chosen, """
+                [default]
+                aws_access_key_id = AKIAFROMPROPERTY
+                aws_secret_access_key = property-secret
+                """);
+        Path other = home.resolve("other-credentials");
+        writeFile(other, """
+                [default]
+                aws_access_key_id = AKIAFROMVARIABLE
+                aws_secret_access_key = variable-secret
+                """);
+        TestEnvironment environment = environment()
+                .with("AWS_SHARED_CREDENTIALS_FILE", other.toString())
+                .withProperty("aws.sharedCredentialsFile", chosen.toString());
+
+        assertThat(new ProfileCredentialsProvider(environment).resolve(null).accessKeyId(), is("AKIAFROMPROPERTY"));
+    }
+
+    private static Path writeFile(Path file, String content) throws IOException {
+        Files.createDirectories(file.getParent());
+        return Files.writeString(file, content);
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/credentials/StaticCredentialsProvidersTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/credentials/StaticCredentialsProvidersTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import org.keycloak.email.aws.FakeTransport;
+import org.keycloak.email.aws.TestEnvironment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The two sources that read the process itself: JVM system properties and environment variables.
+ * <p>
+ * The transport handed to them has no queued response, so it fails the test loudly if either source
+ * ever tries to reach the network — they must resolve without leaving the process.
+ */
+class StaticCredentialsProvidersTest {
+
+    private final FakeTransport noNetwork = new FakeTransport();
+
+    @Test
+    void resolvesALongLivedPairFromSystemProperties() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .withProperty("aws.accessKeyId", "AKIAIOSFODNN7EXAMPLE")
+                .withProperty("aws.secretAccessKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+        AwsCredentials credentials = new SystemPropertiesCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials, is(notNullValue()));
+        assertThat(credentials.accessKeyId(), is("AKIAIOSFODNN7EXAMPLE"));
+        assertThat(credentials.secretAccessKey(), is("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        assertThat(credentials.sessionToken(), is(nullValue()));
+        assertThat(credentials.isTemporary(), is(false));
+        assertThat(credentials.expiration(), is(nullValue()));
+        assertThat(noNetwork.requestCount(), is(0));
+    }
+
+    @Test
+    void carriesTheSessionTokenFromSystemProperties() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .withProperty("aws.accessKeyId", "ASIAIOSFODNN7EXAMPLE")
+                .withProperty("aws.secretAccessKey", "secret")
+                .withProperty("aws.sessionToken", "FwoGZXIvYXdzEExampleToken");
+
+        AwsCredentials credentials = new SystemPropertiesCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials.sessionToken(), is("FwoGZXIvYXdzEExampleToken"));
+        assertThat(credentials.isTemporary(), is(true));
+        assertThat(credentials.expiration(), is(nullValue()));
+    }
+
+    @Test
+    void returnsNullWhenNoSystemPropertyIsSet() throws Exception {
+        AwsCredentials credentials =
+                new SystemPropertiesCredentialsProvider(TestEnvironment.empty()).resolve(noNetwork);
+
+        assertThat(credentials, is(nullValue()));
+    }
+
+    @Test
+    void returnsNullWhenTheSystemPropertiesAreBlank() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .withProperty("aws.accessKeyId", "")
+                .withProperty("aws.secretAccessKey", "   ");
+
+        AwsCredentials credentials = new SystemPropertiesCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials, is(nullValue()));
+    }
+
+    @Test
+    void failsWhenOnlyTheSystemPropertyAccessKeyIdIsSet() {
+        TestEnvironment environment = TestEnvironment.empty()
+                .withProperty("aws.accessKeyId", "AKIAIOSFODNN7EXAMPLE");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new SystemPropertiesCredentialsProvider(environment).resolve(noNetwork));
+
+        assertThat(failure.getMessage(), containsString("aws.secretAccessKey"));
+    }
+
+    @Test
+    void failsWhenOnlyTheSystemPropertySecretAccessKeyIsSet() {
+        TestEnvironment environment = TestEnvironment.empty()
+                .withProperty("aws.secretAccessKey", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new SystemPropertiesCredentialsProvider(environment).resolve(noNetwork));
+
+        assertThat(failure.getMessage(), containsString("aws.accessKeyId"));
+        assertThat(failure.getMessage(), not(containsString("wJalrXUtnFEMI")));
+    }
+
+    @Test
+    void resolvesALongLivedPairFromEnvironmentVariables() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+                .with("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+        AwsCredentials credentials = new EnvironmentVariableCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials, is(notNullValue()));
+        assertThat(credentials.accessKeyId(), is("AKIAIOSFODNN7EXAMPLE"));
+        assertThat(credentials.secretAccessKey(), is("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        assertThat(credentials.sessionToken(), is(nullValue()));
+        assertThat(credentials.isTemporary(), is(false));
+        assertThat(credentials.expiration(), is(nullValue()));
+        assertThat(noNetwork.requestCount(), is(0));
+    }
+
+    @Test
+    void carriesTheSessionTokenFromEnvironmentVariables() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_ACCESS_KEY_ID", "ASIAIOSFODNN7EXAMPLE")
+                .with("AWS_SECRET_ACCESS_KEY", "secret")
+                .with("AWS_SESSION_TOKEN", "FwoGZXIvYXdzEExampleToken");
+
+        AwsCredentials credentials = new EnvironmentVariableCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials.sessionToken(), is("FwoGZXIvYXdzEExampleToken"));
+        assertThat(credentials.isTemporary(), is(true));
+        assertThat(credentials.expiration(), is(nullValue()));
+    }
+
+    @Test
+    void returnsNullWhenNoEnvironmentVariableIsSet() throws Exception {
+        AwsCredentials credentials =
+                new EnvironmentVariableCredentialsProvider(TestEnvironment.empty()).resolve(noNetwork);
+
+        assertThat(credentials, is(nullValue()));
+    }
+
+    /**
+     * The case that matters in practice: docker compose's {@code AWS_ACCESS_KEY_ID: ${VAR:-}} exports
+     * the variable with an empty value instead of omitting it. Treating that as "configured" signs
+     * every message with an empty key and turns a plain misconfiguration into an opaque SES
+     * {@code SignatureDoesNotMatch}, three layers away from the cause.
+     */
+    @Test
+    void returnsNullWhenTheEnvironmentVariablesAreBlank() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_ACCESS_KEY_ID", "")
+                .with("AWS_SECRET_ACCESS_KEY", "   ");
+
+        AwsCredentials credentials = new EnvironmentVariableCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials, is(nullValue()));
+    }
+
+    /** A blank session token is not a session token: it must not turn the pair temporary. */
+    @Test
+    void ignoresABlankSessionToken() throws Exception {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+                .with("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .with("AWS_SESSION_TOKEN", "");
+
+        AwsCredentials credentials = new EnvironmentVariableCredentialsProvider(environment).resolve(noNetwork);
+
+        assertThat(credentials.sessionToken(), is(nullValue()));
+        assertThat(credentials.isTemporary(), is(false));
+    }
+
+    @Test
+    void failsWhenOnlyTheEnvironmentVariableAccessKeyIdIsSet() {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new EnvironmentVariableCredentialsProvider(environment).resolve(noNetwork));
+
+        assertThat(failure.getMessage(), containsString("AWS_SECRET_ACCESS_KEY"));
+    }
+
+    @Test
+    void failsWhenOnlyTheEnvironmentVariableSecretAccessKeyIsSet() {
+        TestEnvironment environment = TestEnvironment.empty()
+                .with("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new EnvironmentVariableCredentialsProvider(environment).resolve(noNetwork));
+
+        assertThat(failure.getMessage(), containsString("AWS_ACCESS_KEY_ID"));
+        assertThat(failure.getMessage(), not(containsString("wJalrXUtnFEMI")));
+    }
+
+    /** The names end up in the "no AWS credentials found" message an administrator has to act on. */
+    @Test
+    void namesTheSourcesTheWayAnOperatorConfiguresThem() {
+        TestEnvironment environment = TestEnvironment.empty();
+
+        assertThat(new SystemPropertiesCredentialsProvider(environment).name(), is("JVM system properties"));
+        assertThat(new EnvironmentVariableCredentialsProvider(environment).name(), is("environment variables"));
+    }
+}

--- a/services/src/test/java/org/keycloak/email/aws/credentials/WebIdentityTokenCredentialsProviderTest.java
+++ b/services/src/test/java/org/keycloak/email/aws/credentials/WebIdentityTokenCredentialsProviderTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email.aws.credentials;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import org.keycloak.email.aws.AwsHttpRequest;
+import org.keycloak.email.aws.FakeTransport;
+import org.keycloak.email.aws.TestEnvironment;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Behaviour of the EKS IRSA credential source. The STS exchange is asserted at the byte level — the
+ * request that would reach the wire — because the failures this flow produces in production
+ * ({@code InvalidIdentityToken}, {@code SignatureDoesNotMatch}) name none of their real causes.
+ */
+class WebIdentityTokenCredentialsProviderTest {
+
+    private static final String TOKEN_FILE_VARIABLE = "AWS_WEB_IDENTITY_TOKEN_FILE";
+    private static final String ROLE_ARN_VARIABLE = "AWS_ROLE_ARN";
+    private static final String SESSION_NAME_VARIABLE = "AWS_ROLE_SESSION_NAME";
+
+    private static final String ROLE_ARN = "arn:aws:iam::123456789012:role/keycloak-ses";
+    /**
+     * Base64url characters only — the alphabet a real projected service-account token uses — so form
+     * encoding leaves it untouched and the assertion on the request body pins the exact bytes STS
+     * would receive instead of restating what the encoder does.
+     * <p>
+     * Deliberately not shaped as three dot-separated JWT segments: the provider treats this value as
+     * opaque, so the realism buys no coverage, while a JWT-shaped literal is flagged by secret
+     * scanners and would fail the repository's own gitleaks gate.
+     */
+    private static final String TOKEN = "projected-service-account-token-for-tests_0123456789-abcdefg";
+    private static final String EXPIRATION = "2026-09-03T12:34:56Z";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void returnsNullWhenTheTokenFileVariableIsNotSet() throws Exception {
+        FakeTransport transport = new FakeTransport();
+
+        AwsCredentials credentials = new WebIdentityTokenCredentialsProvider(
+                TestEnvironment.empty().with(ROLE_ARN_VARIABLE, ROLE_ARN)).resolve(transport);
+
+        assertThat(credentials, is(nullValue()));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void returnsNullWhenTheRoleArnIsNotSet() throws Exception {
+        FakeTransport transport = new FakeTransport();
+
+        AwsCredentials credentials = new WebIdentityTokenCredentialsProvider(
+                TestEnvironment.empty().with(TOKEN_FILE_VARIABLE, writeTokenFile(TOKEN + "\n"))).resolve(transport);
+
+        assertThat(credentials, is(nullValue()));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    @Test
+    void exchangesTheProjectedTokenForTemporaryCredentials() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(EXPIRATION));
+
+        AwsCredentials credentials = new WebIdentityTokenCredentialsProvider(
+                configured().with("AWS_REGION", "eu-south-1")).resolve(transport);
+
+        AwsHttpRequest request = transport.lastRequest();
+        assertThat(request.method(), is("POST"));
+        assertThat(request.uri().toString(), is("https://sts.eu-south-1.amazonaws.com/"));
+        assertThat(request.headers().get("Content-Type"), containsString("application/x-www-form-urlencoded"));
+        assertThat("the STS exchange must go out unsigned, the token is the credential",
+                request.headers().keySet().stream().anyMatch(name -> name.equalsIgnoreCase("Authorization")), is(false));
+
+        String body = request.bodyAsString();
+        assertThat(body, containsString("Action=AssumeRoleWithWebIdentity&Version=2011-06-15"));
+        assertThat(body, containsString("RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fkeycloak-ses"));
+        assertThat(body, containsString("RoleSessionName=keycloak-email-aws-ses"));
+        assertThat(body, containsString("WebIdentityToken=" + TOKEN));
+        assertThat("the newline the kubelet leaves in the file must not reach STS", body, not(containsString("%0A")));
+
+        assertThat(credentials.accessKeyId(), is("ASIAEXAMPLEKEYID"));
+        assertThat(credentials.secretAccessKey(), is("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        assertThat(credentials.sessionToken(), is("FwoGZXIvYXdzEExampleSessionToken"));
+        assertThat(credentials.isTemporary(), is(true));
+        assertThat(credentials.expiration(), is(Instant.parse(EXPIRATION)));
+    }
+
+    @Test
+    void formEncodesACustomSessionName() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(EXPIRATION));
+
+        new WebIdentityTokenCredentialsProvider(
+                configured().with(SESSION_NAME_VARIABLE, "keycloak@node-1")).resolve(transport);
+
+        assertThat(transport.lastRequest().bodyAsString(), containsString("RoleSessionName=keycloak%40node-1"));
+    }
+
+    @Test
+    void fallsBackToAwsDefaultRegionForTheEndpoint() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(EXPIRATION));
+
+        new WebIdentityTokenCredentialsProvider(
+                configured().with("AWS_DEFAULT_REGION", "us-west-2")).resolve(transport);
+
+        assertThat(transport.lastRequest().uri().toString(), is("https://sts.us-west-2.amazonaws.com/"));
+    }
+
+    @Test
+    void usesTheGlobalEndpointWhenNoRegionIsSet() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(EXPIRATION));
+
+        new WebIdentityTokenCredentialsProvider(configured()).resolve(transport);
+
+        assertThat(transport.lastRequest().uri().toString(), is("https://sts.amazonaws.com/"));
+    }
+
+    @Test
+    void reportsTheStatusAndErrorCodeWithoutEchoingTheToken() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(403, """
+                <ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+                  <Error>
+                    <Type>Sender</Type>
+                    <Code>AccessDenied</Code>
+                    <Message>Not authorized to perform sts:AssumeRoleWithWebIdentity: %s</Message>
+                  </Error>
+                </ErrorResponse>
+                """.formatted(TOKEN));
+        AwsCredentialsProvider provider = new WebIdentityTokenCredentialsProvider(configured());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("403"));
+        assertThat(failure.getMessage(), containsString("AccessDenied"));
+        assertThat(failure.getMessage(), not(containsString(TOKEN)));
+    }
+
+    /**
+     * The reason the parser is hardened. With a {@code DocumentBuilderFactory} at its defaults this
+     * response resolves the entity and hands back credentials whose access key id is the content of a
+     * local file, so removing any of the hardening lines fails this test as "expected exception not
+     * thrown" rather than degrading quietly.
+     */
+    @Test
+    void refusesAnXxePayloadInsteadOfResolvingTheEntity() throws Exception {
+        Path secret = tempDir.resolve("xxe-target.txt");
+        Files.writeString(secret, "TOP-SECRET-FILE-CONTENT");
+        FakeTransport transport = new FakeTransport().respondWith(200, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE AssumeRoleWithWebIdentityResponse [<!ENTITY xxe SYSTEM "%s">]>
+                <AssumeRoleWithWebIdentityResponse>
+                  <AssumeRoleWithWebIdentityResult>
+                    <Credentials>
+                      <AccessKeyId>&xxe;</AccessKeyId>
+                      <SecretAccessKey>&xxe;</SecretAccessKey>
+                      <SessionToken>&xxe;</SessionToken>
+                      <Expiration>%s</Expiration>
+                    </Credentials>
+                  </AssumeRoleWithWebIdentityResult>
+                </AssumeRoleWithWebIdentityResponse>
+                """.formatted(secret.toUri(), EXPIRATION));
+        AwsCredentialsProvider provider = new WebIdentityTokenCredentialsProvider(configured());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), not(containsString("TOP-SECRET-FILE-CONTENT")));
+    }
+
+    @Test
+    void rejectsAnExpirationThatIsNotAnInstant() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse("very soon"));
+        AwsCredentialsProvider provider = new WebIdentityTokenCredentialsProvider(configured());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("Expiration"));
+    }
+
+    @Test
+    void rejectsAResponseWithoutAnExpiration() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(null));
+        AwsCredentialsProvider provider = new WebIdentityTokenCredentialsProvider(configured());
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("Expiration"));
+    }
+
+    @Test
+    void failsWhenTheTokenFileIsNotOnDisk() {
+        FakeTransport transport = new FakeTransport();
+        AwsCredentialsProvider provider = new WebIdentityTokenCredentialsProvider(TestEnvironment.empty()
+                .with(TOKEN_FILE_VARIABLE, tempDir.resolve("never-projected").toString())
+                .with(ROLE_ARN_VARIABLE, ROLE_ARN));
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), containsString(TOKEN_FILE_VARIABLE));
+        assertThat("a broken source must not be papered over with an STS call", transport.requestCount(), is(0));
+    }
+
+    @Test
+    void failsWhenTheTokenFileIsEmpty() throws Exception {
+        FakeTransport transport = new FakeTransport();
+        AwsCredentialsProvider provider = new WebIdentityTokenCredentialsProvider(TestEnvironment.empty()
+                .with(TOKEN_FILE_VARIABLE, writeTokenFile("\n"))
+                .with(ROLE_ARN_VARIABLE, ROLE_ARN));
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class, () -> provider.resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("empty"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /**
+     * The region is interpolated into the hostname of a request whose body carries the projected
+     * service-account token. Without validation, a region of {@code attacker.example/collect} builds
+     * {@code https://sts.attacker.example/collect.amazonaws.com/} and posts the token there.
+     */
+    @Test
+    void refusesARegionThatWouldRedirectTheTokenToAnotherHost() throws Exception {
+        FakeTransport transport = new FakeTransport();
+        TestEnvironment environment = configured().with("AWS_REGION", "attacker.example/collect");
+
+        AwsCredentialsException failure = assertThrows(AwsCredentialsException.class,
+                () -> new WebIdentityTokenCredentialsProvider(environment).resolve(transport));
+
+        assertThat(failure.getMessage(), containsString("not a valid AWS region name"));
+        assertThat(transport.requestCount(), is(0));
+    }
+
+    /** STS answers on a different suffix in the China partition, so the region decides the host. */
+    @Test
+    void usesThePartitionSuffixForTheRegionalStsEndpoint() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(EXPIRATION));
+
+        new WebIdentityTokenCredentialsProvider(configured().with("AWS_REGION", "cn-north-1")).resolve(transport);
+
+        assertThat(transport.lastRequest().uri().toString(), is("https://sts.cn-north-1.amazonaws.com.cn/"));
+    }
+
+    /**
+     * The AWS SDKs accept these three as JVM system properties before their environment equivalents.
+     * A deployment that sets them the documented way would otherwise skip web identity entirely and
+     * fall through to a later, wrong source.
+     */
+    @Test
+    void readsTheWebIdentitySettingsFromSystemPropertiesToo() throws Exception {
+        FakeTransport transport = new FakeTransport().respondWith(200, credentialsResponse(EXPIRATION));
+        TestEnvironment environment = TestEnvironment.empty()
+                .withProperty("aws.webIdentityTokenFile", writeTokenFile(TOKEN + "\n"))
+                .withProperty("aws.roleArn", ROLE_ARN)
+                .withProperty("aws.roleSessionName", "from-a-system-property");
+
+        AwsCredentials credentials = new WebIdentityTokenCredentialsProvider(environment).resolve(transport);
+
+        assertThat(credentials.isTemporary(), is(true));
+        assertThat(transport.lastRequest().bodyAsString(), containsString("RoleSessionName=from-a-system-property"));
+    }
+
+    private TestEnvironment configured() throws IOException {
+        return TestEnvironment.empty()
+                .with(TOKEN_FILE_VARIABLE, writeTokenFile(TOKEN + "\n"))
+                .with(ROLE_ARN_VARIABLE, ROLE_ARN);
+    }
+
+    private String writeTokenFile(String content) throws IOException {
+        Path file = tempDir.resolve("web-identity-token");
+        Files.writeString(file, content);
+        return file.toString();
+    }
+
+    /** @param expiration the {@code Expiration} value, or {@code null} to leave the element out */
+    private static String credentialsResponse(String expiration) {
+        return """
+                <AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+                  <AssumeRoleWithWebIdentityResult>
+                    <Credentials>
+                      <AccessKeyId>ASIAEXAMPLEKEYID</AccessKeyId>
+                      <SecretAccessKey>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</SecretAccessKey>
+                      <SessionToken>FwoGZXIvYXdzEExampleSessionToken</SessionToken>
+                      %s
+                    </Credentials>
+                  </AssumeRoleWithWebIdentityResult>
+                </AssumeRoleWithWebIdentityResponse>
+                """.formatted(expiration == null ? "" : "<Expiration>" + expiration + "</Expiration>");
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/providers/AwsSesEmailSenderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/providers/AwsSesEmailSenderTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.providers;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.ws.rs.WebApplicationException;
+
+import org.keycloak.email.aws.AwsSesEmailSenderProviderFactory;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.ErrorRepresentation;
+import org.keycloak.testframework.annotations.InjectHttpServer;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * End-to-end test of the Amazon SES email sender against a stub of the SES v2 API.
+ * <p>
+ * A real Keycloak boots with {@code --spi-email-sender--provider=aws-ses}, an administrator triggers
+ * a real execute-actions email, and the assertions are made on the bytes that left the server. No AWS
+ * account, no credentials and no network are involved: the provider's {@code endpoint} option points
+ * SES at the test framework's shared HTTP server, and the AWS credential chain is fed a throwaway key
+ * pair through the two JVM system properties that sit first in it.
+ * <p>
+ * What this covers that the unit tests cannot: that the provider is reachable through Keycloak's own
+ * provider resolution, that it signs with the right credential scope, and that the message Keycloak
+ * composed survives the round trip to the wire as a valid MIME document.
+ */
+@KeycloakIntegrationTest(config = AwsSesEmailSenderTest.AwsSesServerConfig.class)
+public class AwsSesEmailSenderTest {
+
+    /**
+     * The injected HTTP server is a global singleton shared by every test class, so the context path
+     * has to be unique and has to be removed again after each test.
+     */
+    private static final String STUB_CONTEXT_PATH = "/aws-ses-integration-test";
+
+    /**
+     * The framework's server binds 127.0.0.1:8500. The address cannot be read from the injected
+     * instance here because the server configuration is built before injection happens, so it is
+     * repeated as a constant and checked against the real one in {@link #registerSesStub()}.
+     */
+    private static final String STUB_AUTHORITY = "127.0.0.1:8500";
+    private static final String SES_ENDPOINT = "http://" + STUB_AUTHORITY + STUB_CONTEXT_PATH;
+
+    private static final String REGION = "eu-central-1";
+
+    // The example key pair from the AWS documentation: valid in shape, useless as a credential.
+    private static final String ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE";
+    private static final String SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+    private static final String FROM = "no-reply@keycloak.org";
+    private static final String FROM_DISPLAY_NAME = "Keycloak SES";
+    private static final String RECIPIENT = "ses-recipient@keycloak.org";
+
+    private static final String MESSAGE_ID = "0100018f-aws-ses-it";
+
+    @InjectRealm(config = SesRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectUser(config = SesUserConfig.class)
+    ManagedUser user;
+
+    @InjectHttpServer
+    HttpServer httpServer;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    private final List<RecordedRequest> recorded = Collections.synchronizedList(new ArrayList<>());
+
+    private volatile HttpHandler responder = AwsSesEmailSenderTest::sendAccepted;
+
+    @BeforeEach
+    public void registerSesStub() {
+        // Credentials are deliberately not a server option — the provider has none, so that no secret
+        // can end up in Keycloak's configuration — so they have to arrive through the standard AWS
+        // chain, whose first link is these two JVM system properties. They are set inside the server's
+        // own JVM rather than this one because the framework's default managed server is the
+        // distribution, a separate process that does not share this JVM's properties or environment.
+        runOnServer.run(session -> {
+            System.setProperty("aws.accessKeyId", ACCESS_KEY_ID);
+            System.setProperty("aws.secretAccessKey", SECRET_ACCESS_KEY);
+        });
+
+        assertThat("the SES endpoint option must point at the injected HTTP server",
+                httpServer.getAddress().getHostString() + ":" + httpServer.getAddress().getPort(),
+                equalTo(STUB_AUTHORITY));
+
+        httpServer.createContext(STUB_CONTEXT_PATH, exchange -> {
+            recorded.add(RecordedRequest.read(exchange));
+            responder.handle(exchange);
+        });
+    }
+
+    @AfterEach
+    public void unregisterSesStub() {
+        httpServer.removeContext(STUB_CONTEXT_PATH);
+        runOnServer.run(session -> {
+            System.clearProperty("aws.accessKeyId");
+            System.clearProperty("aws.secretAccessKey");
+        });
+    }
+
+    @Test
+    public void sendsSignedRawMessageToSesEndpoint() throws Exception {
+        executeActionsEmail();
+
+        assertThat(recorded, hasSize(1));
+        RecordedRequest request = recorded.get(0);
+        assertThat(request.method(), equalTo("POST"));
+        assertThat(request.path(), endsWith("/v2/email/outbound-emails"));
+
+        String authorization = request.headers().getFirst("Authorization");
+        assertThat(authorization, startsWith("AWS4-HMAC-SHA256 Credential="));
+        // The signing service is "ses", not the "email" hostname prefix; getting it wrong is a silent
+        // 403 in production.
+        assertThat(authorization, containsString("/" + REGION + "/ses/aws4_request"));
+        assertThat(request.headers().getFirst("X-Amz-Date"), notNullValue());
+
+        JsonNode payload = JsonSerialization.mapper.readTree(request.body());
+        byte[] mime = Base64.getDecoder().decode(payload.get("Content").get("Raw").get("Data").asText());
+
+        assertThat("SES refuses a raw message containing a bare LF", indexOfBareLineFeed(mime), equalTo(-1));
+
+        MimeMessage message = new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(mime));
+        assertThat(message.getHeader("To", null), equalTo(RECIPIENT));
+        assertThat(message.getContentType(), startsWith("multipart/alternative"));
+
+        String from = message.getHeader("From", null);
+        InternetAddress fromAddress = InternetAddress.parse(from)[0];
+        assertThat(fromAddress.getAddress(), equalTo(FROM));
+        assertThat(fromAddress.getPersonal(), equalTo(FROM_DISPLAY_NAME));
+
+        // AWS never documents which identity wins when the envelope sender and the header disagree,
+        // so the provider derives both from one address; this is the assertion that keeps it that way.
+        assertThat(payload.get("FromEmailAddress").asText(), equalTo(from));
+    }
+
+    @Test
+    public void failsTheAdminOperationWhenSesRejectsTheMessage() {
+        responder = AwsSesEmailSenderTest::sendRejected;
+
+        WebApplicationException failure = assertThrows(WebApplicationException.class, this::executeActionsEmail);
+
+        assertThat(failure.getResponse().getStatus(), equalTo(500));
+        assertThat(failure.getResponse().readEntity(ErrorRepresentation.class).getErrorMessage(),
+                allOf(containsString("MessageRejected"), containsString("Email address is not verified.")));
+
+        // SES SendEmail has no idempotency token, so a refused send must not be replayed into a second
+        // message in a real inbox.
+        assertThat(recorded, hasSize(1));
+    }
+
+    private void executeActionsEmail() {
+        realm.admin().users().get(user.getId())
+                .executeActionsEmail(List.of(UserModel.RequiredAction.UPDATE_PASSWORD.name()));
+    }
+
+    private static void sendAccepted(HttpExchange exchange) throws IOException {
+        respond(exchange, 200, Map.of("Content-Type", "application/json"),
+                "{\"MessageId\":\"" + MESSAGE_ID + "\"}");
+    }
+
+    private static void sendRejected(HttpExchange exchange) throws IOException {
+        respond(exchange, 400, Map.of("Content-Type", "application/json", "x-amzn-ErrorType", "MessageRejected"),
+                "{\"message\":\"Email address is not verified.\"}");
+    }
+
+    /**
+     * Not {@code HttpServerUtil.sendResponse}: that helper sets the response headers after
+     * {@code sendResponseHeaders}, by which point they are no longer sent — and this test depends on
+     * {@code x-amzn-ErrorType} reaching the client.
+     */
+    private static void respond(HttpExchange exchange, int status, Map<String, String> headers, String body)
+            throws IOException {
+        headers.forEach((name, value) -> exchange.getResponseHeaders().set(name, value));
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        try {
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        } finally {
+            exchange.close();
+        }
+    }
+
+    /** @return the index of the first {@code 0x0A} not preceded by a {@code 0x0D}, or -1 if there is none */
+    private static int indexOfBareLineFeed(byte[] mime) {
+        for (int i = 0; i < mime.length; i++) {
+            if (mime[i] == '\n' && (i == 0 || mime[i - 1] != '\r')) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private record RecordedRequest(String method, String path, Headers headers, byte[] body) {
+
+        static RecordedRequest read(HttpExchange exchange) throws IOException {
+            Headers headers = new Headers();
+            headers.putAll(exchange.getRequestHeaders());
+            try (InputStream in = exchange.getRequestBody()) {
+                return new RecordedRequest(exchange.getRequestMethod(), exchange.getRequestURI().getPath(),
+                        headers, in.readAllBytes());
+            }
+        }
+    }
+
+    public static class AwsSesServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config
+                    .option("spi-email-sender--provider", AwsSesEmailSenderProviderFactory.PROVIDER_ID)
+                    .spiOption("email-sender", AwsSesEmailSenderProviderFactory.PROVIDER_ID, "region", REGION)
+                    .spiOption("email-sender", AwsSesEmailSenderProviderFactory.PROVIDER_ID, "endpoint", SES_ENDPOINT);
+        }
+    }
+
+    public static class SesRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            // The SES sender takes the sender address and display name from the realm's existing SMTP
+            // block, exactly as the SMTP sender does; host and port have no meaning for it.
+            return realm.update(rep -> rep.setSmtpServer(Map.of("from", FROM, "fromDisplayName", FROM_DISPLAY_NAME)));
+        }
+    }
+
+    public static class SesUserConfig implements UserConfig {
+
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            return user.username("ses-recipient").name("Ses", "Recipient").email(RECIPIENT);
+        }
+    }
+}


### PR DESCRIPTION
Closes #52360
Discussion: #52359

## What

Adds an `EmailSenderProvider` with the id `aws-ses` that delivers Keycloak's transactional email through the **Amazon SES v2 API**, signed with **AWS SigV4**, instead of through SES's SMTP interface. It does nothing unless selected with `--spi-email-sender--provider=aws-ses`.

## Why

SES SMTP requires a username and password derived from a long-lived IAM user's secret access key. It cannot be an assumed role, AWS does not rotate it, and it lives in `realm.smtpServer.password`. A Keycloak on EKS, ECS or EC2 cannot use the identity its platform already gives it. `email.adoc` documents the dead end today: *"XOAUTH2 is not supported by the AWS-SMTP service. The AWS-service requires the use of a password."*

## How

- **No new dependencies.** SigV4 signing, the AWS credential chain, JSON and MIME are implemented against what the server already ships: `HttpClientProvider` (Apache HttpClient), `JsonSerialization` (Jackson) and `jakarta.mail`. No AWS SDK, no new Maven module, no pom changes — one package under `services/src/main/java/org/keycloak/email/aws/` and one appended line in `META-INF/services/org.keycloak.email.EmailSenderProviderFactory`, the same shape as #36665.
- **Message parity.** The MIME is built exactly as `DefaultEmailSenderProvider` builds it — same `multipart/alternative`, same header order, same RFC 2047 subject encoding, `Reply-To` defaulting to `From`, the same IDN conversion `convertEmail` performs — and sent as `Content.Raw`, so a realm that switches transport changes nothing a recipient can observe. `FromEmailAddress` and the MIME `From` header are derived from a single `InternetAddress`, so the parameter and the header cannot disagree.
  One difference from the SMTP path is deliberate: `MimeMessage.writeTo` emits bare LF inside 7bit parts, which the mail implementation's own CRLF stream hides on the SMTP socket and nothing hides on an API call, so line endings are normalised before the message is base64-encoded.
- **Realm settings keep their meaning**: `from`, `fromDisplayName`, `replyTo`, `replyToDisplayName`, `timeout`, `connectionTimeout`. `envelopeFrom` maps to `FeedbackForwardingEmailAddress`; that mapping is partial — SES fixes the SMTP envelope sender to the identity's MAIL FROM domain — and is documented and warned about rather than presented as lossless.
- **Credentials** come only from the standard AWS chain (system properties, environment, web identity token, shared config files, container credentials, IMDSv2), never from Keycloak configuration, because `kc.sh show-config` prints unregistered SPI options unmasked. The container and instance-metadata lookups are constrained to the documented AWS endpoints, and IMDSv1 is not implemented.
- **No retries.** SES `SendEmail` has no idempotency token, so a retried request that reached AWS would put a second activation email in a user's inbox. Note that the shared HTTP client installs `DefaultHttpRequestRetryHandler` regardless, and turns it into a resend-after-send when `spi-connections-http-client-default-max-retries` is set; since that cannot be opted out of per request, the factory logs a warning when it sees it.
- **Inert by default.** `order()` stays 0, so the provider cannot win default-provider resolution by accident. A misconfiguration is fatal at boot only when this provider is the one the server was told to use — a Keycloak that cannot send an activation link should not start pretending it can — and is silent otherwise.

## Testing

- **234 unit tests** in `services/src/test/java/org/keycloak/email/aws/`: SigV4 against **AWS's published signing test vectors**, MIME parity with the SMTP sender, the request body, error mapping, and every credential source. JUnit 5 + Hamcrest, **no mocking framework** — the three collaborators that touch the outside world (HTTP, the process environment, the clock) are interfaces with hand-written fakes.
- **`AwsSesEmailSenderTest`** in `tests/base` (`org.keycloak.tests.providers`, already registered in Base3, so `check-base-suites.sh` needs no change) runs a real server with the sender selected, points the provider's `endpoint` option at the `@InjectHttpServer` stub, triggers an admin execute-actions email, and asserts on the bytes that left the server: the SigV4 credential scope, and the base64-decoded MIME's structure, `To`, `From` and line endings. A second test answers `400` with `x-amzn-ErrorType: MessageRejected` and asserts the failure reaches the administrator. **No AWS account, no credentials, no network.**
- Additionally run against real `quay.io/keycloak/keycloak` containers for **26.0.7 and 26.7.3** to confirm the compatibility decision below, including a negative control (with the option removed the run fails, so the test cannot pass for the wrong reason).

## Compatibility

`validate(Map)` is declared **without `@Override`**: it does not exist on 26.0.x, 26.1.x or 26.3.0–26.3.2 and is abstract on newer releases, so this is what lets one implementation work across the range. Verified on both ends: on 26.7.3 a realm update with a malformed `from` returns 400 with this provider's own message, i.e. the server really does dispatch into it; on 26.0.7 the same update returns 204.

Nothing existing changes behaviour: the default sender stays `default`, and the only edit to an existing file is the appended service-registration line.

## Documentation

- `server_admin/topics/realms/email.adoc`: a section inside the existing `ifeval::[{project_community}==true]` guard, next to the XOAUTH2 vendor notes, carrying the same "provided as-is" disclaimer.
- A release note in `release_notes/topics/26_8_0.adoc`.

## Notes for the reviewer

While writing the integration test I hit what looks like a pre-existing bug in the test framework: `HttpServerUtil.sendResponse` sets the response headers *after* calling `exchange.sendResponseHeaders(...)`, so they are never sent. Its only current caller does not check them, which is why it has gone unnoticed. I have sent a separate one-line fix; this PR carries its own small `respond()` helper so the two are independent.

*Disclosure per CONTRIBUTING: AI agents were used in researching and writing this change.*
