### PR TITLE
Stabilize Chrome tests against "Node with given id does not belong to the document"

### DIFF
--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/webdriver/WaitUtils.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/webdriver/WaitUtils.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class WaitUtils {
@@ -23,7 +24,12 @@ public class WaitUtils {
     public WaitUtils waitForPage(AbstractPage page) {
         String expectedPageId = page.getExpectedPageId();
         try {
-            createDefaultWait().ignoring(StaleElementReferenceException.class).until(d -> expectedPageId.equals(managed.page().getCurrentPageId()));
+            createDefaultWait()
+                    .ignoring(StaleElementReferenceException.class)
+                    // Also ignore WebDriverException: Chrome CDP throws "Node with given id does not belong to the document"
+                    // instead of StaleElementReferenceException when getCurrentPageId() polls during a page navigation.
+                    .ignoring(WebDriverException.class)
+                    .until(d -> expectedPageId.equals(managed.page().getCurrentPageId()));
         } catch (TimeoutException e) {
             Assertions.fail("Expected page '" + expectedPageId + "' to be loaded, but currently on page '" + managed.page().getCurrentPageId() + "' after timeout");
         }


### PR DESCRIPTION
Closes #52415

## Summary

`WaitUtils.waitForPage()` now also ignores `WebDriverException` when polling for page transitions, in addition to `StaleElementReferenceException`.

## Decision: `WebDriverException` in `WaitUtils` vs. converting in `PageUtils`

The previous fix (PR #51774, reverted in 9b43a60) caught the Chrome CDP error in `PageUtils.getCurrentPageId()` and converted it to `StaleElementReferenceException`. This PR instead handles it in `WaitUtils.waitForPage()` by ignoring `WebDriverException` directly.

This approach was chosen because:
- The polling loop in `waitForPage()` is the right place to decide what is retryable — `PageUtils` shouldn't need to know which callers will retry.
- `WebDriverException` is the parent of `StaleElementReferenceException`, so the existing `.ignoring(StaleElementReferenceException.class)` is now technically redundant but kept for readability.
- Ignoring the broader `WebDriverException` during polling is safe here: the `until()` condition still requires the expected page ID to match, and `TimeoutException` still fires if the page never arrives.