### PR TITLE
Fix SAML endpoint 500 on unauthenticated LogoutRequest with no logout URL

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -703,6 +703,14 @@ public class SamlService extends AuthorizationEndpointBase {
             // default
             String logoutBinding = getBindingType();
             String logoutBindingUri = SamlProtocol.getLogoutServiceUrl(session, client, logoutBinding, true);
+            if (! SamlProtocol.SAML_SOAP_BINDING.equals(logoutBinding) && (logoutBindingUri == null || logoutBindingUri.trim().isEmpty())) {
+                // no logout service URL (or management URL fallback) is configured for this client/binding,
+                // so there is nowhere to send the LogoutResponse to; fail the same way validateDestination()
+                // does above instead of letting the response builders below throw on a null destination.
+                event.detail(Details.REASON, "logout_binding_uri_missing");
+                event.error(Errors.INVALID_SAML_LOGOUT_REQUEST);
+                return error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);
+            }
             String logoutRelayState = relayState;
             SAML2LogoutResponseBuilder builder = new SAML2LogoutResponseBuilder();
             builder.logoutRequestID(logoutRequest.getID());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -826,6 +826,37 @@ public class LogoutTest extends AbstractSamlTest {
         );
     }
 
+    /**
+     * https://github.com/keycloak/keycloak/issues/51371
+     *
+     * An unauthenticated LogoutRequest (no Keycloak session/identity cookie for the requesting
+     * browser) for a client that has no logout service URL configured for the binding used on
+     * the request must be rejected with a 400 INVALID_REQUEST, not fail with a 500. The "sales-post"
+     * client only has its POST single-logout-service URL configured (see {@link #setup()}), so a
+     * REDIRECT-bound logout request has no destination to send the LogoutResponse to.
+     */
+    @Test
+    public void testLogoutNoLogoutServiceUrlConfiguredForBindingReturnsBadRequest() throws IOException {
+        new SamlClientBuilder()
+          .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
+          .login().user(bburkeUser).build()
+          .processSamlResponse(POST)
+            .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
+            .build()
+
+          // Simulate an unauthenticated request: no identity cookie is sent with the LogoutRequest below.
+          .clearCookies()
+
+          .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, REDIRECT)
+            .nameId(nameIdRef::get)
+            .sessionIndex(sessionIndexRef::get)
+            .build()
+
+          .doNotFollowRedirects()
+          .assertResponse(LogoutTest::assertBadRequest)
+          .execute();
+    }
+
     private void testLogoutDestination(Binding binding, final Consumer<CreateLogoutRequestStepBuilder> logoutReqUpdater, Consumer<? super CloseableHttpResponse> responseTester) throws IOException {
         final RealmResource realm = adminClient.realm(REALM_NAME);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -857,6 +857,43 @@ public class LogoutTest extends AbstractSamlTest {
           .execute();
     }
 
+    /**
+     * https://github.com/keycloak/keycloak/issues/51371
+     *
+     * Companion to {@link #testLogoutNoLogoutServiceUrlConfiguredForBindingReturnsBadRequest()} covering the
+     * other binding: the "sales-post" client is reconfigured to have only its REDIRECT single-logout-service
+     * URL set, and the unauthenticated LogoutRequest is sent over the POST binding. Again there is no
+     * destination to send the LogoutResponse to, so the endpoint must answer 400 INVALID_REQUEST, not 500.
+     */
+    @Test
+    public void testLogoutNoLogoutServiceUrlConfiguredForPostBindingReturnsBadRequest() throws IOException {
+        try (Closeable sales = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST)
+            .setFrontchannelLogout(true)
+            .removeAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_POST_ATTRIBUTE)
+            .setAttribute(SamlProtocol.SAML_SINGLE_LOGOUT_SERVICE_URL_REDIRECT_ATTRIBUTE, "http://url")
+            .update()) {
+
+            new SamlClientBuilder()
+              .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, SAML_ASSERTION_CONSUMER_URL_SALES_POST, POST).build()
+              .login().user(bburkeUser).build()
+              .processSamlResponse(POST)
+                .transformObject(this::extractNameIdAndSessionIndexAndTerminate)
+                .build()
+
+              // Simulate an unauthenticated request: no identity cookie is sent with the LogoutRequest below.
+              .clearCookies()
+
+              .logoutRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_SALES_POST, POST)
+                .nameId(nameIdRef::get)
+                .sessionIndex(sessionIndexRef::get)
+                .build()
+
+              .doNotFollowRedirects()
+              .assertResponse(LogoutTest::assertBadRequest)
+              .execute();
+        }
+    }
+
     private void testLogoutDestination(Binding binding, final Consumer<CreateLogoutRequestStepBuilder> logoutReqUpdater, Consumer<? super CloseableHttpResponse> responseTester) throws IOException {
         final RealmResource realm = adminClient.realm(REALM_NAME);
 


### PR DESCRIPTION
Closes #51371

### Problem

`SamlService.BindingProtocol.logoutRequest()` falls through to its default POST/Redirect `LogoutResponse` path whenever the incoming `LogoutRequest` is unauthenticated (no identity cookie) and carries no matching session index. That path calls `SamlProtocol.getLogoutServiceUrl()`, which returns `null` when the client has no single-logout-service URL configured for the binding in use and no management URL to fall back to.

The `null` destination then flows into the response builders (`builder.destination(null)` / `binding.redirectBinding(...).response(null)`), where `KeycloakUriBuilder.fromUri()` throws `IllegalArgumentException: uri parameter is null`. It is wrapped into a `RuntimeException` and surfaces to the client as an unhandled **HTTP 500** instead of a clean error.

Both HTTP-Redirect and HTTP-POST bindings are affected.

### Fix

Guard the `null`/blank destination the same way the method already guards `validateDestination()` failures a few lines above: log an `INVALID_SAML_LOGOUT_REQUEST` event and return **400 `INVALID_REQUEST`**. This matches the behaviour the issue asks for and is consistent with how the same method already rejects other unusable logout requests.

SOAP binding is excluded from the check since its response path does not need a destination URL.

```java
String logoutBindingUri = SamlProtocol.getLogoutServiceUrl(session, client, logoutBinding, true);
if (! SamlProtocol.SAML_SOAP_BINDING.equals(logoutBinding) && (logoutBindingUri == null || logoutBindingUri.trim().isEmpty())) {
    event.detail(Details.REASON, "logout_binding_uri_missing");
    event.error(Errors.INVALID_SAML_LOGOUT_REQUEST);
    return error(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_REQUEST);
}
```

### Testing

- `LogoutTest.testLogoutNoLogoutServiceUrlConfiguredForBindingReturnsBadRequest` reproduces the exact scenario: the `sales-post` client is configured with only its **POST** single-logout-service URL, then an unauthenticated (`clearCookies()`) `LogoutRequest` is sent over the **REDIRECT** binding — so there is no destination for the `LogoutResponse`. The test asserts a `400` response rather than a `500`.
- `LogoutTest.testLogoutNoLogoutServiceUrlConfiguredForPostBindingReturnsBadRequest` covers the mirror case: the client reconfigured with only its **REDIRECT** SLO URL, receiving an unauthenticated **POST**-bound `LogoutRequest`.

### AI agent disclosure

This PR was authored with the assistance of an AI agent (Claude Code) working from a prompt. The author has reviewed and understands the change, verified it against the codebase, and is responsible for addressing review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)