### PR TITLE
Enable mdoc in Admin UI E2E tests

### DIFF
--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Start Keycloak server
         run: |
           tar xfvz keycloak-999.0.0-SNAPSHOT.tar.gz
-          keycloak-999.0.0-SNAPSHOT/bin/kc.sh start-dev --features=admin-fine-grained-authz:v2,transient-users,spiffe,oid4vc-vci,kubernetes-service-accounts,jwt-authorization-grant,workflows,ssf &> ~/server.log &
+          keycloak-999.0.0-SNAPSHOT/bin/kc.sh start-dev --features=admin-fine-grained-authz:v2,transient-users,spiffe,oid4vc-vci,oid4vc-mdoc,kubernetes-service-accounts,jwt-authorization-grant,workflows,ssf &> ~/server.log &
         env:
           KC_BOOTSTRAP_ADMIN_USERNAME: admin
           KC_BOOTSTRAP_ADMIN_PASSWORD: admin

--- a/js/apps/admin-ui/test/client-scope/oid4vci-mappers.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/oid4vci-mappers.spec.ts
@@ -2,7 +2,11 @@ import { type Page, expect, test } from "@playwright/test";
 import { createTestBed } from "../support/testbed.ts";
 import { goToClientScopes } from "../utils/sidebar.ts";
 import { clickSaveButton, selectItem } from "../utils/form.ts";
-import { clickTableRowItem, clickTableToolbarItem } from "../utils/table.ts";
+import {
+  clickTableRowItem,
+  clickTableToolbarItem,
+  searchItem,
+} from "../utils/table.ts";
 import { login } from "../utils/login.ts";
 import { toClientScopes } from "../../src/client-scopes/routes/ClientScopes.tsx";
 import { assertNotificationMessage } from "../utils/masthead.ts";
@@ -120,7 +124,7 @@ test.describe("OID4VCI Protocol Mapper Configuration", () => {
     await saveMapperAndAssertSuccess(page);
 
     await page.getByTestId("nav-item-client-scopes").click();
-    await page.getByPlaceholder("Search for client scope").fill(scopeName);
+    await searchItem(page, "Search for client scope", scopeName);
     await clickTableRowItem(page, scopeName);
     await goToMappersTab(page);
     await clickTableRowItem(page, mapperName);


### PR DESCRIPTION
## Description

- Enable `oid4vc-mdoc` in the Admin UI E2E CI environment.
- Fix client scope search in the OID4VCI mapper test to reliably find the target scope.

Closes #52452 