### PR TITLE
enforce one-to-one mapping between SCIM attributes and User Profile attributes

### DIFF
--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -2013,6 +2013,30 @@ public class UserTest extends AbstractScimTest {
         }
     }
 
+    @Test
+    public void testManyToOneScimAttributeMapping() {
+        String customSchema = "urn:my:params:scim:schemas:extension:custom:1.0:User";
+        String scimAttribute = customSchema + ":mobileNumber";
+        UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
+
+        UPAttribute mobileAttr = new UPAttribute("mobile", Map.of(
+                ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, scimAttribute));
+        mobileAttr.setPermissions(new UPAttributePermissions(Set.of(UPConfigUtils.ROLE_ADMIN), Set.of(UPConfigUtils.ROLE_ADMIN)));
+        upConfig.addOrReplaceAttribute(mobileAttr);
+
+        UPAttribute phoneAttr = new UPAttribute("phone", Map.of(
+                ANNOTATION_SCIM_SCHEMA_ATTRIBUTE, scimAttribute));
+        phoneAttr.setPermissions(new UPAttributePermissions(Set.of(UPConfigUtils.ROLE_ADMIN), Set.of(UPConfigUtils.ROLE_ADMIN)));
+        upConfig.addOrReplaceAttribute(phoneAttr);
+
+        try {
+            realm.admin().users().userProfile().update(upConfig);
+            fail("should fail because multiple user profile attributes cannot be mapped to the same SCIM attribute");
+        } catch (BadRequestException e) {
+            assertTrue(e.getResponse().getStatus() == 400);
+        }
+    }
+
     private void setupMultivaluedCustomAttributes(String customSchema) {
         UPConfig upConfig = realm.admin().users().userProfile().getConfiguration();
 

--- a/services/src/main/java/org/keycloak/userprofile/config/UPConfigUtils.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPConfigUtils.java
@@ -146,6 +146,43 @@ public class UPConfigUtils {
     }
 
     private static List<String> validateScimAttributeMappings(UPConfig config) {
+        List<String> errors = new ArrayList<>();
+
+        errors.addAll(validateOneToOneScimAttributeMappings(config));
+        errors.addAll(validateComplexScimAttributeMappings(config));
+
+        return errors;
+    }
+
+    private static List<String> validateOneToOneScimAttributeMappings(UPConfig config) {
+        Map<String, String> attributeNamesByScimAttribute = new HashMap<>();
+        List<String> errors = new ArrayList<>();
+
+        for (UPAttribute attribute : config.getAttributes()) {
+            Map<String, Object> annotations = attribute.getAnnotations();
+
+            if (annotations == null) {
+                continue;
+            }
+
+            Object scimValue = annotations.get(ANNOTATION_SCIM_SCHEMA_ATTRIBUTE);
+
+            if (!(scimValue instanceof String scimName) || isBlank(scimName)) {
+                continue;
+            }
+
+            String existingAttributeName = attributeNamesByScimAttribute.putIfAbsent(scimName, attribute.getName());
+
+            if (existingAttributeName != null) {
+                errors.add("Duplicate SCIM attribute mapping '" + scimName + "' configured for attributes '"
+                        + existingAttributeName + "' and '" + attribute.getName() + "'");
+            }
+        }
+
+        return errors;
+    }
+
+    private static List<String> validateComplexScimAttributeMappings(UPConfig config) {
         Map<String, List<ScimSubAttributeMapping>> mappingsByParent = new HashMap<>();
 
         for (UPAttribute attribute : config.getAttributes()) {


### PR DESCRIPTION
Add validation to the User Profile Configuration to ensure that each SCIM attribute is mapped to only one User Profile attribute.

Closes #52206