### PR TITLE
Extend startup time for MySQL migrations and force cleanup after failure

### DIFF
--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakRunner.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakRunner.java
@@ -42,7 +42,8 @@ public class KeycloakRunner {
     private DistributionTest config;
     private KeycloakDistribution delegate;
     private StopServer.Mode stopServer;
-    private long startTimeout = TimeUnit.SECONDS.toMillis(Long.getLong("keycloak.distribution.start.timeout", 120L));
+    // MySQL Liquibase migrations can exceed 2 minutes on slow CI runners
+    private long startTimeout = TimeUnit.SECONDS.toMillis(Long.getLong("keycloak.distribution.start.timeout", 300L));
 
     public KeycloakRunner(DistributionTest config,
                                          KeycloakDistribution delegate) {

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -208,7 +208,9 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
                 destroyDescendantsOnWindows(keycloak, false);
 
                 keycloak.destroy();
-                keycloak.waitFor(DEFAULT_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                if (!keycloak.waitFor(DEFAULT_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    throw new RuntimeException("Server process did not stop within " + DEFAULT_SHUTDOWN_TIMEOUT_SECONDS + " seconds");
+                }
             } catch (Exception cause) {
                 destroyDescendantsOnWindows(keycloak, true);
                 keycloak.destroyForcibly();


### PR DESCRIPTION
Closes #52423

## Summary

This might have been caused by us adding more and more DB schema migrations over time, and MySQL is known to be very slow. 

The code was written with the wrong assumption that `waitFor()` would throw an exception when failing to stop the container, and not just return false.

Things that were changed:

- Increase `startTimeout` default from 120s to 300s in `KeycloakRunner` to accommodate slow MySQL Liquibase migrations on CI runners.
- Fix `RawKeycloakDistribution.stop()` to force-kill the process when graceful shutdown times out, instead of silently falling through to `exitValue()`.

## Decisions

**Startup timeout of 300s (vs. a smaller increase):** The observed MySQL migration took ~127s on the CI runner that failed, just over the 120s limit. A small bump (e.g., 150s) would leave little headroom. 300s gives a comfortable margin without being so large that it masks real hangs — the timeout is still overridable via `-Dkeycloak.distribution.start.timeout`.

**Shutdown timeout stays at 10s:** The shutdown timeout (`DEFAULT_SHUTDOWN_TIMEOUT_SECONDS`) was not changed. The process that's stuck in migration won't respond to SIGTERM faster with more time — it's the startup timeout that needs the headroom. 10s is enough for a normal Quarkus graceful shutdown; if it doesn't stop in that time, force-killing is the right escalation.

**Timeout in `stop()` throws into the existing catch block:** Rather than adding a separate code path, the timeout now throws a `RuntimeException` that falls into the existing `catch (Exception)` block. This reuses the force-kill + thread dump + rethrow logic that was already there for other failure cases, keeping one cleanup path.