### PR TITLE
Clear leftover OIDC response parameters before the account console logs in

### DIFF
--- a/js/libs/ui-shared/src/context/KeycloakContext.tsx
+++ b/js/libs/ui-shared/src/context/KeycloakContext.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { AlertProvider } from "../alerts/Alerts";
+import { stripForeignAuthResponse } from "../utils/stripForeignAuthResponse";
 import { ErrorPage } from "./ErrorPage";
 import { Help } from "./HelpContext";
 import { BaseEnvironment } from "./environment";
@@ -75,6 +76,15 @@ export const KeycloakProvider = <T extends BaseEnvironment>({
     // only needed in dev mode
     if (calledOnce.current) {
       return;
+    }
+
+    // Discard an authorization response that was not requested by this application before the
+    // adapter reads the current URL, so that it cannot end up in the `redirect_uri` of the login
+    // we are about to start.
+    const cleanedUrl = stripForeignAuthResponse(window.location.href);
+
+    if (cleanedUrl) {
+      window.history.replaceState(window.history.state, "", cleanedUrl);
     }
 
     const init = () =>

--- a/js/libs/ui-shared/src/utils/stripForeignAuthResponse.test.ts
+++ b/js/libs/ui-shared/src/utils/stripForeignAuthResponse.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { stripForeignAuthResponse } from "./stripForeignAuthResponse";
+
+const CONSOLE_URL = "https://localhost:8443/realms/master/account/";
+
+describe("stripForeignAuthResponse", () => {
+  it("strips a response this application did not request", () => {
+    // an organization invitation completes an authorization code flow that lands here
+    const url = `${CONSOLE_URL}?session_state=abc&iss=https%3A%2F%2Flocalhost%3A8443%2Frealms%2Fmaster&code=def`;
+
+    expect(stripForeignAuthResponse(url)).toBe(CONSOLE_URL);
+  });
+
+  it("strips an error response this application did not request", () => {
+    const url = `${CONSOLE_URL}?error=access_denied&error_description=denied`;
+
+    expect(stripForeignAuthResponse(url)).toBe(CONSOLE_URL);
+  });
+
+  it("keeps a response carrying state, which keycloak-js handles itself", () => {
+    const url = `${CONSOLE_URL}?code=def&state=ghi&session_state=abc`;
+
+    expect(stripForeignAuthResponse(url)).toBeUndefined();
+  });
+
+  it("keeps a URL without a response", () => {
+    expect(
+      stripForeignAuthResponse(`${CONSOLE_URL}#/account-security/signing-in`),
+    ).toBeUndefined();
+  });
+
+  it("preserves the path, the fragment and unrelated parameters", () => {
+    const url = `${CONSOLE_URL}groups?code=def&iss=abc&referrer=admin#/details`;
+
+    expect(stripForeignAuthResponse(url)).toBe(
+      `${CONSOLE_URL}groups?referrer=admin#/details`,
+    );
+  });
+});

--- a/js/libs/ui-shared/src/utils/stripForeignAuthResponse.ts
+++ b/js/libs/ui-shared/src/utils/stripForeignAuthResponse.ts
@@ -1,0 +1,49 @@
+/**
+ * Parameters keycloak-js recognizes on a callback URL, and removes from it once the callback
+ * has been handled.
+ */
+const AUTH_RESPONSE_PARAMS = [
+  "code",
+  "state",
+  "session_state",
+  "iss",
+  "error",
+  "error_description",
+  "error_uri",
+  "kc_action",
+  "kc_action_status",
+];
+
+/**
+ * Removes the parameters of an authorization response that cannot belong to this application.
+ *
+ * keycloak-js treats a URL as its own callback only when it carries `state` alongside `code` or
+ * `error`, and strips the response parameters from the address bar when it does. A response
+ * without `state` was never requested by this application — keycloak-js always sends one — so it
+ * goes unrecognized and the parameters are left behind. They would then be sent as the
+ * `redirect_uri` of the next authorization request made from the page, which the server rejects
+ * for carrying OIDC response parameters, leaving the page unable to log in at all.
+ *
+ * @param url the current URL
+ * @returns the URL with the response parameters removed, or `undefined` if it should be left as
+ * it is, either because it carries no response or because the response belongs to this
+ * application and keycloak-js will deal with it.
+ */
+export function stripForeignAuthResponse(url: string): string | undefined {
+  const parsed = new URL(url);
+  const params = parsed.searchParams;
+
+  if (!params.has("code") && !params.has("error")) {
+    return undefined;
+  }
+
+  if (params.has("state")) {
+    return undefined;
+  }
+
+  for (const param of AUTH_RESPONSE_PARAMS) {
+    params.delete(param);
+  }
+
+  return parsed.toString();
+}


### PR DESCRIPTION
Accepting an organization invitation as a new user ends on `Invalid parameter: redirect_uri`, even though the account is created, the membership is written and the session is valid. With the organization's Redirect URL left empty — the documented default — every organization hits this.

### What happens

The invitation link starts an authorization code flow for the `account` client and delivers the response to the account console, a page that belongs to `account-console` and can never exchange that code. The request carries no `state`, so keycloak-js does not recognize the URL as a callback (it requires `(code || error) && state`) and leaves `code`, `session_state` and `iss` in the address bar. `onLoad: "login-required"` then starts a login whose `redirect_uri` defaults to `location.href`, still carrying `code`, and the check added for #49430 rejects it. The page cannot recover on its own: reloading keeps the same URL.

### The fix

Clear those parameters before `keycloak.init()` reads the URL, in the provider both consoles share. They are discarded only when `code` or `error` appears **without** `state` — a shape keycloak-js's own requests never produce — so a genuine callback is never touched. Deep links, the fragment and unrelated query parameters are preserved.

This also covers the admin console, and every other way a stray response can land on one of them, not just organization invitations.

### Note on the earlier revision

The first version of this PR added a `state` parameter to the invitation link instead. @pedroigor pointed out that a server-generated state would reach third-party clients as well; this approach avoids that entirely, since nothing outside our own console changes.

### On the test

`js/libs/ui-shared` has no `test` script, and the `UI Shared` CI job runs only `lint` and `build`, so the three existing `*.test.ts` files there do not run — and neither will this one. Enabling them first requires fixing `useSetTimeout.test.ts`, which imports `@testing-library/react` and declares a jsdom environment that the package does not depend on. That belongs in its own PR; happy to do it if a maintainer prefers it folded in here.

Fixes #52157

Assisted-by: Claude Opus 5