### PR TITLE
Fix nested group URLs in the admin console

### DIFF
--- a/js/apps/admin-ui/src/PageNav.tsx
+++ b/js/apps/admin-ui/src/PageNav.tsx
@@ -14,6 +14,7 @@ import { useRealm } from "./context/realm-context/RealmContext";
 import { useServerInfo } from "./context/server-info/ServerInfoProvider";
 import type { Environment } from "./environment-types";
 import { toPage } from "./page/routes";
+import { normalizeNavRoutePath } from "./page-nav-utils";
 import { routes } from "./routes";
 import { resolveDisplayName } from "./util";
 import useIsFeatureEnabled, { Feature } from "./utils/useIsFeatureEnabled";
@@ -31,9 +32,9 @@ const LeftNav = ({ title, path, id }: LeftNavProps) => {
   const { hasAccess } = useAccess();
   const { realm } = useRealm();
   const encodedRealm = encodeURIComponent(realm);
+  const navPath = id || path;
   const route = routes.find(
-    (route) =>
-      route.path.replace(/\/:.+?(\?|(?:(?!\/).)*|$)/g, "") === (id || path),
+    (route) => normalizeNavRoutePath(route.path) === navPath,
   );
 
   const accessAllowed =

--- a/js/apps/admin-ui/src/__tests__/page-nav-utils.test.ts
+++ b/js/apps/admin-ui/src/__tests__/page-nav-utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { normalizeNavRoutePath } from "../page-nav-utils";
+
+describe("normalizeNavRoutePath", () => {
+  it("matches splat routes to their base nav path", () => {
+    expect(normalizeNavRoutePath("/:realm/groups/*")).toBe("/groups");
+  });
+
+  it("matches parameterized routes without splats", () => {
+    expect(normalizeNavRoutePath("/:realm/clients")).toBe("/clients");
+    expect(normalizeNavRoutePath("/:realm/groups/:id")).toBe("/groups");
+  });
+});

--- a/js/apps/admin-ui/src/groups/__tests__/Groups.test.ts
+++ b/js/apps/admin-ui/src/groups/__tests__/Groups.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { toGroups } from "../routes/Groups";
+
+describe("toGroups", () => {
+  it("preserves hierarchy separators in realm group paths", () => {
+    expect(
+      toGroups({ realm: "master", id: "parent-id/child-id" }).pathname,
+    ).toBe("/master/groups/parent-id/child-id");
+  });
+
+  it("preserves hierarchy separators in organization group paths", () => {
+    expect(
+      toGroups({
+        realm: "master",
+        orgId: "organization-id",
+        id: "parent-id/child-id",
+      }).pathname,
+    ).toBe("/master/organizations/organization-id/groups/parent-id/child-id");
+  });
+
+  it("generates the group root path without an id", () => {
+    expect(toGroups({ realm: "master" }).pathname).toBe("/master/groups");
+  });
+});

--- a/js/apps/admin-ui/src/groups/routes.ts
+++ b/js/apps/admin-ui/src/groups/routes.ts
@@ -1,6 +1,6 @@
 import type { AppRouteObject } from "../routes";
-import { GroupsRoute, GroupsWithIdRoute } from "./routes/Groups";
+import { GroupsRoute } from "./routes/Groups";
 
-const routes: AppRouteObject[] = [GroupsRoute, GroupsWithIdRoute];
+const routes: AppRouteObject[] = [GroupsRoute];
 
 export default routes;

--- a/js/apps/admin-ui/src/groups/routes/Groups.tsx
+++ b/js/apps/admin-ui/src/groups/routes/Groups.tsx
@@ -27,16 +27,6 @@ export const OrgGroupsRoute: AppRouteObject = {
   },
 };
 
-export const GroupsWithIdRoute: AppRouteObject = {
-  ...GroupsRoute,
-  path: "/:realm/groups/:id",
-};
-
-export const OrgGroupsWithIdRoute: AppRouteObject = {
-  ...OrgGroupsRoute,
-  path: "/:realm/organizations/:orgId/groups/:id",
-};
-
 export const toGroups = (params: GroupsParams): Partial<Path> => {
   const path = params.orgId ? OrgGroupsRoute.path : GroupsRoute.path;
 

--- a/js/apps/admin-ui/src/groups/routes/Groups.tsx
+++ b/js/apps/admin-ui/src/groups/routes/Groups.tsx
@@ -38,14 +38,9 @@ export const OrgGroupsWithIdRoute: AppRouteObject = {
 };
 
 export const toGroups = (params: GroupsParams): Partial<Path> => {
-  const routes = {
-    orgGroups: params.id ? OrgGroupsWithIdRoute.path : OrgGroupsRoute.path,
-    realmGroups: params.id ? GroupsWithIdRoute.path : GroupsRoute.path,
-  };
-
-  const path = params.orgId ? routes.orgGroups : routes.realmGroups;
+  const path = params.orgId ? OrgGroupsRoute.path : GroupsRoute.path;
 
   return {
-    pathname: generatePath(path, params),
+    pathname: generatePath(path, { ...params, "*": params.id }),
   };
 };

--- a/js/apps/admin-ui/src/page-nav-utils.ts
+++ b/js/apps/admin-ui/src/page-nav-utils.ts
@@ -1,0 +1,2 @@
+export const normalizeNavRoutePath = (routePath: string): string =>
+  routePath.replace(/\/:.+?(\?|(?:(?!\/).)*|$)/g, "").replace(/\/\*$/, "");


### PR DESCRIPTION
Fixes #52241

Clicking a child group in the admin console currently builds a URL with `%2F` between the parent and child IDs, so the group details page fails to load.

This started with 26.7.3 when [PR #52136](https://github.com/keycloak/keycloak/pull/52136) upgraded React Router from 6.30.4 to 7.18.2 ([commit](https://github.com/keycloak/keycloak/commit/6afd3d75895c6889581d9c3f4a0dafd58ab0d435)). React Router 7 now escapes `/` in `:id` parameters. Since the group URL builder passes the whole hierarchy as one ID, the separator gets escaped too.

The fix builds the nested path as separate URL segments instead of passing the whole hierarchy through a single `:id` parameter. Tests cover both realm and organization group paths.

Tested with:
`vitest run src/groups/__tests__/Groups.test.ts`