### PR TITLE
Avoid HHH100503 INFO message after constraint violation

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
@@ -113,6 +113,13 @@ public abstract class KeycloakLogFilter implements Filter {
             return false;
         }
 
+        // HHH100503 "JDBC batch still contained JDBC statements on release" is logged at INFO after a
+        // constraint violation that Keycloak already handles. Logged too loudly for a normal occurrence.
+        // https://hibernate.atlassian.net/browse/HHH-20861
+        if (Objects.equals(record.getLevel(), Level.INFO) && record.getLoggerName().equals("org.hibernate.orm.jdbc.batch") && record.getMessage().startsWith("HHH100503")) {
+            return false;
+        }
+
         if (executor != null && ThreadCreator.isVirtual(Thread.currentThread())) {
             executor.submit(new RecordLogger(ExtLogRecord.wrap(record), this));
             return false;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/KeycloakLogFilter.java
@@ -115,8 +115,11 @@ public abstract class KeycloakLogFilter implements Filter {
 
         // HHH100503 "JDBC batch still contained JDBC statements on release" is logged at INFO after a
         // constraint violation that Keycloak already handles. Logged too loudly for a normal occurrence.
+        // TODO: Remove this suppression once Hibernate addresses HHH-20861 by no longer logging
+        // HHH100503 at INFO for this handled condition, or otherwise changes the upstream behavior
+        // so this message is no longer emitted in normal operation.
         // https://hibernate.atlassian.net/browse/HHH-20861
-        if (Objects.equals(record.getLevel(), Level.INFO) && record.getLoggerName().equals("org.hibernate.orm.jdbc.batch") && record.getMessage().startsWith("HHH100503")) {
+        if (Objects.equals(record.getLevel(), Level.INFO) && record.getLoggerName().equals("org.hibernate.orm.jdbc.batch") && record.getMessage().startsWith("HHH100503:")) {
             return false;
         }
 


### PR DESCRIPTION
Closes #52586

## Summary

Suppress the Hibernate `HHH100503: JDBC batch still contained JDBC statements on release` INFO message in `KeycloakLogFilter`. This message is logged during normal session teardown after a constraint violation that Keycloak already handles correctly (e.g., duplicate user creation via concurrent SCIM requests).

Raised upstream as [HHH-20861](https://hibernate.atlassian.net/browse/HHH-20861) to lower the log level in Hibernate itself.

## Decisions and assumptions

- **Filter suppression over log category level**: Setting `quarkus.log.category."org.hibernate.orm.jdbc.batch".level=WARN` would also suppress `HHH100501` ("Automatic JDBC statement batching enabled"), which is a useful startup diagnostic. The targeted filter preserves all other batch log messages.

- **Suppression rather than level change**: `KeycloakLogFilter` can only suppress messages (`return false`), not change their level. The JBoss `LogRecord` level is already set by Hibernate before the filter runs. This is consistent with how the filter handles other noisy messages (ARJUNA012125, MariaDB 1020, ISPN000312, ISPN000208).

- **Intended to be temporary**: Once Hibernate lowers the log level upstream ([HHH-20861](https://hibernate.atlassian.net/browse/HHH-20861)), this filter entry can be removed.