### PR TITLE
Automatically clear admin events before the actual test run 

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/KeycloakIntegrationTestExtension.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/KeycloakIntegrationTestExtension.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 
-public class KeycloakIntegrationTestExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, TestWatcher, InvocationInterceptor, ParameterResolver {
+public class KeycloakIntegrationTestExtension implements BeforeAllCallback, BeforeEachCallback, BeforeTestExecutionCallback, AfterEachCallback, AfterAllCallback, TestWatcher, InvocationInterceptor, ParameterResolver {
 
     @Override
     public void beforeAll(ExtensionContext context) {
@@ -30,6 +31,11 @@ public class KeycloakIntegrationTestExtension implements BeforeAllCallback, Befo
         getRegistry(context).beforeEach(context.getRequiredTestInstance(), context.getRequiredTestMethod());
         getLogHandler(context).beforeEachCompleted(context);
         DebugHelper.testStarted(context.getRequiredTestClass(), context.getRequiredTestMethod());
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        getRegistry(context).beforeTestExecution();
     }
 
     @Override

--- a/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEvents.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEvents.java
@@ -115,7 +115,7 @@ public abstract class AbstractEvents<R> {
     }
 
     void testStarted() {
-        // Discard events from the previous test's cleanup to avoid them leaking into this test's poll() window
+        // Discard events from cleanup and @BeforeEach setup to avoid them leaking into this test's poll() window
         skipAll();
         timeOffset = getCurrentTimeOffset();
     }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEventsSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEventsSupplier.java
@@ -38,8 +38,15 @@ public abstract class AbstractEventsSupplier<E extends AbstractEvents, A extends
         return true;
     }
 
+    // Called twice: before @BeforeEach to exclude cleanup events from the previous test,
+    // and after @BeforeEach to exclude events generated during setup from the test's poll() window.
     @Override
     public void onBeforeEach(InstanceContext<E, A> instanceContext) {
+        instanceContext.getValue().testStarted();
+    }
+
+    @Override
+    public void onBeforeTestExecution(InstanceContext<E, A> instanceContext) {
         instanceContext.getValue().testStarted();
     }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/Registry.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/Registry.java
@@ -417,6 +417,12 @@ public class Registry implements AutoCloseable {
         }
     }
 
+    public void beforeTestExecution() {
+        for (InstanceContext i : deployedInstances) {
+            i.getSupplier().onBeforeTestExecution(i);
+        }
+    }
+
     private TestFrameworkExecutor getExecutor(Method testMethod) {
         return extensions.getTestFrameworkExecutors().stream().filter(TestFrameworkExecutorPredicates.shouldExecute(testMethod)).findFirst().orElse(null);
     }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/Supplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/Supplier.java
@@ -41,6 +41,9 @@ public interface Supplier<T, S extends Annotation> {
     default void onBeforeEach(InstanceContext<T, S> instanceContext) {
     }
 
+    default void onBeforeTestExecution(InstanceContext<T, S> instanceContext) {
+    }
+
     default int order() {
         return SupplierOrder.DEFAULT;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
@@ -111,7 +111,6 @@ public class RoleByIdResourceTest {
                 .forEach(r -> roleIds.put(r.getName(), r.getId()));
 
         resource = managedRealm.admin().rolesById();
-        adminEvents.skipAll(); // Tested in RealmRolesTest already
     }
 
     @Test


### PR DESCRIPTION
Closes #52426

## Assumptions and decisions

- **`testStarted()` is called twice per test** — once in `onBeforeEach` (to exclude cleanup events from the previous test) and again in `onBeforeTestExecution` (to exclude events generated during `@BeforeEach` setup). The double call is intentional: the first call is needed because setup itself may trigger events before `@BeforeEach` runs (e.g., managed resource injection), and the second resets the window after `@BeforeEach` completes.
- **`onBeforeTestExecution` is a general-purpose lifecycle hook on `Supplier`**, not event-specific — other suppliers could use it in the future, though only `AbstractEventsSupplier` implements it today.
- **`RoleByIdResourceTest.before()` was the only `@BeforeEach` with a `skipAll()` call** — audited all remaining `skipAll()` usages (`ImpersonationTest`, `FlowTest`, `GroupTest`, `IdentityProviderOidcTest`) and they are all mid-test calls to discard events from setup done within the test method body, which is a different use case not addressed by this change.