### PR TITLE
Fix LDAP sync to return error on authentication/connection failures

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageSyncTask.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageSyncTask.java
@@ -1,5 +1,9 @@
 package org.keycloak.storage;
 
+import javax.naming.AuthenticationException;
+import javax.naming.CommunicationException;
+import javax.naming.ServiceUnavailableException;
+
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.cluster.ExecutionResult;
 import org.keycloak.common.util.Time;
@@ -18,6 +22,8 @@ import org.keycloak.timer.TimerProvider;
 import org.keycloak.timer.TimerProvider.TimerTaskContext;
 
 import org.jboss.logging.Logger;
+
+import static org.keycloak.common.util.Throwables.isCausedBy;
 
 final class UserStorageSyncTask implements ScheduledTask {
 
@@ -71,7 +77,25 @@ final class UserStorageSyncTask implements ScheduledTask {
                 case CHANGED -> runIncrementalSync(session);
             };
         } catch (Throwable t) {
-            logger.errorf(t, "Error occurred during %s users-sync in realm %s and user provider %s",  syncMode, realmId, providerId);
+            String providerName = getStorageModel(session).getName();
+
+            // If already StorageUnavailableException (e.g., from LDAPQuery.getResultList()), rethrow it
+            if (t instanceof StorageUnavailableException) {
+                logger.errorf(t, "LDAP storage unavailable during %s users-sync in realm %s and user provider id %s",
+                        syncMode, realmId, providerId);
+                throw (StorageUnavailableException) t;
+            }
+
+            // Check if this is a critical LDAP error (caused by JNDI exceptions)
+            if (isCausedBy(t, AuthenticationException.class, CommunicationException.class, ServiceUnavailableException.class)) {
+                logger.errorf(t, "LDAP authentication or connection failure during %s users-sync in realm %s and user provider id %s",
+                        syncMode, realmId, providerId);
+                throw new StorageUnavailableException("LDAP authentication or connection failure for provider [" + providerName + "]", t);
+            }
+
+            // For non-critical errors, log and return empty result
+            logger.errorf(t, "Error occurred during %s users-sync in realm %s and user provider id %s (provider name %s)",
+                    syncMode, realmId, providerId, providerName);
         }
 
         return SynchronizationResult.empty();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.testsuite.federation.ldap;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -729,5 +731,65 @@ public class LDAPSyncTest extends AbstractLDAPTest {
             mapperModel.getConfig().putSingle(UserAttributeLDAPStorageMapper.LDAP_ATTRIBUTE, ctx.getLdapProvider().getLdapIdentityStore().getConfig().getUsernameLdapAttribute());
             ctx.getRealm().updateComponent(mapperModel);
         });
+    }
+
+    // Test for issue #52293 - LDAP sync should return error on authentication failure
+    @Test
+    public void testSyncWithInvalidBindCredentials() {
+        ComponentRepresentation ldapRep = managedRealm.admin().components().component(ldapModelId).toRepresentation();
+
+        try {
+            // Update bind credentials to incorrect value
+            ldapRep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, "wrongPassword123!");
+            managedRealm.admin().components().component(ldapModelId).update(ldapRep);
+
+            // Trigger full sync via Admin REST API - should throw BadRequestException (not return 200 OK)
+            Assertions.assertThrows(BadRequestException.class,
+                    () -> managedRealm.admin().userStorage().syncUsers(ldapModelId, "triggerFullSync"),
+                    "Sync should have failed with authentication error (HTTP 400)");
+
+            // Also verify periodic sync fails the same way
+            Assertions.assertThrows(BadRequestException.class,
+                    () -> managedRealm.admin().userStorage().syncUsers(ldapModelId, "triggerChangedUsersSync"),
+                    "Periodic sync should have failed with authentication error (HTTP 400)");
+
+        } finally {
+            // Restore correct bind credential for subsequent tests (LDAPRule default)
+            ldapRep.getConfig().putSingle(LDAPConstants.BIND_CREDENTIAL, "secret");
+            managedRealm.admin().components().component(ldapModelId).update(ldapRep);
+        }
+    }
+
+    // Test for issue #52293 - LDAP sync should return error when LDAP server is unreachable
+    @Test
+    public void testSyncWithUnreachableLDAPServer() throws IOException {
+        ComponentRepresentation ldapRep = managedRealm.admin().components().component(ldapModelId).toRepresentation();
+
+        try {
+            // Allocate an ephemeral port that's currently unused
+            int unusedPort;
+            try (ServerSocket socket = new ServerSocket(0)) {
+                unusedPort = socket.getLocalPort();
+            }
+
+            // Update connection URL to unreachable server (localhost with unused port for fast deterministic failure)
+            ldapRep.getConfig().putSingle(LDAPConstants.CONNECTION_URL, "ldap://localhost:" + unusedPort);
+            managedRealm.admin().components().component(ldapModelId).update(ldapRep);
+
+            // Trigger full sync via Admin REST API - should throw BadRequestException (not return 200 OK)
+            Assertions.assertThrows(BadRequestException.class,
+                    () -> managedRealm.admin().userStorage().syncUsers(ldapModelId, "triggerFullSync"),
+                    "Sync should have failed with communication error (HTTP 400)");
+
+            Assertions.assertThrows(BadRequestException.class,
+                    () -> managedRealm.admin().userStorage().syncUsers(ldapModelId, "triggerChangedUsersSync"),
+                    "Sync should have failed with communication error (HTTP 400)");
+
+        } finally {
+            // Restore correct connection URL for subsequent tests (from LDAPRule config)
+            String correctConnectionUrl = getLDAPRule().getConfig().get(LDAPConstants.CONNECTION_URL);
+            ldapRep.getConfig().putSingle(LDAPConstants.CONNECTION_URL, correctConnectionUrl);
+            managedRealm.admin().components().component(ldapModelId).update(ldapRep);
+        }
     }
 }


### PR DESCRIPTION
Fixes #52293

LDAP User Federation sync was incorrectly returning HTTP 200 OK with empty results when authentication or connection failures occurred, instead of properly reporting errors.

Changes:
- Detect critical LDAP exceptions (AuthenticationException, CommunicationException, ServiceUnavailableException) using Keycloak's existing isCausedBy() utility
- Throw as StorageUnavailableException to match existing LDAP error handling pattern
- Add integration tests for authentication and connection failures

The existing error handling in UserStorageProviderResource already properly converts StorageUnavailableException to HTTP 400 Bad Request responses.
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
