### PR TITLE
Follow-up to #52391: fix stale provider client lookup in KcSamlSignedDocumentOnlyBrokerTest

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/broker/saml/KcSamlSignedDocumentOnlyBrokerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/saml/KcSamlSignedDocumentOnlyBrokerTest.java
@@ -21,7 +21,10 @@ public class KcSamlSignedDocumentOnlyBrokerTest extends AbstractKcSamlBrokerTest
         String providerSigningCert = activeRs256SigCert(providerRealm);
         String consumerSigningCert = activeRs256SigCert(consumerRealm);
 
-        String samlClientId = "http://localhost:8080/realms/" + CONSUMER_REALM;
+        // AbstractKcSamlBrokerTest.configureSamlBrokerEndpoints() (superclass @BeforeEach, runs before
+        // this one) already renamed the provider client from the seeded placeholder entity id to the
+        // consumer's actual base URL, so that's the id to look up here, not the placeholder.
+        String samlClientId = consumerRealm.getBaseUrl();
         ClientRepresentation client = providerRealm.admin().clients().findByClientId(samlClientId).get(0);
         client.getAttributes().put(SamlConfigAttributes.SAML_ASSERTION_SIGNATURE, "false");
         client.getAttributes().put(SamlConfigAttributes.SAML_SERVER_SIGNATURE, "true");


### PR DESCRIPTION
## Summary

Follow-up fix for #52391 (already merged), found while auditing the broker test migration epic (#51955) for the same class of bug Copilot flagged in #52376.

- `KcSamlSignedDocumentOnlyBrokerTest.configureSignedDocumentOnly()` (added by #52391) looks up the provider-side client by a hardcoded `http://localhost:8080/realms/<consumer>` literal.
- `AbstractKcSamlBrokerTest.configureSamlBrokerEndpoints()` (superclass `@BeforeEach`, which JUnit 5 runs before this subclass's own `@BeforeEach`) already renames that same client from its seeded placeholder entity id to the consumer realm's real base URL.
- So the lookup only ever found the client because the test framework's current default happens to bind to `http://localhost:8080` - under any other base URL it would return an empty list and throw `IndexOutOfBoundsException`.
- Fix: look the client up by `consumerRealm.getBaseUrl()`, the value it was actually renamed to.

Not caught during #52391's review because it currently passes CI by coincidence (default base URL matches the hardcoded literal); this closes that gap.

## Test plan
- [ ] `KcSamlSignedDocumentOnlyBrokerTest` passes locally