### PR TITLE
Fix DPoP bind enforcer to exempt public clients using refresh-token-only binding

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/DPoPBindEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/DPoPBindEnforcerExecutor.java
@@ -122,7 +122,7 @@ public class DPoPBindEnforcerExecutor implements ClientPolicyExecutorProvider<DP
             case REGISTER, UPDATE -> {
                 ClientCRUDContext clientUpdateContext = (ClientCRUDContext)context;
                 autoConfigure(clientUpdateContext.getProposedClientRepresentation());
-                validate(clientUpdateContext.getProposedClientRepresentation());
+                validate(clientUpdateContext);
             }
             case AUTHORIZATION_REQUEST -> {
                 AuthorizationRequestContext authzRequestContext = (AuthorizationRequestContext) context;
@@ -159,10 +159,30 @@ public class DPoPBindEnforcerExecutor implements ClientPolicyExecutorProvider<DP
         }
     }
 
-    private void validate(ClientRepresentation rep) throws ClientPolicyException {
-        boolean isUseDPoP = OIDCAdvancedConfigWrapper.fromClientRepresentation(rep).isUseDPoP();
+    private void validate(ClientCRUDContext context) throws ClientPolicyException {
+        boolean isPublicClient = getEffectivePublicClientConfiguration(context);
+        if (isPublicClient && configuration.getAllowOnlyRefreshTokenBinding() == Boolean.TRUE) {
+            // Public clients relying on refresh-token-only binding don't need to enable DPoP for access tokens as well.
+            return;
+        }
+        boolean isUseDPoP = OIDCAdvancedConfigWrapper.fromClientRepresentation(context.getProposedClientRepresentation()).isUseDPoP();
         if (!isUseDPoP) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT_METADATA, "Invalid client metadata: DPoP token is disabled");
+        }
+    }
+
+    private boolean getEffectivePublicClientConfiguration(ClientCRUDContext context) {
+        Boolean isPublicClient = context.getProposedClientRepresentation().isPublicClient();
+        if (isPublicClient != null) {
+            return isPublicClient;
+        } else {
+            // The "publicClient" field is not filled in the representation, so it effectively has same value as before the update
+            if (context.getTargetClient() != null) {
+                return context.getTargetClient().isPublicClient();
+            } else {
+                // Registration of new client, default to false (confidential client)
+                return false;
+            }
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/DPoPTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/DPoPTest.java
@@ -68,6 +68,8 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
 import org.keycloak.representations.idm.ClientInitialAccessPresentation;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -140,6 +142,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -923,28 +926,59 @@ public class DPoPTest {
                         .addCondition(AnyClientConditionFactory.PROVIDER_ID, createAnyClientConditionConfig())
                         .addProfile("MyProfile")
                         .toRepresentation()));
-        int clockSkew = 10; // acceptable clock skew is +-10sec
+        try {
+            int clockSkew = 10; // acceptable clock skew is +-10sec
 
-        //public client without proof
-        sendAuthorizationRequestWithDPoPJkt(null);
-        failureTokenProceduresWithDPoP(null, "DPoP proof is missing");
-        deleteAllCookiesForRealm();
+            // the public client can still be updated while keeping DPoP for access tokens disabled - it only gets refresh token binding.
+            // Re-submitting the already-set attribute value (rather than an unrelated field) exercises the update without leaving
+            // the shared fixture client in a permanently altered state for subsequent tests
+            ClientRepresentation client = realm.admin().clients().findByClientId(TEST_PUBLIC_CLIENT_ID).get(0);
+            updateClientByAdmin(client.getId(), c -> c.getAttributes().put(OIDCConfigAttributes.DPOP_BOUND_ACCESS_TOKENS, Boolean.FALSE.toString()));
+            client = realm.admin().clients().findByClientId(TEST_PUBLIC_CLIENT_ID).get(0);
+            assertEquals(Boolean.FALSE.toString(), client.getAttributes().get(OIDCConfigAttributes.DPOP_BOUND_ACCESS_TOKENS));
 
-        //public client with proof
-        sendAuthorizationRequestWithDPoPJkt(null);
-        String dpopProofEcEncoded = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST, oauth.getEndpoints().getToken(), Time.currentTimeSeconds() + clockSkew, Algorithm.ES256, jwsEcHeader, ecKeyPair.getPrivate(), null);
-        successTokenProceduresWithDPoP(dpopProofEcEncoded, jktEc, false, true);
+            // the confidential client without DPoP for access tokens must still be rejected - refresh-token-only binding is public-client only
+            String confidentialClientUuid = realm.admin().clients().findByClientId(TEST_CONFIDENTIAL_CLIENT_ID).get(0).getId();
+            ClientPolicyException exception = assertThrows(ClientPolicyException.class,
+                    () -> updateClientByAdmin(confidentialClientUuid, (ClientRepresentation c) -> c.getAttributes().put(OIDCConfigAttributes.DPOP_BOUND_ACCESS_TOKENS, Boolean.FALSE.toString())));
+            assertEquals(OAuthErrorException.INVALID_CLIENT_METADATA, exception.getMessage());
 
-        //confidential client without proof
-        oauth.client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET);
-        oauth.doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
-        successTokenProceduresWithDPoP(null, jktEc, false, false);
+            //public client without proof
+            sendAuthorizationRequestWithDPoPJkt(null);
+            failureTokenProceduresWithDPoP(null, "DPoP proof is missing");
+            deleteAllCookiesForRealm();
 
-        //confidential client with proof
-        oauth.client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET);
-        oauth.doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
-        dpopProofEcEncoded = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST, oauth.getEndpoints().getToken(), Time.currentTimeSeconds() + clockSkew, Algorithm.ES256, jwsEcHeader, ecKeyPair.getPrivate(), null);
-        successTokenProceduresWithDPoP(dpopProofEcEncoded, jktEc, true, false);
+            //public client with proof
+            sendAuthorizationRequestWithDPoPJkt(null);
+            String dpopProofEcEncoded = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST, oauth.getEndpoints().getToken(), Time.currentTimeSeconds() + clockSkew, Algorithm.ES256, jwsEcHeader, ecKeyPair.getPrivate(), null);
+            successTokenProceduresWithDPoP(dpopProofEcEncoded, jktEc, false, true);
+
+            //confidential client without proof
+            oauth.client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET);
+            oauth.doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
+            successTokenProceduresWithDPoP(null, jktEc, false, false);
+
+            //confidential client with proof
+            oauth.client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET);
+            oauth.doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
+            dpopProofEcEncoded = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST, oauth.getEndpoints().getToken(), Time.currentTimeSeconds() + clockSkew, Algorithm.ES256, jwsEcHeader, ecKeyPair.getPrivate(), null);
+            successTokenProceduresWithDPoP(dpopProofEcEncoded, jktEc, true, false);
+        } finally {
+            // explicitly clear the policy/profile via the REST resource directly (not realm.updateClientPolicy/
+            // updateClientProfile, which would register another teardown task referencing the policy/profile we're
+            // about to remove) so the enforcing policy is gone by the time the automatically-registered teardown
+            // reverts the clients' DPOP_BOUND_ACCESS_TOKENS attribute above - teardown tasks run in registration
+            // order, so without this the confidential client's attribute revert would be rejected by the very
+            // policy under test. Run this in a finally block so it also cleans up if an earlier assertion in this
+            // test fails.
+            ClientPoliciesRepresentation emptyPolicies = new ClientPoliciesRepresentation();
+            emptyPolicies.setPolicies(List.of());
+            realm.admin().clientPoliciesPoliciesResource().updatePolicies(emptyPolicies);
+
+            ClientProfilesRepresentation emptyProfiles = new ClientProfilesRepresentation();
+            emptyProfiles.setProfiles(List.of());
+            realm.admin().clientPoliciesProfilesResource().updateProfiles(emptyProfiles);
+        }
     }
 
     @Test


### PR DESCRIPTION
`DPoPBindEnforcerExecutor.validate()` incorrectly rejected public client register/update requests with `invalid_client_metadata` whenever a client policy condition matched the client and the effective executor configuration had `allow-only-refresh-token-binding=true`, even though that flag only adds refresh token binding and never mandates full DPoP enforcement for such clients. Public clients matched by such a policy are now exempt from the DPoP-enabled requirement.

Generative AI was used to help write and iterate on the added test case.

Closes #52441