### PR TITLE
Make the hybrid branch in GrantTypeCondition reachable

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/GrantTypeCondition.java
@@ -100,14 +100,15 @@ public class GrantTypeCondition extends AbstractClientPolicyConditionProvider<Gr
         if (request == null) return false;
         try {
             OIDCResponseType parsedResponseType = OIDCResponseType.parse(request.getAuthorizationEndpointRequest().getResponseType());
-            if (parsedResponseType.hasResponseType(OIDCResponseType.CODE)) {
-                return isGrantMatching(OAuth2Constants.AUTHORIZATION_CODE);
-            }
-            else if (parsedResponseType.isImplicitFlow()) {
+            if (parsedResponseType.isImplicitFlow()) {
                 return isGrantMatching(OAuth2Constants.IMPLICIT);
             }
             else if (parsedResponseType.isImplicitOrHybridFlow()) {
+                // hybrid, the response carries a code and a front channel token
                 return isGrantMatching(OAuth2Constants.AUTHORIZATION_CODE) || isGrantMatching(OAuth2Constants.IMPLICIT);
+            }
+            else if (parsedResponseType.hasResponseType(OIDCResponseType.CODE)) {
+                return isGrantMatching(OAuth2Constants.AUTHORIZATION_CODE);
             }
             else {
                 return false;

--- a/services/src/test/java/org/keycloak/services/clientpolicy/condition/GrantTypeConditionTest.java
+++ b/services/src/test/java/org/keycloak/services/clientpolicy/condition/GrantTypeConditionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.condition;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.protocol.ClientData;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
+import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GrantTypeConditionTest {
+
+    private static final List<String> HYBRID_RESPONSE_TYPES = Arrays.asList("code token", "code id_token", "code id_token token");
+
+    private static final List<ClientPolicyVote> ALL_YES = Arrays.asList(ClientPolicyVote.YES, ClientPolicyVote.YES, ClientPolicyVote.YES);
+
+    @Test
+    public void codeResponseMatchesAuthorizationCodeOnly() throws ClientPolicyException {
+        assertEquals(ClientPolicyVote.YES, vote("code", OAuth2Constants.AUTHORIZATION_CODE));
+        assertEquals(ClientPolicyVote.NO, vote("code", OAuth2Constants.IMPLICIT));
+    }
+
+    @Test
+    public void implicitResponseMatchesImplicitOnly() throws ClientPolicyException {
+        for (String responseType : Arrays.asList("token", "id_token", "id_token token")) {
+            assertEquals(responseType, ClientPolicyVote.YES, vote(responseType, OAuth2Constants.IMPLICIT));
+            assertEquals(responseType, ClientPolicyVote.NO, vote(responseType, OAuth2Constants.AUTHORIZATION_CODE));
+        }
+    }
+
+    @Test
+    public void hybridResponseMatchesImplicit() throws ClientPolicyException {
+        assertEquals(ALL_YES, votes(OAuth2Constants.IMPLICIT));
+    }
+
+    @Test
+    public void hybridResponseMatchesAuthorizationCode() throws ClientPolicyException {
+        assertEquals(ALL_YES, votes(OAuth2Constants.AUTHORIZATION_CODE));
+    }
+
+    @Test
+    public void noneResponseMatchesNothing() throws ClientPolicyException {
+        assertEquals(ClientPolicyVote.NO, vote("none", OAuth2Constants.AUTHORIZATION_CODE));
+        assertEquals(ClientPolicyVote.NO, vote("none", OAuth2Constants.IMPLICIT));
+    }
+
+    private List<ClientPolicyVote> votes(String... grantTypes) throws ClientPolicyException {
+        List<ClientPolicyVote> votes = new ArrayList<>();
+        for (String responseType : HYBRID_RESPONSE_TYPES) {
+            votes.add(vote(responseType, grantTypes));
+        }
+        return votes;
+    }
+
+    private ClientPolicyVote vote(String responseType, String... grantTypes) throws ClientPolicyException {
+        GrantTypeCondition condition = new GrantTypeCondition(null);
+        GrantTypeCondition.Configuration configuration = new GrantTypeCondition.Configuration();
+        configuration.setGrantTypes(Arrays.asList(grantTypes));
+        condition.setupConfiguration(configuration);
+
+        AuthorizationEndpointRequest request = AuthorizationEndpointRequest.fromClientData(
+                new ClientData(null, responseType, null, null));
+
+        return condition.applyPolicy(new AuthorizationRequestContext(
+                OIDCResponseType.parse(responseType), request, null, null, null));
+    }
+}


### PR DESCRIPTION
Closes #51159

the third branch in `GrantTypeCondition.isGrantTypeMatching` can never run :

```java
if (parsedResponseType.hasResponseType(CODE)) {          // 1
    return isGrantMatching(AUTHORIZATION_CODE);
} else if (parsedResponseType.isImplicitFlow()) {        // 2
    return isGrantMatching(IMPLICIT);
} else if (parsedResponseType.isImplicitOrHybridFlow()) { // 3, unreachable
    return isGrantMatching(AUTHORIZATION_CODE) || isGrantMatching(IMPLICIT);
}
```

to reach 3 you need no `code` in the response type . but with no `code` ,
`isImplicitFlow()` is `(token || id_token) && !code` and `isImplicitOrHybridFlow()` is
`(token || id_token)` , which are the same test . so if 2 is false , 3 is false too .

what that costs : `response_type=code token` goes to branch 1 and only ever checks
`authorization_code` . a policy set up with `grant_types=[implicit]` votes no on it , so an
executor meant to cover the front channel token never runs , even though the redirect carries
one . same for `code id_token` and `code id_token token` .

putting implicit first , then hybrid , then code makes the branch reachable . nothing inside
the branches changed , it is a reorder plus a comment . plain `code` still matches
`authorization_code` , plain implicit still matches `implicit` , `none` still returns false ,
and hybrid with `grant_types=[authorization_code]` still votes yes .

five tests added . one fails without the change , all three hybrid types come back
`[NO, NO, NO]` where they should be `[YES, YES, YES]` . the other four pin the cases that must
not move and pass either way .

`mvn -pl services test` is 684 passing , 0 failures . the tree without this runs 679 , so the
only difference is the five new ones . `spotless:check` is clean .

i could not run the integration suites , docker is not available on this machine . i checked
by hand that no integration test asserts the old behaviour : `ClientPoliciesTest`
`testClientGrantTypeCondition` only sends `response_type=code` against
`grant_types=[authorization_code]` , which is unchanged here , and
`testProhibitedImplicitOrHybridFlow` uses `AnyClientCondition` with
`RejectImplicitGrantExecutor` , not this class .

---

ai usage , per the generative ai section of CONTRIBUTING . i used claude code ( claude opus 5 )
as an agent to help find the dead branch , write the patch and the tests , and draft this
description . i went through the reasoning myself , confirmed the branch is unreachable from
the two predicate definitions , and ran everything quoted above locally .
