### PR TITLE
Close directory export output streams

### DIFF
--- a/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirExportProvider.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirExportProvider.java
@@ -70,15 +70,17 @@ public class DirExportProvider extends MultipleStepsExportProvider<DirExportProv
     @Override
     protected void writeUsers(String fileName, KeycloakSession session, RealmModel realm, List<UserModel> users) throws IOException {
         File file = new File(getRootDirectory(), fileName);
-        FileOutputStream os = new FileOutputStream(file);
-        ExportUtils.exportUsersToStream(session, realm, users, JsonSerialization.prettyMapper, os);
+        try (FileOutputStream os = new FileOutputStream(file)) {
+            ExportUtils.exportUsersToStream(session, realm, users, JsonSerialization.prettyMapper, os);
+        }
     }
 
     @Override
     protected void writeFederatedUsers(String fileName, KeycloakSession session, RealmModel realm, List<String> users) throws IOException {
         File file = new File(getRootDirectory(), fileName);
-        FileOutputStream os = new FileOutputStream(file);
-        ExportUtils.exportFederatedUsersToStream(session, realm, users, JsonSerialization.prettyMapper, os);
+        try (FileOutputStream os = new FileOutputStream(file)) {
+            ExportUtils.exportFederatedUsersToStream(session, realm, users, JsonSerialization.prettyMapper, os);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

Ensures directory export streams for user and federated user files are closed with try-with-resources. This prevents file descriptor leaks and makes cleanup reliable when export writing completes or fails.

Resolves keycloak/keycloak#52634

## How to test?

- `./mvnw -pl model/storage-services -am -DskipTests -DskipExamples -DskipTestsuite -DskipAdapters -DskipDocs -DskipDistribution compile`

AI agents were used to generate this complete solution from a prompt, and the change was reviewed for scope and repository conventions.