### PR TITLE
Remove azure-cli version pin and simplify VM provisioning

### DIFF
--- a/.github/scripts/ansible/azure_vm_manager.sh
+++ b/.github/scripts/ansible/azure_vm_manager.sh
@@ -17,10 +17,7 @@ VM_SIZE="Standard_D2s_v5"
 IMAGE="Ubuntu2404"
 
 if [[ "$ACTION" == "create" ]]; then
-  # Pin Azure CLI to 2.82.0 (azure-core 1.38.0+ causes JSON parsing errors with az vm create)
-  sudo apt-get install -y -q --allow-downgrades azure-cli=2.82.0-1~noble
-
-  # 1. Resource group (created via idempotent command)
+  # 1. Resource group
   az group create --name "$CLUSTER" --location "$REGION"
 
   # 2. SSH key
@@ -28,45 +25,25 @@ if [[ "$ACTION" == "create" ]]; then
     ssh-keygen -t rsa -b 2048 -f "${SSH_KEY}" -N ""
   fi
 
-  # 3. Network security group
-  az network nsg create --resource-group "$CLUSTER" --name "$CLUSTER-nsg"
-  az network nsg rule create --resource-group "$CLUSTER" --nsg-name "$CLUSTER-nsg" --name Allow-SSH --protocol Tcp --priority 1000 --destination-port-range 22 --access Allow --direction Inbound
-
-  # 4. Public IP
-  az network public-ip create --resource-group "$CLUSTER" --name "$CLUSTER-pip" --allocation-method Static
-
-  # 5. Virtual network
-  az network vnet create --resource-group "$CLUSTER" --name "$CLUSTER-vnet" --address-prefix 10.0.0.0/16
-
-  # 6. Subnet
-  az network vnet subnet create --resource-group "$CLUSTER" --vnet-name "$CLUSTER-vnet" --name "$CLUSTER-subnet" --address-prefix 10.0.0.0/24
-
-  # 7. Network interface
-  az network nic create --resource-group "$CLUSTER" --name "$CLUSTER-nic" --vnet-name "$CLUSTER-vnet" --subnet "$CLUSTER-subnet" --network-security-group "$CLUSTER-nsg" --public-ip-address "$CLUSTER-pip"
-
-  # 8. VM
-  az vm create \
+  # 3. VM (networking resources are created automatically)
+  VM_IP=$(az vm create \
     --resource-group "$CLUSTER" \
     --name "$CLUSTER-vm" \
-    --nics "$CLUSTER-nic" \
     --image "$IMAGE" \
     --size "$VM_SIZE" \
     --admin-username "$ADMIN_USER" \
     --ssh-key-values "${SSH_KEY}.pub" \
     --authentication-type ssh \
-    --no-wait
+    --public-ip-address-allocation static \
+    --query publicIpAddress -o tsv)
 
-  # 9. Wait for VM IP
-  az vm wait --created --resource-group "$CLUSTER" --name "$CLUSTER-vm"
-  VM_IP=$(az network public-ip show --resource-group "$CLUSTER" --name "$CLUSTER-pip" --query ipAddress -o tsv)
-
-  # 10. Wait for SSH
+  # 4. Wait for SSH
   for i in {1..30}; do
     if nc -z "$VM_IP" 22; then break; fi
     sleep 5
   done
 
-  # 11. Create inventory file with both host and group
+  # 5. Create inventory file
   cat > "${CLUSTER}_${REGION}_inventory.yml" <<EOF
 all:
   hosts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,7 +685,7 @@ jobs:
       - id: azure-init
         name: Initialize Azure environment
         run: |
-          AZURE_REGION=westeurope
+          AZURE_REGION=uksouth
           echo "AZURE Region: ${AZURE_REGION}"
 
           AZURE_CLUSTER_NAME="gh-action-$(git rev-parse --short HEAD)-${{ github.run_id }}-${{ github.run_attempt }}"


### PR DESCRIPTION
* removed pinned azure-cli install broken by runner image update
* simplified azure_vm_manager.sh by letting az vm create handle networking resources and IP retrieval automatically (less API calls could also save some time - very roughly, based on a datapoint from my fork, ~30-60 seconds saved per run)
* switched Azure region from westeurope (Netherlands) to uksouth (London) per Azure cost recommendation (estimation based on the publicly available pricing for the UK region is 13 cents a month saved 😊)

Closes #52460

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
