### PR TITLE
Select EC2 image dynamically for EC2 tests

### DIFF
--- a/.github/scripts/ansible/roles/aws_ec2/README.md
+++ b/.github/scripts/ansible/roles/aws_ec2/README.md
@@ -16,7 +16,8 @@ variables `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` are set in the environment.
 - `cluster_name`: Unique name of the instance cluster within the region. Defaults to `keycloak_{{ cluster_identifier }}`.
 - `cluster_identifier`: Identifier to distingish multiple clusters within the region. Defaults to `${USER}`.
 - `cluster_size`: Number of EC2 instances to be created.
-- `ami_name`: Name of the AMI image to be used for spawning instances.
+- `ami_owner`: AWS account ID of the AMI owner. Defaults to Red Hat (`309956199498`).
+- `ami_name_pattern`: Wildcard pattern for the AMI name lookup. The role picks the latest available AMI matching the pattern. Defaults to `RHEL-9.6*_HVM*-x86_64-*-Hourly2-GP3`.
 - `instance_type`: [AWS instance type](https://aws.amazon.com/ec2/instance-types/).
 - `instance_volume_size`: Size of instance storage device.
 - `instance_device`: Path to Linux storage device.

--- a/.github/scripts/ansible/roles/aws_ec2/defaults/main.yml
+++ b/.github/scripts/ansible/roles/aws_ec2/defaults/main.yml
@@ -4,8 +4,8 @@ cluster_size: 1
 
 cidr_ip: "{{ control_host_ip.stdout }}/32"
 
-# aws ec2 describe-images --owners 309956199498 --filters "Name=architecture,Values=x86_64" "Name=virtualization-type,Values=hvm"  --region eu-west-1 --no-include-deprecated     --query 'Images[] | sort_by(@, &CreationDate)[].Name'
-ami_name: RHEL-9.4_HVM_GA-20240827-x86_64-0-Hourly2-GP3
+ami_owner: "309956199498"
+ami_name_pattern: "RHEL-9.6*_HVM*-x86_64-*-Hourly2-GP3"
 
 instance_type: t3.large
 instance_volume_size: 20

--- a/.github/scripts/ansible/roles/aws_ec2/tasks/create-resources.yml
+++ b/.github/scripts/ansible/roles/aws_ec2/tasks/create-resources.yml
@@ -42,12 +42,29 @@
     mode: 0600
   no_log: "{{ no_log_sensitive }}"
 
-- name: Look up AMI '{{ ami_name }}'
+- name: Look up latest RHEL 9 AMI matching '{{ ami_name_pattern }}'
   amazon.aws.ec2_ami_info:
-    region: '{{ region}}'
+    region: '{{ region }}'
+    owners:
+      - '{{ ami_owner }}'
     filters:
-      name: '{{ ami_name }}'
+      name: '{{ ami_name_pattern }}'
+      architecture: x86_64
+      state: available
   register: ami_info
+
+- name: Fail if no AMI found
+  ansible.builtin.fail:
+    msg: "No AMI found matching '{{ ami_name_pattern }}' from owner {{ ami_owner }} in {{ region }}"
+  when: ami_info.images | length == 0
+
+- name: Select most recent AMI
+  set_fact:
+    selected_ami: "{{ (ami_info.images | sort(attribute='creation_date') | last) }}"
+
+- name: Show selected AMI
+  debug:
+    msg: "Using AMI {{ selected_ami.image_id }} ({{ selected_ami.name }}, created {{ selected_ami.creation_date }})"
 
 - name: Create {{ cluster_size }} EC2 Instances
   amazon.aws.ec2_instance:
@@ -56,7 +73,7 @@
     name: "{{ cluster_name }}"
     exact_count: "{{ cluster_size }}"
     instance_type: '{{ instance_type }}'
-    image_id: '{{ ami_info.images[0].image_id }}'
+    image_id: '{{ selected_ami.image_id }}'
     key_name: '{{ cluster_name }}'
     security_group: '{{ group.group_id }}'
     network:


### PR DESCRIPTION
Closes #52493

Test run: https://github.com/ahus1/keycloak/actions/runs/34137730326/job/101792554843

## Design decisions and assumptions

**RHEL 9.6 instead of 9.4 or 9.***

The old AMI was RHEL 9.4 from August 2024. Instead of just picking a newer 9.4 image or opening the pattern to all of 9.x:

- **Not 9.4:** While 14 RHEL 9.4 AMIs still exist in us-east-1, the earliest ones already deprecate in late 2026. Staying on 9.4 shortens the runway before the next break.
- **Not 9.\*:** A fully open pattern would silently jump to 9.8, which may introduce untested OS-level differences. Pinning the minor version keeps the blast radius small.
- **9.6** is the middle ground: current stable release (GA since Apr 2025), 11 AMIs available, the latest (2026-08-11) doesn't deprecate until 2028+. This gives ~2 years before any action is needed.

**Dynamic lookup instead of a new hardcoded AMI name**

A static AMI name fix would work today but break again in ~2 years when AWS deregisters that image too. The dynamic lookup:

- Filters by Red Hat's owner ID (`309956199498`), `state: available`, and `architecture: x86_64` to exclude deprecated/deregistered images
- Sorts by `creation_date` and picks the latest, so patch-level OS updates are adopted automatically
- Logs the selected AMI name and creation date for debuggability
- Fails early with a clear message if no AMI matches, instead of the cryptic `_AnsibleLazyTemplateList object has no element 0`

**Scope: Aurora only, not Azure**

The Azure CI (`AzureDB IT`) also fails at VM creation, but that's a separate issue (Azure credential parsing: `Failed to parse subscriptionId from AZURE_CREDENTIALS`). Azure uses its own `azure_vm_manager.sh` script with `az` CLI, not the Ansible AWS roles changed here.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
