### PR TITLE
Sync vulnerability scanning reports into GitHub Issues

### DIFF
--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -79,9 +79,6 @@ jobs:
           output: 'trivy-report.json'
           scanners: 'vuln'          
           skip-setup-trivy: true
-      - name: Display report
-        run: |
-          cat trivy-report.json | jq -r '"| ID | PKG | INSTALLED | FIXED | SEVERITY |", "| -- | -- | -- | -- | -- |", ([.Results[] | select(.Vulnerabilities != null) | .Vulnerabilities[]] | unique_by(.VulnerabilityID) | .[] | "| \(.VulnerabilityID) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion) | \(.Severity) |")' >> $GITHUB_STEP_SUMMARY
       - name: Convert to sarif
         run: |
           trivy convert --format sarif -o trivy-report.sarif --scanners vuln trivy-report.json
@@ -99,4 +96,31 @@ jobs:
         with:
           name: ${{ env.TRIVY_ARTIFACT_NAME }}
           path: trivy-report.json
-          retention-days: 30
+          retention-days: 7
+
+  parse-reports:
+    name: Parse Reports
+    needs: scan-dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download report artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/trivy-logs
+          pattern: trivy-report-*
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+      - name: List artifacts
+        run: tree /tmp/trivy-logs
+      - name: Parse reports
+        run: ./mvnw -f misc/vuln-to-issues package exec:java -Dexec.mainClass="org.keycloak.misc.TrivyReportParser"

--- a/misc/vuln-to-issues/pom.xml
+++ b/misc/vuln-to-issues/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-parent</artifactId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>vuln-to-issues</artifactId>
+
+    <name>Sync vulnerabilities to GitHub Issues</name>
+    <description>Sync vulnerabilities to GitHub Issues</description>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.kohsuke</groupId>
+            <artifactId>github-api</artifactId>
+            <version>2.0-rc.7</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/misc/vuln-to-issues/src/main/java/org/keycloak/misc/TrivyReport.java
+++ b/misc/vuln-to-issues/src/main/java/org/keycloak/misc/TrivyReport.java
@@ -1,0 +1,38 @@
+package org.keycloak.misc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TrivyReport(
+        @JsonProperty("ReportID") String reportID,
+        @JsonProperty("Results") List<Result> results) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Result(
+            @JsonProperty("Target") String target,
+            @JsonProperty("Packages") List<Package> packages,
+            @JsonProperty("Vulnerabilities") List<Vulnerability> vulnerabilities) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Package(
+            @JsonProperty("ID") String id,
+            @JsonProperty("Name") String name,
+            @JsonProperty("Version") String version) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Vulnerability(
+            @JsonProperty("VulnerabilityID") String vulnerabilityId,
+            @JsonProperty("PkgId") String pkgId,
+            @JsonProperty("PkgName") String pkgName,
+            @JsonProperty("InstalledVersion") String installedVersion,
+            @JsonProperty("FixedVersion") String fixedVersion,
+            @JsonProperty("Status") String status,
+            @JsonProperty("Severity") String severity) {
+    }
+
+}

--- a/misc/vuln-to-issues/src/main/java/org/keycloak/misc/TrivyReportParser.java
+++ b/misc/vuln-to-issues/src/main/java/org/keycloak/misc/TrivyReportParser.java
@@ -1,0 +1,176 @@
+package org.keycloak.misc;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.keycloak.misc.Vulnerability.AffectsRef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueBuilder;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHIssueStateReason;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+
+public class TrivyReportParser {
+
+    private static final String GH_TOKEN = System.getenv("GH_TOKEN");
+    private static final String GITHUB_REPOSITORY = System.getenv("GITHUB_REPOSITORY");
+    private static final String GITHUB_STEP_SUMMARY = System.getenv("GITHUB_STEP_SUMMARY");
+
+    public static void main(String[] args) throws IOException {
+        GitHub github = new GitHubBuilder().withJwtToken(GH_TOKEN).build();
+
+        File runDir = new File("/tmp/trivy-logs");
+
+        Map<String, Vulnerability> vulnerabilities = parseTrivyReports(runDir);
+        updateGitHubIssues(github, vulnerabilities);
+        createReport(vulnerabilities);
+    }
+
+    private static Map<String, Vulnerability> parseTrivyReports(File runDir) throws IOException {
+        Map<String, Vulnerability> vulnerabilities = new HashMap<>();
+        File[] refReportsDir = runDir.listFiles(File::isDirectory);
+
+        for (File refReportDir : refReportsDir) {
+            String refName = getRefNameFromReportDir(refReportDir.getName());
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            TrivyReport trivyReport = objectMapper.reader().readValue(new File(refReportDir, "trivy-report.json"), TrivyReport.class);
+
+            for (TrivyReport.Result result : trivyReport.results()) {
+                if (result.vulnerabilities() != null && !result.vulnerabilities().isEmpty()) {
+                    for (TrivyReport.Vulnerability v : result.vulnerabilities()) {
+                        Vulnerability vulnerability = vulnerabilities.computeIfAbsent(v.vulnerabilityId(), s -> new Vulnerability(s, v.severity(), v.pkgName()));
+
+                        AffectsRef affectsRef = vulnerability.getAffectsRefs().computeIfAbsent(refName, s -> new AffectsRef(s, v.installedVersion(), v.fixedVersion()));
+                        affectsRef.getTargets().add(result.target());
+                    }
+                }
+            }
+        }
+        return vulnerabilities;
+    }
+
+    private static void updateGitHubIssues(GitHub github, Map<String, Vulnerability> vulnerabilities) throws IOException {
+        for (Vulnerability v : vulnerabilities.values()) {
+            String[] repositorySplit = GITHUB_REPOSITORY.split("/");
+            List<GHIssue> searchIssues = github.searchIssues().repo(repositorySplit[0], repositorySplit[1]).isIssue().q(v.getId() + " " + v.getPackageName()).list().toList();
+            List<GHIssue> issues = new LinkedList<>(searchIssues);
+
+            Optional<GHIssue> existingIssue = searchIssues.stream().filter(i -> i.getLabels().stream().anyMatch(l -> l.getName().equals("source/scan-dependencies"))).findFirst();
+            if (existingIssue.isPresent()) {
+                GHIssue issue = existingIssue.get();
+
+                if (v.getAffectsRefs().containsKey("main")) {
+                    if (!GHIssueState.OPEN.equals(issue.getState())) {
+                        issue.reopen();
+                    }
+                } else if (GHIssueState.CLOSED.equals(issue.getState()) && !GHIssueStateReason.COMPLETED.equals(issue.getStateReason())) {
+                    issue.reopen();
+                }
+
+                List<String> backportLabels = getBackportLabels(v);
+                List<String> missingBackportLabels = backportLabels.stream().filter(bl -> issue.getLabels().stream().noneMatch(l -> l.getName().equals(bl))).toList();
+                if (!missingBackportLabels.isEmpty()) {
+                    issue.addLabels(missingBackportLabels.toArray(String[]::new));
+                }
+
+                issues.remove(issue);
+                issues.add(0, issue);
+            } else {
+                issues.add(0, createIssue(github, v));
+            }
+
+            v.setIssues(issues);
+        }
+    }
+
+    private static GHIssue createIssue(GitHub gitHub, Vulnerability vulnerability) throws IOException {
+        String title = vulnerability.getId() + " " + vulnerability.getPackageName();
+
+        StringBuilder body = new StringBuilder();
+
+        body.append("* **CVE ID**: [").append(vulnerability.getId()).append("](").append("https://www.cve.org/CVERecord?id=").append(vulnerability.getId()).append(")\n");
+        body.append("* **Package:** ").append(vulnerability.getPackageName()).append('\n');
+        body.append("* **Severity:** ").append(vulnerability.getSeverity().toLowerCase()).append('\n');
+        body.append("* **Affects:** ").append(vulnerability.getAffectsRefs().keySet().stream().collect(Collectors.joining(", "))).append('\n');
+        body.append("* **Installed versions:** ").append(vulnerability.getAffectsRefs().values().stream().map(Vulnerability.AffectsRef::getInstalledVersion).distinct().collect(Collectors.joining(", "))).append('\n');
+        body.append("* **Fixed versions:** ").append(vulnerability.getAffectsRefs().values().stream().map(Vulnerability.AffectsRef::getFixedVersions).distinct().collect(Collectors.joining(", ")));
+        body.append('\n');
+
+        body.append("# Affected modules").append('\n');
+
+        for (Vulnerability.AffectsRef affectsRef : vulnerability.getAffectsRefs().values()) {
+            body.append("## ").append(affectsRef.getRefName()).append('\n');
+            body.append("```\n");
+            affectsRef.getTargets().forEach(t -> body.append(t).append('\n'));
+            body.append("```\n");
+        }
+
+        GHIssueBuilder issueBuilder = gitHub.getRepository(GITHUB_REPOSITORY).createIssue(title).body(body.toString());
+
+        issueBuilder.label("status/triage").label("source/scan-dependencies").label("area/dependencies").label("kind/cve").label("severity/" + vulnerability.getSeverity().toLowerCase());
+
+        getBackportLabels(vulnerability).forEach(issueBuilder::label);
+
+        return issueBuilder.create();
+    }
+
+    private static List<String> getBackportLabels(Vulnerability vulnerability) {
+        return vulnerability.getAffectsRefs().keySet().stream()
+                .filter(a -> a.startsWith("release/"))
+                .map(a -> a.replace("release/", "backport/"))
+                .toList();
+    }
+
+    private static void createReport(Map<String, Vulnerability> vulnerabilities) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("| CVE ID | Package | Severity | Affects | Installed versions | Fixed versions | GitHub Issues |").append('\n');
+        sb.append("| ------ | ------- | -------- | ------- | ------------------ | -------------- | ------------- |").append('\n');
+
+        for (Vulnerability v : vulnerabilities.values()) {
+            sb.append("| ");
+            sb.append("[" + v.getId()).append("](").append("https://www.cve.org/CVERecord?id=").append(v.getId()).append(")");
+            sb.append(" | ");
+            sb.append(v.getPackageName());
+            sb.append(" | ");
+            sb.append(v.getSeverity().toLowerCase());
+            sb.append(" | ");
+            sb.append(v.getAffectsRefs().keySet().stream().collect(Collectors.joining(", ")));
+            sb.append(" | ");
+            sb.append(v.getAffectsRefs().values().stream().map(AffectsRef::getInstalledVersion).distinct().collect(Collectors.joining(", ")));
+            sb.append(" | ");
+            sb.append(v.getAffectsRefs().values().stream().map(AffectsRef::getFixedVersions).distinct().collect(Collectors.joining(", ")));
+            sb.append(" | ");
+            sb.append(v.getIssues().stream().map(i -> "[" + i.getNumber() + "](" + i.getHtmlUrl() + ")").collect(Collectors.joining(" ")));
+            sb.append(" |\n");
+        }
+
+        try {
+            PrintWriter pw = new PrintWriter(new FileWriter(GITHUB_STEP_SUMMARY, true));
+            pw.print(sb);
+            pw.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String getRefNameFromReportDir(String reportDirName) {
+        return reportDirName.replace("trivy-report-", "")
+                .replace('_', '/')
+                .replace("refs/heads/", "")
+                .replace("refs/tags/", "tag/");
+    }
+
+}

--- a/misc/vuln-to-issues/src/main/java/org/keycloak/misc/Vulnerability.java
+++ b/misc/vuln-to-issues/src/main/java/org/keycloak/misc/Vulnerability.java
@@ -1,0 +1,78 @@
+package org.keycloak.misc;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.kohsuke.github.GHIssue;
+
+public class Vulnerability {
+    private String id;
+    private String severity;
+    private final String packageName;
+    private Map<String, AffectsRef> affectsRefs = new HashMap<>();
+    private List<GHIssue> issues;
+
+    public Vulnerability(String id, String severity, String packageName) {
+        this.id = id;
+        this.severity = severity;
+        this.packageName = packageName;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public Map<String, AffectsRef> getAffectsRefs() {
+        return affectsRefs;
+    }
+
+    public List<GHIssue> getIssues() {
+        return issues;
+    }
+
+    public void setIssues(List<GHIssue> issues) {
+        this.issues = issues;
+    }
+
+    public static class AffectsRef {
+
+        private final String refName;
+        private final String installedVersion;
+        private final String fixedVersions;
+        private final Set<String> targets = new HashSet<>();
+
+        public AffectsRef(String refName, String installedVersion, String fixedVersions) {
+            this.refName = refName;
+            this.installedVersion = installedVersion;
+            this.fixedVersions = fixedVersions;
+        }
+
+        public String getRefName() {
+            return refName;
+        }
+
+        public Set<String> getTargets() {
+            return targets;
+        }
+
+        public String getInstalledVersion() {
+            return installedVersion;
+        }
+
+        public String getFixedVersions() {
+            return fixedVersions;
+        }
+    }
+
+}


### PR DESCRIPTION
Syncs vulnerabilities from Trivy scan into GitHub Issues, and provides a single report (summary) of all branches to the scan dependencies workflow.

Example of the updated report:

<img width="1512" height="741" alt="image" src="https://github.com/user-attachments/assets/d859aa67-7bd6-4a11-ad4e-3fbd0bb597a1" />

Example of a GitHub Issue:

<img width="1262" height="1127" alt="image" src="https://github.com/user-attachments/assets/9eca9316-504b-4a71-ba9a-935f285a4d6a" />

This has been tested in my own fork

* https://github.com/stianst/keycloak/actions/runs/34213537776
* https://github.com/stianst/keycloak/issues

Closes #52512

Signed-off-by: stianst <stianst@gmail.com>
