### PR TITLE
Stabilizing tests like FlowTest.testRemoveExecutionSubflow

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEvents.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/events/AbstractEvents.java
@@ -115,9 +115,9 @@ public abstract class AbstractEvents<R> {
     }
 
     void testStarted() {
-        testStarted = getCurrentTime();
+        // Discard events from the previous test's cleanup to avoid them leaking into this test's poll() window
+        skipAll();
         timeOffset = getCurrentTimeOffset();
-        lastFetch = -1;
     }
 
     protected abstract List<R> getEvents(long from, long to);


### PR DESCRIPTION
This avoids leaking events from previous tests

Closes #52329

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
