### PR TITLE
UserSessionLimitsAuthenticator: Correlate log messages with event details

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -168,7 +168,7 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
     private List<UserSessionModel> handleLimitExceeded(AuthenticationFlowContext context, List<UserSessionModel> userSessions, String eventDetails, long limit) {
         switch (behavior) {
             case UserSessionLimitsAuthenticatorFactory.DENY_NEW_SESSION:
-                logger.info("Denying new session");
+                logger.info("Denying new session (%s)", eventDetails);
                 String errorMessage = Optional.ofNullable(context.getAuthenticatorConfig())
                         .map(AuthenticatorConfigModel::getConfig)
                         .map(f -> f.get(UserSessionLimitsAuthenticatorFactory.ERROR_MESSAGE))
@@ -180,8 +180,8 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
                 return Collections.emptyList();
 
             case UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION:
-                logger.info("Terminating oldest session");
-                var removedSessions = logoutOldestSessions(userSessions, limit, context.getEvent());
+                logger.info("Terminating oldest session (%s)", eventDetails);
+                var removedSessions = logoutOldestSessions(userSessions, limit, context.getEvent(), eventDetails);
                 context.success();
                 return removedSessions;
         }
@@ -192,16 +192,16 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
     /**
      * @return A list of logged-out user sessions, if any.
      */
-    private List<UserSessionModel> logoutOldestSessions(List<UserSessionModel> userSessions, long limit, EventBuilder eventBuilder) {
+    private List<UserSessionModel> logoutOldestSessions(List<UserSessionModel> userSessions, long limit, EventBuilder eventBuilder, String eventDetail) {
         long numberOfSessionsThatNeedToBeLoggedOut = getNumberOfSessionsThatNeedToBeLoggedOut(userSessions.size(), limit);
 
         if (numberOfSessionsThatNeedToBeLoggedOut == 0) {
-            logger.debug("No additional sessions that need to be logged out");
+            logger.debug("No additional sessions that need to be logged out (%s)", eventDetails);
             return Collections.emptyList();
         } else if (numberOfSessionsThatNeedToBeLoggedOut == 1) {
-            logger.info("Logging out oldest session");
+            logger.info("Logging out oldest session (%s)", eventDetails);
         } else {
-            logger.infof("Logging out oldest %s sessions", numberOfSessionsThatNeedToBeLoggedOut);
+            logger.infof("Logging out oldest %s sessions (%s)", numberOfSessionsThatNeedToBeLoggedOut, eventDetails);
         }
 
         List<UserSessionModel> userSessionsToBeRemoved = userSessions

--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -168,7 +168,7 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
     private List<UserSessionModel> handleLimitExceeded(AuthenticationFlowContext context, List<UserSessionModel> userSessions, String eventDetails, long limit) {
         switch (behavior) {
             case UserSessionLimitsAuthenticatorFactory.DENY_NEW_SESSION:
-                logger.info("Denying new session (%s)", eventDetails);
+                logger.infof("Denying new session (%s)", eventDetails);
                 String errorMessage = Optional.ofNullable(context.getAuthenticatorConfig())
                         .map(AuthenticatorConfigModel::getConfig)
                         .map(f -> f.get(UserSessionLimitsAuthenticatorFactory.ERROR_MESSAGE))
@@ -180,7 +180,7 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
                 return Collections.emptyList();
 
             case UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION:
-                logger.info("Terminating oldest session (%s)", eventDetails);
+                logger.infof("Terminating oldest session (%s)", eventDetails);
                 var removedSessions = logoutOldestSessions(userSessions, limit, context.getEvent(), eventDetails);
                 context.success();
                 return removedSessions;
@@ -192,14 +192,14 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
     /**
      * @return A list of logged-out user sessions, if any.
      */
-    private List<UserSessionModel> logoutOldestSessions(List<UserSessionModel> userSessions, long limit, EventBuilder eventBuilder, String eventDetail) {
+    private List<UserSessionModel> logoutOldestSessions(List<UserSessionModel> userSessions, long limit, EventBuilder eventBuilder, String eventDetails) {
         long numberOfSessionsThatNeedToBeLoggedOut = getNumberOfSessionsThatNeedToBeLoggedOut(userSessions.size(), limit);
 
         if (numberOfSessionsThatNeedToBeLoggedOut == 0) {
-            logger.debug("No additional sessions that need to be logged out (%s)", eventDetails);
+            logger.debugf("No additional sessions that need to be logged out (%s)", eventDetails);
             return Collections.emptyList();
         } else if (numberOfSessionsThatNeedToBeLoggedOut == 1) {
-            logger.info("Logging out oldest session (%s)", eventDetails);
+            logger.infof("Logging out oldest session (%s)", eventDetails);
         } else {
             logger.infof("Logging out oldest %s sessions (%s)", numberOfSessionsThatNeedToBeLoggedOut, eventDetails);
         }


### PR DESCRIPTION
When you try to understand handling of exceeding limits in the log you can't correlate actions with the event.
