### PR TITLE
Fix NPE on user import when deprecated credentials format omits hashIterations

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -271,7 +271,8 @@ public class RepresentationToModel {
     }
 
 
-    private static void convertDeprecatedCredentialsFormat(UserRepresentation user) {
+    // Package-private rather than private so RepresentationToModelTest can exercise this directly.
+    static void convertDeprecatedCredentialsFormat(UserRepresentation user) {
         if (user.getCredentials() != null) {
             for (CredentialRepresentation cred : user.getCredentials()) {
                 try {
@@ -279,6 +280,11 @@ public class RepresentationToModel {
                         logger.warnf("Using deprecated 'credentials' format in JSON representation for user '%s'. It will be removed in future versions", user.getUsername());
 
                         if (PasswordCredentialModel.TYPE.equals(cred.getType()) || PasswordCredentialModel.PASSWORD_HISTORY.equals(cred.getType())) {
+                            if (cred.getHashIterations() == null) {
+                                throw new ModelValidationException(
+                                        "Cannot convert deprecated credentials format for user '%s': missing required field 'hashIterations' for credential type '%s'."
+                                                .formatted(user.getUsername(), cred.getType()));
+                            }
                             PasswordCredentialData credentialData = new PasswordCredentialData(cred.getHashIterations(), cred.getAlgorithm());
                             cred.setCredentialData(JsonSerialization.writeValueAsString(credentialData));
                             // Created this manually to avoid conversion from Base64 and back

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/RepresentationToModelTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/RepresentationToModelTest.java
@@ -38,7 +38,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class RepresentationToModelTest {
 
@@ -69,7 +68,8 @@ public class RepresentationToModelTest {
 
         ModelValidationException ex = assertThrows(ModelValidationException.class,
                 () -> RepresentationToModel.convertDeprecatedCredentialsFormat(user));
-        assertTrue(ex.getMessage().contains("hashIterations"));
+        assertEquals("Cannot convert deprecated credentials format for user 'test-user': "
+                + "missing required field 'hashIterations' for credential type 'password'.", ex.getMessage());
     }
 
     @Test
@@ -78,7 +78,8 @@ public class RepresentationToModelTest {
 
         ModelValidationException ex = assertThrows(ModelValidationException.class,
                 () -> RepresentationToModel.convertDeprecatedCredentialsFormat(user));
-        assertTrue(ex.getMessage().contains("hashIterations"));
+        assertEquals("Cannot convert deprecated credentials format for user 'test-user': "
+                + "missing required field 'hashIterations' for credential type 'password-history'.", ex.getMessage());
     }
 
     @Test
@@ -92,17 +93,25 @@ public class RepresentationToModelTest {
         assertNotNull(user.getCredentials().get(0).getSecretData());
     }
 
+    /**
+     * The deprecated credential fields have no setters on {@link org.keycloak.representations.idm.CredentialRepresentation},
+     * so the representation is built the way the server receives it - by deserializing JSON.
+     */
     private static UserRepresentation deprecatedPasswordUser(String type, Integer hashIterations) throws Exception {
-        String hashIterationsField = hashIterations == null ? "" : "\"hashIterations\":" + hashIterations + ",";
-        return JsonSerialization.readValue(
-                "{\"username\":\"test-user\",\"credentials\":[{"
-                        + "\"type\":\"" + type + "\","
-                        + "\"hashedSaltedValue\":\"aGFzaGVk\","
-                        + "\"salt\":\"c2FsdA==\","
-                        + hashIterationsField
-                        + "\"algorithm\":\"pbkdf2-sha256\""
-                        + "}]}",
-                UserRepresentation.class);
+        Map<String, Object> credential = new HashMap<>();
+        credential.put("type", type);
+        credential.put("hashedSaltedValue", "aGFzaGVk");
+        credential.put("salt", "c2FsdA==");
+        credential.put("algorithm", "pbkdf2-sha256");
+        if (hashIterations != null) {
+            credential.put("hashIterations", hashIterations);
+        }
+
+        Map<String, Object> user = new HashMap<>();
+        user.put("username", "test-user");
+        user.put("credentials", Collections.singletonList(credential));
+
+        return JsonSerialization.readValue(JsonSerialization.writeValueAsString(user), UserRepresentation.class);
     }
 
     private static RealmModel realm(String clientId, ClientModel client) {

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/RepresentationToModelTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/RepresentationToModelTest.java
@@ -24,14 +24,21 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.util.JsonSerialization;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class RepresentationToModelTest {
 
@@ -54,6 +61,48 @@ public class RepresentationToModelTest {
 
         assertEquals(0, addedRoles.get());
         assertEquals("imported", existingRole.getDescription());
+    }
+
+    @Test
+    public void convertDeprecatedPasswordCredentialWithoutHashIterationsFailsValidation() throws Exception {
+        UserRepresentation user = deprecatedPasswordUser("password", null);
+
+        ModelValidationException ex = assertThrows(ModelValidationException.class,
+                () -> RepresentationToModel.convertDeprecatedCredentialsFormat(user));
+        assertTrue(ex.getMessage().contains("hashIterations"));
+    }
+
+    @Test
+    public void convertDeprecatedPasswordHistoryCredentialWithoutHashIterationsFailsValidation() throws Exception {
+        UserRepresentation user = deprecatedPasswordUser("password-history", null);
+
+        ModelValidationException ex = assertThrows(ModelValidationException.class,
+                () -> RepresentationToModel.convertDeprecatedCredentialsFormat(user));
+        assertTrue(ex.getMessage().contains("hashIterations"));
+    }
+
+    @Test
+    public void convertDeprecatedPasswordCredentialWithHashIterationsSucceeds() throws Exception {
+        UserRepresentation user = deprecatedPasswordUser("password", 27500);
+
+        RepresentationToModel.convertDeprecatedCredentialsFormat(user);
+
+        assertNull(user.getCredentials().get(0).getValue());
+        assertNotNull(user.getCredentials().get(0).getCredentialData());
+        assertNotNull(user.getCredentials().get(0).getSecretData());
+    }
+
+    private static UserRepresentation deprecatedPasswordUser(String type, Integer hashIterations) throws Exception {
+        String hashIterationsField = hashIterations == null ? "" : "\"hashIterations\":" + hashIterations + ",";
+        return JsonSerialization.readValue(
+                "{\"username\":\"test-user\",\"credentials\":[{"
+                        + "\"type\":\"" + type + "\","
+                        + "\"hashedSaltedValue\":\"aGFzaGVk\","
+                        + "\"salt\":\"c2FsdA==\","
+                        + hashIterationsField
+                        + "\"algorithm\":\"pbkdf2-sha256\""
+                        + "}]}",
+                UserRepresentation.class);
     }
 
     private static RealmModel realm(String clientId, ClientModel client) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCreateTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCreateTest.java
@@ -271,6 +271,10 @@ public class UserCreateTest extends AbstractUserTest {
         assertEquals(CredentialRepresentation.PASSWORD, credentialHashed.getType());
     }
 
+    /**
+     * Same payload as {@link #createUserWithDeprecatedCredentialsFormat()}, which is accepted, except that
+     * {@code hashIterations} is omitted - so the rejection can only be caused by the missing field.
+     */
     @Test
     public void createUserWithDeprecatedCredentialsFormatMissingHashIterations() throws IOException {
         UserRepresentation user = new UserRepresentation();
@@ -292,11 +296,16 @@ public class UserCreateTest extends AbstractUserTest {
         user.setCredentials(Arrays.asList(deprecatedHashedPassword));
 
         try (Response response = managedRealm.admin().users().create(user)) {
+            // A ModelValidationException is reported as 400 with the generic message that
+            // UsersResource uses for every ModelException; the specific reason (the missing
+            // 'hashIterations' field) is logged server-side.
             assertEquals(400, response.getStatus());
             ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
             Assertions.assertEquals("Could not create user", error.getErrorMessage());
             Assertions.assertNull(adminEvents.poll());
         }
+
+        assertEquals(0, managedRealm.admin().users().search("user_creds_no_iterations", null, null, true).size());
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCreateTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserCreateTest.java
@@ -272,6 +272,34 @@ public class UserCreateTest extends AbstractUserTest {
     }
 
     @Test
+    public void createUserWithDeprecatedCredentialsFormatMissingHashIterations() throws IOException {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("user_creds_no_iterations");
+        user.setEmail("email.noiter@localhost");
+
+        PasswordCredentialModel pcm = PasswordCredentialModel.createFromValues("my-algorithm", "theSalt".getBytes(), 22, "ABC");
+        String deprecatedCredential = "{\n" +
+                "      \"type\" : \"password\",\n" +
+                "      \"hashedSaltedValue\" : \"" + pcm.getPasswordSecretData().getValue() + "\",\n" +
+                "      \"salt\" : \"" + Base64.getEncoder().encodeToString(pcm.getPasswordSecretData().getSalt()) + "\",\n" +
+                "      \"algorithm\" : \"" + pcm.getPasswordCredentialData().getAlgorithm() + "\"\n" +
+                "    }";
+
+        CredentialRepresentation deprecatedHashedPassword = JsonSerialization.readValue(deprecatedCredential, CredentialRepresentation.class);
+        Assertions.assertNull(deprecatedHashedPassword.getHashIterations());
+        deprecatedHashedPassword.setType(CredentialRepresentation.PASSWORD);
+
+        user.setCredentials(Arrays.asList(deprecatedHashedPassword));
+
+        try (Response response = managedRealm.admin().users().create(user)) {
+            assertEquals(400, response.getStatus());
+            ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
+            Assertions.assertEquals("Could not create user", error.getErrorMessage());
+            Assertions.assertNull(adminEvents.poll());
+        }
+    }
+
+    @Test
     public void createUserWithTemporaryCredentials() {
         UserRepresentation user = new UserRepresentation();
         user.setUsername("user_temppw");


### PR DESCRIPTION
## Before

`POST /admin/realms/{realm}/users` with a password credential supplied in the deprecated `credentials` format that omits `hashIterations` fails with an uncaught `NullPointerException` (HTTP 500):

```
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "org.keycloak.representations.idm.CredentialRepresentation.getHashIterations()" is null
	at org.keycloak.models.utils.RepresentationToModel.convertDeprecatedCredentialsFormat(RepresentationToModel.java:245)
	at org.keycloak.models.utils.RepresentationToModel.createCredentials(RepresentationToModel.java:778)
	at org.keycloak.services.resources.admin.UsersResource.createUser(UsersResource.java:173)
```

`convertDeprecatedCredentialsFormat` passes `CredentialRepresentation.getHashIterations()` (a nullable `Integer`) straight into `new PasswordCredentialData(int hashIterations, ...)`, so a missing value auto-unboxes `null` and throws.

## After

When a `password` / `password-history` credential in the deprecated format has no `hashIterations`, `convertDeprecatedCredentialsFormat` throws `ModelValidationException` instead of dereferencing `null`.

`UsersResource.createUser` already catches `ModelException` and maps it to **HTTP 400**. As with every other `ModelException` on that endpoint the response body carries the existing generic message (`"Could not create user"`); the specific reason is logged server-side:

```
WARN  [org.keycloak.services.resources.admin.UsersResource] Could not create user: org.keycloak.models.ModelValidationException: Cannot convert deprecated credentials format for user '...': missing required field 'hashIterations' for credential type 'password'.
```

So the observable change is 500 -> 400; no existing error-response contract is altered.

## Testing

**Unit** - `RepresentationToModelTest` (the class had no prior coverage of `convertDeprecatedCredentialsFormat`):

- deprecated `password` credential without `hashIterations` -> `ModelValidationException`
- deprecated `password-history` credential without `hashIterations` -> `ModelValidationException`
- deprecated `password` credential with `hashIterations` -> conversion still succeeds

**Integration** - `UserCreateTest.createUserWithDeprecatedCredentialsFormatMissingHashIterations`: posts the same payload as the existing (accepted) `createUserWithDeprecatedCredentialsFormat` with `hashIterations` omitted, and asserts HTTP 400 instead of 500 and that no user is created.

`convertDeprecatedCredentialsFormat` was changed from `private` to package-private, with a comment recording that it is for `RepresentationToModelTest`, so the two credential-type branches can be covered without booting a server. The project does not use a `@VisibleForTesting` annotation.

Verified locally: `./mvnw -pl server-spi-private test -Dtest=RepresentationToModelTest`, `./mvnw -pl tests/base test -Dtest='UserCreateTest#createUserWithDeprecatedCredentialsFormatMissingHashIterations'`, and `./mvnw spotless:check` all pass.

## AI usage disclosure

An AI coding agent (Claude Code) was used to help investigate the stack trace, locate the root cause, and draft the fix and the tests. I have reviewed and understand every line of the change and can revise it based on review feedback.

Closes #41640
