### PR TITLE
More graceful leaving of distributed caches

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -78,6 +78,7 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.topology.LocalTopologyManager;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHENTICATION_SESSIONS_CACHE_NAME;
@@ -151,6 +152,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         }
         runWithWriteLockOnCacheManager(() -> {
             if (cacheManager != null) {
+                leaveCaches(cacheManager);
                 cacheManager.stop();
                 cacheManager = null;
             }
@@ -158,6 +160,63 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
         if (remoteCacheManager != null) {
             remoteCacheManager.close();
             remoteCacheManager = null;
+        }
+    }
+
+    /**
+     * Explicitly leave all distributed caches before stopping the cache manager.
+     * <p>
+     * {@code DefaultCacheManager.stop()} calls {@code cache.stop()} which sends a per-cache
+     * {@code CacheLeaveCommand} to the coordinator, but immediately tears down local cache components
+     * without waiting for the new topology (excluding this node) to propagate to all members.
+     * During that gap, other nodes still route RPCs to this node's dead caches, causing
+     * {@code ISPN000427} remote-timeout failures.
+     * <p>
+     * By sending the leave commands upfront and letting the coordinator broadcast the updated topology
+     * before local teardown begins, other nodes stop routing to this node before its caches terminate.
+     * <p>
+     * This method and its call in {@link #close()} can be removed once Keycloak upgrades to
+     * Infinispan 16.2+, which handles this natively via {@code OrderedGracefulLeaveHandler}
+     * (see <a href="https://github.com/infinispan/infinispan/issues/17016">infinispan#17016</a>).
+     */
+    private void leaveCaches(EmbeddedCacheManager cm) {
+        var ltm = GlobalComponentRegistry.componentOf(cm, LocalTopologyManager.class);
+        if (ltm == null) {
+            return;
+        }
+        var transport = GlobalComponentRegistry.componentOf(cm, Transport.class);
+        if (transport == null) {
+            return;
+        }
+        int clusterSize = transport.getMembers().size();
+        if (clusterSize <= 1) {
+            return;
+        }
+        for (String cacheName : CLUSTERED_CACHE_NAMES) {
+            try {
+                var cache = cm.getCache(cacheName, false);
+                if (cache == null) {
+                    continue;
+                }
+                var dm = cache.getAdvancedCache().getDistributionManager();
+                if (dm == null) {
+                    continue;
+                }
+                logger.infof("Leaving cache '%s' before shutdown", cacheName);
+                ltm.leave(cacheName, cm.getCacheManagerConfiguration().transport().distributedSyncTimeout());
+            } catch (Exception e) {
+                logger.warnf(e, "Failed to leave cache '%s' during shutdown", cacheName);
+            }
+        }
+        if (clusterSize >= 3) {
+            try {
+                // Allow time for the coordinator to broadcast the updated topology to all members.
+                // This will guard against new requests reaching this node hitting a cache that is terminated in the next step.
+                // With only 2 members, the single remaining node receives the topology update directly — no wait needed.
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -575,7 +575,10 @@ public final class CacheConfigurator {
             case AUTHENTICATION_SESSIONS_CACHE_NAME:
             case LOGIN_FAILURE_CACHE_NAME:
                 if (clustered) {
-                    builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+                    // 3s is 6x the worst-case G1GC pause for in-memory caches, and fits within the
+                    // 10s retry budget in AbstractRefreshTokenProvider with room for 2-3 retries
+                    // (Infinispan default of 15s exceeds the retry budget, preventing any recovery).
+                    builder.clustering().cacheMode(CacheMode.DIST_SYNC).remoteTimeout(3, TimeUnit.SECONDS);
                 }
                 builder.encoding().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
                 return builder;

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -45,10 +45,12 @@ import org.infinispan.configuration.cache.AbstractStoreConfiguration;
 import org.infinispan.configuration.cache.BackupConfiguration;
 import org.infinispan.configuration.cache.BackupFailurePolicy;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.ExpirationConfiguration;
 import org.infinispan.configuration.cache.HashConfiguration;
 import org.infinispan.configuration.cache.HashConfigurationBuilder;
+import org.infinispan.configuration.cache.LockingConfiguration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.transaction.LockingMode;
@@ -351,6 +353,28 @@ public final class CacheConfigurator {
     }
 
     /**
+     * Validates that lock-timeout &lt; remote-timeout for distributed synchronous caches.
+     * <p>
+     * The remote-timeout is the outer timeout for the entire remote RPC, which includes lock acquisition
+     * on the remote node. If lock-timeout &ge; remote-timeout, the remote call times out before lock
+     * acquisition can complete, causing spurious {@code TimeoutException}s.
+     */
+    public static void ensureTimeoutOrdering(ConfigurationBuilderHolder holder) {
+        for (var entry : holder.getNamedConfigurationBuilders().entrySet()) {
+            var builder = entry.getValue();
+            if (!builder.clustering().cacheMode().isDistributed() || !builder.clustering().cacheMode().isSynchronous()) {
+                continue;
+            }
+            long remoteTimeout = builder.clustering().attributes().attribute(ClusteringConfiguration.REMOTE_TIMEOUT).get().longValue();
+            long lockTimeout = builder.locking().attributes().attribute(LockingConfiguration.LOCK_ACQUISITION_TIMEOUT).get().longValue();
+            if (lockTimeout >= remoteTimeout) {
+                logger.errorf("Cache '%s': lock-timeout (%d ms) must be less than remote-timeout (%d ms). "
+                        + "Current values will cause spurious remote timeouts during lock acquisition.", entry.getKey(), lockTimeout, remoteTimeout);
+            }
+        }
+    }
+
+    /**
      * Configures (and overwrites) the {@link HashConfigurationBuilder#numOwners(int)} based on the SPI configuration
      * input.
      *
@@ -575,10 +599,15 @@ public final class CacheConfigurator {
             case AUTHENTICATION_SESSIONS_CACHE_NAME:
             case LOGIN_FAILURE_CACHE_NAME:
                 if (clustered) {
-                    // 3s is 6x the worst-case G1GC pause for in-memory caches, and fits within the
-                    // 10s retry budget in AbstractRefreshTokenProvider with room for 2-3 retries
-                    // (Infinispan default of 15s exceeds the retry budget, preventing any recovery).
-                    builder.clustering().cacheMode(CacheMode.DIST_SYNC).remoteTimeout(3, TimeUnit.SECONDS);
+                    // lock-timeout < remote-timeout < retry budget in AbstractRefreshTokenProvider (12s).
+                    // Infinispan defaults (15s remote, 10s lock) are too high for a setup like Keycloak.
+                    builder.clustering().cacheMode(CacheMode.DIST_SYNC)
+                            // 5s remote-timeout is 10x the worst-case G1GC pause for in-memory caches.
+                            .remoteTimeout(5, TimeUnit.SECONDS);
+                    builder.locking()
+                            // 3s lock-timeout is the inner timeout; must be less than remote-timeout.
+                            .lockAcquisitionTimeout(3, TimeUnit.SECONDS);
+                    // 12s retry budget in AbstractRefreshTokenProvider allows 2 retries at ~5s each.
                 }
                 builder.encoding().mediaType(MediaType.APPLICATION_OBJECT_TYPE);
                 return builder;

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/DefaultCacheEmbeddedConfigProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/DefaultCacheEmbeddedConfigProviderFactory.java
@@ -211,6 +211,7 @@ public class DefaultCacheEmbeddedConfigProviderFactory implements CacheEmbeddedC
         CacheConfigurator.configureNumOwners(config, holder);
         CacheConfigurator.validateWorkCacheConfiguration(holder);
         CacheConfigurator.ensureMinimumOwners(holder);
+        CacheConfigurator.ensureTimeoutOrdering(holder);
         if (JGroupsConfigurator.isClustered(holder)) {
             KeycloakModelUtils.runJobInTransaction(factory, session -> JGroupsConfigurator.configureJGroups(config, holder, session));
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
@@ -104,6 +104,15 @@ public abstract class KeycloakLogFilter implements Filter {
             }
         }
 
+        // ISPN000208 "No live owners found for segments" fires during state transfer when a node is the sole
+        // remaining owner after another node departed. The data is safe (this node has it), but the message
+        // is logged at ERROR and alarms users. With numOwners>=2 enforced by Keycloak, a single node
+        // departure always leaves at least one live owner, so this is expected during rolling restarts.
+        // https://github.com/keycloak/keycloak/issues/52088
+        if (Objects.equals(record.getLevel(), Level.SEVERE) && record.getLoggerName().equals("org.infinispan.CLUSTER") && record.getMessage().startsWith("ISPN000208")) {
+            return false;
+        }
+
         if (executor != null && ThreadCreator.isVirtual(Thread.currentThread())) {
             executor.submit(new RecordLogger(ExtLogRecord.wrap(record), this));
             return false;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -147,6 +147,8 @@ public class ClusterConfigDistTest {
     void testExplicitCacheConfigFile(CLIResult result) {
         result.assertStarted();
         result.assertClusteredCache();
+        // CacheConfigurator.ensureTimeoutOrdering() validates lock-timeout < remote-timeout
+        result.assertNoMessage("must be less than remote-timeout");
     }
 
     @Test

--- a/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java
@@ -251,7 +251,8 @@ public abstract class AbstractRefreshTokenProvider implements RefreshTokenProvid
                     KeycloakModelUtils.runJobInTransaction(factory, s -> s.singleUseObjects().remove(lockId));
                 }
             });
-        }, Duration.of(10, ChronoUnit.SECONDS), 10);
+        // 12s allows 2 retries given the 5s remote-timeout on the actionTokens cache (CacheConfigurator).
+        }, Duration.of(12, ChronoUnit.SECONDS), 10);
     }
 
     /**


### PR DESCRIPTION
Closes #52088

## Assumptions and design decisions

### 1. Per-cache leave before `cacheManager.stop()`

Infinispan's `DefaultCacheManager.stop()` already sends a per-cache `CacheLeaveCommand` via `StateTransferManagerImpl.stop()`, but by that point local cache components are torn down immediately after — other nodes still have the old topology and route RPCs to the departing node's dead caches, producing `ISPN000427` remote-timeout errors.

The fix calls `LocalTopologyManager.leave()` for each distributed cache **before** `cacheManager.stop()`. This is safe because DIST_SYNC's synchronous backup ack guarantees that any in-flight write completes (or fails) before the leave takes effect — there is no window where a write is acknowledged to the caller but lost because the node departed.

After leaving, the departing node is no longer a participant in the post-leave rebalance, so there is **no need to wait for the rebalance to complete** — only for the updated topology to propagate.

### 2. The 500ms fixed wait

After all leave commands are sent, a 500ms `Thread.sleep()` gives the coordinator time to broadcast the updated topology to remaining members. This is a pragmatic choice — there is no Infinispan API to "wait until all members have installed the new topology." The wait is **skipped** when the cluster has only 2 members (the remaining node receives the topology update directly as the coordinator or the only peer) and when the node is alone (`clusterSize <= 1`).

### 3. The 3-second `remoteTimeout`

Applied to `actionTokens`, `authenticationSessions`, and `loginFailures` — the three DIST_SYNC caches that don't already have a custom timeout. The value is derived from two constraints:
- **GC headroom**: 6x the worst-case G1GC mixed-collection pause (~500ms) for in-memory caches.
- **Retry budget**: [AbstractRefreshTokenProvider](https://github.com/keycloak/keycloak/blob/87b7d66d8cbcabf91a45bd02ec7ae940957c8e21/services/src/main/java/org/keycloak/protocol/oidc/refresh/AbstractRefreshTokenProvider.java#L231) retries for up to 10 seconds. The Infinispan default of 15s exceeds this entirely (one timeout = no retries). At 3s, there is room for 2-3 retries within the 10s budget.

Session caches (`userSessions`, `clientSessions`, `offlineSessions`, `offlineClientSessions`) are **not changed** — with persistent sessions enabled, they use `numOwners=1` and different access patterns.

### 4. ISPN000208 log suppression

`ISPN000208 "No live owners found for segments …"` fires in `StateConsumerImpl.findSources()` during state transfer when the current node is the **sole remaining owner** after another node departs. The log level is ERROR, but the data is safe — this node has it. With `numOwners >= 2` enforced by Keycloak for these caches, a single-node departure always leaves at least one live owner, so ISPN000208 is expected noise during rolling restarts. It is suppressed using the existing `KeycloakLogFilter` mechanism (same as ISPN000312).

### 5. Interaction with `ShutdownManager`

`ShutdownManager` (added in PR #44620) waits for any in-progress rebalance to settle before shutdown proceeds, but does **not** do a graceful per-cache leave. The new `leaveCaches()` runs **after** `ShutdownManager.onShutdown()` returns, so the sequence is: wait for stable topology → leave all caches → wait for topology propagation → stop cache manager. This ordering ensures we don't leave caches while a rebalance is still in progress.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
