### PR TITLE
Honor kc_locale on the account v3 console

### DIFF
--- a/js/apps/account-ui/src/i18n.ts
+++ b/js/apps/account-ui/src/i18n.ts
@@ -13,6 +13,12 @@ export const keycloakLanguageDetector: LanguageDetectorModule = {
   type: "languageDetector",
 
   detect() {
+    const kcLocale = new URLSearchParams(window.location.search)
+      .get("kc_locale")
+      ?.trim();
+    if (kcLocale) {
+      return kcLocale;
+    }
     return environment.locale;
   },
 };


### PR DESCRIPTION
The login theme already reads `kc_locale` from the query string. The account console ignored it and always used the injected locale.

Closes #36116
