### PR TITLE
fix: merge scopes from subject token and form params in token exchange

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
@@ -20,9 +20,11 @@
 package org.keycloak.protocol.oidc.tokenexchange;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.MediaType;
@@ -37,6 +39,7 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -274,28 +277,65 @@ public class V1TokenExchangeProvider extends AbstractTokenExchangeProvider {
         if (token != null && token.getScope() != null && scope == null) {
             scope = token.getScope();
 
-            Set<String> targetClientScopes = new HashSet<String>();
-            targetClientScopes.addAll(targetClient.getClientScopes(true).keySet());
-            targetClientScopes.addAll(targetClient.getClientScopes(false).keySet());
+            Map<String, ClientScopeModel> targetClientScopeModels = collectTargetClientScopeModels(targetClient);
             //from return scope remove scopes that are not default or optional scopes for targetClient
-            scope = Arrays.stream(scope.split(" ")).filter(s -> "openid".equals(s) || (targetClientScopes.contains(Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES) ? s.split(":")[0] : s))).collect(Collectors.joining(" "));
+            scope = Arrays.stream(scope.split(" ")).filter(s -> "openid".equals(s) || targetClientScopeModels.containsKey(resolveScopeKey(s, targetClientScopeModels.values()))).collect(Collectors.joining(" "));
         } else if (token != null && token.getScope() != null) {
-            String subjectTokenScopes = token.getScope();
-            if (Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES)) {
-                Set<String> subjectTokenScopesSet = Arrays.stream(subjectTokenScopes.split(" ")).map(s -> s.split(":")[0]).collect(Collectors.toSet());
-                scope = Arrays.stream(scope.split(" ")).filter(sc -> subjectTokenScopesSet.contains(sc.split(":")[0])).collect(Collectors.joining(" "));
-            } else {
-                Set<String> subjectTokenScopesSet = Arrays.stream(subjectTokenScopes.split(" ")).collect(Collectors.toSet());
-                scope = Arrays.stream(scope.split(" ")).filter(sc -> subjectTokenScopesSet.contains(sc)).collect(Collectors.joining(" "));
-            }
+            Map<String, ClientScopeModel> targetClientScopeModels = collectTargetClientScopeModels(targetClient);
 
-            Set<String> targetClientScopes = new HashSet<String>();
-            targetClientScopes.addAll(targetClient.getClientScopes(true).keySet());
-            targetClientScopes.addAll(targetClient.getClientScopes(false).keySet());
+            // merge scopes from the subject token and the form params (union, not intersection).
+            // Each raw scope token is resolved to the name of the registered client scope it
+            // actually matches (via longest-prefix parameterized-scope matching, mirroring
+            // ClientScopeAuthorizationRequestParser#getMatchingClientScope) so that "scope:param"
+            // variants are deduped by their real target scope and not by a naive split(":")[0],
+            // which would incorrectly collide scopes whose own name contains a colon. The same
+            // resolver is used for the target-client-scope filter below, so a resolved
+            // parameterized scope is not immediately re-dropped by a naive split.
+            String subjectTokenScopes = token.getScope();
+            Map<String, String> scopeByResolvedName = new HashMap<>();
+            for (String s : subjectTokenScopes.split(" ")) {
+                if (!s.isEmpty()) {
+                    scopeByResolvedName.put(resolveScopeKey(s, targetClientScopeModels.values()), s);
+                }
+            }
+            for (String s : scope.split(" ")) {
+                if (!s.isEmpty()) {
+                    scopeByResolvedName.put(resolveScopeKey(s, targetClientScopeModels.values()), s);
+                }
+            }
+            scope = String.join(" ", scopeByResolvedName.values());
+
             //from return scope remove scopes that are not default or optional scopes for targetClient
-            scope = Arrays.stream(scope.split(" ")).filter(s -> "openid".equals(s) || (targetClientScopes.contains(Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES) ? s.split(":")[0] : s))).collect(Collectors.joining(" "));
+            scope = Arrays.stream(scope.split(" ")).filter(s -> "openid".equals(s) || targetClientScopeModels.containsKey(resolveScopeKey(s, targetClientScopeModels.values()))).collect(Collectors.joining(" "));
         }
         return scope;
+    }
+
+    /**
+     * Resolves a raw requested scope token (e.g. "read" or "read:account:42") to the name of the
+     * registered {@link ClientScopeModel} it actually matches, using the longest-name-first
+     * parameterized-scope matching strategy also used by
+     * {@link org.keycloak.protocol.oidc.rar.parsers.ClientScopeAuthorizationRequestParser}. Falls
+     * back to the raw token when no registered scope matches (e.g. the scope is invalid for the
+     * target client, in which case it is dropped by the caller's target-client-scope filter anyway).
+     */
+    private static String resolveScopeKey(String rawScope, Collection<ClientScopeModel> registeredScopes) {
+        if (!Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES)) {
+            return rawScope;
+        }
+        return registeredScopes.stream()
+                .sorted(Comparator.comparingInt((ClientScopeModel s) -> s.getName().length()).reversed())
+                .filter(s -> s.isParameterizedScope() ? s.getParameterFromScope(rawScope).isPresent() : s.getName().equals(rawScope))
+                .findFirst()
+                .map(ClientScopeModel::getName)
+                .orElse(rawScope);
+    }
+
+    private static Map<String, ClientScopeModel> collectTargetClientScopeModels(ClientModel targetClient) {
+        Map<String, ClientScopeModel> targetClientScopeModels = new HashMap<>();
+        targetClient.getClientScopes(true).values().forEach(s -> targetClientScopeModels.put(s.getName(), s));
+        targetClient.getClientScopes(false).values().forEach(s -> targetClientScopeModels.put(s.getName(), s));
+        return targetClientScopeModels;
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV1Test.java
@@ -248,7 +248,10 @@ public class StandardTokenExchangeV1Test extends AbstractKeycloakTest {
         Assertions.assertEquals(token.getPreferredUsername(), "user");
         Assertions.assertTrue(token.getRealmAccess() == null || !token.getRealmAccess().isUserInRole("example"));
         Assert.assertNames(Arrays.asList(token.getScope().split(" ")),"profile", "email", "openid", "phone");
-        //change scopes for token exchange - profile,phone must be removed
+        //change scopes for token exchange - email is removed via form scope (and also
+        //invalid for different-scope-client); phone is omitted from the form scope but
+        //still present on the subject token and valid for different-scope-client, so the
+        //scope-union logic preserves it in the exchanged token below
         oauth.scope("openid profile email");
         oauth.client("different-scope-client", "secret");
         {
@@ -259,7 +262,7 @@ public class StandardTokenExchangeV1Test extends AbstractKeycloakTest {
             Assertions.assertEquals("different-scope-client", exchangedToken.getIssuedFor());
             Assertions.assertNull(exchangedToken.getAudience());
             Assertions.assertEquals(exchangedToken.getPreferredUsername(), "user");
-            Assert.assertNames(Arrays.asList(exchangedToken.getScope().split(" ")),"profile", "openid");
+            Assert.assertNames(Arrays.asList(exchangedToken.getScope().split(" ")),"profile", "openid", "phone");
             Assertions.assertNull(exchangedToken.getEmailVerified());
         }
 
@@ -275,6 +278,37 @@ public class StandardTokenExchangeV1Test extends AbstractKeycloakTest {
             Assert.assertNames(Arrays.asList(exchangedToken.getScope().split(" ")),"profile", "email","openid");
             Assertions.assertFalse(exchangedToken.getEmailVerified());
         }
+        oauth.scope(null);
+    }
+
+    @Test
+    @UncaughtServerErrorExpected
+    public void testExchangeScopeParameterMergesWithSubjectTokenScope() throws Exception {
+        setupRealm();
+
+        oauth.realm(TEST);
+        oauth.client("client-exchanger", "secret");
+        // subject token intentionally does NOT include "phone"
+        oauth.scope("openid profile");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest("user", "password");
+        String accessToken = response.getAccessToken();
+        TokenVerifier<AccessToken> accessTokenVerifier = TokenVerifier.create(accessToken, AccessToken.class);
+        AccessToken token = accessTokenVerifier.parse().getToken();
+        Assert.assertNames(Arrays.asList(token.getScope().split(" ")), "profile", "openid");
+
+        // exchange requests "phone" via the form scope parameter, which is valid for
+        // different-scope-client but absent from the subject token above. The result
+        // must be the union of both scope sets (filtered by what the target client
+        // allows), not their intersection - otherwise "phone" would be silently dropped.
+        oauth.client("different-scope-client", "secret");
+        oauth.scope("openid profile phone");
+        response = oauth.doTokenExchange(accessToken);
+        String exchangedTokenString = response.getAccessToken();
+        TokenVerifier<AccessToken> verifier = TokenVerifier.create(exchangedTokenString, AccessToken.class);
+        AccessToken exchangedToken = verifier.parse().getToken();
+        Assertions.assertEquals("different-scope-client", exchangedToken.getIssuedFor());
+        Assert.assertNames(Arrays.asList(exchangedToken.getScope().split(" ")), "profile", "openid", "phone");
+
         oauth.scope(null);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/TokenExchangeTestUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/TokenExchangeTestUtils.java
@@ -74,6 +74,7 @@ public class TokenExchangeTestUtils {
         differentScopeClient.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
         differentScopeClient.setFullScopeAllowed(false);
         differentScopeClient.removeClientScope(realm.getClientScopesStream().filter(scope->"email".equals(scope.getName())).findAny().get());
+        differentScopeClient.addClientScope(realm.getClientScopesStream().filter(scope->"phone".equals(scope.getName())).findAny().get(), false);
 
         ClientModel clientExchanger = realm.addClient("client-exchanger");
         clientExchanger.setClientId("client-exchanger");


### PR DESCRIPTION
Fixes #52404

## What

`V1TokenExchangeProvider.getRequestedScope()` currently discards scopes that are present only in the form `scope` parameter when the subject token also carries a scope — it keeps the intersection of the two sets instead of the union.

This PR merges scopes from both sources (subject token + form params) into a single set before applying the existing target-client-scope filter.

Each raw scope token is resolved to the name of the **registered client scope it actually matches** — using the same longest-prefix parameterized-scope matching strategy as `ClientScopeAuthorizationRequestParser#getMatchingClientScope` — rather than a naive `split(":")[0]`. This avoids incorrectly colliding scopes whose own registered name legitimately contains a colon (e.g. a static scope `read:account` vs. a further-parameterized request `read:account:42`). The same resolver is reused for the target-client-scope filter, so a correctly-resolved parameterized scope is not immediately re-dropped by a naive split.

## Why

A client should be able to request additional valid scopes via the form parameter on top of what the subject token already carries, without either side silently overriding the other. We have run an earlier version of this fix in a downstream deployment for several months without regressions and would like to contribute it back properly.

## Testing

- `./mvnw -pl services -am compile` — clean
- `./mvnw -Pdocs,distribution,operator spotless:check -pl services` — clean
- Added `StandardTokenExchangeV1Test#testExchangeScopeParameterMergesWithSubjectTokenScope`: subject token has `openid profile`, form scope requests `openid profile phone`; exchanged token must contain all three. Fails under the old intersection-based logic (would drop `phone`).
- Extended `TokenExchangeTestUtils` to assign `phone` as an optional scope to `different-scope-client`, and updated `testExchangeDifferentScopesWithScopeParameter`'s existing assertion/comment accordingly (phone is now correctly preserved from the subject-token side of the union too).

## Commits

Two atomic, signed-off commits:
1. `fix:` — production code change (`V1TokenExchangeProvider.java`)
2. `test:` — regression test + required fixture change (test files)

## Checklist
- [x] Linked to issue #52404
- [x] Focused, minimal diff (no unrelated refactors)
- [x] Test coverage
- [x] DCO sign-off on all commits
- [x] Addressed all Copilot review feedback (scope collision on colon-containing names, filter consistency, missing regression test, existing-test regression)
