### PR TITLE
Extend startup time for MySQL migrations and force cleanup after failure

### DIFF
--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakRunner.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakRunner.java
@@ -42,7 +42,8 @@ public class KeycloakRunner {
     private DistributionTest config;
     private KeycloakDistribution delegate;
     private StopServer.Mode stopServer;
-    private long startTimeout = TimeUnit.SECONDS.toMillis(Long.getLong("keycloak.distribution.start.timeout", 120L));
+    // MySQL Liquibase migrations can exceed 2 minutes on slow CI runners
+    private long startTimeout = TimeUnit.SECONDS.toMillis(Long.getLong("keycloak.distribution.start.timeout", 300L));
 
     public KeycloakRunner(DistributionTest config,
                                          KeycloakDistribution delegate) {

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -208,7 +208,9 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
                 destroyDescendantsOnWindows(keycloak, false);
 
                 keycloak.destroy();
-                keycloak.waitFor(DEFAULT_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                if (!keycloak.waitFor(DEFAULT_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    throw new RuntimeException("Server process did not stop within " + DEFAULT_SHUTDOWN_TIMEOUT_SECONDS + " seconds");
+                }
             } catch (Exception cause) {
                 destroyDescendantsOnWindows(keycloak, true);
                 keycloak.destroyForcibly();


### PR DESCRIPTION
Closes #52423

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
