### PR TITLE
Fix extend account console content routes

### DIFF
--- a/js/apps/account-ui/src/content/ContentComponent.tsx
+++ b/js/apps/account-ui/src/content/ContentComponent.tsx
@@ -21,7 +21,10 @@ function findComponent(
       return item.modulePath;
     }
     if ("children" in item) {
-      return findComponent(item.children, componentId);
+      const modulePath = findComponent(item.children, componentId);
+      if (modulePath) {
+        return modulePath;
+      }
     }
   }
   return undefined;
@@ -39,7 +42,7 @@ export const ContentComponent = () => {
     [content, componentId],
   );
 
-  return modulePath && <Component modulePath={modulePath} />;
+  return modulePath && <Component key={modulePath} modulePath={modulePath} />;
 };
 
 type ComponentProps = {

--- a/js/apps/account-ui/src/root/Root.tsx
+++ b/js/apps/account-ui/src/root/Root.tsx
@@ -19,7 +19,7 @@ import { type AccountEnvironment } from "..";
 import { usePromise } from "../utils/usePromise";
 import { Header } from "./Header";
 import { MenuItem, PageNav } from "./PageNav";
-import { routes } from "../routes";
+import { ContentRoute, routes } from "../routes";
 
 function mapRoutes(
   context: KeycloakContext<AccountEnvironment>,
@@ -33,6 +33,13 @@ function mapRoutes(
 
       // Do not add route disabled via feature flags
       if (item.isVisible && !context.environment.features[item.isVisible]) {
+        return null;
+      }
+
+      // Custom content is rendered by ContentRoute. Adding an exact route for
+      // every custom item here would shadow the generic content/:componentId
+      // route with an element that cannot be resolved from the built-in routes.
+      if (item.modulePath) {
         return null;
       }
 
@@ -81,6 +88,7 @@ export const Root = () => {
           errorElement: <ErrorPage />,
           children: [
             ...mapRoutes(context, content),
+            ContentRoute,
             { path: "*", element: <CatchAllRedirect /> },
           ],
         },


### PR DESCRIPTION
Fixes the extending of the account console using the content routes.

Closes #41433 and https://github.com/keycloak/keycloak-quickstarts/issues/678