### PR TITLE
Use Pod name as Infinispan/JGroups node name for stable metrics

### DIFF
--- a/docs/documentation/release_notes/topics/26_8_0.adoc
+++ b/docs/documentation/release_notes/topics/26_8_0.adoc
@@ -30,6 +30,18 @@ Deployments using the `multi-site` or `clusterless` features continue to store l
 The previous in-memory behavior is available as `login-failures:v1` but is deprecated.
 For details, see the link:{upgradingguide_link}[{upgradingguide_name}].
 
+== First-class CLI options for cluster and node name
+// https://github.com/keycloak/keycloak/issues/44605
+
+The embedded cache cluster name and node name can now be configured with the new `--cache-embedded-cluster-name` and `--cache-embedded-node-name` CLI options, replacing the low-level SPI options that were previously required.
+
+By default, the node name is a random value generated on each start, making it difficult to correlate metrics, logs, and JGroups diagnostics across restarts.
+Setting a stable node name is especially useful for observability tools such as Grafana dashboards and log aggregation.
+
+When deploying with the {project_name} Operator, the node name is now automatically set to the Kubernetes pod name (for example, `keycloak-0`).
+For standalone deployments on Kubernetes, set `KC_CACHE_EMBEDDED_NODE_NAME` using the downward API to inject the pod name.
+For non-Kubernetes deployments, pass `--cache-embedded-node-name=<name>` with a value that uniquely identifies each node.
+
 == Automatic non-blocking index creation for large tables
 // https://github.com/keycloak/keycloak/issues/46555
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -257,7 +257,7 @@ env:
         fieldPath: metadata.name
 ----
 
-*Bare-metal of VM deployments*
+*Bare-metal or VM deployments*
 
 Pass `+--cache-embedded-node-name=<name>+` with a value that uniquely identifies each node, for example the hostname.
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -219,14 +219,47 @@ You can opt out of this feature by setting `+--spi-connections-jpa--quarkus--asy
 
 === Stateless feature requires a distinct cluster name
 
-The `stateless` feature now requires `--cache-embedded-cluster-name` to be set explicitly to a value other than the default `ISPN`.
+The `stateless` feature now requires `+--cache-embedded-cluster-name+` to be set explicitly to a value other than the default `ISPN`.
 {project_name} refuses to start if the `stateless` feature is enabled and this option is missing or still set to `ISPN`.
 
-Previously, the cluster name had to be configured through the low-level SPI option `spi-cache-embedded--default--cluster-name` (or the environment variable `KC_SPI_CACHE_EMBEDDED__DEFAULT__CLUSTER_NAME`).
-This option is now superseded by the first-class CLI option `--cache-embedded-cluster-name` (environment variable `KC_CACHE_EMBEDDED_CLUSTER_NAME`).
+Previously, the cluster name had to be configured through the low-level SPI option `+spi-cache-embedded--default--cluster-name+` (or the environment variable `+KC_SPI_CACHE_EMBEDDED__DEFAULT__CLUSTER_NAME+`).
+This option is now superseded by the first-class CLI option `+--cache-embedded-cluster-name+` (environment variable `+KC_CACHE_EMBEDDED_CLUSTER_NAME+`).
 
-If you use the `stateless` feature, add `--cache-embedded-cluster-name=<unique-name>` to your startup command with a name that is unique per deployment.
+If you use the `stateless` feature, add `+--cache-embedded-cluster-name=<unique-name>+` to your startup command with a name that is unique per deployment.
 Two deployments sharing the same database must use different cluster names so that cross-cluster cache invalidation works correctly.
+
+=== First-class CLI options for cluster and node name
+// https://github.com/keycloak/keycloak/issues/44605
+
+The embedded cache cluster name and node name are now configurable with the first-class CLI options `--cache-embedded-cluster-name` (environment variable `+KC_CACHE_EMBEDDED_CLUSTER_NAME+`) and `--cache-embedded-node-name` (environment variable `+KC_CACHE_EMBEDDED_NODE_NAME+`).
+These replace the low-level SPI options `+spi-cache-embedded--default--cluster-name+` and `+spi-cache-embedded--default--node-name+`.
+The SPI options continue to work but the new CLI options are recommended.
+
+The node name appears in Infinispan and JGroups log messages, metrics tags, and management tools.
+By default, a random name is generated on each start, which makes it difficult to correlate metrics and logs across restarts.
+Setting a stable node name improves observability, especially with tools such as Grafana dashboards and log aggregation.
+
+*{project_name} Operator*
+
+When deploying with the {project_name} Operator, this is now set automatically to the Kubernetes Pod name.
+No additional configuration is needed.
+
+*Standalone Kubernetes deployments (without the Operator)*
+
+Add the following environment variable to your pod spec to set the node name to the Pod name:
+
+[source,yaml]
+----
+env:
+  - name: KC_CACHE_EMBEDDED_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+----
+
+*Bare-metal of VM deployments*
+
+Pass `+--cache-embedded-node-name=<name>+` with a value that uniquely identifies each node, for example the hostname.
 
 === Keycloak validates cluster names when using jdbc-ping discovery
 

--- a/docs/guides/observability/partials/jgrp_metrics.adoc
+++ b/docs/guides/observability/partials/jgrp_metrics.adoc
@@ -5,6 +5,9 @@
 If metrics from multiple clusters are being collected, this tag helps identify where they belong to.
 
 `node=<node>`:: The name of the node reporting the metric.
+By default, this is a random name generated on each start.
+To assign a stable name, set `+--cache-embedded-node-name+` as described in <@links.server id="caching" anchor="cluster-identification"/>.
+The {project_name} Operator sets this to the pod name automatically.
 ====
 
 [WARNING]

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -87,6 +87,7 @@ public class KeycloakDeploymentDependentResource extends VersionTolerantCRUDKube
 
     public static final String POD_IP = "POD_IP";
     public static final String HOST_IP_SPI_OPTION = "KC_SPI_CACHE_EMBEDDED_DEFAULT_MACHINE_NAME";
+    public static final String CACHE_EMBEDDED_NODE_NAME = "KC_CACHE_EMBEDDED_NODE_NAME";
 
     private static final List<String> COPY_ENV = Arrays.asList("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY");
 
@@ -585,6 +586,9 @@ public class KeycloakDeploymentDependentResource extends VersionTolerantCRUDKube
         // Using spec.nodeName to avoid exposing the IP addresses in the logs.
         envVars.add(new EnvVarBuilder().withName(HOST_IP_SPI_OPTION).withNewValueFrom().withNewFieldRef()
                 .withFieldPath("spec.nodeName").withApiVersion("v1").endFieldRef().endValueFrom().build());
+
+        envVars.add(new EnvVarBuilder().withName(CACHE_EMBEDDED_NODE_NAME).withNewValueFrom().withNewFieldRef()
+                .withFieldPath("metadata.name").withApiVersion("v1").endFieldRef().endValueFrom().build());
 
         return envVars;
     }

--- a/operator/src/main/java/org/keycloak/operator/update/impl/BaseUpdateLogic.java
+++ b/operator/src/main/java/org/keycloak/operator/update/impl/BaseUpdateLogic.java
@@ -157,6 +157,7 @@ abstract class BaseUpdateLogic implements UpdateLogic {
         return container.getEnv().stream()
                 .filter(envVar -> !envVar.getName().equals(KeycloakDeploymentDependentResource.POD_IP))
                 .filter(envVar -> !envVar.getName().equals(KeycloakDeploymentDependentResource.HOST_IP_SPI_OPTION))
+                .filter(envVar -> !envVar.getName().equals(KeycloakDeploymentDependentResource.CACHE_EMBEDDED_NODE_NAME))
                 .collect(Collectors.toMap(EnvVar::getName, Function.identity()));
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -534,6 +534,10 @@ public class PodTemplateTest {
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TELEMETRY_RESOURCE_ATTRIBUTES));
         assertThat(envVars.stream()).noneMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRACING_RESOURCE_ATTRIBUTES));
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.POD_IP));
+        assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.CACHE_EMBEDDED_NODE_NAME)
+                && envVar.getValueFrom() != null
+                && envVar.getValueFrom().getFieldRef() != null
+                && "metadata.name".equals(envVar.getValueFrom().getFieldRef().getFieldPath()));
 
         var readiness = container.getReadinessProbe().getHttpGet();
         assertNotNull(readiness);


### PR DESCRIPTION
Closes #44605

## Summary

- The Keycloak Operator now automatically sets `KC_CACHE_EMBEDDED_NODE_NAME` to the Kubernetes pod name via the downward API (`metadata.name`), giving each pod a stable node name (e.g. `keycloak-0`) for metrics and logs.
- Added release notes, migration guide entries, and a note in the JGroups metrics docs.

## Design decisions

### Stable name instead of filtering the tag

The issue proposed filtering out the `node` tag from Infinispan metrics. Instead, this PR makes the tag stable by setting it to the pod name, which preserves the tag's usefulness for correlating metrics across nodes while solving the cardinality problem caused by random names on every restart.

### Env var set unconditionally (user value takes precedence)

The `KC_CACHE_EMBEDDED_NODE_NAME` env var is added alongside the existing downward API env vars (`POD_IP`, `KC_SPI_CACHE_EMBEDDED_DEFAULT_MACHINE_NAME`). If a user explicitly sets `cache-embedded-node-name` via `additionalOptions` or the unsupported pod template, their value takes precedence because those sources are merged first in the env var priority order in `addEnvVars()`.

### Excluded from rolling-update equality check

`BaseUpdateLogic.envVars()` filters out downward API env vars before comparing actual vs. desired state, because their values are pod-specific and resolved at runtime. `KC_CACHE_EMBEDDED_NODE_NAME` is added to this filter list, matching the existing treatment of `POD_IP` and `KC_SPI_CACHE_EMBEDDED_DEFAULT_MACHINE_NAME`.

## Test plan

- [x] `PodTemplateTest#testDefaults` extended to assert `KC_CACHE_EMBEDDED_NODE_NAME` is present with `metadata.name` field ref


I also performed a local test and it works as expected, with the Pod name being `keycloak-operator-0` in this case (for an operator based Keycloak deployment): 

```
2026-09-03 14:54:18,416 INFO  [org.infinispan.CLUSTER] (executor-thread-1) ISPN000094: Received new cluster view for channel ISPN: [keycloak-operator-0(v=16.0.14, m=minikube)|0] (1) [keycloak-operator-0(v=16.0.14, m=minikube)]
2026-09-03 14:54:18,419 INFO  [org.keycloak.jgroups.certificates.CertificateReloadManager] (executor-thread-1) Reloading JGroups Certificate
2026-09-03 14:54:18,479 INFO  [org.infinispan.CLUSTER] (executor-thread-1) ISPN000079: Channel `ISPN` local address is `keycloak-operator-0`, physical addresses are `[10.244.0.128:7800]`
```