### PR TITLE
Download Java Maven cache in Operator CI

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Setup Java
         uses: ./.github/actions/java-setup
 
+      - name: Restore Maven cache
+        uses: ./.github/actions/maven-cache
+
       - name: Restore Quarkus snapshot cache
         if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
         uses: ./.github/actions/quarkus-snapshot-cache
@@ -93,6 +96,9 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Maven cache
+        uses: ./.github/actions/maven-cache
 
       - name: Restore Quarkus snapshot cache
         if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
@@ -145,6 +151,9 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Maven cache
+        uses: ./.github/actions/maven-cache
 
       - name: Restore Quarkus snapshot cache
         if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
@@ -210,6 +219,9 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Maven cache
+        uses: ./.github/actions/maven-cache
 
       - name: Restore Quarkus snapshot cache
         if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
@@ -279,6 +291,9 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Maven cache
+        uses: ./.github/actions/maven-cache
 
       - name: Restore Quarkus snapshot cache
         if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
@@ -390,6 +405,9 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Maven cache
+        uses: ./.github/actions/maven-cache
 
       - name: Restore Quarkus snapshot cache
         if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'


### PR DESCRIPTION
Closes #52506

## Summary

All 6 test jobs in `operator-ci.yml` (`test-local-apiserver`, `test-remote`, `test-helm`, `test-helm-install`, `test-olm`, `test-kustomize`) were missing the `.github/actions/maven-cache` restore step. The `build` job populates and caches `~/.m2` via `build-keycloak`, but no test job restored it — each downloaded all dependencies from Maven Central from scratch.

This caused the "Test OLM installation" job to fail when a transient network timeout hit during download of `io.smallrye.common:smallrye-common-expression:jar:2.19.0`.

## Approach

Added `Restore Maven cache` step (using `.github/actions/maven-cache` with its default `create-cache-if-it-doesnt-exist: false`) to each of the 6 test jobs, placed between `java-setup` and `quarkus-snapshot-cache` — consistent with how other CI workflows (`ci.yml`, `conformance.yml`) handle this via their composite setup actions.

The `build` job already creates the cache via `build-keycloak`, so the test jobs only need to restore it. No other workflows were found to have this gap.