### PR TITLE
Stabilize test cleanup in the Operator tests

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -411,30 +411,26 @@ public enum OperatorDeployment {local_apiserver,local,remote}
       }
       Log.info("Deleting Keycloak CR");
 
-      // Graceful scaledown: wait for instances==0 (pods terminated) AND observedGeneration
-      // matching generation (reconciler finished processing the scaledown). Checking both
-      // reduces the chance that an in-flight reconciliation re-creates the StatefulSet after
-      // the CR is deleted below — see https://github.com/keycloak/keycloak/issues/52497
-      // Skip paused CRs: the reconciler returns noUpdate() without scaling down or updating
-      // observedGeneration, so neither condition would ever be met.
-      var keycloaks = k8sclient.resources(Keycloak.class).list().getItems();
-      keycloaks.stream().filter(k -> !Boolean.parseBoolean(
-              Optional.ofNullable(k.getMetadata().getAnnotations())
-                      .map(a -> a.get(Constants.KEYCLOAK_PAUSE_ANNOTATION)).orElse(null)))
-              .forEach(k -> k8sclient.resource(new KeycloakBuilder(k).editSpec().withInstances(0).endSpec().build()).unlock().patch());
+      // Graceful scaledown: unpause, set instances=0, then wait for instances==0 AND
+      // observedGeneration matching generation (reconciler finished processing the scaledown).
+      // Checking both reduces the chance that an in-flight reconciliation re-creates the
+      // StatefulSet after the CR is deleted below — see https://github.com/keycloak/keycloak/issues/52497
+      k8sclient.resources(Keycloak.class).list().getItems().forEach(k -> {
+          var annotations = k.getMetadata().getAnnotations();
+          if (annotations != null) {
+              annotations.remove(Constants.KEYCLOAK_PAUSE_ANNOTATION);
+          }
+          k8sclient.resource(new KeycloakBuilder(k).editSpec().withInstances(0).endSpec().build()).unlock().patch();
+      });
 
       try {
           k8sclient.resources(Keycloak.class).informOnCondition(
-                  l -> l.stream()
-                      .filter(k -> !Boolean.parseBoolean(
-                              Optional.ofNullable(k.getMetadata().getAnnotations())
-                                      .map(a -> a.get(Constants.KEYCLOAK_PAUSE_ANNOTATION)).orElse(null)))
-                      .allMatch(k -> {
-                          var status = k.getStatus();
-                          return Optional.ofNullable(status).map(KeycloakStatus::getInstances).orElse(0).equals(0)
-                                  && Optional.ofNullable(status).map(KeycloakStatus::getObservedGeneration).orElse(0L)
-                                          .equals(k.getMetadata().getGeneration());
-                      }))
+                  l -> l.stream().allMatch(k -> {
+                      var status = k.getStatus();
+                      return Optional.ofNullable(status).map(KeycloakStatus::getInstances).orElse(0).equals(0)
+                              && Optional.ofNullable(status).map(KeycloakStatus::getObservedGeneration).orElse(0L)
+                                      .equals(k.getMetadata().getGeneration());
+                  }))
                   .get(40, TimeUnit.SECONDS);
       } catch (Exception e) {
           throw KubernetesClientException.launderThrowable(e);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -411,21 +411,30 @@ public enum OperatorDeployment {local_apiserver,local,remote}
       }
       Log.info("Deleting Keycloak CR");
 
-      // first graceful scaledown
+      // Graceful scaledown: wait for instances==0 (pods terminated) AND observedGeneration
+      // matching generation (reconciler finished processing the scaledown). Checking both
+      // reduces the chance that an in-flight reconciliation re-creates the StatefulSet after
+      // the CR is deleted below — see https://github.com/keycloak/keycloak/issues/52497
       k8sclient.resources(Keycloak.class).list().getItems().forEach(
               k -> k8sclient.resource(new KeycloakBuilder(k).editSpec().withInstances(0).endSpec().build()).unlock().patch());
 
       try {
           k8sclient.resources(Keycloak.class).informOnCondition(
-                  l -> l.stream().allMatch(k -> Optional.ofNullable(k.getStatus()).map(KeycloakStatus::getInstances).orElse(0).equals(0)))
+                  l -> l.stream().allMatch(k -> {
+                      var status = k.getStatus();
+                      return Optional.ofNullable(status).map(KeycloakStatus::getInstances).orElse(0).equals(0)
+                              && Optional.ofNullable(status).map(KeycloakStatus::getObservedGeneration).orElse(0L)
+                                      .equals(k.getMetadata().getGeneration());
+                  }))
                   .get(40, TimeUnit.SECONDS);
       } catch (Exception e) {
           throw KubernetesClientException.launderThrowable(e);
       }
 
-      // this can be simplified to just the root deletion after we pick up the fix
-      // it can be further simplified after https://github.com/fabric8io/kubernetes-client/issues/5838
-      // to just a timed foreground deletion
+      // Foreground cascade deletion would simplify this to just deleting the CRs and waiting
+      // for them to disappear, but it requires blockOwnerDeletion=true on owner references.
+      // fabric8 defaults it to null and https://github.com/fabric8io/kubernetes-client/issues/5838
+      // was auto-closed as stale without a fix, so that path is not available.
       var roots = List.of(Keycloak.class, KeycloakRealmImport.class, KeycloakOIDCClient.class, KeycloakSAMLClient.class);
       roots.forEach(c -> k8sclient.resources(c).delete());
       // enforce that at least the statefulset are gone

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -415,17 +415,26 @@ public enum OperatorDeployment {local_apiserver,local,remote}
       // matching generation (reconciler finished processing the scaledown). Checking both
       // reduces the chance that an in-flight reconciliation re-creates the StatefulSet after
       // the CR is deleted below — see https://github.com/keycloak/keycloak/issues/52497
-      k8sclient.resources(Keycloak.class).list().getItems().forEach(
-              k -> k8sclient.resource(new KeycloakBuilder(k).editSpec().withInstances(0).endSpec().build()).unlock().patch());
+      // Skip paused CRs: the reconciler returns noUpdate() without scaling down or updating
+      // observedGeneration, so neither condition would ever be met.
+      var keycloaks = k8sclient.resources(Keycloak.class).list().getItems();
+      keycloaks.stream().filter(k -> !Boolean.parseBoolean(
+              Optional.ofNullable(k.getMetadata().getAnnotations())
+                      .map(a -> a.get(Constants.KEYCLOAK_PAUSE_ANNOTATION)).orElse(null)))
+              .forEach(k -> k8sclient.resource(new KeycloakBuilder(k).editSpec().withInstances(0).endSpec().build()).unlock().patch());
 
       try {
           k8sclient.resources(Keycloak.class).informOnCondition(
-                  l -> l.stream().allMatch(k -> {
-                      var status = k.getStatus();
-                      return Optional.ofNullable(status).map(KeycloakStatus::getInstances).orElse(0).equals(0)
-                              && Optional.ofNullable(status).map(KeycloakStatus::getObservedGeneration).orElse(0L)
-                                      .equals(k.getMetadata().getGeneration());
-                  }))
+                  l -> l.stream()
+                      .filter(k -> !Boolean.parseBoolean(
+                              Optional.ofNullable(k.getMetadata().getAnnotations())
+                                      .map(a -> a.get(Constants.KEYCLOAK_PAUSE_ANNOTATION)).orElse(null)))
+                      .allMatch(k -> {
+                          var status = k.getStatus();
+                          return Optional.ofNullable(status).map(KeycloakStatus::getInstances).orElse(0).equals(0)
+                                  && Optional.ofNullable(status).map(KeycloakStatus::getObservedGeneration).orElse(0L)
+                                          .equals(k.getMetadata().getGeneration());
+                      }))
                   .get(40, TimeUnit.SECONDS);
       } catch (Exception e) {
           throw KubernetesClientException.launderThrowable(e);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -416,11 +416,13 @@ public enum OperatorDeployment {local_apiserver,local,remote}
       // Checking both reduces the chance that an in-flight reconciliation re-creates the
       // StatefulSet after the CR is deleted below — see https://github.com/keycloak/keycloak/issues/52497
       k8sclient.resources(Keycloak.class).list().getItems().forEach(k -> {
-          var annotations = k.getMetadata().getAnnotations();
-          if (annotations != null) {
-              annotations.remove(Constants.KEYCLOAK_PAUSE_ANNOTATION);
-          }
-          k8sclient.resource(new KeycloakBuilder(k).editSpec().withInstances(0).endSpec().build()).unlock().patch();
+          var patched = new KeycloakBuilder(k)
+                  .editMetadata()
+                      .addToAnnotations(Constants.KEYCLOAK_PAUSE_ANNOTATION, null)
+                  .endMetadata()
+                  .editSpec().withInstances(0).endSpec()
+                  .build();
+          k8sclient.resource(patched).unlock().patch();
       });
 
       try {

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -416,13 +416,14 @@ public enum OperatorDeployment {local_apiserver,local,remote}
       // Checking both reduces the chance that an in-flight reconciliation re-creates the
       // StatefulSet after the CR is deleted below — see https://github.com/keycloak/keycloak/issues/52497
       k8sclient.resources(Keycloak.class).list().getItems().forEach(k -> {
-          var patched = new KeycloakBuilder(k)
-                  .editMetadata()
+          var builder = new KeycloakBuilder(k);
+          if (k.getMetadata().getAnnotations() != null
+                  && k.getMetadata().getAnnotations().containsKey(Constants.KEYCLOAK_PAUSE_ANNOTATION)) {
+              builder.editMetadata()
                       .addToAnnotations(Constants.KEYCLOAK_PAUSE_ANNOTATION, null)
-                  .endMetadata()
-                  .editSpec().withInstances(0).endSpec()
-                  .build();
-          k8sclient.resource(patched).unlock().patch();
+                      .endMetadata();
+          }
+          k8sclient.resource(builder.editSpec().withInstances(0).endSpec().build()).unlock().patch();
       });
 
       try {


### PR DESCRIPTION
Closes #52497

## Assumptions and design decisions

### 1. Adding `observedGeneration` to the scaledown wait

The cleanup patches the Keycloak CR to `instances=0` and previously only waited for `status.instances == 0`. This is insufficient because the reconciler may still be mid-execution when the CR is deleted — JOSDK submits reconciliations to a thread pool, and a reconciliation already running on the executor continues even as the CR is deleted.

By also waiting for `status.observedGeneration == metadata.generation`, we confirm the reconciler has fully processed the scaledown spec change. This dramatically narrows the window where a stale in-flight reconciliation could re-create the StatefulSet after the CR is deleted and the StatefulSet is cascade-deleted by the garbage collector.

### 2. Keeping `informOnCondition` for the StatefulSet check

We verified by reading the fabric8 7.8.0 source that `informOnCondition(List::isEmpty)` works correctly — it evaluates the condition only after the informer's initial LIST populates the cache (via `onAdd`/`onDelete`/`onList` handlers). It does not suffer from a cache-sync race.

The StatefulSet reappearing after `informOnCondition` returned was caused by the operator's reconciler re-creating it, not by `informOnCondition` returning prematurely. With the `observedGeneration` check reducing the chance of an in-flight reconciliation, `informOnCondition` should be reliable enough. If it still flakes, the next step is `withTimeout().delete()` which actively fights re-creation.

### 3. Updating the fabric8 comment

The old comment referenced https://github.com/fabric8io/kubernetes-client/issues/5838 as a future fix that would enable foreground cascade deletion. That issue was auto-closed as stale without a fix — fabric8 still defaults `blockOwnerDeletion` to `null`. The comment is updated to prevent someone from going down that path.