### PR TITLE
[OID4VCI] Reject client scopes without a credential builder

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -230,7 +230,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
         if (clientScope.getAttributes() == null) {
             clientScope.setAttributes(new HashMap<>());
         }
-        
+
         clientScope.getAttributes().computeIfAbsent(VC_FORMAT, k -> getFormatFromScope(scopeName));
         String format = clientScope.getAttributes().get(VC_FORMAT);
 
@@ -445,37 +445,39 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
      *
      * @param session Keycloak session
      * @param clientScope the client scope representation to validate
-     * @throws ErrorResponseException if binding is required and not provided OR the binding or proof-type configuration is invalid
+     * @throws ErrorResponseException if the credential format has no builder, binding is required and not provided,
+     * or the binding or proof-type configuration is invalid
      */
-    private void validateBindingConfiguration(KeycloakSession session,  ClientScopeRepresentation clientScope) throws ErrorResponseException {
+    private void validateBindingConfiguration(KeycloakSession session, ClientScopeRepresentation clientScope) throws ErrorResponseException {
         if (clientScope.getAttributes() == null) {
             return;
         }
 
         boolean bindingRequired = Boolean.parseBoolean(clientScope.getAttributes().get(VC_BINDING_REQUIRED));
-String format = Objects.requireNonNullElseGet(
-        clientScope.getAttributes().get(VC_FORMAT),
-        () -> getFormatFromScope(clientScope.getName()));
+        String format = Objects.requireNonNullElseGet(
+                clientScope.getAttributes().get(VC_FORMAT),
+                () -> getFormatFromScope(clientScope.getName()));
 
         CredentialBuilder credentialBuilder = session.getProvider(CredentialBuilder.class, format);
-        if (credentialBuilder != null) {
-            Set<String> allowedBindingMethods = credentialBuilder.getSupportedBindingMethods();
+        if (credentialBuilder == null) {
+            throw ErrorResponse.error(
+                    String.format("No credential builder found for format '%s' of credential scope '%s'", format, clientScope.getName()),
+                    Response.Status.BAD_REQUEST);
+        }
 
-            String bindingMethodsAttr = clientScope.getAttributes().get(VC_CRYPTOGRAPHIC_BINDING_METHODS);
-            if (bindingRequired || !StringUtil.isBlank(bindingMethodsAttr)) {
-                List<String> effectiveBindingMethods = parseCommaSeparated(bindingMethodsAttr);
+        Set<String> allowedBindingMethods = credentialBuilder.getSupportedBindingMethods();
 
-                if (effectiveBindingMethods.isEmpty() || !allowedBindingMethods.containsAll(effectiveBindingMethods)) {
-                    throw ErrorResponse.error(
-                            String.format("When vc.binding_required is true, vc.cryptographic_binding_methods_supported must " +
-                                            "contain at least one valid value. Supported values for format '%s': %s",
-                                    format, allowedBindingMethods),
-                            Response.Status.BAD_REQUEST);
-                }
+        String bindingMethodsAttr = clientScope.getAttributes().get(VC_CRYPTOGRAPHIC_BINDING_METHODS);
+        if (bindingRequired || !StringUtil.isBlank(bindingMethodsAttr)) {
+            List<String> effectiveBindingMethods = parseCommaSeparated(bindingMethodsAttr);
+
+            if (effectiveBindingMethods.isEmpty() || !allowedBindingMethods.containsAll(effectiveBindingMethods)) {
+                throw ErrorResponse.error(
+                        String.format("When vc.binding_required is true, vc.cryptographic_binding_methods_supported must " +
+                                        "contain at least one valid value. Supported values for format '%s': %s",
+                                format, allowedBindingMethods),
+                        Response.Status.BAD_REQUEST);
             }
-        } else {
-            // Skip the binding for unsupported formats as such client scope cannot be used in runtime to build any credentials. Might happen in some corner case scenarios (EG. when realm with MDOC credential scope is imported when OID4VC_MDOC feature is disabled)
-            LOGGER.warnf("Not able to obtain credential builder for the format '%s' of credential scope '%s'. Skip validation of binding methods",  format, clientScope.getName());
         }
 
         Set<String> allowedProofTypes = session.listProviderIds(ProofValidator.class);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -326,6 +326,16 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         assertTrue(error.contains(VC_CRYPTOGRAPHIC_BINDING_METHODS));
     }
 
+    @Test
+    public void testCredentialFormatWithoutBuilderRejected() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation("issue-52515-unsupported-format");
+        scope.setFormat("unsupported-format");
+
+        String error = assertClientScopeCreateFailure(scope);
+        assertTrue(error.contains("No credential builder found"), error);
+        assertTrue(error.contains("unsupported-format"), error);
+    }
+
     private String createCredentialScope(ClientScopesResource clientScopes, String name,
                                          String credentialConfigurationId) {
         CredentialScopeRepresentation scope = new CredentialScopeRepresentation(name);
@@ -341,7 +351,7 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         ClientScopesResource clientScopes = testRealm.admin().clientScopes();
         try (Response response = clientScopes.create(scope)) {
             assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus(),
-                    "Should reject scope when binding_required=true and cryptographic_binding_methods_supported is absent");
+                    "Should reject invalid OID4VC client scope configuration");
             return response.readEntity(String.class);
         }
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCExportImportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCExportImportTest.java
@@ -68,7 +68,7 @@ public class OID4VCExportImportTest extends OID4VCIssuerTestBase {
         List<UserVerifiableCredentialRepresentation> verifiableCreds = testRealm.admin().users().get(john.getId()).verifiableCredentials().getCredentials();
         Map<String, List<String>> userAttributes = john.getRawAttributes();
         assertNotNull(userAttributes);
-        assertUserCredentials(verifiableCreds, userAttributes, jwtTypeCredentialScopeName, sdJwtTypeCredentialScopeName, mdocTypeCredentialScopeName, minimalJwtTypeCredentialScopeName, jwtTypeNaturalPersonScopeName, sdJwtTypeNaturalPersonScopeName);
+        assertUserCredentials(verifiableCreds, userAttributes, jwtTypeCredentialScopeName, sdJwtTypeCredentialScopeName, minimalJwtTypeCredentialScopeName, jwtTypeNaturalPersonScopeName, sdJwtTypeNaturalPersonScopeName);
 
         // Export realm
         exportRealm("oid4vc-test-realm.json");
@@ -88,7 +88,7 @@ public class OID4VCExportImportTest extends OID4VCIssuerTestBase {
         assertEquals(verifiableCreds, importedVerifiableCreds);
 
         // Verify each credential's userAttributes are preserved
-        assertUserCredentials(importedVerifiableCreds, userAttributes, jwtTypeCredentialScopeName, sdJwtTypeCredentialScopeName, mdocTypeCredentialScopeName, minimalJwtTypeCredentialScopeName, jwtTypeNaturalPersonScopeName, sdJwtTypeNaturalPersonScopeName);
+        assertUserCredentials(importedVerifiableCreds, userAttributes, jwtTypeCredentialScopeName, sdJwtTypeCredentialScopeName, minimalJwtTypeCredentialScopeName, jwtTypeNaturalPersonScopeName, sdJwtTypeNaturalPersonScopeName);
 
     }
 
@@ -150,7 +150,7 @@ public class OID4VCExportImportTest extends OID4VCIssuerTestBase {
         String userId = john.getId();
 
         List<UserVerifiableCredentialRepresentation> verifiableCreds =
-            testRealm.admin().users().get(userId).verifiableCredentials().getCredentials();
+                testRealm.admin().users().get(userId).verifiableCredentials().getCredentials();
         assertNotNull(verifiableCreds);
 
         // Get the wallet client ID

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.VCFormat;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientPoliciesPoliciesResource;
@@ -114,6 +116,7 @@ import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.server.KeycloakUrls;
 import org.keycloak.testframework.ui.annotations.InjectWebDriver;
 import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenRequest;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
@@ -231,7 +234,6 @@ public abstract class OID4VCIssuerTestBase {
     protected CredentialScopeRepresentation jwtTypeCredentialScope;
     protected CredentialScopeRepresentation sdJwtTypeCredentialScope;
     protected CredentialScopeRepresentation keyAttestationCredentialScope;
-    protected CredentialScopeRepresentation mdocTypeCredentialScope;
     protected CredentialScopeRepresentation minimalJwtTypeCredentialScope;
     protected CredentialScopeRepresentation jwtNaturalPersonCredentialScope;
     protected CredentialScopeRepresentation sdJwtNaturalPersonCredentialScope;
@@ -259,23 +261,28 @@ public abstract class OID4VCIssuerTestBase {
             });
         });
 
-        // The natural person mdoc scope is created automatically on servers with the mdoc feature enabled. Since the
-        // realm representation cannot reference it upfront, attach it to the wallet clients and test users here.
+        // Mdoc scopes cannot be part of the initial realm representation because strict validation rejects them when
+        // the mdoc feature is disabled. Create and assign them only for test classes that explicitly enable mdoc.
         boolean isMdocEnabled = runOnServer.fetch(session -> Profile.isFeatureEnabled(Profile.Feature.OID4VC_MDOC), Boolean.class);
         if (isMdocEnabled) {
+            CredentialScopeRepresentation mdoc = createBaseMdocCredentialScope(realmResource);
             CredentialScopeRepresentation mdocNaturalPerson = requireExistingCredentialScope(mdocTypeNaturalPersonScopeName);
             for (String clientId : List.of(OID4VCI_CLIENT_ID, OID4VCI_ABCA_CLIENT_ID, OID4VCI_PUBLIC_CLIENT_ID)) {
                 ClientRepresentation clientRep = realmResource.clients().findByClientId(clientId).get(0);
-                realmResource.clients().get(clientRep.getId()).addOptionalClientScope(mdocNaturalPerson.getId());
+                for (CredentialScopeRepresentation scope : List.of(mdoc, mdocNaturalPerson)) {
+                    realmResource.clients().get(clientRep.getId()).addOptionalClientScope(scope.getId());
+                }
             }
             for (String username : List.of("john", "alice")) {
                 var credentialsResource = realmResource.users().get(requireExistingUser(username).getId()).verifiableCredentials();
-                boolean alreadyPresent = credentialsResource.getCredentials().stream()
-                        .anyMatch(cred -> mdocTypeNaturalPersonScopeName.equals(cred.getCredentialScopeName()));
-                if (!alreadyPresent) {
-                    UserVerifiableCredentialRepresentation cred = new UserVerifiableCredentialRepresentation();
-                    cred.setCredentialScopeName(mdocTypeNaturalPersonScopeName);
-                    credentialsResource.createCredential(cred);
+                for (String scopeName : List.of(mdocTypeCredentialScopeName, mdocTypeNaturalPersonScopeName)) {
+                    boolean alreadyPresent = credentialsResource.getCredentials().stream()
+                            .anyMatch(cred -> scopeName.equals(cred.getCredentialScopeName()));
+                    if (!alreadyPresent) {
+                        UserVerifiableCredentialRepresentation cred = new UserVerifiableCredentialRepresentation();
+                        cred.setCredentialScopeName(scopeName);
+                        credentialsResource.createCredential(cred);
+                    }
                 }
             }
         }
@@ -292,6 +299,30 @@ public abstract class OID4VCIssuerTestBase {
         }
     }
 
+    private CredentialScopeRepresentation createBaseMdocCredentialScope(RealmResource realmResource) {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation(mdocTypeCredentialScopeName)
+                .setIncludeInTokenScope(true)
+                .setExpiryInSeconds(CREDENTIALS_EXPIRATION_IN_SECONDS)
+                .setCredentialConfigurationId(mdocTypeCredentialConfigurationIdName)
+                .setCredentialIdentifier(mdocTypeCredentialScopeName)
+                .setFormat(VCFormat.MSO_MDOC)
+                .setVct(mdocTypeCredentialDocType)
+                .setSigningAlg("ES256")
+                .setBindingRequired(true)
+                .setCryptographicBindingMethods(List.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY));
+        scope.setProtocolMappers(List.of(
+                ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1"),
+                ProtocolMapperUtils.getUserAttributeMapper("family_name", "lastName", "org.iso.18013.5.1"),
+                ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.iso.18013.5.1")
+        ));
+        scope.getAttributes().put(VC_BINDING_REQUIRED_PROOF_TYPES, "jwt");
+
+        try (Response response = realmResource.clientScopes().create(scope)) {
+            String scopeId = ApiUtil.getCreatedId(response);
+            return new CredentialScopeRepresentation(realmResource.clientScopes().get(scopeId).toRepresentation());
+        }
+    }
+
     @BeforeEach
     void beforeEachBase() {
 
@@ -302,7 +333,6 @@ public abstract class OID4VCIssuerTestBase {
         jwtTypeCredentialScope = requireExistingCredentialScope(jwtTypeCredentialScopeName);
         sdJwtTypeCredentialScope = requireExistingCredentialScope(sdJwtTypeCredentialScopeName);
         keyAttestationCredentialScope = requireExistingCredentialScope(keyAttestationCredentialScopeName);
-        mdocTypeCredentialScope = requireExistingCredentialScope(mdocTypeCredentialScopeName);
         minimalJwtTypeCredentialScope = requireExistingCredentialScope(minimalJwtTypeCredentialScopeName);
         jwtNaturalPersonCredentialScope = requireExistingCredentialScope(jwtTypeNaturalPersonScopeName);
         sdJwtNaturalPersonCredentialScope = requireExistingCredentialScope(sdJwtTypeNaturalPersonScopeName);
@@ -796,8 +826,6 @@ public abstract class OID4VCIssuerTestBase {
                     null
             ));
 
-            realm.clientScopes(createMdocCredentialScope());
-
             realm.users(createUser("John Doe", Map.of(), List.of(), Collections.emptyMap()));
             realm.users(createUser("Alice Wonderland", Map.of(), List.of(), Map.of()));
 
@@ -1034,27 +1062,6 @@ public abstract class OID4VCIssuerTestBase {
             return scope;
         }
 
-        private CredentialScopeRepresentation createMdocCredentialScope() {
-            CredentialScopeRepresentation cs = new CredentialScopeRepresentation(mdocTypeCredentialScopeName)
-                    .setIncludeInTokenScope(true)
-                    .setExpiryInSeconds(CREDENTIALS_EXPIRATION_IN_SECONDS)
-                    .setCredentialConfigurationId(mdocTypeCredentialConfigurationIdName)
-                    .setCredentialIdentifier(mdocTypeCredentialScopeName)
-                    .setFormat(VCFormat.MSO_MDOC)
-                    .setVct(mdocTypeCredentialDocType)
-                    .setSigningAlg("ES256")
-                    .setBindingRequired(true)
-                    .setCryptographicBindingMethods(List.of(CRYPTOGRAPHIC_BINDING_METHOD_COSE_KEY));
-            cs.setProtocolMappers(List.of(
-                    ProtocolMapperUtils.getUserAttributeMapper("given_name", "firstName", "org.iso.18013.5.1"),
-                    ProtocolMapperUtils.getUserAttributeMapper("family_name", "lastName", "org.iso.18013.5.1"),
-                    ProtocolMapperUtils.getSubjectIdMapper("id", UserModel.USERNAME, "org.iso.18013.5.1")
-            ));
-            cs.getAttributes().put(VC_BINDING_REQUIRED_PROOF_TYPES, "jwt");
-
-            return cs;
-        }
-
         private UserRepresentation createUser(
                 String fullName,
                 Map<String, String> attributes,
@@ -1082,8 +1089,7 @@ public abstract class OID4VCIssuerTestBase {
                     .verifiableCredential(sdJwtTypeCredentialScopeName)
                     .verifiableCredential(minimalJwtTypeCredentialScopeName)
                     .verifiableCredential(jwtTypeNaturalPersonScopeName)
-                    .verifiableCredential(sdJwtTypeNaturalPersonScopeName)
-                    .verifiableCredential(mdocTypeCredentialScopeName);
+                    .verifiableCredential(sdJwtTypeNaturalPersonScopeName);
 
             attributes.forEach(userBuilder::attribute);
 
@@ -1118,7 +1124,6 @@ public abstract class OID4VCIssuerTestBase {
                     minimalJwtTypeCredentialScopeName,
                     jwtTypeNaturalPersonScopeName,
                     sdJwtTypeNaturalPersonScopeName,
-                    mdocTypeCredentialScopeName,
                     "email"
             };
             client.clientId(OID4VCI_ABCA_CLIENT_ID)
@@ -1145,7 +1150,6 @@ public abstract class OID4VCIssuerTestBase {
                     minimalJwtTypeCredentialScopeName,
                     jwtTypeNaturalPersonScopeName,
                     sdJwtTypeNaturalPersonScopeName,
-                    mdocTypeCredentialScopeName,
                     "email"
             };
             client.clientId(OID4VCI_CLIENT_ID)
@@ -1170,7 +1174,6 @@ public abstract class OID4VCIssuerTestBase {
                     minimalJwtTypeCredentialScopeName,
                     jwtTypeNaturalPersonScopeName,
                     sdJwtTypeNaturalPersonScopeName,
-                    mdocTypeCredentialScopeName,
                     "email"
             };
             client.clientId(OID4VCI_PUBLIC_CLIENT_ID)

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocFeatureDisabledWellKnownProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocFeatureDisabledWellKnownProviderTest.java
@@ -16,27 +16,33 @@
  */
 package org.keycloak.tests.oid4vc;
 
-import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.VCFormat;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
-public class OID4VCMdocFeatureDisabledWellKnownProviderTest extends OID4VCMdocTestBase {
+public class OID4VCMdocFeatureDisabledWellKnownProviderTest extends OID4VCIssuerTestBase {
 
     @Test
-    void testMdocCredentialConfigurationHiddenWhenFeatureDisabled() {
-        CredentialScopeRepresentation mdocScope = createMdocCredentialScope("mdoc-feature-off-scope", "mdoc-feature-off-config");
+    void testMdocCredentialConfigurationRejectedWhenFeatureDisabled() {
+        CredentialScopeRepresentation mdocScope = new CredentialScopeRepresentation("mdoc-feature-off-scope")
+                .setCredentialConfigurationId("mdoc-feature-off-config")
+                .setFormat(VCFormat.MSO_MDOC);
 
-        CredentialIssuer credentialIssuer = oauth.oid4vc().doIssuerMetadataRequest().getMetadata();
-        assertNotNull(credentialIssuer);
-        assertFalse(credentialIssuer.getCredentialsSupported().containsKey(mdocScope.getCredentialConfigurationId()),
-                "mso_mdoc configuration must not be advertised when the mDoc feature is disabled");
+        try (Response response = testRealm.admin().clientScopes().create(mdocScope)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+            String error = response.readEntity(String.class);
+            assertTrue(error.contains(VCFormat.MSO_MDOC), error);
+            assertTrue(error.contains("No credential builder found"), error);
+        }
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMdocTestBase.java
@@ -73,7 +73,7 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
         CredentialScopeRepresentation existingScope = base.getCredentialScope(scopeName);
         if (existingScope != null) {
             addScopeToOid4vciClients(base, existingScope.getId());
-            addCredentialToTestUser(base, scopeName);
+            addCredentialToTestUsers(base, scopeName);
             return existingScope;
         }
 
@@ -114,7 +114,7 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
         CredentialScopeRepresentation existingScope = base.getCredentialScope(scopeName);
         if (existingScope != null) {
             addScopeToOid4vciClients(base, existingScope.getId());
-            addCredentialToTestUser(base, scopeName);
+            addCredentialToTestUsers(base, scopeName);
             return existingScope;
         }
 
@@ -152,7 +152,7 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
         base.testRealm.cleanup().add(realm -> realm.clientScopes().get(scopeId).remove());
 
         addScopeToOid4vciClients(base, scopeId);
-        addCredentialToTestUser(base, scopeName);
+        addCredentialToTestUsers(base, scopeName);
         return new CredentialScopeRepresentation(base.testRealm.admin().clientScopes().get(scopeId).toRepresentation());
     }
 
@@ -162,11 +162,18 @@ public abstract class OID4VCMdocTestBase extends OID4VCIssuerTestBase {
 
     private static void addScopeToOid4vciClients(OID4VCIssuerTestBase base, String scopeId) {
         base.testRealm.admin().clients().get(base.client.getId()).addOptionalClientScope(scopeId);
+        base.testRealm.admin().clients().get(base.abcaClient.getId()).addOptionalClientScope(scopeId);
         base.testRealm.admin().clients().get(base.pubClient.getId()).addOptionalClientScope(scopeId);
     }
 
-    private static void addCredentialToTestUser(OID4VCIssuerTestBase base, String scopeName) {
-        String userId = base.requireExistingUser(TEST_USER).getId();
+    private static void addCredentialToTestUsers(OID4VCIssuerTestBase base, String scopeName) {
+        for (String username : List.of(TEST_USER, "alice")) {
+            addCredentialToTestUser(base, username, scopeName);
+        }
+    }
+
+    private static void addCredentialToTestUser(OID4VCIssuerTestBase base, String username, String scopeName) {
+        String userId = base.requireExistingUser(username).getId();
         boolean alreadyPresent = base.testRealm.admin().users().get(userId).verifiableCredentials().getCredentials().stream()
                 .anyMatch(credential -> scopeName.equals(credential.getCredentialScopeName()));
         if (!alreadyPresent) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/OID4VCMdocAuthorizationCodeFlowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/OID4VCMdocAuthorizationCodeFlowTest.java
@@ -36,7 +36,7 @@ public class OID4VCMdocAuthorizationCodeFlowTest extends OID4VCAuthorizationCode
     @Override
     protected CredentialScopeRepresentation getCredentialScope() {
         ensureEcSigningKeyProvider("mdoc-issuer-key", "P-256", "ES256", 200);
-        return mdocTypeCredentialScope;
+        return requireExistingCredentialScope(mdocTypeCredentialScopeName);
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCMdocAuthorizationDetailsFlowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCMdocAuthorizationDetailsFlowTest.java
@@ -28,7 +28,7 @@ public class OID4VCMdocAuthorizationDetailsFlowTest extends OID4VCAuthorizationD
     @Override
     protected CredentialScopeRepresentation getCredentialScope() {
         ensureEcSigningKeyProvider("mdoc-auth-details-issuer-key", "P-256", "ES256", 200);
-        return mdocTypeCredentialScope;
+        return requireExistingCredentialScope(mdocTypeCredentialScopeName);
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCMdocAuthorizationDetailsFlowPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCMdocAuthorizationDetailsFlowPreAuthTest.java
@@ -36,7 +36,7 @@ public class OID4VCMdocAuthorizationDetailsFlowPreAuthTest extends OID4VCAuthori
     @Override
     protected ClientScopeRepresentation getCredentialClientScope() {
         ensureEcSigningKeyProvider("mdoc-preauth-auth-details-issuer-key", "P-256", "ES256", 200);
-        return mdocTypeCredentialScope;
+        return requireExistingCredentialScope(mdocTypeCredentialScopeName);
     }
 
     @Override


### PR DESCRIPTION
When validating an OID4VCI client scope, validation now fails if no `CredentialBuilder` provider is registered for the configured credential format. Previously, this condition only produced a warning and skipped the binding-method validation.

The OID4VCI test setup was also updated so that mdoc-specific client scopes, client assignments, and user verifiable credentials are created only when the `oid4vc-mdoc` feature is enabled.

The changes include:

- Rejecting credential scopes whose format has no registered `CredentialBuilder`.
- Adding coverage for unsupported credential formats.
- Verifying that mdoc credential scopes are rejected when the mdoc feature is disabled.
- Creating and assigning mdoc test fixtures only for tests that enable the mdoc feature.
- Updating the affected mdoc and export/import tests.

Closes #52515