### PR TITLE
Align URN resource indicator validation with RFC 8141

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/resourceindicators/ResourceIndicatorValidation.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/resourceindicators/ResourceIndicatorValidation.java
@@ -6,7 +6,11 @@ import java.util.regex.Pattern;
 
 public class ResourceIndicatorValidation {
 
-    private static final Pattern URN_REGEX = Pattern.compile("^urn:[a-z0-9][a-z0-9-]{0,31}:([a-z0-9()+,-.:=@;$_!*']|%[0-9a-f]{2})++$", Pattern.CASE_INSENSITIVE);
+    // RFC 8141: NID = alphanum 0*30(ldh) alphanum, NSS = pchar *(pchar / "/"),
+    // with pchar as defined by RFC 3986: unreserved / pct-encoded / sub-delims / ":" / "@".
+    private static final String PCHAR = "[a-z0-9\\-._~!$&'()*+,;=:@]|%[0-9a-f]{2}";
+
+    private static final Pattern URN_REGEX = Pattern.compile("^urn:[a-z0-9][a-z0-9-]{0,30}[a-z0-9]:(" + PCHAR + ")((" + PCHAR + ")|/)*+$", Pattern.CASE_INSENSITIVE);
 
     private ResourceIndicatorValidation() {
     }

--- a/services/src/test/java/org/keycloak/protocol/oidc/resourceindicators/ResourceIndicatorValidationTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/resourceindicators/ResourceIndicatorValidationTest.java
@@ -27,6 +27,43 @@ public class ResourceIndicatorValidationTest {
     }
 
     @Test
+    public void testNamespaceSpecificStringAllowsAllPchar() {
+        // RFC 8141: NSS = pchar *(pchar / "/"), with pchar from RFC 3986.
+        assertValid("urn:example:rootgroup/subgroup/child");
+        assertValid("urn:example:foo~bar");
+        assertValid("urn:example:foo&bar");
+        assertValid("urn:example:a:b@c;d=e,f");
+        assertValid("urn:example:foo%2Fbar");
+        assertValid("urn:example:foo%2fbar");
+        assertValid("urn:example:Foo");
+    }
+
+    @Test
+    public void testNamespaceSpecificStringRejectsNonPchar() {
+        // A slash cannot be the first character of the NSS, and the NSS cannot be empty.
+        assertInvalid("urn:example:/foo");
+        assertInvalid("urn:example:");
+        assertInvalid("urn:example:foo bar");
+        assertInvalid("urn:example:foo%zz");
+    }
+
+    @Test
+    public void testNamespaceIdentifier() {
+        // RFC 8141: NID = alphanum 0*30(ldh) alphanum, so two to thirty-two characters
+        // starting and ending with an alphanumeric one. The scheme and the NID are
+        // both case-insensitive.
+        assertValid("URN:example:test");
+        assertValid("urn:EXAMPLE:test");
+        assertValid("urn:ab:test");
+        assertValid("urn:0123456789012345678901234567890a:test");
+
+        assertInvalid("urn:a:test");
+        assertInvalid("urn:example-:test");
+        assertInvalid("urn:-example:test");
+        assertInvalid("urn:0123456789012345678901234567890ab:test");
+    }
+
+    @Test
     public void testInvalidResourceIndicatorUrls() {
         assertInvalid("https://something#something");
         assertInvalid("https://something?something");


### PR DESCRIPTION
Closes #52324

`ResourceIndicatorValidation` rejects URNs that RFC 8141 allows, and accepts NIDs that it does not.

RFC 8141 defines `NSS = pchar *(pchar / "/")`, with `pchar` from RFC 3986: unreserved (which includes `~`), pct-encoded, sub-delims (which include `&`), `:` and `@`. The current character class leaves out `/`, `~` and `&`, so a URN carrying a group path — the case in the issue — is refused. It also defines `NID = alphanum 0*30(ldh) alphanum`, i.e. two to thirty-two characters starting and ending with an alphanumeric one, while the current `[a-z0-9][a-z0-9-]{0,31}` accepts a single character and lets the NID end in `-`.

A note on the table in the issue: four of the deviations listed there do not reproduce, because the pattern is compiled with `Pattern.CASE_INSENSITIVE`. `URN:example:test`, `urn:EXAMPLE:test`, `urn:example:Foo` and `%2F` are all accepted today. I checked each case against the current pattern before changing anything, so this PR only touches the five that do reproduce:

| input | before | after | RFC 8141 |
|---|---|---|---|
| `urn:example:foo/bar` | rejected | accepted | allowed |
| `urn:example:foo~bar` | rejected | accepted | allowed |
| `urn:example:foo&bar` | rejected | accepted | allowed |
| `urn:a:test` | accepted | rejected | NID needs two characters |
| `urn:example-:test` | accepted | rejected | NID must end alphanumeric |

Unchanged: `/` still cannot open the NSS, the NSS still cannot be empty, and `#` and `?` are still refused, as RFC 8707 requires.

The quantifier stays possessive, so the pattern keeps its linear matching behaviour.

## Tests

Three new cases in `ResourceIndicatorValidationTest` covering the NSS character set, the NSS boundaries and the NID grammar, including the 32-character NID and the 33-character one either side of the limit. Two of them fail without the change. The existing cases are untouched and still pass.
