### PR TITLE
Avoid the HHH90010101 warning until fixed in Hibernate

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
@@ -27,6 +27,8 @@ import org.hibernate.Session;
 import org.hibernate.dialect.OracleDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.engine.internal.TransactionCompletionCallbacksImpl;
+import org.hibernate.engine.spi.ActionQueue;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventType;
@@ -36,6 +38,7 @@ import org.hibernate.event.spi.PreInsertEvent;
 import org.hibernate.event.spi.PreInsertEventListener;
 import org.hibernate.event.spi.PreUpdateEvent;
 import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.internal.SessionImpl;
 import org.jboss.logging.Logger;
 
 /**
@@ -164,6 +167,21 @@ public abstract class AsyncCommitIntegrator implements PreInsertEventListener, P
                     (SharedSessionContractImplementor sess) -> {
                         if (!Boolean.TRUE.equals(((Session) sess).getProperties().get(SYNC_REQUIRED))) {
                             sess.doWork(this::applyAsyncCommit);
+                        }
+                    }
+            );
+            // Workaround for https://hibernate.atlassian.net/browse/HHH-20863:
+            // On rollback, beforeTransactionCompletion() is never called, so the BeforeCompletionCallback
+            // above remains in the ActionQueue and triggers HHH90010101 during em.close().
+            // Clear it on rollback via an AfterCompletionCallback.
+            session.getTransactionCompletionCallbacks().registerCallback(
+                    (boolean success, SharedSessionContractImplementor sess) -> {
+                        if (!success && sess instanceof SessionImpl si) {
+                            ActionQueue aq = si.getActionQueue();
+                            if (aq.hasBeforeTransactionActions()) {
+                                aq.setTransactionCompletionCallbacks(
+                                        new TransactionCompletionCallbacksImpl(si), false);
+                            }
                         }
                     }
             );


### PR DESCRIPTION
Closes #52583

## Summary

Workaround for [HHH-20863](https://hibernate.atlassian.net/browse/HHH-20863): Hibernate's `ActionQueue.clear()` does not clear `transactionCompletionCallbacks` on rollback, causing HHH90010101 warnings during `em.close()`.

## Root cause

`AsyncCommitIntegrator` registers a `BeforeCompletionCallback` on the Hibernate `ActionQueue` during pre-insert/pre-update/pre-delete events. On commit, these callbacks are processed normally by `beforeTransactionCompletion()`. On rollback, `beforeTransactionCompletion()` is never called, so the callback remains orphaned. `ActionQueue.clear()` (called during rollback) does not clear the `transactionCompletionCallbacks` field. When `em.close()` runs, `SessionImpl.checkBeforeClosingJdbcCoordinator()` detects the unprocessed callback and logs the HHH90010101 warning.

## Approach

Register an `AfterCompletionCallback` alongside the `BeforeCompletionCallback` in `AsyncCommitIntegrator`. Since `afterTransactionCompletion()` is called on both commit and rollback, the after-callback clears the orphaned before-callback on rollback by replacing the `transactionCompletionCallbacks` with a fresh instance. This keeps the workaround co-located with the code that causes the problem.

## Decisions and assumptions

- **Workaround registered at the source**: The `AfterCompletionCallback` is registered in `AsyncCommitIntegrator` right next to the `BeforeCompletionCallback` that causes the issue, making the cause and fix easy to find together.

- **Replaces entire `transactionCompletionCallbacks`**: On rollback, no `BeforeCompletionCallback` should survive — they would never execute anyway. Replacing the whole object is what Hibernate should be doing in `ActionQueue.clear()`.

- **Uses Hibernate internals (`SessionImpl`, `ActionQueue`, `TransactionCompletionCallbacksImpl`)**: This is a workaround for [HHH-20863](https://hibernate.atlassian.net/browse/HHH-20863) and intentionally uses internal APIs. It should be removed once Hibernate fixes `ActionQueue.clear()` to also clear `transactionCompletionCallbacks`.