### PR TITLE
Do not sanitize the plain-text organization invitation email

### DIFF
--- a/themes/src/main/resources/theme/base/email/text/org-invite.ftl
+++ b/themes/src/main/resources/theme/base/email/text/org-invite.ftl
@@ -1,8 +1,8 @@
 <#ftl output_format="plainText">
 
 <#if firstName?? && lastName??>
-    ${kcSanitize(msg("orgInviteBodyPersonalized", link, linkExpiration, realmName, organization.name, linkExpirationFormatter(linkExpiration), firstName, lastName))}
+    ${msg("orgInviteBodyPersonalized", link, linkExpiration, realmName, organization.name, linkExpirationFormatter(linkExpiration), firstName, lastName)}
 <#else>
-    ${kcSanitize(msg("orgInviteBody", link, linkExpiration, realmName, organization.name, linkExpirationFormatter(linkExpiration)))}
+    ${msg("orgInviteBody", link, linkExpiration, realmName, organization.name, linkExpirationFormatter(linkExpiration))}
 </#if>
 


### PR DESCRIPTION
Closes #52449

`base/email/text/org-invite.ftl` declares `output_format="plainText"` but still passes
the message through `kcSanitize`. The sanitizer HTML-encodes the invitation URL — `=`
becomes `&#61;` and `&` becomes `&amp;` — so the link in the `text/plain` part of the
invitation cannot be used. The `text/html` part is unaffected.

Both branches of the template are affected (with and without the invitee's name), and
so are both endpoints, `invite-user` and `invite-existing-user`.

No other plain-text email template sanitizes a message containing a link:
`password-reset.ftl`, `email-verification.ftl`, `executeActions.ftl`,
`identity-provider-link.ftl` and `email-update-confirmation.ftl` interpolate `msg(...)`
directly. (`text/workflow-notification.ftl` also calls `kcSanitize`, but it carries no
link.)

### Verification

Manual, against 26.7.2 with a local mail catcher, following the reproduction in #52449:
before the change the `text/plain` part contained
`.../login-actions/action-token?key&#61;eyJhbGciOi...`; after it, the same URL as the
`text/html` part.

I did not add an automated test: I could not run the integration suite in my
environment, and I would rather not submit a test I have not executed. Happy to add one
if you point me at the right test class.
