### PR TITLE
Organization group: Error response when removing non-member from org group

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
@@ -38,6 +38,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.util.ObjectUtil;
@@ -424,6 +425,8 @@ public class OrganizationGroupResource {
             } catch (ModelException me) {
                 throw ErrorResponse.error(me.getMessage(), Response.Status.BAD_REQUEST);
             }
+        } else {
+            throw ErrorResponse.error("User not a member", Status.BAD_REQUEST);
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/organization/group/OrganizationGroupMembershipTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/group/OrganizationGroupMembershipTest.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -570,5 +571,28 @@ public class OrganizationGroupMembershipTest extends AbstractOrganizationTest {
         } catch (jakarta.ws.rs.NotFoundException expected) {
             // expected - memberB is not a member of orgA
         }
+    }
+
+    @Test
+    public void testRemoveMemberFailsForNonMembers() {
+        OrganizationRepresentation orgRep = createOrganization();
+        OrganizationResource orgResource = realm.admin().organizations().get(orgRep.getId());
+
+        MemberRepresentation member = addMember(orgResource);
+
+        // Create a group
+        GroupRepresentation groupRep = new GroupRepresentation();
+        groupRep.setName("test-group");
+        String groupId;
+        try (Response response = orgResource.groups().addTopLevelGroup(groupRep)) {
+            groupId = ApiUtil.getCreatedId(response);
+        }
+
+        // Attempt to remove user from group they're not in - should throw BadRequest
+        String finalGroupId = groupId;
+        assertThrows(jakarta.ws.rs.BadRequestException.class,
+            () -> orgResource.groups().group(finalGroupId).removeMember(member.getId()),
+            "removeMember should fail when user is not a member of the group"
+        );
     }
 }


### PR DESCRIPTION
When attempting to remove a user who is not a member of an organization group, the endpoint should return 400 Bad Request, not silently succeed with 204 No Content. This ensures correct REST semantics and enables proper audit logging of failed removal operations.

Fixes #52587

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
