### PR TITLE
ClosingStream should close streams on thrown exception

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/utils/ClosingDoubleStream.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ClosingDoubleStream.java
@@ -104,119 +104,155 @@ class ClosingDoubleStream implements DoubleStream {
 
     @Override
     public void forEach(DoubleConsumer action) {
-        delegate.forEach(action);
-        close();
+        try {
+            delegate.forEach(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public void forEachOrdered(DoubleConsumer action) {
-        delegate.forEachOrdered(action);
-        close();
+        try {
+            delegate.forEachOrdered(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public double[] toArray() {
-        double[] result = delegate.toArray();
-        close();
-        return result;
+        try {
+            return delegate.toArray();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public double reduce(double identity, DoubleBinaryOperator op) {
-        double result = delegate.reduce(identity, op);
-        close();
-        return result;
+        try {
+            return delegate.reduce(identity, op);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble reduce(DoubleBinaryOperator op) {
-        OptionalDouble result = delegate.reduce(op);
-        close();
-        return result;
+        try {
+            return delegate.reduce(op);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-        R result = delegate.collect(supplier, accumulator, combiner);
-        close();
-        return result;
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public double sum() {
-        double result = delegate.sum();
-        close();
-        return result;
+        try {
+            return delegate.sum();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble min() {
-        OptionalDouble result = delegate.min();
-        close();
-        return result;
+        try {
+            return delegate.min();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble max() {
-        OptionalDouble result = delegate.max();
-        close();
-        return result;
+        try {
+            return delegate.max();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long count() {
-        long result = delegate.count();
-        close();
-        return result;
+        try {
+            return delegate.count();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble average() {
-        OptionalDouble result = delegate.average();
-        close();
-        return result;
+        try {
+            return delegate.average();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public DoubleSummaryStatistics summaryStatistics() {
-        DoubleSummaryStatistics result = delegate.summaryStatistics();
-        close();
-        return result;
+        try {
+            return delegate.summaryStatistics();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean anyMatch(DoublePredicate predicate) {
-        boolean result = delegate.anyMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.anyMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean allMatch(DoublePredicate predicate) {
-        boolean result = delegate.allMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.allMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean noneMatch(DoublePredicate predicate) {
-        boolean result = delegate.noneMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.noneMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble findFirst() {
-        OptionalDouble result = delegate.findFirst();
-        close();
-        return result;
+        try {
+            return delegate.findFirst();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble findAny() {
-        OptionalDouble result = delegate.findAny();
-        close();
-        return result;
+        try {
+            return delegate.findAny();
+        } finally {
+            close();
+        }
     }
 
     @Override
@@ -274,8 +310,14 @@ class ClosingDoubleStream implements DoubleStream {
 
         @Override
         public boolean hasNext() {
-            final boolean res = iterator.hasNext();
-            if (! res) {
+            boolean res;
+            try {
+                res = iterator.hasNext();
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -293,8 +335,11 @@ class ClosingDoubleStream implements DoubleStream {
 
         @Override
         public void forEachRemaining(DoubleConsumer action) {
-            iterator.forEachRemaining(action);
-            close();
+            try {
+                iterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override
@@ -313,8 +358,14 @@ class ClosingDoubleStream implements DoubleStream {
 
         @Override
         public boolean tryAdvance(DoubleConsumer action) {
-            final boolean res = spliterator.tryAdvance(action);
-            if (! res) {
+            boolean res;
+            try {
+                res = spliterator.tryAdvance(action);
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -322,8 +373,11 @@ class ClosingDoubleStream implements DoubleStream {
 
         @Override
         public void forEachRemaining(DoubleConsumer action) {
-            spliterator.forEachRemaining(action);
-            close();
+            try {
+                spliterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/ClosingIntStream.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ClosingIntStream.java
@@ -258,20 +258,12 @@ class ClosingIntStream implements IntStream {
 
     @Override
     public LongStream asLongStream() {
-        try {
-            return delegate.asLongStream();
-        } finally {
-            close();
-        }
+        return new ClosingLongStream(delegate.asLongStream());
     }
 
     @Override
     public DoubleStream asDoubleStream() {
-        try {
-            return delegate.asDoubleStream();
-        } finally {
-            close();
-        }
+        return new ClosingDoubleStream(delegate.asDoubleStream());
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/ClosingIntStream.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ClosingIntStream.java
@@ -105,133 +105,173 @@ class ClosingIntStream implements IntStream {
 
     @Override
     public void forEach(IntConsumer action) {
-        delegate.forEach(action);
-        close();
+        try {
+            delegate.forEach(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public void forEachOrdered(IntConsumer action) {
-        delegate.forEachOrdered(action);
-        close();
+        try {
+            delegate.forEachOrdered(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public int[] toArray() {
-        int[] result = delegate.toArray();
-        close();
-        return result;
+        try {
+            return delegate.toArray();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public int reduce(int identity, IntBinaryOperator op) {
-        int result = delegate.reduce(identity, op);
-        close();
-        return result;
+        try {
+            return delegate.reduce(identity, op);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalInt reduce(IntBinaryOperator op) {
-        OptionalInt result = delegate.reduce(op);
-        close();
-        return result;
+        try {
+            return delegate.reduce(op);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-        R result = delegate.collect(supplier, accumulator, combiner);
-        close();
-        return result;
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public int sum() {
-        int result = delegate.sum();
-        close();
-        return result;
+        try {
+            return delegate.sum();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalInt min() {
-        OptionalInt result = delegate.min();
-        close();
-        return result;
+        try {
+            return delegate.min();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalInt max() {
-        OptionalInt result = delegate.max();
-        close();
-        return result;
+        try {
+            return delegate.max();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long count() {
-        long result = delegate.count();
-        close();
-        return result;
+        try {
+            return delegate.count();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble average() {
-        OptionalDouble result = delegate.average();
-        close();
-        return result;
+        try {
+            return delegate.average();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public IntSummaryStatistics summaryStatistics() {
-        IntSummaryStatistics result = delegate.summaryStatistics();
-        close();
-        return result;
+        try {
+            return delegate.summaryStatistics();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean anyMatch(IntPredicate predicate) {
-        boolean result = delegate.anyMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.anyMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean allMatch(IntPredicate predicate) {
-        boolean result = delegate.allMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.allMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean noneMatch(IntPredicate predicate) {
-        boolean result = delegate.noneMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.noneMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalInt findFirst() {
-        OptionalInt result = delegate.findFirst();
-        close();
-        return result;
+        try {
+            return delegate.findFirst();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalInt findAny() {
-        OptionalInt result = delegate.findAny();
-        close();
-        return result;
+        try {
+            return delegate.findAny();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public LongStream asLongStream() {
-        LongStream result = delegate.asLongStream();
-        close();
-        return result;
+        try {
+            return delegate.asLongStream();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public DoubleStream asDoubleStream() {
-        DoubleStream result = delegate.asDoubleStream();
-        close();
-        return result;
+        try {
+            return delegate.asDoubleStream();
+        } finally {
+            close();
+        }
     }
 
     @Override
@@ -289,8 +329,14 @@ class ClosingIntStream implements IntStream {
 
         @Override
         public boolean hasNext() {
-            final boolean res = iterator.hasNext();
-            if (! res) {
+            boolean res;
+            try {
+                res = iterator.hasNext();
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -308,8 +354,11 @@ class ClosingIntStream implements IntStream {
 
         @Override
         public void forEachRemaining(IntConsumer action) {
-            iterator.forEachRemaining(action);
-            close();
+            try {
+                iterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override
@@ -328,8 +377,14 @@ class ClosingIntStream implements IntStream {
 
         @Override
         public boolean tryAdvance(IntConsumer action) {
-            final boolean res = spliterator.tryAdvance(action);
-            if (! res) {
+            boolean res;
+            try {
+                res = spliterator.tryAdvance(action);
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -337,8 +392,11 @@ class ClosingIntStream implements IntStream {
 
         @Override
         public void forEachRemaining(IntConsumer action) {
-            spliterator.forEachRemaining(action);
-            close();
+            try {
+                spliterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/ClosingLongStream.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ClosingLongStream.java
@@ -258,11 +258,7 @@ class ClosingLongStream implements LongStream {
 
     @Override
     public DoubleStream asDoubleStream() {
-        try {
-            return delegate.asDoubleStream();
-        } finally {
-            close();
-        }
+        return new ClosingDoubleStream(delegate.asDoubleStream());
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/ClosingLongStream.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ClosingLongStream.java
@@ -105,126 +105,164 @@ class ClosingLongStream implements LongStream {
 
     @Override
     public void forEach(LongConsumer action) {
-        delegate.forEach(action);
-        close();
+        try {
+            delegate.forEach(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public void forEachOrdered(LongConsumer action) {
-        delegate.forEachOrdered(action);
-        close();
+        try {
+            delegate.forEachOrdered(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long[] toArray() {
-        long[] result = delegate.toArray();
-        close();
-        return result;
+        try {
+            return delegate.toArray();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long reduce(long identity, LongBinaryOperator op) {
-        long result = delegate.reduce(identity, op);
-        close();
-        return result;
+        try {
+            return delegate.reduce(identity, op);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalLong reduce(LongBinaryOperator op) {
-        OptionalLong result = delegate.reduce(op);
-        close();
-        return result;
+        try {
+            return delegate.reduce(op);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-        R result = delegate.collect(supplier, accumulator, combiner);
-        close();
-        return result;
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long sum() {
-        long result = delegate.sum();
-        close();
-        return result;
+        try {
+            return delegate.sum();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalLong min() {
-        OptionalLong result = delegate.min();
-        close();
-        return result;
+        try {
+            return delegate.min();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalLong max() {
-        OptionalLong result = delegate.max();
-        close();
-        return result;
+        try {
+            return delegate.max();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long count() {
-        long result = delegate.count();
-        close();
-        return result;
+        try {
+            return delegate.count();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalDouble average() {
-        OptionalDouble result = delegate.average();
-        close();
-        return result;
+        try {
+            return delegate.average();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public LongSummaryStatistics summaryStatistics() {
-        LongSummaryStatistics result = delegate.summaryStatistics();
-        close();
-        return result;
+        try {
+            return delegate.summaryStatistics();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean anyMatch(LongPredicate predicate) {
-        boolean result = delegate.anyMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.anyMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean allMatch(LongPredicate predicate) {
-        boolean result = delegate.allMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.allMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean noneMatch(LongPredicate predicate) {
-        boolean result = delegate.noneMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.noneMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalLong findFirst() {
-        OptionalLong result = delegate.findFirst();
-        close();
-        return result;
+        try {
+            return delegate.findFirst();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public OptionalLong findAny() {
-        OptionalLong result = delegate.findAny();
-        close();
-        return result;
+        try {
+            return delegate.findAny();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public DoubleStream asDoubleStream() {
-        DoubleStream result = delegate.asDoubleStream();
-        close();
-        return result;
+        try {
+            return delegate.asDoubleStream();
+        } finally {
+            close();
+        }
     }
 
     @Override
@@ -282,8 +320,14 @@ class ClosingLongStream implements LongStream {
 
         @Override
         public boolean hasNext() {
-            final boolean res = iterator.hasNext();
-            if (! res) {
+            boolean res;
+            try {
+                res = iterator.hasNext();
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -301,8 +345,11 @@ class ClosingLongStream implements LongStream {
 
         @Override
         public void forEachRemaining(LongConsumer action) {
-            iterator.forEachRemaining(action);
-            close();
+            try {
+                iterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override
@@ -321,8 +368,14 @@ class ClosingLongStream implements LongStream {
 
         @Override
         public boolean tryAdvance(LongConsumer action) {
-            final boolean res = spliterator.tryAdvance(action);
-            if (! res) {
+            boolean res;
+            try {
+                res = spliterator.tryAdvance(action);
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -330,8 +383,11 @@ class ClosingLongStream implements LongStream {
 
         @Override
         public void forEachRemaining(LongConsumer action) {
-            spliterator.forEachRemaining(action);
-            close();
+            try {
+                spliterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override

--- a/server-spi-private/src/main/java/org/keycloak/utils/ClosingStream.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/ClosingStream.java
@@ -125,119 +125,155 @@ class ClosingStream<R> implements Stream<R> {
 
     @Override
     public void forEach(Consumer<? super R> action) {
-        delegate.forEach(action);
-        close();
+        try {
+            delegate.forEach(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public void forEachOrdered(Consumer<? super R> action) {
-        delegate.forEachOrdered(action);
-        close();
+        try {
+            delegate.forEachOrdered(action);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public Object[] toArray() {
-        Object[] result = delegate.toArray();
-        close();
-        return result;
+        try {
+            return delegate.toArray();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <A> A[] toArray(IntFunction<A[]> generator) {
-        A[] result = delegate.toArray(generator);
-        close();
-        return result;
+        try {
+            return delegate.toArray(generator);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public R reduce(R identity, BinaryOperator<R> accumulator) {
-        R result = delegate.reduce(identity, accumulator);
-        close();
-        return result;
+        try {
+            return delegate.reduce(identity, accumulator);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public Optional<R> reduce(BinaryOperator<R> accumulator) {
-        Optional<R> result = delegate.reduce(accumulator);
-        close();
-        return result;
+        try {
+            return delegate.reduce(accumulator);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <U> U reduce(U identity, BiFunction<U, ? super R, U> accumulator, BinaryOperator<U> combiner) {
-        U result = delegate.reduce(identity, accumulator, combiner);
-        close();
-        return result;
+        try {
+            return delegate.reduce(identity, accumulator, combiner);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <R1> R1 collect(Supplier<R1> supplier, BiConsumer<R1, ? super R> accumulator, BiConsumer<R1, R1> combiner) {
-        R1 result = delegate.collect(supplier, accumulator, combiner);
-        close();
-        return result;
+        try {
+            return delegate.collect(supplier, accumulator, combiner);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public <R1, A> R1 collect(Collector<? super R, A, R1> collector) {
-        R1 result = delegate.collect(collector);
-        close();
-        return result;
+        try {
+            return delegate.collect(collector);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public Optional<R> min(Comparator<? super R> comparator) {
-        Optional<R> result = delegate.min(comparator);
-        close();
-        return result;
+        try {
+            return delegate.min(comparator);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public Optional<R> max(Comparator<? super R> comparator) {
-        Optional<R> result = delegate.max(comparator);
-        close();
-        return result;
+        try {
+            return delegate.max(comparator);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public long count() {
-        long result = delegate.count();
-        close();
-        return result;
+        try {
+            return delegate.count();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean anyMatch(Predicate<? super R> predicate) {
-        boolean result = delegate.anyMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.anyMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean allMatch(Predicate<? super R> predicate) {
-        boolean result = delegate.allMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.allMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public boolean noneMatch(Predicate<? super R> predicate) {
-        boolean result = delegate.noneMatch(predicate);
-        close();
-        return result;
+        try {
+            return delegate.noneMatch(predicate);
+        } finally {
+            close();
+        }
     }
 
     @Override
     public Optional<R> findFirst() {
-        Optional<R> result = delegate.findFirst();
-        close();
-        return result;
+        try {
+            return delegate.findFirst();
+        } finally {
+            close();
+        }
     }
 
     @Override
     public Optional<R> findAny() {
-        Optional<R> result = delegate.findAny();
-        close();
-        return result;
+        try {
+            return delegate.findAny();
+        } finally {
+            close();
+        }
     }
 
     @Override
@@ -290,8 +326,14 @@ class ClosingStream<R> implements Stream<R> {
 
         @Override
         public boolean hasNext() {
-            final boolean res = iterator.hasNext();
-            if (! res) {
+            boolean res;
+            try {
+                res = iterator.hasNext();
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -309,8 +351,11 @@ class ClosingStream<R> implements Stream<R> {
 
         @Override
         public void forEachRemaining(Consumer<? super R> action) {
-            iterator.forEachRemaining(action);
-            close();
+            try {
+                iterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
     }
 
@@ -324,8 +369,14 @@ class ClosingStream<R> implements Stream<R> {
 
         @Override
         public boolean tryAdvance(Consumer<? super R> action) {
-            final boolean res = spliterator.tryAdvance(action);
-            if (! res) {
+            boolean res;
+            try {
+                res = spliterator.tryAdvance(action);
+            } catch (RuntimeException | Error e) {
+                close();
+                throw e;
+            }
+            if (!res) {
                 close();
             }
             return res;
@@ -333,8 +384,11 @@ class ClosingStream<R> implements Stream<R> {
 
         @Override
         public void forEachRemaining(Consumer<? super R> action) {
-            spliterator.forEachRemaining(action);
-            close();
+            try {
+                spliterator.forEachRemaining(action);
+            } finally {
+                close();
+            }
         }
 
         @Override

--- a/server-spi-private/src/test/java/org/keycloak/utils/StreamsUtilTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/utils/StreamsUtilTest.java
@@ -103,6 +103,34 @@ public class StreamsUtilTest {
     }
 
     @Test
+    public void testClosingStreamClosesOnExceptionDuringTerminalOperation() {
+        AtomicBoolean closed = new AtomicBoolean();
+        try {
+            StreamsUtil.closing(Stream.of(1, 2, 3).onClose(() -> closed.set(true)))
+                    .forEach(i -> { throw new RuntimeException("fail"); });
+            Assert.fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            Assert.assertEquals("fail", e.getMessage());
+        }
+        Assert.assertTrue("Stream should be closed even when terminal operation throws", closed.get());
+    }
+
+    @Test
+    public void testClosingStreamClosesOnExceptionDuringToList() {
+        AtomicBoolean closed = new AtomicBoolean();
+        try {
+            StreamsUtil.closing(Stream.of(1, 2, 3)
+                    .map(i -> { if (i == 2) throw new RuntimeException("fail"); return i; })
+                    .onClose(() -> closed.set(true)))
+                    .toList();
+            Assert.fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            // expected
+        }
+        Assert.assertTrue("Stream should be closed even when toList throws", closed.get());
+    }
+
+    @Test
     public void testSortedInsideOfFlatMapShouldRespectTerminalOperation() {
         AtomicInteger numberOfFetchedElements = new AtomicInteger();
 

--- a/server-spi-private/src/test/java/org/keycloak/utils/StreamsUtilTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/utils/StreamsUtilTest.java
@@ -131,6 +131,70 @@ public class StreamsUtilTest {
     }
 
     @Test
+    public void testClosingIntStreamClosesOnExceptionDuringTerminalOperation() {
+        AtomicBoolean closed = new AtomicBoolean();
+        try {
+            StreamsUtil.closing(Stream.of(1, 2, 3).onClose(() -> closed.set(true)))
+                    .mapToInt(i -> i)
+                    .forEach(i -> { throw new RuntimeException("fail"); });
+            Assert.fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            Assert.assertEquals("fail", e.getMessage());
+        }
+        Assert.assertTrue("IntStream should be closed even when terminal operation throws", closed.get());
+    }
+
+    @Test
+    public void testClosingLongStreamClosesOnExceptionDuringTerminalOperation() {
+        AtomicBoolean closed = new AtomicBoolean();
+        try {
+            StreamsUtil.closing(Stream.of(1, 2, 3).onClose(() -> closed.set(true)))
+                    .mapToLong(i -> i)
+                    .forEach(i -> { throw new RuntimeException("fail"); });
+            Assert.fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            Assert.assertEquals("fail", e.getMessage());
+        }
+        Assert.assertTrue("LongStream should be closed even when terminal operation throws", closed.get());
+    }
+
+    @Test
+    public void testClosingDoubleStreamClosesOnExceptionDuringTerminalOperation() {
+        AtomicBoolean closed = new AtomicBoolean();
+        try {
+            StreamsUtil.closing(Stream.of(1, 2, 3).onClose(() -> closed.set(true)))
+                    .mapToDouble(i -> i)
+                    .forEach(i -> { throw new RuntimeException("fail"); });
+            Assert.fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            Assert.assertEquals("fail", e.getMessage());
+        }
+        Assert.assertTrue("DoubleStream should be closed even when terminal operation throws", closed.get());
+    }
+
+    @Test
+    public void testClosingIntStreamAsLongStreamPreservesClose() {
+        AtomicBoolean closed = new AtomicBoolean();
+        long sum = StreamsUtil.closing(Stream.of(1, 2, 3).onClose(() -> closed.set(true)))
+                .mapToInt(i -> i)
+                .asLongStream()
+                .sum();
+        Assert.assertEquals(6L, sum);
+        Assert.assertTrue("Stream should be closed after asLongStream() terminal operation", closed.get());
+    }
+
+    @Test
+    public void testClosingIntStreamAsDoubleStreamPreservesClose() {
+        AtomicBoolean closed = new AtomicBoolean();
+        double sum = StreamsUtil.closing(Stream.of(1, 2, 3).onClose(() -> closed.set(true)))
+                .mapToInt(i -> i)
+                .asDoubleStream()
+                .sum();
+        Assert.assertEquals(6.0, sum, 0.001);
+        Assert.assertTrue("Stream should be closed after asDoubleStream() terminal operation", closed.get());
+    }
+
+    @Test
     public void testSortedInsideOfFlatMapShouldRespectTerminalOperation() {
         AtomicInteger numberOfFetchedElements = new AtomicInteger();
 


### PR DESCRIPTION
Closes #52580

## Summary

Ensure `ClosingStream`, `ClosingIntStream`, `ClosingLongStream`, and `ClosingDoubleStream` close the underlying stream when a terminal operation throws an exception. Previously, exceptions during terminal operations would bypass `close()`, leaking JDBC `ResultSet` cursors.

Also fixes `asLongStream()`, `asDoubleStream()` in `ClosingIntStream` and `asDoubleStream()` in `ClosingLongStream` which were incorrectly treated as terminal operations instead of intermediate operations.

## Decisions and assumptions

- **`try-finally` for all terminal operations**: Every terminal method (`forEach`, `toArray`, `reduce`, `collect`, `count`, `min`, `max`, `anyMatch`, `allMatch`, `noneMatch`, `findFirst`, `findAny`, `toList`, `sum`, `average`) wraps the delegate call in `try-finally` to guarantee `close()` runs regardless of success or failure.

- **`try-catch` for `hasNext()` and `tryAdvance()`**: These methods are called repeatedly — closing on every call would break iteration. Instead, they close on exception (via `try-catch`) and on exhaustion (when returning `false`). This preserves the existing behavior of closing when the stream is fully consumed.

- **`try-finally` for `forEachRemaining()`**: Both `ClosingIterator.forEachRemaining()` and `ClosingSpliterator.forEachRemaining()` consume all remaining elements in a single call, so `try-finally` is appropriate here.

- **No change to `next()`**: `Iterator.next()` is always preceded by `hasNext()`, which already handles close-on-error and close-on-exhaustion.

- **`asLongStream()` / `asDoubleStream()` are intermediate, not terminal**: These were incorrectly closing the underlying stream and returning an unwrapped stream. Fixed to return `ClosingLongStream` / `ClosingDoubleStream` wrappers, consistent with `boxed()`.

- **No suppressed exception handling in `try-finally`**: If both the terminal operation and `close()` throw, the close exception masks the original. This matches standard `try-finally` semantics and is acceptable because `Stream.close()` internally catches and aggregates exceptions from `onClose()` handlers, making a throwing `close()` extremely unlikely.

- **All four stream classes updated consistently**: The same pattern is applied to `ClosingStream<R>`, `ClosingIntStream`, `ClosingLongStream`, and `ClosingDoubleStream`.

- **Tests cover all stream types**: Exception-on-terminal tests added for `ClosingStream`, `ClosingIntStream`, `ClosingLongStream`, and `ClosingDoubleStream`. Additional tests verify that `asLongStream()` and `asDoubleStream()` preserve close propagation.