### PR TITLE
Stabilize test execution to work with and without users

### DIFF
--- a/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/userprofile.spec.ts
@@ -16,6 +16,7 @@ import {
   clickAddValidator,
   clickCancelAttribute,
   clickCreateAttribute,
+  clickCreateUser,
   clickSaveAttribute,
   clickSaveValidator,
   fillAttributeForm,
@@ -146,7 +147,7 @@ test.describe.serial("User profile tabs", () => {
     await switchOn(page, "#kc-edit-username-switch");
 
     await goToUsers(page);
-    await page.getByTestId("no-users-found-empty-action").click();
+    await clickCreateUser(page);
     await expect(page.getByTestId(attrName)).toBeHidden();
     await page.getByTestId("username").fill("testuser7");
     await page.getByTestId("user-creation-save").click();
@@ -168,7 +169,7 @@ test.describe.serial("User profile tabs", () => {
     await switchOn(page, "#kc-email-as-username-switch");
 
     await goToUsers(page);
-    await page.getByTestId("no-users-found-empty-action").click();
+    await clickCreateUser(page);
     await page.getByTestId("email").fill("testuser8@gmail.com");
     await expect(page.getByTestId(attrName)).toBeHidden();
     await page.getByTestId("user-creation-save").click();
@@ -196,7 +197,7 @@ test.describe.serial("User profile tabs", () => {
     await switchOffIfOn(page, "#kc-email-as-username-switch");
 
     await goToUsers(page);
-    await page.getByTestId("no-users-found-empty-action").click();
+    await clickCreateUser(page);
     await expect(page.getByTestId(attrName)).toBeVisible();
     await page.getByTestId("username").fill("testuser10");
     await page.getByTestId("user-creation-save").click();
@@ -221,7 +222,7 @@ test.describe.serial("User profile tabs", () => {
     await clickSaveAttribute(page);
 
     await goToUsers(page);
-    await page.getByTestId("no-users-found-empty-action").click();
+    await clickCreateUser(page);
     await expect(page.getByTestId(attrName)).toBeVisible();
     await page.getByTestId("username").fill("testuser11");
     await page.getByTestId("user-creation-save").click();
@@ -255,7 +256,7 @@ test.describe.serial("User profile tabs", () => {
     );
 
     await goToUsers(page);
-    await page.getByTestId("no-users-found-empty-action").click();
+    await clickCreateUser(page);
 
     await expect(page.getByRole("heading", { name: group })).toBeVisible();
   });

--- a/js/apps/admin-ui/test/realm-settings/userprofile.ts
+++ b/js/apps/admin-ui/test/realm-settings/userprofile.ts
@@ -46,6 +46,13 @@ export async function goToAttributeGroupsTab(page: Page) {
   await page.getByTestId("attributesGroupTab").click();
 }
 
+export async function clickCreateUser(page: Page) {
+  await page
+    .getByTestId("no-users-found-empty-action")
+    .or(page.getByTestId("add-user"))
+    .click({ timeout: 15_000 });
+}
+
 export async function switchOffIfOn(page: Page, selector: string) {
   if (await page.isChecked(selector)) {
     await page.locator(selector).click({ force: true });


### PR DESCRIPTION
Closes #52430

## Summary

Minimal backport of the `clickCreateUser` fix from PR #50995 to `release/26.7`. Replaces all 5 direct `page.getByTestId("no-users-found-empty-action").click()` calls in `userprofile.spec.ts` with a helper that handles both the empty-state and populated user list.

## Decision: minimal backport vs full PR #50995

PR #50995 on `main` overhauled many test helpers (`table.ts`, `form.ts`) and restructured multiple test suites. Only the `clickCreateUser` portion is relevant to this failure. This PR extracts just that:

- **`userprofile.ts`**: Added `clickCreateUser(page)` helper using `.or().click()` — simpler than the `main` implementation which uses if-statements
- **`userprofile.spec.ts`**: Replaced all 5 raw `no-users-found-empty-action` clicks and added the import

## Decision: `.or().click()` over if-statement branching

The `main` implementation checks `emptyAction.count()` and `isVisible()` then conditionally clicks one button or the other. This is a TOCTOU race (state can change between the check and the click).

Since `ListEmptyState` is a separate React component that replaces the table entirely, only one of the two buttons (`no-users-found-empty-action` or `add-user`) exists in the DOM at a time. This means `.or()` always matches exactly one element, and Playwright's `.click()` waits for it to be actionable. No branching needed.

## Why the raw click fails

The test suite uses `test.describe.serial`, so tests share realm state. Earlier tests create users (testuser7–9), making the empty-state action disappear. Later tests that click `no-users-found-empty-action` directly will wait forever since only the `add-user` button is rendered.
