### PR TITLE
Preserve the typed username as a login hint on organization fall-through

### DIFF
--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -456,6 +456,12 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         if (username != null) {
             authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
             authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.USERNAME_HIDDEN, Boolean.TRUE.toString());
+            // The next authenticator in the flow (e.g. identity-provider-redirector, when this
+            // falls through with no matching organization) reads the login hint from the CLIENT
+            // note, not from an auth note. tryRedirectBroker's matching-domain path already passes
+            // this same username straight into redirect(...) as the login hint; do the same here so
+            // the fall-through path is not silently missing it.
+            authenticationSession.setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, username);
         }
 
         context.attempted();

--- a/tests/base/src/test/java/org/keycloak/tests/organization/authentication/OrganizationLoginHintFallthroughTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/authentication/OrganizationLoginHintFallthroughTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.organization.authentication;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.page.LoginUsernamePage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.testsuite.util.FlowUtil;
+import org.keycloak.tests.organization.admin.AbstractOrganizationTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Regression test for the organization authenticator dropping the typed username when it falls
+ * through to the default identity-provider-redirector because no organization matches the email
+ * domain. See https://github.com/keycloak/keycloak/issues/52268.
+ */
+@KeycloakIntegrationTest
+public class OrganizationLoginHintFallthroughTest extends AbstractOrganizationTest {
+
+    @InjectRealm(ref = "provider", config = AbstractOrganizationTest.ProviderRealmConf.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm providerRealm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @InjectWebDriver
+    ManagedWebDriver driver;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectPage
+    LoginPage loginPage;
+
+    @InjectPage
+    LoginUsernamePage loginUsernamePage;
+
+    @Test
+    public void testLoginHintPreservedOnFallthroughToDefaultProvider() {
+        // an organization exists, but with a domain that will not match the email used below, so
+        // resolveOrganization() returns null and the authenticator falls through
+        createOrganization(realm, "unrelated-org", "unrelated-org.example");
+
+        String defaultIdpAlias = "default-identity-provider";
+        IdentityProviderRepresentation defaultIdp = createRealOrgBroker(defaultIdpAlias, providerRealm);
+        // forwarding login_hint to the external authorization URL is opt-in per broker
+        // (AbstractOAuth2IdentityProvider#createAuthorizationUrl checks isLoginHint()); the
+        // shared createRealOrgBroker helper does not set it, so add it here rather than change
+        // a helper other tests share.
+        defaultIdp.getConfig().put(IdentityProviderModel.LOGIN_HINT, "true");
+        realm.admin().identityProviders().create(defaultIdp).close();
+        realm.cleanup().add(r -> r.identityProviders().get(defaultIdpAlias).remove());
+
+        configureBrowserFlowWithDefaultProviderAfterOrganization(defaultIdpAlias);
+
+        String typedUsername = "alice@other-domain.example";
+
+        oauth.openLoginForm();
+        loginUsernamePage.fillLoginWithUsernameOnly(typedUsername);
+        loginUsernamePage.submit();
+
+        // the fall-through should have redirected to the default provider (the provider realm)
+        assertThat("Should have fallen through to the default provider",
+                driver.getCurrentUrl(), Matchers.containsString("/realms/" + providerRealm.getName() + "/"));
+
+        // the provider realm's login form is the plain combined username+password form (the
+        // provider realm has no organizations / identity-first split configured), so login_hint
+        // pre-fills the username input's value directly rather than the identity-first
+        // "attempted username" banner; getUsername() reads that input, not getAttemptedUsername()
+        assertThat(loginPage.getUsername(), Matchers.equalTo(typedUsername));
+    }
+
+    /**
+     * The default browser flow runs identity-provider-redirector (priority 25) before the
+     * organization sub-flow (priority 26), so a fall-through from organization never reaches it.
+     * Copy the flow (raise/lowerPriority reject built-in flows outright) and add a second
+     * identity-provider-redirector at priority 27, between organization (26) and forms (30), so a
+     * fall-through from organization is the next alternative tried. The original, unconfigured
+     * redirector at 25 is left in the copy untouched: with no default provider it just calls
+     * context.attempted() immediately, so it does not interfere.
+     */
+    private void configureBrowserFlowWithDefaultProviderAfterOrganization(String defaultProviderAlias) {
+        String newFlowAlias = "browser - login hint fallthrough test";
+        runOnServer.run(session -> FlowUtil.inCurrentRealm(session)
+                .copyBrowserFlow(newFlowAlias)
+                .addAuthenticatorExecution(Requirement.ALTERNATIVE, "identity-provider-redirector", 27,
+                        config -> config.getConfig().put("defaultProvider", defaultProviderAlias))
+                .defineAsBrowserFlow());
+    }
+}


### PR DESCRIPTION
Closes #52268

## Problem

With an organization configured for domain-based IdP selection plus a `identity-provider-redirector` default provider as a catch-all, the typed username reaches the upstream IdP as `login_hint` only when the email domain matches an organization. On a non-matching domain the flow falls through to the redirector and the username is dropped.

It is a note mismatch between two authenticators in the same flow:

```java
// IdentityProviderAuthenticator#redirect (the next authenticator on fall-through)
// reads a CLIENT note
String loginHint = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM);

// OrganizationAuthenticator#attempted (called on fall-through) writes only AUTH notes
authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.USERNAME_HIDDEN, Boolean.TRUE.toString());
```

The matching-domain path does not hit this, because it never goes through `attempted()` at all: it calls `redirect(context, idp.getAlias(), username)` directly, passing the username straight through as the login hint.

## Fix

Set the client note alongside the existing auth notes in `attempted(context, String username)`, so the redirector picks it up the same way the matching-domain path already ensures it has it:

```java
authenticationSession.setClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM, username);
```

This one helper is the fall-through path for all three places that call `attempted(context, username)` with a non-null username, so all of them are covered by the one change.

## Testing

Added `OrganizationLoginHintFallthroughTest`, an integration test that:

- creates an organization whose domain does not match the email used to log in, so `resolveOrganization()` returns null and the fall-through path is exercised,
- configures a copy of the browser flow with a second `identity-provider-redirector` positioned to run right after the organization sub-flow (the default flow runs the redirector *before* organization, so it never sees this fall-through; raising/lowering priority on the built-in flow's own executions is rejected by the admin API, so the test copies the flow instead, matching the existing `FlowUtil`/`runOnServer` pattern used elsewhere in this test suite),
- drives a login with a non-matching email through to the resulting redirect, and asserts the provider realm's own login page shows the typed username, meaning `login_hint` carried across the fall-through.

Verified with a negative control: reverting only the fix in `OrganizationAuthenticator.java` (keeping the test, and rebuilding the server distribution so the change actually reaches the running server under test) makes the test fail with the username field coming back empty, matching the reported symptom. Restoring the fix passes again.

## Documentation

No documentation change is included; this corrects existing behavior rather than introducing anything user-configurable.
