### PR TITLE
Fix role inheritance display to show direct and inherited instances s…

### DIFF
--- a/js/apps/admin-ui/src/components/role-mapping/RoleMapping.tsx
+++ b/js/apps/admin-ui/src/components/role-mapping/RoleMapping.tsx
@@ -44,26 +44,72 @@ export const mapRoles = (
   assignedRoles: Row[],
   effectiveRoles: Row[],
   hide: boolean,
-) => [
-  ...(hide
-    ? assignedRoles.map((row) => ({
-        id: row.role.id,
-        ...row,
-        role: {
-          ...row.role,
-          isInherited: false,
-        },
-      }))
-    : effectiveRoles.map((row) => ({
-        id: row.role.id,
-        ...row,
-        role: {
-          ...row.role,
-          isInherited:
-            assignedRoles.find((r) => r.role.id === row.role.id) === undefined,
-        },
-      }))),
-];
+) => {
+  if (hide) {
+    return assignedRoles.map((row) => ({
+      id: row.role.id,
+      ...row,
+      role: {
+        ...row.role,
+        isInherited: false,
+      },
+    }));
+  }
+
+  const assignedRoleIds = new Set(
+    assignedRoles.filter((r) => r.role.id).map((r) => r.role.id),
+  );
+  const effectiveRoleCountMap = new Map<string, number>();
+  effectiveRoles.forEach((row) => {
+    if (row.role.id) {
+      effectiveRoleCountMap.set(
+        row.role.id,
+        (effectiveRoleCountMap.get(row.role.id) || 0) + 1,
+      );
+    }
+  });
+
+  const result: Row[] = [];
+  const seenRoleIds = new Set<string>();
+
+  effectiveRoles.forEach((row) => {
+    if (row.role.id && !seenRoleIds.has(row.role.id)) {
+      seenRoleIds.add(row.role.id);
+      const isAssigned = assignedRoleIds.has(row.role.id);
+      const effectiveCount = effectiveRoleCountMap.get(row.role.id) || 0;
+
+      if (isAssigned && effectiveCount > 1) {
+        result.push({
+          id: `${row.role.id}-direct`,
+          ...row,
+          role: {
+            ...row.role,
+            isInherited: false,
+          },
+        });
+        result.push({
+          id: `${row.role.id}-inherited`,
+          ...row,
+          role: {
+            ...row.role,
+            isInherited: true,
+          },
+        });
+      } else {
+        result.push({
+          id: row.role.id,
+          ...row,
+          role: {
+            ...row.role,
+            isInherited: !isAssigned,
+          },
+        });
+      }
+    }
+  });
+
+  return result;
+};
 
 export const ServiceRole = ({ role, client }: Row) => (
   <>


### PR DESCRIPTION
…eparately

When a role is assigned both directly to a user and indirectly via group membership (possibly multiple groups), the role mapping UI now correctly displays it with both inherited=false (direct assignment) and inherited=true (group inheritance). Inherited role instances are deduplicated when a role comes from multiple groups.

The fix maintains the sorted order from the effective roles API while properly handling the deduplication logic: a role appears once if only directly assigned or only inherited, but appears twice (both direct and inherited) when it has both types of assignment.

Closes #50687

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
