### PR TITLE
Do not swallow 404s in listSubGroups and listMembers

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/groups.ts
+++ b/js/libs/keycloak-admin-client/src/resources/groups.ts
@@ -131,7 +131,6 @@ export class Groups extends Resource<{ realm?: string }> {
       path: "/{parentId}/children",
       urlParamKeys: ["parentId"],
       queryParamKeys: ["search", "first", "max", "briefRepresentation"],
-      catchNotFound: true,
     },
   );
 
@@ -146,7 +145,6 @@ export class Groups extends Resource<{ realm?: string }> {
     method: "GET",
     path: "/{id}/members",
     urlParamKeys: ["id"],
-    catchNotFound: true,
   });
 
   /**


### PR DESCRIPTION
Closes #52475

`GroupsResource.listSubGroups()` and `listMembers()` are declared to return arrays, but both carried `catchNotFound: true`, which `agent.ts` documents as *"If responding with 404, catch it and return null instead"*.

Callers trust the declared type. `GroupTable` passes the result straight to `KeycloakDataTable`, whose `convertToColumns()` calls `data.map()`, so a 404 throws `TypeError: Cannot read properties of null (reading 'map')` from inside the `useFetch` success callback — a blank page instead of an error the console can render.

Dropping the flag makes a 404 reject with `NetworkError`, which `useFetch` already forwards to the error boundary, and makes the declared return types truthful.

`findOne` keeps `catchNotFound: true`: there the nullable result is intentional and its return type (`GroupRepresentation | undefined`) reflects it.

### Testing

No existing test depends on the previous behaviour:

- `groups.spec.ts` — *"list subgroups"* queries an existing parent and asserts `groups.length`
- `groupUser.spec.ts` — calls `listMembers` on an existing group
- the only `expect(...).to.be.null` in `groups.spec.ts` covers `findOne`, which is unchanged

I did not add a case for the 404 path because the suite runs against a live server and I could not verify a new test in CI from my side. Happy to add one if you would like it.