### PR TITLE
Flaky Admin UI E2E test: "Should show items on next page" in scope.spec.ts

### DIFF
--- a/js/apps/admin-ui/test/client-scope/main.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/main.spec.ts
@@ -129,12 +129,23 @@ test.describe("Client scopes filtering", () => {
     expect(protocols).not.toContain(FilterProtocol.OpenID);
   });
 
-  test("shows items on next page are more than 11", async ({ page }) => {
+  test("shows items on next page when there are more than 11 entries", async ({
+    page,
+  }) => {
     await using testBed = await createTestBed();
 
     await login(page, { to: toClientScopes({ realm: testBed.realm }) });
 
+    const firstPageRows = await getTableData(page, tableName);
     await clickNextPageButton(page);
+    await expect
+      .poll(
+        async () => {
+          return await getTableData(page, tableName);
+        },
+        { message: "expected table data to change after clicking next page" },
+      )
+      .not.toEqual(firstPageRows);
     const rows = await getTableData(page, tableName);
     expect(rows.length).toBeGreaterThan(1);
   });

--- a/js/apps/admin-ui/test/clients/scope.spec.ts
+++ b/js/apps/admin-ui/test/clients/scope.spec.ts
@@ -152,8 +152,19 @@ test.describe.serial("Client details - Client scopes subtab", () => {
     await assertRowExists(page, itemName);
   });
 
-  test("Should show items on next page are more than 11", async ({ page }) => {
+  test("Should show items on next page when there are more than 11 entries", async ({
+    page,
+  }) => {
+    const firstPageRows = await getTableData(page, tableName);
     await clickNextPageButton(page);
+    await expect
+      .poll(
+        async () => {
+          return await getTableData(page, tableName);
+        },
+        { message: "expected table data to change after clicking next page" },
+      )
+      .not.toEqual(firstPageRows);
     const rows = await getTableData(page, tableName);
     expect(rows.length).toBeGreaterThan(1);
   });


### PR DESCRIPTION
Closes #52490

## Problem

The E2E test "Should show items on next page are more than 11" is flaky in two test files. After clicking the next page button, `getTableData` calls `waitFor({ state: "visible" })` on the `tbody`, which passes immediately against stale page-1 DOM. By the time `locator.count()` runs, React has re-rendered with `loading=true` and removed the `DataTable`, resulting in 0 rows.

## Fix

Applied to both affected files (`clients/scope.spec.ts` and `client-scope/main.spec.ts`):

- Snapshot the page-1 table data before clicking next page
- Use `expect.poll` to wait until `getTableData` returns different data, ensuring the page-2 render is complete before asserting
- Fix the test descriptions (was missing words: "are more than 11" → "when there are more than 11 entries")

The third call site (`clients/main.spec.ts`) is not affected — its `clickNextPageButton` is followed by `searchItem`, which introduces its own waiting and re-fetch.

## Decisions & assumptions

- **`expect.poll` over exact row count:** The number of rows on page 2 depends on built-in realm scopes, which can change between Keycloak versions. Polling for a data change is resilient to that, while a hardcoded count would be brittle.
- **Comparing full table data rather than a single cell:** Checking that the entire `getTableData` result changed is more robust than inspecting a specific cell, and reuses the existing test helper without direct page access.