### PR TITLE
Update outgoinghttp.adoc

### DIFF
--- a/docs/guides/server/outgoinghttp.adoc
+++ b/docs/guides/server/outgoinghttp.adoc
@@ -17,7 +17,7 @@ to configure a {project_name} Truststore so that {project_name} is able to perfo
 == Client Configuration Command
 The HTTP client that {project_name} uses for outgoing communication is highly configurable. To configure the {project_name} outgoing HTTP client, enter this command:
 
-<@kc.start parameters="--spi-connections-http-client--default--<configurationoption>=<value>"/>
+<@kc.start parameters="--spi-connections-http-client-default-<configurationoption>=<value>"/>
 
 The following are the command options:
 
@@ -134,7 +134,7 @@ For example, consider the following regex:
 
 You apply a regex-based hostname pattern by entering this command:
 
-<@kc.start parameters="--spi-connections-http-client--default--proxy-mappings=\'.*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080\'"/>
+<@kc.start parameters="--spi-connections-http-client-default-proxy-mappings=\'.*\\\\.(google|googleapis)\\\\.com;http://www-proxy.acme.com:8080\'"/>
 
 The backslash character `\` is escaped again because micro-profile config is used to parse the array of mappings.
 


### PR DESCRIPTION
In the documentation, the examples use both *--default--* and *-default-* configuration formats. Based on my testing with Keycloak, only properties defined as *-default-* work. Properties defined as *--default--* are recognized but do not work.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
