### PR TITLE
Fix duplicate credentials fetch in Admin Console

### DIFF
--- a/js/apps/admin-ui/src/user/UserCredentials.tsx
+++ b/js/apps/admin-ui/src/user/UserCredentials.tsx
@@ -110,6 +110,9 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
   const [groupedUserCredentials, setGroupedUserCredentials] = useState<
     ExpandableCredentialRepresentation[]
   >([]);
+  const [credentialTypes, setCredentialTypes] = useState<
+    CredentialRepresentation[] | undefined
+  >();
   const [selectedCredential, setSelectedCredential] =
     useState<CredentialRepresentation>({});
   const [isResetPassword, setIsResetPassword] = useState(false);
@@ -131,14 +134,12 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
       return Promise.resolve([]);
     },
     (credentials) => {
-      credentials = [
-        ...credentials.filter((c: CredentialRepresentation) => {
-          return c.federationLink === undefined;
-        }),
-      ];
-      setUserCredentials(credentials);
+      const ownCredentials = credentials.filter(
+        (c: CredentialRepresentation) => c.federationLink === undefined,
+      );
+      setUserCredentials(ownCredentials);
 
-      const groupedCredentials = credentials.reduce((r, a) => {
+      const groupedCredentials = ownCredentials.reduce((r, a) => {
         r[a.type!] = r[a.type!] || [];
         r[a.type!].push(a);
         return r;
@@ -153,6 +154,12 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
           ...groupedCredential,
           isExpanded: false,
         })),
+      );
+
+      setCredentialTypes(
+        credentials.filter(
+          (c: CredentialRepresentation) => c.federationLink !== undefined,
+        ),
       );
     },
     [key],
@@ -361,27 +368,6 @@ export const UserCredentials = ({ user, setUser }: UserCredentialsProps) => {
   };
 
   const useFederatedCredentials = user.federationLink;
-  const [credentialTypes, setCredentialTypes] = useState<
-    CredentialRepresentation[] | undefined
-  >();
-
-  useFetch(
-    () => {
-      if (user.enabled) {
-        return adminClient.users.getCredentials({ id: user.id! });
-      }
-      return Promise.resolve([]);
-    },
-    (credentials) => {
-      credentials = [
-        ...credentials.filter((c: CredentialRepresentation) => {
-          return c.federationLink !== undefined;
-        }),
-      ];
-      setCredentialTypes(credentials);
-    },
-    [key],
-  );
 
   if (!credentialTypes) {
     return <KeycloakSpinner />;


### PR DESCRIPTION
Closes #52471

Opening the Credentials tab for a user in the Admin Console fired two identical `GET` requests to `/admin/realms/{realm}/users/{id}/credentials`.

`UserCredentials.tsx` had two separate `useFetch` hooks both calling `adminClient.users.getCredentials({ id: user.id! })` with identical params — one filtered the result for `federationLink === undefined` (own credentials), the other for `federationLink !== undefined` (federated credential types). Both hooks fetched the exact same data and only differed in how they filtered it client-side afterwards.

This change fetches once and derives both filtered lists from the single response.

### Verified locally
- Built a local Quarkus server + admin-ui dev server (`pnpm start --local --admin-dev` / `pnpm dev`)
- Before fix: opening a user's Credentials tab showed 2 identical `getCredentials` requests in the Network tab (4 under React StrictMode's dev double-invoke)
- After fix: down to 1 request (2 under StrictMode)
- Credentials tab still renders correctly, no visual/behavioral change

### Testing
- `tsc --noEmit` clean
- `eslint` clean on the changed file
- No test coverage previously existed for this component's fetch behavior; happy to add a regression test if reviewers want one guarding the single-request expectation

### AI usage disclosure
Per CONTRIBUTING.md: I used an AI coding assistant (Claude) to help trace the root cause and draft this fix. I reviewed and understand the change, verified it locally as described above, and take responsibility for it.