### PR TITLE
Stabilizing asynchronous login failure processing

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/WaitUtils.java
@@ -168,6 +168,13 @@ public final class WaitUtils {
         waitUntilElementIsNotPresent(By.className("modal-backdrop"));
     }
 
+    /**
+     * Wait for the brute force executor to finish processing all pending login failure tasks.
+     * Needed because {@code DefaultBlockingBruteForceProtector} processes failure counting asynchronously.
+     * Without this wait, a subsequent login request may race with the in-flight task and miss incrementing
+     * the failure counter (see <a href="https://github.com/keycloak/keycloak/issues/52428">#52428</a>).
+     * Once <a href="https://github.com/keycloak/keycloak/issues/52128">#52128</a> makes brute force processing synchronous, this method becomes unnecessary.
+     */
     public static void waitForBruteForceExecutors(KeycloakTestingClient testingClient) {
         testingClient.server().run(session -> {
             ExecutorsProvider provider = session.getProvider(ExecutorsProvider.class);
@@ -177,7 +184,7 @@ public final class WaitUtils {
                 CompletableFuture.runAsync(() -> {
                     do {
                         try {
-                            Thread.sleep(1000);
+                            Thread.sleep(100);
                         } catch (InterruptedException e) {
                             throw new RuntimeException(e);
                         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPReadOnlyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPReadOnlyTest.java
@@ -219,8 +219,6 @@ public class LDAPReadOnlyTest extends AbstractLDAPTest  {
             loginInvalidPassword("johnkeycloak");
             assertUserNumberOfFailures(user.getId(), failureFactor);
 
-            WaitUtils.waitForBruteForceExecutors(testingClient);
-
             // Make sure user is now disabled
             bruteForceStatus = managedRealm.admin().attackDetection().bruteForceUserStatus(user.getId());
             assertTrue((boolean) bruteForceStatus.get("disabled"), "User should be disabled by brute force.");
@@ -246,6 +244,8 @@ public class LDAPReadOnlyTest extends AbstractLDAPTest  {
         loginPage.assertCurrent();
 
         Assertions.assertEquals("Invalid username or password.", loginPage.getInputError());
+
+        WaitUtils.waitForBruteForceExecutors(testingClient);
 
         events.clear();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -270,6 +270,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             Assertions.assertNull(response.getAccessToken());
             Assertions.assertEquals(response.getError(), "invalid_grant");
             Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -278,6 +279,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             Assertions.assertNull(response.getAccessToken());
             Assertions.assertEquals(response.getError(), "invalid_grant");
             Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -315,6 +317,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             Assertions.assertNull(response.getAccessToken());
             Assertions.assertEquals(response.getError(), "invalid_grant");
             Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -322,6 +325,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             Assertions.assertNull(response.getAccessToken());
             Assertions.assertEquals(response.getError(), "invalid_grant");
             Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -363,6 +367,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             Assertions.assertNull(response.getAccessToken());
             Assertions.assertEquals(response.getError(), "invalid_grant");
             Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -370,6 +375,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             Assertions.assertNull(response.getAccessToken());
             Assertions.assertEquals(response.getError(), "invalid_grant");
             Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -413,6 +419,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
                 Assertions.assertNull(response.getAccessToken());
                 Assertions.assertEquals("invalid_grant", response.getError());
                 Assertions.assertEquals("Invalid user credentials", response.getErrorDescription());
+                WaitUtils.waitForBruteForceExecutors(testingClient);
                 events.clear();
             }
             {
@@ -536,8 +543,6 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             managedRealm.admin().update(realm);
             loginInvalidPassword();
 
-            //Wait for brute force executor to process the login and then wait for delta time
-            WaitUtils.waitForBruteForceExecutors(testingClient);
             timeOffSet.set(5);
 
             loginInvalidPassword();
@@ -604,8 +609,6 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         RealmRepresentation realm = managedRealm.admin().toRepresentation();
         loginInvalidPassword();
 
-        //Wait for brute force executor to process the login and then wait for delta time
-        WaitUtils.waitForBruteForceExecutors(testingClient);
         timeOffSet.set(realm.getMaxDeltaTimeSeconds());
 
         String realmId = realm.getId();
@@ -1156,7 +1159,9 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         String sessionId = EventAssertion.expectLoginSuccess(events.poll()).getEvent().getSessionId();
 
         getTestToken("wrongpass", totpSecret);
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         getTestToken("wrongpass", totpSecret);
+        WaitUtils.waitForBruteForceExecutors(testingClient);
 
         AccessTokenResponse shouldBeLocked = getTestToken(getPassword("test-user@localhost"), totpSecret);
         Assertions.assertNull(shouldBeLocked.getAccessToken());
@@ -1387,6 +1392,8 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
 
         Assertions.assertEquals("Invalid username or password.", loginPage.getInputError());
 
+        WaitUtils.waitForBruteForceExecutors(testingClient);
+
         if (clearEventsQueue) {
             events.clear();
         }
@@ -1442,6 +1449,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         Assertions.assertNull(response.getAccessToken());
         Assertions.assertEquals(response.getError(), "invalid_grant");
         Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -1322,6 +1322,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         loginTotpPage.login("123456");
         loginTotpPage.assertCurrent();
         Assertions.assertEquals("Invalid authenticator code.", loginTotpPage.getInputError());
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
     }
 
@@ -1359,6 +1360,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
 
         loginTotpPage.assertCurrent();
         Assertions.assertEquals("Invalid authenticator code.", loginTotpPage.getInputError());
+        WaitUtils.waitForBruteForceExecutors(testingClient);
     }
 
     public void continueLoginWithMissingTotp() {
@@ -1368,6 +1370,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
 
         loginTotpPage.assertCurrent();
         Assertions.assertEquals("Invalid authenticator code.", loginTotpPage.getInputError());
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
     }
 
@@ -1381,6 +1384,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         loginTotpPage.assertCurrent();
         Assertions.assertEquals("Invalid authenticator code.", loginTotpPage.getInputError());
 
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -262,6 +262,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             AccessTokenResponse response = getTestToken(getPassword("test-user@localhost"), totpSecret);
             Assertions.assertNotNull(response.getAccessToken());
             Assertions.assertNull(response.getError());
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -310,6 +311,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             AccessTokenResponse response = getTestToken(getPassword("test-user@localhost"), totpSecret);
             Assertions.assertNotNull(response.getAccessToken());
             Assertions.assertNull(response.getError());
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -360,6 +362,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             AccessTokenResponse response = getTestToken(getPassword("test-user@localhost"), totpSecret);
             Assertions.assertNotNull(response.getAccessToken());
             Assertions.assertNull(response.getError());
+            WaitUtils.waitForBruteForceExecutors(testingClient);
             events.clear();
         }
         {
@@ -412,6 +415,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
                 AccessTokenResponse response = getTestToken(getPassword("test-user@localhost"), totpSecret);
                 Assertions.assertNotNull(response.getAccessToken());
                 Assertions.assertNull(response.getError());
+                WaitUtils.waitForBruteForceExecutors(testingClient);
                 events.clear();
             }
             for (int i = 0; i <= managedRealm.admin().toRepresentation().getMaxSecondaryAuthFailures(); i++) {
@@ -1045,6 +1049,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         Assertions.assertNull(response.getAccessToken());
         Assertions.assertEquals(response.getError(), "invalid_grant");
         Assertions.assertEquals(response.getErrorDescription(), "Invalid user credentials");
+        WaitUtils.waitForBruteForceExecutors(testingClient);
 
         UserRepresentation user = adminClient.realm("test").users().search("test-user@localhost", 0, 1).get(0);
         Map<String, Object> userAttackInfo = adminClient.realm("test").attackDetection().bruteForceUserStatus(user.getId());
@@ -1053,6 +1058,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         response = getTestToken(getPassword("test-user@localhost"), totpSecret);
         Assertions.assertNotNull(response.getAccessToken());
         Assertions.assertNull(response.getError());
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
 
         userAttackInfo = adminClient.realm("test").attackDetection().bruteForceUserStatus(user.getId());
@@ -1157,6 +1163,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         loginTotpPage.login(totpSecret);
         Assertions.assertTrue(oauth.parseLoginResponse().isSuccess());
         String sessionId = EventAssertion.expectLoginSuccess(events.poll()).getEvent().getSessionId();
+        WaitUtils.waitForBruteForceExecutors(testingClient);
 
         getTestToken("wrongpass", totpSecret);
         WaitUtils.waitForBruteForceExecutors(testingClient);
@@ -1302,6 +1309,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         String code = oauth.parseLoginResponse().getCode();
         String idTokenHint = oauth.doAccessTokenRequest(code ).getIdToken();
         oauth.logoutForm().idTokenHint(idTokenHint).withRedirect().open();
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
     }
 
@@ -1458,6 +1466,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         AccessTokenResponse response = getTestToken(getPassword("test-user@localhost"), totpSecret);
         Assertions.assertNotNull(response.getAccessToken());
         Assertions.assertNull(response.getError());
+        WaitUtils.waitForBruteForceExecutors(testingClient);
         events.clear();
 
         for (int i = 0; i < failureFactor; ++i) {


### PR DESCRIPTION
Closes #52502

## Root cause

Same as #52428 / #52429: `DefaultBlockingBruteForceProtector` processes failure counting asynchronously via an executor. When two login failures for the same user arrive in quick succession, the second request hits `isLoginInProgress() == true`, gets a `forceChallenge()` instead of `failureChallenge()`, and `failedLogin()` is never called — so the failure counter is not incremented. The counter stays at 1 instead of reaching `failureFactor=2`, and subsequent lockout assertions fail.

PR #52429 fixed this for `AttackDetectionResourceTest` (new testsuite, password grant). The same race exists in `BruteForceTest` and `LDAPReadOnlyTest` (old testsuite), both for browser-based and password-grant login attempts.

## Approach

Added `WaitUtils.waitForBruteForceExecutors(testingClient)` after each invalid login attempt to ensure the async executor task completes before the next request is sent. This is the old-testsuite equivalent of the `awaitNumFailures()` polling used in PR #52429 for the new testsuite.

The wait is added inside the shared helper methods (`loginInvalidPassword()`, `sendInvalidPasswordPasswordGrant()`) so all callers are covered, plus explicit waits at direct `getTestToken()` call sites. Redundant standalone `waitForBruteForceExecutors` calls that existed before are removed.

Once #52128 makes brute force processing synchronous, these waits become unnecessary.