### PR TITLE
[OID4VCI] Server-side validations for "Supported proof types" and "Cr…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultClientScopes.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultClientScopes.java
@@ -40,7 +40,7 @@ public class DefaultClientScopes {
     public static void createDefaultClientScopes(KeycloakSession session, RealmModel realm, boolean addScopesToExistingClients) {
         session.getKeycloakSessionFactory().getProviderFactoriesStream(LoginProtocol.class)
                 .map(LoginProtocolFactory.class::cast)
-                .forEach(lpf -> lpf.createDefaultClientScopes(realm, addScopesToExistingClients));
+                .forEach(lpf -> lpf.createDefaultClientScopes(session, realm, addScopesToExistingClients));
     }
 
 

--- a/server-spi-private/src/main/java/org/keycloak/protocol/AbstractLoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/AbstractLoginProtocolFactory.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.keycloak.Config;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderEvent;
@@ -58,7 +59,7 @@ public abstract class AbstractLoginProtocolFactory implements LoginProtocolFacto
 
 
     @Override
-    public void createDefaultClientScopes(RealmModel newRealm, boolean addScopesToExistingClients) {
+    public void createDefaultClientScopes(KeycloakSession session, RealmModel newRealm, boolean addScopesToExistingClients) {
         createDefaultClientScopesImpl(newRealm);
 
         // Create default client scopes for realm built-in clients too

--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
@@ -52,10 +52,11 @@ public interface LoginProtocolFactory extends ProviderFactory<LoginProtocol> {
     /**
      * Called when new realm is created
      *
+     * @param session Keycloak session
      * @param newRealm
      * @param addScopesToExistingClients If true, then existing realm clients will be updated (created realm default scopes will be added to them)
      */
-    void createDefaultClientScopes(RealmModel newRealm, boolean addScopesToExistingClients);
+    void createDefaultClientScopes(KeycloakSession session, RealmModel newRealm, boolean addScopesToExistingClients);
 
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 
@@ -48,11 +49,12 @@ import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
+import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidator;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCMapper;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCSubjectIdMapper;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCUserAttributeMapper;
 import org.keycloak.protocol.oid4vc.model.DisplayObject;
-import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -151,7 +153,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 	}
 
     @Override
-    public void createDefaultClientScopes(RealmModel newRealm, boolean addScopesToExistingClients) {
+    public void createDefaultClientScopes(KeycloakSession session, RealmModel newRealm, boolean addScopesToExistingClients) {
         LOGGER.debugf("Create default scopes for realm %s", newRealm.getName());
 
         List<String> formats = new ArrayList<>(Arrays.asList(VCFormat.SUPPORTED_FORMATS));
@@ -176,9 +178,10 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
                 }
 
                 ClientScopeRepresentation clientScopeRep = ModelToRepresentation.toRepresentation(clientScope);
+                Set<String> allowedProofTypes = session.listProviderIds(ProofValidator.class);
                 clientScopeRep.setAttributes(new HashMap<>(Map.of(
                         VC_BINDING_REQUIRED, "true",
-                        VC_BINDING_REQUIRED_PROOF_TYPES, ProofType.JWT + "," + ProofType.ATTESTATION
+                        VC_BINDING_REQUIRED_PROOF_TYPES, String.join(",", allowedProofTypes)
                 )));
                 if (isMdoc) {
                     clientScopeRep.getAttributes().put(VCT, NATURAL_PERSON_MDOC_NAMESPACE);
@@ -285,6 +288,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 
         validateOID4VCIRefreshInterval(clientScope);
         validateCredentialConfigurationId(session, clientScope);
+        validateBindingConfiguration(session, clientScope);
     }
 
     @Override
@@ -434,5 +438,71 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
                             refreshInterval, expiry),
                     Response.Status.BAD_REQUEST);
         }
+    }
+
+    /**
+     * Validate "Cryptographic binding methods supported" and proof-types
+     *
+     * @param session Keycloak session
+     * @param clientScope the client scope representation to validate
+     * @throws ErrorResponseException if binding is required and not provided OR the binding or proof-type configuration is invalid
+     */
+    private void validateBindingConfiguration(KeycloakSession session,  ClientScopeRepresentation clientScope) throws ErrorResponseException {
+        if (clientScope.getAttributes() == null) {
+            return;
+        }
+
+        boolean bindingRequired = Boolean.parseBoolean(clientScope.getAttributes().get(VC_BINDING_REQUIRED));
+        String format = clientScope.getAttributes().getOrDefault(VC_FORMAT, CredentialScopeModel.VC_FORMAT_DEFAULT);
+
+        CredentialBuilder credentialBuilder = session.getProvider(CredentialBuilder.class, format);
+        if (credentialBuilder != null) {
+            List<String> allowedBindingMethods = credentialBuilder.getSupportedBindingMethods();
+
+            String bindingMethodsAttr = clientScope.getAttributes().get(VC_CRYPTOGRAPHIC_BINDING_METHODS);
+            if (bindingRequired || !StringUtil.isBlank(bindingMethodsAttr)) {
+                List<String> effectiveBindingMethods = parseCommaSeparated(bindingMethodsAttr).stream()
+                        .filter(allowedBindingMethods::contains)
+                        .toList();
+
+                if (effectiveBindingMethods.isEmpty()) {
+                    throw ErrorResponse.error(
+                            String.format("When vc.binding_required is true, vc.cryptographic_binding_methods_supported must " +
+                                            "contain at least one valid value. Supported values for format '%s': %s",
+                                    format, allowedBindingMethods),
+                            Response.Status.BAD_REQUEST);
+                }
+            }
+        } else {
+            // Skip the binding for unsupported formats as such client scope cannot be used in runtime to build any credentials. Might happen in some corner case scenarios (EG. when realm with MDOC credential scope is imported when OID4VC_MDOC feature is disabled)
+            LOGGER.warnf("Not able to obtain credential builder for the format '%s' of credential scope '%s'. Skip validation of binding methods",  format, clientScope.getName());
+        }
+
+        Set<String> allowedProofTypes = session.listProviderIds(ProofValidator.class);
+
+        String proofTypesAttr = clientScope.getAttributes().get(VC_BINDING_REQUIRED_PROOF_TYPES);
+        if (bindingRequired || !StringUtil.isBlank(proofTypesAttr)) {
+            List<String> effectiveProofTypes = parseCommaSeparated(proofTypesAttr).stream()
+                    .filter(allowedProofTypes::contains)
+                    .toList();
+
+            if (effectiveProofTypes.isEmpty()) {
+                throw ErrorResponse.error(
+                        String.format("When vc.binding_required is true, vc.binding_required_proof_types must " +
+                                        "contain at least one valid value. Supported values: %s",
+                                allowedProofTypes),
+                        Response.Status.BAD_REQUEST);
+            }
+        }
+    }
+
+    private static List<String> parseCommaSeparated(String value) {
+        if (StringUtil.isBlank(value)) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -457,15 +457,13 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 
         CredentialBuilder credentialBuilder = session.getProvider(CredentialBuilder.class, format);
         if (credentialBuilder != null) {
-            List<String> allowedBindingMethods = credentialBuilder.getSupportedBindingMethods();
+            Set<String> allowedBindingMethods = credentialBuilder.getSupportedBindingMethods();
 
             String bindingMethodsAttr = clientScope.getAttributes().get(VC_CRYPTOGRAPHIC_BINDING_METHODS);
             if (bindingRequired || !StringUtil.isBlank(bindingMethodsAttr)) {
-                List<String> effectiveBindingMethods = parseCommaSeparated(bindingMethodsAttr).stream()
-                        .filter(allowedBindingMethods::contains)
-                        .toList();
+                List<String> effectiveBindingMethods = parseCommaSeparated(bindingMethodsAttr);
 
-                if (effectiveBindingMethods.isEmpty()) {
+                if (effectiveBindingMethods.isEmpty() || !allowedBindingMethods.containsAll(effectiveBindingMethods)) {
                     throw ErrorResponse.error(
                             String.format("When vc.binding_required is true, vc.cryptographic_binding_methods_supported must " +
                                             "contain at least one valid value. Supported values for format '%s': %s",
@@ -482,11 +480,9 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 
         String proofTypesAttr = clientScope.getAttributes().get(VC_BINDING_REQUIRED_PROOF_TYPES);
         if (bindingRequired || !StringUtil.isBlank(proofTypesAttr)) {
-            List<String> effectiveProofTypes = parseCommaSeparated(proofTypesAttr).stream()
-                    .filter(allowedProofTypes::contains)
-                    .toList();
+            List<String> effectiveProofTypes = parseCommaSeparated(proofTypesAttr);
 
-            if (effectiveProofTypes.isEmpty()) {
+            if (effectiveProofTypes.isEmpty() || !allowedProofTypes.containsAll(effectiveProofTypes)) {
                 throw ErrorResponse.error(
                         String.format("When vc.binding_required is true, vc.binding_required_proof_types must " +
                                         "contain at least one valid value. Supported values: %s",

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -453,7 +453,9 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
         }
 
         boolean bindingRequired = Boolean.parseBoolean(clientScope.getAttributes().get(VC_BINDING_REQUIRED));
-        String format = clientScope.getAttributes().getOrDefault(VC_FORMAT, CredentialScopeModel.VC_FORMAT_DEFAULT);
+String format = Objects.requireNonNullElseGet(
+        clientScope.getAttributes().get(VC_FORMAT),
+        () -> getFormatFromScope(clientScope.getName()));
 
         CredentialBuilder credentialBuilder = session.getProvider(CredentialBuilder.class, format);
         if (credentialBuilder != null) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -71,7 +71,6 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
@@ -81,7 +80,6 @@ import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBody;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderException;
-import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderFactory;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProvider;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
@@ -206,27 +204,13 @@ public class OID4VCIssuerEndpoint {
     // lifespan of credential offers in seconds
     private final int credentialOfferLifespan;
 
-    /**
-     * Credential builders are responsible for initiating the production of
-     * credentials in a specific format. Their output is an appropriate credential
-     * representation to be signed by a credential signer of the same format.
-     * <p></p>
-     * Due to technical constraints, we explicitly load credential builders into
-     * this map for they are configurable components. The key of the map is the
-     * credential {@link VCFormat} associated with the builder. The matching credential
-     * signer is directly loaded from the Keycloak container.
-     */
-    private final Map<String, CredentialBuilder> credentialBuilders;
-
     public OID4VCIssuerEndpoint(KeycloakSession session,
-                                Map<String, CredentialBuilder> credentialBuilders,
                                 AppAuthManager.BearerTokenAuthenticator authenticator,
                                 TimeProvider timeProvider,
                                 int credentialOfferLifespan) {
         this.session = session;
         this.bearerTokenAuthenticator = authenticator;
         this.timeProvider = timeProvider;
-        this.credentialBuilders = credentialBuilders;
         this.credentialOfferLifespan = credentialOfferLifespan;
     }
 
@@ -234,9 +218,6 @@ public class OID4VCIssuerEndpoint {
         this.session = keycloakSession;
         this.bearerTokenAuthenticator = new AppAuthManager.BearerTokenAuthenticator(keycloakSession);
         this.timeProvider = new OffsetTimeProvider();
-
-        this.credentialBuilders = loadCredentialBuilders(session);
-
         this.credentialOfferLifespan = getCredentialOfferLifespan(keycloakSession.getContext().getRealm());
     }
 
@@ -255,20 +236,6 @@ public class OID4VCIssuerEndpoint {
                     configuredLifespan, realm.getName(), DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S);
             return DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S;
         }
-    }
-
-    /**
-     * Create credential builders from configured component models in Keycloak.
-     *
-     * @return a map of the created credential builders with their supported formats as keys.
-     */
-    private Map<String, CredentialBuilder> loadCredentialBuilders(KeycloakSession keycloakSession) {
-        KeycloakSessionFactory keycloakSessionFactory = keycloakSession.getKeycloakSessionFactory();
-        return keycloakSessionFactory.getProviderFactoriesStream(CredentialBuilder.class)
-                .map(factory -> (CredentialBuilderFactory) factory)
-                .map(factory -> factory.create(keycloakSession, null))
-                .collect(Collectors.toMap(CredentialBuilder::getSupportedFormat,
-                        credentialBuilder ->  credentialBuilder));
     }
 
     /**
@@ -1912,7 +1879,7 @@ public class OID4VCIssuerEndpoint {
         // Build format-specific credential
         CredentialBody credentialBody;
         try {
-            credentialBody = this.findCredentialBuilder(credentialConfig)
+            credentialBody = this.findCredentialBuilder(session, credentialConfig)
                     .buildCredentialBody(vc, credentialConfig.getCredentialBuildConfig());
         } catch (CredentialBuilderException e) {
             throw badRequestException(ErrorType.INVALID_CREDENTIAL_REQUEST,
@@ -1973,9 +1940,9 @@ public class OID4VCIssuerEndpoint {
         }
     }
 
-    private CredentialBuilder findCredentialBuilder(SupportedCredentialConfiguration credentialConfig) {
+    private CredentialBuilder findCredentialBuilder(KeycloakSession session, SupportedCredentialConfiguration credentialConfig) {
         String format = credentialConfig.getFormat();
-        CredentialBuilder credentialBuilder = credentialBuilders.get(format);
+        CredentialBuilder credentialBuilder = session.getProvider(CredentialBuilder.class, format);
 
         if (credentialBuilder == null) {
             String message = String.format("No credential builder found for format %s", format);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -53,7 +53,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder;
-import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderFactory;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialRequestEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryptionMetadata;
@@ -477,14 +476,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
         }
 
         // Find the CredentialBuilder for this format using the factory pattern
-        CredentialBuilder credentialBuilder = keycloakSession.getKeycloakSessionFactory()
-                .getProviderFactoriesStream(CredentialBuilder.class)
-                .map(factory -> (CredentialBuilderFactory) factory)
-                .filter(factory -> format.equals(factory.getSupportedFormat()))
-                .findFirst()
-                .map(factory -> factory.create(keycloakSession, null))
-                .orElse(null);
-
+        CredentialBuilder credentialBuilder = keycloakSession.getProvider(CredentialBuilder.class, format);
         if (credentialBuilder == null) {
             LOGGER.debugf("No CredentialBuilder found for format: %s", format);
             return;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilder.java
@@ -17,11 +17,15 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
+import java.util.List;
+
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.provider.Provider;
+
+import static org.keycloak.OID4VCConstants.CRYPTOGRAPHIC_BINDING_METHOD_JWK;
 
 public interface CredentialBuilder extends Provider {
 
@@ -33,6 +37,13 @@ public interface CredentialBuilder extends Provider {
      * Returns the credential format supported by the builder.
      */
     String getSupportedFormat();
+
+    /**
+     * Returns list of supported binding methods for this credential format
+     */
+    default List<String> getSupportedBindingMethods() {
+        return List.of(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
+    }
 
     /**
      * Builds a verifiable credential of a specific format from the basis of

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilder.java
@@ -17,7 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
-import java.util.List;
+import java.util.Set;
 
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
@@ -41,8 +41,8 @@ public interface CredentialBuilder extends Provider {
     /**
      * Returns list of supported binding methods for this credential format
      */
-    default List<String> getSupportedBindingMethods() {
-        return List.of(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
+    default Set<String> getSupportedBindingMethods() {
+        return Set.of(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactory.java
@@ -18,18 +18,16 @@
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
 import org.keycloak.Config;
-import org.keycloak.component.ComponentFactory;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.protocol.oid4vc.OID4VCEnvironmentProviderFactory;
+import org.keycloak.provider.ProviderFactory;
 
 /**
  * Provider Factory to create {@link  CredentialBuilder}'s
  *
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
-public interface CredentialBuilderFactory extends
-        ComponentFactory<CredentialBuilder, CredentialBuilder>,
-        OID4VCEnvironmentProviderFactory {
+public interface CredentialBuilderFactory extends ProviderFactory<CredentialBuilder>, OID4VCEnvironmentProviderFactory {
 
     /**
      * Returns the credential format supported by the credential builder.

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderFactory.java
@@ -17,21 +17,15 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import org.keycloak.VCFormat;
-import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.OffsetTimeProvider;
-import org.keycloak.provider.ProviderConfigProperty;
 
 /**
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
 public class JwtCredentialBuilderFactory implements CredentialBuilderFactory {
-
-    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     @Override
     public String getSupportedFormat() {
@@ -39,17 +33,7 @@ public class JwtCredentialBuilderFactory implements CredentialBuilderFactory {
     }
 
     @Override
-    public String getHelpText() {
-        return "Builds verifiable credentials on the JWT-VC format (https://identity.foundation/jwt-vc-presentation-profile).";
-    }
-
-    @Override
-    public List<ProviderConfigProperty> getConfigProperties() {
-        return configProperties;
-    }
-
-    @Override
-    public CredentialBuilder create(KeycloakSession session, ComponentModel model) {
+    public CredentialBuilder create(KeycloakSession session) {
         return new JwtCredentialBuilder(new OffsetTimeProvider(), session);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/LDCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/LDCredentialBuilderFactory.java
@@ -17,20 +17,14 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import org.keycloak.VCFormat;
-import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.provider.ProviderConfigProperty;
 
 /**
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
 public class LDCredentialBuilderFactory implements CredentialBuilderFactory {
-
-    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     @Override
     public String getSupportedFormat() {
@@ -38,17 +32,7 @@ public class LDCredentialBuilderFactory implements CredentialBuilderFactory {
     }
 
     @Override
-    public String getHelpText() {
-        return "Builds verifiable credentials on the LDP-VC format (https://www.w3.org/TR/vc-data-model).";
-    }
-
-    @Override
-    public List<ProviderConfigProperty> getConfigProperties() {
-        return configProperties;
-    }
-
-    @Override
-    public CredentialBuilder create(KeycloakSession session, ComponentModel model) {
+    public CredentialBuilder create(KeycloakSession session) {
         return new LDCredentialBuilder();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilder.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.keycloak.VCFormat;
@@ -29,11 +30,18 @@ import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.utils.StringUtil;
 
+import static org.keycloak.OID4VCConstants.CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY;
+
 public class MdocCredentialBuilder implements CredentialBuilder {
 
     @Override
     public String getSupportedFormat() {
         return VCFormat.MSO_MDOC;
+    }
+
+    @Override
+    public List<String> getSupportedBindingMethods() {
+        return List.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilder.java
@@ -19,8 +19,8 @@ package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
 import java.time.Instant;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.keycloak.VCFormat;
 import org.keycloak.mdoc.MdocValidityInfo;
@@ -40,8 +40,8 @@ public class MdocCredentialBuilder implements CredentialBuilder {
     }
 
     @Override
-    public List<String> getSupportedBindingMethods() {
-        return List.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY);
+    public Set<String> getSupportedBindingMethods() {
+        return Set.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/MdocCredentialBuilderFactory.java
@@ -17,18 +17,12 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import org.keycloak.VCFormat;
-import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.OID4VCMdocEnvironmentProviderFactory;
-import org.keycloak.provider.ProviderConfigProperty;
 
 public class MdocCredentialBuilderFactory implements CredentialBuilderFactory, OID4VCMdocEnvironmentProviderFactory {
-
-    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     @Override
     public String getSupportedFormat() {
@@ -36,17 +30,7 @@ public class MdocCredentialBuilderFactory implements CredentialBuilderFactory, O
     }
 
     @Override
-    public String getHelpText() {
-        return "Builds verifiable credentials on the mso_mdoc format defined by OpenID4VCI Appendix A.2.";
-    }
-
-    @Override
-    public List<ProviderConfigProperty> getConfigProperties() {
-        return configProperties;
-    }
-
-    @Override
-    public CredentialBuilder create(KeycloakSession session, ComponentModel model) {
+    public CredentialBuilder create(KeycloakSession session) {
         return new MdocCredentialBuilder();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderFactory.java
@@ -17,20 +17,14 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
-import java.util.ArrayList;
-import java.util.List;
 
 import org.keycloak.VCFormat;
-import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.provider.ProviderConfigProperty;
 
 /**
  * @author <a href="mailto:Ingrid.Kamga@adorsys.com">Ingrid Kamga</a>
  */
 public class SdJwtCredentialBuilderFactory implements CredentialBuilderFactory {
-
-    protected static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
     @Override
     public String getSupportedFormat() {
@@ -38,17 +32,7 @@ public class SdJwtCredentialBuilderFactory implements CredentialBuilderFactory {
     }
 
     @Override
-    public String getHelpText() {
-        return "Builds verifiable credentials on the SD-JWT format (https://drafts.oauth.net/oauth-sd-jwt-vc/draft-ietf-oauth-sd-jwt-vc.html).";
-    }
-
-    @Override
-    public List<ProviderConfigProperty> getConfigProperties() {
-        return configProperties;
-    }
-
-    @Override
-    public CredentialBuilder create(KeycloakSession session, ComponentModel model) {
+    public CredentialBuilder create(KeycloakSession session) {
         return new SdJwtCredentialBuilder();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialScopeRepresentation.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialScopeRepresentation.java
@@ -15,6 +15,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 import static org.keycloak.models.ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VCT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BINDING_REQUIRED;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BINDING_REQUIRED_PROOF_TYPES;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_HASH_ALGORITHM;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_HASH_ALGORITHM_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_SD_JWT_VISIBLE_CLAIMS;
@@ -243,6 +244,21 @@ public class CredentialScopeRepresentation extends ClientScopeRepresentation {
 
     public CredentialScopeRepresentation setCryptographicBindingMethods(List<String> cryptographicBindingMethods) {
         return setAttribute(VC_CRYPTOGRAPHIC_BINDING_METHODS, String.join(",", cryptographicBindingMethods));
+    }
+
+    public List<String> getRequiredProofTypes() {
+        return Optional.ofNullable(getAttribute(VC_BINDING_REQUIRED_PROOF_TYPES))
+                .map(s -> s.split(","))
+                .map(Arrays::asList)
+                .orElse(Collections.emptyList());
+    }
+
+    public CredentialScopeRepresentation setRequiredProofTypes(String proofTypes) {
+        return setAttribute(VC_BINDING_REQUIRED_PROOF_TYPES, proofTypes);
+    }
+
+    public CredentialScopeRepresentation setRequiredProofTypes(List<String> proofTypes) {
+        return setAttribute(VC_BINDING_REQUIRED_PROOF_TYPES, String.join(",", proofTypes));
     }
 
     public List<String> getBuildConfigSdJwtVisibleClaims() {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -20,12 +20,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.keycloak.VCFormat;
 import org.keycloak.mdoc.MdocAlgorithm;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -147,7 +149,7 @@ public class SupportedCredentialConfiguration {
                     configuredBindingMethods);
         }
 
-        List<String> allowedProofTypes = List.of(ProofType.JWT, ProofType.ATTESTATION);
+        Set<String> allowedProofTypes = keycloakSession.listProviderIds(ProofValidator.class);
         List<String> effectiveProofTypes = Optional.ofNullable(requiredProofTypes)
                 .orElse(Collections.emptyList())
                 .stream()

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -27,6 +27,7 @@ import org.keycloak.VCFormat;
 import org.keycloak.mdoc.MdocAlgorithm;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,8 +35,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jboss.logging.Logger;
 
-import static org.keycloak.OID4VCConstants.CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY;
-import static org.keycloak.OID4VCConstants.CRYPTOGRAPHIC_BINDING_METHOD_JWK;
 
 /**
  * A supported credential, as used in the Credentials Issuer Metadata in OID4VCI
@@ -131,9 +130,11 @@ public class SupportedCredentialConfiguration {
         // OID4VCI 1.0 Section 12.2.4 defines binding methods as the key-material representation in the issued
         // credential: "jwk" for JWK and "cose_key" for COSE_Key, which is the representation used by ISO mdoc.
         // Normalize configured values so unsupported admin/API configuration does not leak into issuer metadata.
-        List<String> allowedBindingMethods = VCFormat.MSO_MDOC.equals(format)
-                ? List.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY)
-                : List.of(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
+        CredentialBuilder credentialBuilder = keycloakSession.getProvider(CredentialBuilder.class, format);
+        Set<String> allowedBindingMethods = Optional.ofNullable(credentialBuilder)
+                .map(CredentialBuilder::getSupportedBindingMethods)
+                .orElse(Collections.emptySet());
+
         List<String> effectiveBindingMethods = Optional.ofNullable(configuredBindingMethods)
                 .orElse(Collections.emptyList())
                 .stream()

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilderFactoryTest.java
@@ -18,7 +18,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 
 public class CredentialBuilderFactoryTest {
 
@@ -48,10 +47,6 @@ public class CredentialBuilderFactoryTest {
             .toList();
 
         assertFalse(credentialBuilderFactories.isEmpty());
-
-        for (CredentialBuilderFactory credentialBuilderFactory : credentialBuilderFactories) {
-            assertNotNull(credentialBuilderFactory.getConfigProperties());
-        }
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -38,6 +38,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.DisplayObject;
+import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -50,6 +51,9 @@ import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.OID4VCConstants.CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY;
+import static org.keycloak.OID4VCConstants.CRYPTOGRAPHIC_BINDING_METHOD_JWK;
+import static org.keycloak.OID4VCConstants.FORMAT_SD_JWT_VC;
 import static org.keycloak.VCFormat.JWT_VC;
 import static org.keycloak.VCFormat.SD_JWT_VC;
 import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
@@ -228,6 +232,100 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         }
     }
 
+    /**
+     * Issue #52421 - Case 1: binding_required=true but binding methods is null/blank should be rejected.
+     */
+    @Test
+    public void testBindingRequiredWithNullBindingMethodsRejected() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-null-binding-methods");
+        scope.setBindingRequired(true);
+        // leave vc.cryptographic_binding_methods_supported absent (null)
+        // leave vc.binding_required_proof_types absent (null)
+
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains(VC_CRYPTOGRAPHIC_BINDING_METHODS));
+    }
+
+    /**
+     * Issue #52421 - Case 2: binding_required=true but binding methods contains only invalid values should be rejected.
+     */
+    @Test
+    public void testBindingRequiredWithInvalidBindingMethodsRejected() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-invalid-binding-methods");
+        scope.setBindingRequired(true);
+        scope.setCryptographicBindingMethods("incorrect-value");
+        // leave vc.binding_required_proof_types absent so we catch the binding method error first
+
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains(VC_CRYPTOGRAPHIC_BINDING_METHODS));
+    }
+
+    /**
+     * Issue #52421 - Case 3: binding_required=true, invalid binding method for the proof type
+     */
+    @Test
+    public void testBindingRequiredWithValidProofTypeButInvalidBindingMethodRejected() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-null-proof-types");
+        scope.setFormat(FORMAT_SD_JWT_VC);
+        scope.setBindingRequired(true);
+        scope.setCryptographicBindingMethods(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY); // This binding method is supported just for the "mdoc" format, but not for "sd-jwt"
+        scope.setRequiredProofTypes(ProofType.JWT);
+
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains(VC_CRYPTOGRAPHIC_BINDING_METHODS));
+    }
+
+    /**
+     * Issue #52421 - Case 4: binding_required=true, valid binding method, but proof types contains only invalid values should be rejected.
+     */
+    @Test
+    public void testBindingRequiredWithInvalidProofTypesRejected() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-invalid-proof-types");
+        scope.setBindingRequired(true);
+        scope.setCryptographicBindingMethods(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
+        scope.setRequiredProofTypes("incorrect-value");
+
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains("vc.binding_required_proof_types"));
+    }
+
+    /**
+     * Issue #52421 - Valid case: binding_required=true with valid binding methods and proof types should succeed.
+     */
+    @Test
+    public void testBindingRequiredWithValidConfigAccepted() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-valid-binding");
+        scope.setBindingRequired(true);
+        scope.setCryptographicBindingMethods(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
+        scope.setRequiredProofTypes(ProofType.JWT);
+
+        ClientScopesResource clientScopes = testRealm.admin().clientScopes();
+        String scopeId = null;
+        try (Response response = clientScopes.create(scope)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus(),
+                    "Should accept scope when binding_required=true with valid binding methods and proof types");
+            scopeId = ApiUtil.getCreatedId(response);
+        } finally {
+            if (scopeId != null) {
+                clientScopes.get(scopeId).remove();
+            }
+        }
+    }
+
+    /**
+     * Issue #52421 - binding_required=false , but cryptographic-binding-methods and proofTypes provided. Should be still rejected
+     */
+    @Test
+    public void testBindingNotRequiredInvalidBindingMethodsAndProofType() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-no-binding");
+        scope.setBindingRequired(false);
+        scope.setCryptographicBindingMethods("incorrect-value");
+        scope.setRequiredProofTypes("incorrect-value");
+
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains(VC_CRYPTOGRAPHIC_BINDING_METHODS));
+    }
+
     private String createCredentialScope(ClientScopesResource clientScopes, String name,
                                          String credentialConfigurationId) {
         CredentialScopeRepresentation scope = new CredentialScopeRepresentation(name);
@@ -235,6 +333,16 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         try (Response response = clientScopes.create(scope)) {
             assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
             return ApiUtil.getCreatedId(response);
+        }
+    }
+
+    // Assert that creation of clientScope fails. Return the error message returned by the server
+    private String assertClientScopeCreateFailure(CredentialScopeRepresentation scope) {
+        ClientScopesResource clientScopes = testRealm.admin().clientScopes();
+        try (Response response = clientScopes.create(scope)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus(),
+                    "Should reject scope when binding_required=true and cryptographic_binding_methods_supported is absent");
+            return response.readEntity(String.class);
         }
     }
 
@@ -321,7 +429,7 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
                 assertEquals(VC_BUILD_CONFIG_HASH_ALGORITHM_DEFAULT, attrs.remove(VC_BUILD_CONFIG_HASH_ALGORITHM));
                 assertEquals(String.valueOf(VC_EXPIRY_IN_SECONDS_DEFAULT), attrs.remove(VC_EXPIRY_IN_SECONDS));
                 assertEquals(CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT, attrs.remove(VC_CRYPTOGRAPHIC_BINDING_METHODS));
-                assertEquals("jwt,attestation", attrs.remove(VC_BINDING_REQUIRED_PROOF_TYPES));
+                assertEquals("attestation,jwt", attrs.remove(VC_BINDING_REQUIRED_PROOF_TYPES));
                 assertEquals("oid4vc_natural_person", attrs.remove(VC_SUPPORTED_TYPES));
                 assertEquals("oid4vc_natural_person", attrs.remove(VC_CONTEXTS));
                 assertEquals("oid4vc_natural_person", attrs.remove(VCT));
@@ -450,15 +558,9 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         ClientScopesResource clientScopes = testRealm.admin().clientScopes();
 
         // When/Then: creating the scope should fail
-        try (Response response = clientScopes.create(scope)) {
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus(),
-                    "Should reject client scope when refresh interval exceeds lifetime");
-
-            // Verify error message mentions the problem
-            String body = response.readEntity(String.class);
-            assertTrue(body.contains("refresh interval") && body.contains("exceed"),
-                    "Error message should explain the validation failure");
-        }
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains("refresh interval") && error.contains("exceed"),
+                "Error message should explain the validation failure");
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -276,17 +276,17 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
     }
 
     /**
-     * Issue #52421 - Case 4: binding_required=true, valid binding method, but proof types contains only invalid values should be rejected.
+     * Issue #52421 - Case 4: binding_required=true, valid binding method, but proof types contains invalid values should be rejected.
      */
     @Test
     public void testBindingRequiredWithInvalidProofTypesRejected() {
         CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52421-invalid-proof-types");
         scope.setBindingRequired(true);
         scope.setCryptographicBindingMethods(CRYPTOGRAPHIC_BINDING_METHOD_JWK);
-        scope.setRequiredProofTypes("incorrect-value");
+        scope.setRequiredProofTypes("jwt,incorrect-value");
 
         String error = assertClientScopeCreateFailure(scope);
-        assertTrue(error.contains("vc.binding_required_proof_types"));
+        assertTrue(error.contains(VC_BINDING_REQUIRED_PROOF_TYPES));
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerEndpointTest.java
@@ -47,9 +47,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
-import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder;
-import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.JwtCredentialBuilder;
-import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.SdJwtCredentialBuilder;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
@@ -417,30 +414,12 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCIssuerTestBase {
 
     record OAuth2CodeEntry(String key, OAuth2Code code) {}
 
-
     protected static OID4VCIssuerEndpoint prepareIssuerEndpoint(
             KeycloakSession session,
             AppAuthManager.BearerTokenAuthenticator authenticator) {
 
-        JwtCredentialBuilder jwtCredentialBuilder = new JwtCredentialBuilder(TIME_PROVIDER, session);
-        SdJwtCredentialBuilder sdJwtCredentialBuilder = new SdJwtCredentialBuilder();
-
-        Map<String, CredentialBuilder> credentialBuilders = Map.of(
-                jwtCredentialBuilder.getSupportedFormat(), jwtCredentialBuilder,
-                sdJwtCredentialBuilder.getSupportedFormat(), sdJwtCredentialBuilder
-        );
-
-        return prepareIssuerEndpoint(session, authenticator, credentialBuilders);
-    }
-
-    protected static OID4VCIssuerEndpoint prepareIssuerEndpoint(
-            KeycloakSession session,
-            AppAuthManager.BearerTokenAuthenticator authenticator,
-            Map<String, CredentialBuilder> credentialBuilders) {
-
         return new OID4VCIssuerEndpoint(
                 session,
-                credentialBuilders,
                 authenticator,
                 TIME_PROVIDER,
                 30

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.TokenVerifier;
 import org.keycloak.VCFormat;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Time;
@@ -56,12 +58,14 @@ import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryption;
+import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.ErrorResponse;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oid4vc.model.JwtProof;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
+import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
@@ -93,10 +97,13 @@ import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
 import static org.keycloak.OID4VCConstants.CREDENTIAL_SUBJECT;
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
 import static org.keycloak.OID4VCConstants.SDJWT_DELIMITER;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider.ATTR_REQUEST_ENCRYPTION_REQUIRED;
+import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_PROOF;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.generateJwtProof;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.generateJwtProofWithClaims;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.jwtProofs;
@@ -132,7 +139,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode(),
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode(),
                 "Should return BAD_REQUEST");
     }
 
@@ -142,7 +149,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .credentialOfferUriRequest("test-credential")
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode(),
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode(),
                 "Should return BAD_REQUEST");
     }
 
@@ -153,7 +160,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken("invalid-token")
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode(),
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode(),
                 "Should return BAD_REQUEST");
     }
 
@@ -197,7 +204,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .credentialOfferRequest("some-nonce")
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
     }
 
     @Test
@@ -216,7 +223,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .credentialOfferRequest("unpreparedNonce")
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode(),
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode(),
                 "Should return BAD_REQUEST when nonce has no prepared offer");
     }
 
@@ -278,7 +285,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken("token")
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode(), "Should return BAD_REQUEST");
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode(), "Should return BAD_REQUEST");
     }
 
     @Test
@@ -302,30 +309,31 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         String cNonce = getCNonce();
         String credentialIssuerId = credentialIssuer.getCredentialIssuer();
 
+        // Update client scope to not accept "jwt" proof
+        ClientScopeResource clientScopeRes = testRealm.admin().clientScopes().get(jwtTypeCredentialScope.getId());
+        CredentialScopeRepresentation credScope = new CredentialScopeRepresentation(clientScopeRes.toRepresentation());
+        List<String> origProofTypes = credScope.getRequiredProofTypes();
+        List<String> newProofTypes = new ArrayList<>(origProofTypes);
+        assertTrue(newProofTypes.remove(ProofType.JWT));
+        credScope.setRequiredProofTypes(newProofTypes);
+        clientScopeRes.update(credScope);
+
         try {
-            withCausePropagation(() -> runOnServer.run(session -> {
-                try {
-                    BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
-                    authenticator.setTokenString(token);
+            Proofs proofs = jwtProofs(credentialIssuerId, cNonce);
 
-                    // Prepare the issue endpoint with no credential builders.
-                    OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator, Map.of());
-                    Proofs proofs = jwtProofs(credentialIssuerId, cNonce);
+            CredentialRequest credentialRequest = new CredentialRequest()
+                    .setCredentialIdentifier(credentialIdentifier)
+                    .setProofs(proofs);
 
-                    CredentialRequest credentialRequest = new CredentialRequest()
-                            .setCredentialIdentifier(credentialIdentifier)
-                            .setProofs(proofs);
-
-                    String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
-                    issuerEndpoint.requestCredential(requestPayload);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }));
-            fail("Should have thrown an exception");
-        } catch (Exception e) {
-            assertInstanceOf(BadRequestException.class, e);
-            assertEquals("No credential builder found for format jwt_vc_json", e.getMessage());
+            Oid4vcCredentialResponse credentialResponse = oauth.oid4vc()
+                    .credentialRequest(credentialRequest)
+                    .bearerToken(token)
+                    .send();
+            assertEquals(BAD_REQUEST.getStatusCode(), credentialResponse.getStatusCode());
+            assertEquals(INVALID_PROOF.getValue(), credentialResponse.getError());
+        } finally {
+            credScope.setRequiredProofTypes(origProofTypes);
+            clientScopeRes.update(credScope);
         }
     }
 
@@ -341,7 +349,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertNotNull(response.getError());
     }
 
@@ -363,7 +371,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(ErrorType.INVALID_ENCRYPTION_PARAMETERS.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("requires encrypted Credential Request"));
     }
@@ -383,7 +391,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .send();
 
         // This payload is not valid JSON and not a decryptable JWE, so it is malformed request payload.
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Failed to parse JSON request"));
     }
@@ -403,7 +411,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     .bearerToken(token)
                     .send();
 
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
             assertEquals(ErrorType.INVALID_ENCRYPTION_PARAMETERS.getValue(), response.getError());
             assertTrue(response.getErrorDescription().contains("Encryption is required"));
         } finally {
@@ -506,7 +514,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue(), response.getError());
     }
 
@@ -821,8 +829,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     .bearerToken(token)
                     .send();
 
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-            assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+            assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals(INVALID_PROOF.getValue(), response.getError());
             assertEquals("key_attestation JWT header claim is required by the credential configuration but was not provided",
                     response.getErrorDescription());
         } finally {
@@ -863,8 +871,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Proof signature algorithm not supported"));
     }
 
@@ -898,8 +906,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
     }
 
     @Test
@@ -932,8 +940,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
     }
 
     @Test
@@ -1002,8 +1010,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Issuer claim must be the client_id"));
     }
 
@@ -1042,8 +1050,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Audience claim must be single value"));
     }
 
@@ -1084,13 +1092,13 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Proof iat is in the future"));
         EventAssertion.assertError(events.poll())
                 .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
                 .clientId(OID4VCI_CLIENT_ID)
-                .error(ErrorType.INVALID_PROOF.getValue())
+                .error(INVALID_PROOF.getValue())
                 .details(Details.REASON, "Proof iat is in the future beyond allowed clock skew");
     }
 
@@ -1130,8 +1138,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Proof has expired"));
     }
 
@@ -1171,8 +1179,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("Proof is not yet valid"));
     }
 
@@ -1206,8 +1214,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("trust_chain"));
     }
 
@@ -1241,8 +1249,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
-        assertEquals(ErrorType.INVALID_PROOF.getValue(), response.getError());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(INVALID_PROOF.getValue(), response.getError());
         assertTrue(response.getErrorDescription().contains("mutually exclusive"));
     }
 
@@ -1388,7 +1396,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .bearerToken(token)
                 .send();
 
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals(BAD_REQUEST.getStatusCode(), response.getStatusCode());
         assertEquals(ErrorType.UNKNOWN_CREDENTIAL_IDENTIFIER.getValue(), response.getError());
     }
 
@@ -1440,7 +1448,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             try {
                 BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                 authenticator.setTokenString(token);
-                OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator, Map.of());
+                OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
                 Proofs proofs = jwtProofs(credentialIssuerId, cNonce);
 
                 CredentialRequest credentialRequest = new CredentialRequest()
@@ -1448,13 +1456,14 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                         .setProofs(proofs);
 
                 String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
+                requestPayload = requestPayload.replaceAll("\"jwt\"", "\"unsupported\""); // Manually update proof to unsupported proof type
 
                 try {
                     issuerEndpoint.requestCredential(requestPayload);
                     fail("Expected BadRequestException due to missing credential builder for format");
                 } catch (BadRequestException e) {
                     ErrorResponse error = (ErrorResponse) e.getResponse().getEntity();
-                    assertEquals(ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION.getValue(), error.getError());
+                    assertEquals(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue(), error.getError());
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -1499,8 +1508,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     .bearerToken(token)
                     .send();
 
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatusCode());
-            assertEquals(ErrorType.INVALID_PROOF.getValue(), response1.getError());
+            assertEquals(BAD_REQUEST.getStatusCode(), response1.getStatusCode());
+            assertEquals(INVALID_PROOF.getValue(), response1.getError());
             assertEquals("Could not validate JWT proof", response1.getErrorDescription());
 
             // Test 2: Create a request with both proof and proofs fields - should fail validation
@@ -1521,7 +1530,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     .bearerToken(token)
                     .send();
 
-            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response2.getStatusCode(), "Expected HTTP 400 Bad Request");
+            assertEquals(BAD_REQUEST.getStatusCode(), response2.getStatusCode(), "Expected HTTP 400 Bad Request");
             assertEquals(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue(), response2.getError());
             assertEquals("Both 'proof' and 'proofs' must not be present at the same time", response2.getErrorDescription());
         } catch (IOException e) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -111,7 +111,6 @@ import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.jwtProofs;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;


### PR DESCRIPTION
…yptographioc binding methods"

closes #52421

- Added server-side validations to `OID4VCLoginProtocolFactory` for validate supported binding methods and proof types for the credential configuration

- Cleanup of `CredentialBuilder` provider. The `CredentialBuilderFactory` incorrectly inherited from `ComponentFactory` even if it the `CredentialBuilder` provider type does not use components (`ComponentModel` stuff) at all. Removing this inheritance allowed some cleanup in the `CredentialBuilder` implementations as well as in some methods, which used that provider.