### PR TITLE
Correct groups-in-role schema in Admin REST OpenAPI spec

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -634,7 +634,7 @@ public class RoleContainerResource extends RoleResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ROLES)
     @Operation(summary = "Returns a stream of groups that have the specified role name")
     @APIResponses(value = {
-        @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = UserRepresentation.class, type = SchemaType.ARRAY))),
+        @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = GroupRepresentation.class, type = SchemaType.ARRAY))),
         @APIResponse(responseCode = "403", description = "Forbidden"),
         @APIResponse(responseCode = "404", description = "Not Found")
     })


### PR DESCRIPTION
The Admin REST OpenAPI specification declares the groups-in-role endpoints as returning UserRepresentation arrays even though their runtime responses contain GroupRepresentation arrays.

This changes only the OpenAPI response schema annotation on RoleContainerResource.getGroupsInRole(). It does not change runtime endpoint behavior. Because the resource is mounted for both realm and client roles, the generated specification is corrected for both endpoints:

- GET /admin/realms/{realm}/roles/{role-name}/groups
- GET /admin/realms/{realm}/clients/{client-uuid}/roles/{role-name}/groups

The generated Admin REST OpenAPI specification was validated after the change. Both operations now define the 200 response as an array whose items reference GroupRepresentation.

Closes #52378

Validation:
- ./mvnw spotless:check
- ./mvnw -pl services -am test -DskipTests=false (679 tests run, 0 failures, 0 errors, 2 skipped)
- ./mvnw clean package -am -pl services -Pjboss-release -DskipTests (OpenAPI schema, AsciiDoc, and HTML documentation generation)

AI usage: Codex was used to help implement and validate this change.