### PR TITLE
Handle async processing of the brute force detection when counting login failures

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/AttackDetectionResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AttackDetectionResourceTest.java
@@ -72,22 +72,27 @@ public class AttackDetectionResourceTest {
 
         assertBruteForce(detection.bruteForceUserStatus(testUser.getId()), 0, 0, false, false);
 
+        // Wait for each failure to be processed before sending the next request for the same user.
+        // DefaultBlockingBruteForceProtector blocks concurrent logins for the same user,
+        // and the blocked request won't increment the failure counter.
+        // These waits can be removed once brute force processing is synchronous and login-failures V1 is removed
+        // https://github.com/keycloak/keycloak/pull/52128
         oauthClient.doPasswordGrantRequest(testUser.getUsername(), "invalid");
+        awaitNumFailures(detection, testUser.getId(), 1);
+
         oauthClient.doPasswordGrantRequest(testUser.getUsername(), "invalid");
+        awaitNumFailures(detection, testUser.getId(), 2);
+
+        // Third attempt: user is now locked (failureFactor=2), won't increment numFailures
         oauthClient.doPasswordGrantRequest(testUser.getUsername(), "invalid");
 
         oauthClient.doPasswordGrantRequest(testUser2.getUsername(), "invalid");
+        awaitNumFailures(detection, testUser2.getId(), 1);
+
         oauthClient.doPasswordGrantRequest(testUser2.getUsername(), "invalid");
         oauthClient.doPasswordGrantRequest("nosuchuser", "invalid");
 
-        // Check testUser2 to ensure all failure processing is completed
-        await().atMost(5, TimeUnit.SECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> {
-                    Map<String, Object> status = detection.bruteForceUserStatus(testUser2.getId());
-                    assertEquals(2, status.get("numFailures"),
-                            "Waiting for testUser2 processing to complete");
-                });
+        awaitNumFailures(detection, testUser2.getId(), 2);
 
         assertBruteForce(detection.bruteForceUserStatus(testUser.getId()), 2, 1, true, true);
         assertBruteForce(detection.bruteForceUserStatus(testUser2.getId()), 2, 1, true, true);
@@ -121,6 +126,12 @@ public class AttackDetectionResourceTest {
             assertEquals("0", status.get("lastFailure").toString());
             assertEquals("0", status.get("failedLoginNotBefore").toString());
         }
+    }
+
+    private void awaitNumFailures(AttackDetectionResource detection, String userId, int expected) {
+        await().atMost(5, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertEquals(expected, detection.bruteForceUserStatus(userId).get("numFailures")));
     }
 
     private static class AttackDetectionResourceRealmConfig implements RealmConfig {


### PR DESCRIPTION
Closes #52428

## Summary

Stabilizes `AttackDetectionResourceTest.test` by waiting for each brute force failure to be fully processed before sending the next login request for the same user.

## Root cause

`DefaultBlockingBruteForceProtector` tracks concurrent login attempts per user in a `loginAttempts` map. When a second request for the same user arrives while the first is still being processed:

1. `isTemporarilyDisabled()` returns `true` (login in progress)
2. `ValidateUsername` calls `context.forceChallenge()` (not `failureChallenge()`)
3. `FORCE_CHALLENGE` does **not** call `logFailure()` / `failedLogin()` (unlike `FAILURE_CHALLENGE`)
4. The failure counter is never incremented for the blocked request

This means `numFailures` stays at 1 instead of reaching the expected 2 — permanently, not just slowly. Increasing the awaitility timeout would not help.

## Fix

After sending each login request, poll `bruteForceUserStatus` until `numFailures` reaches the expected value before sending the next request for the same user. This ensures the async executor task has completed and the `loginAttempts` entry has been cleared.

For `testUser` (3 requests, `failureFactor=2`):
- Request 1 → wait for `numFailures=1`
- Request 2 → wait for `numFailures=2` (user is now locked)
- Request 3 → user is temporarily disabled by the real lockout, no counter increment expected

For `testUser2` (2 requests):
- Request 1 → wait for `numFailures=1`
- Request 2 → counter increments to 2

These waits can be removed once brute force processing is synchronous (#52128).

