### PR TITLE
Match client policy source groups by full group path

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -35,6 +35,12 @@ Note that {project_name}'s trust store (or mTLS store) is shared for all the rea
 
 Revalidating certificates can be problematic in certain installations (for example if a proxy is configured for TLS termination and the certificates are passed to {project_name} using headers). The trust-store or mTLS store in {project_name} should always be configured correctly to validate the client certificate chain. Please see link:https://www.keycloak.org/server/reverseproxy[Using a reverse proxy] and link:https://www.keycloak.org/server/mutual-tls[Configuring trusted certificates for mTLS], for more information if you are using a TLS termination proxy and X509 client authentication.
 
+=== Client policy source groups condition matches the full group path
+
+The `client-updater-source-groups` client policy condition now matches groups by their full path instead of the simple group name. A configured value without a leading slash is treated as a top level group, so a condition configured with `topGroup` matches `/topGroup` and keeps behaving as before. Top level groups configured by their simple name do not require any change.
+
+Only the conditions configured with the simple name of a subgroup need to be updated to the full path of that group, for example `/topGroup/level2group`.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -1179,7 +1179,7 @@ searchForProtocol=Search protocol mapper
 eventTypes.CLIENT_INFO.name=Client info
 eventTypes.OAUTH2_DEVICE_CODE_TO_TOKEN.description=OAuth2 device code to token
 eventTypes.UPDATE_TOTP_ERROR.name=Update totp error
-client-updater-source-groups.tooltip=Name of groups to check. The condition evaluates to true if the entity who creates or updates the client is a member of one or more of the specified groups. Configured groups are specified by their simple name, which must match the name of the Keycloak group. No support for group hierarchy is used here.
+client-updater-source-groups.tooltip=Path of groups to check. The condition evaluates to true if the entity who creates or updates the client is a member of one or more of the specified groups. Configured groups are specified by their full path, for example /topGroup/level2group. No support for group hierarchy is used here.
 webAuthnPolicyRpId=Relying party ID
 ldapRolesDnHelp=LDAP DN where roles of this tree are saved. For example, 'ou\=finance,dc\=example,dc\=org'.
 serviceAccount=Service account roles

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdaterSourceGroupsCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientUpdaterSourceGroupsCondition.java
@@ -17,15 +17,18 @@
 
 package org.keycloak.services.clientpolicy.condition;
 
-import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
@@ -122,24 +125,35 @@ public class ClientUpdaterSourceGroupsCondition extends AbstractClientPolicyCond
     private boolean isGroupsMatched(UserModel user) {
         if (user == null) return false;
 
-        Set<String> expectedGroups = instantiateGroupsForMatching();
-        if (expectedGroups == null) return false;
+        List<String> configuredGroups = configuration.getGroups();
+        if (configuredGroups == null) return false;
 
-        // user.getGroupsStream() never returns null according to {@link UserModel.getGroupsStream}
-        Set<String> groups = user.getGroupsStream().map(GroupModel::getName).collect(Collectors.toSet());
+        Set<String> expectedGroups = configuredGroups.stream().map(this::resolveGroup).filter(Objects::nonNull)
+                .map(GroupModel::getId).collect(Collectors.toSet());
+
+        Set<String> groups = user.getGroupsStream().map(GroupModel::getId).collect(Collectors.toSet());
 
         if (logger.isTraceEnabled()) {
-            groups.forEach(i -> logger.tracev("user group = {0}", i));
-            expectedGroups.forEach(i -> logger.tracev("expected user group = {0}", i));
+            groups.forEach(i -> logger.tracev("user group id = {0}", i));
+            expectedGroups.forEach(i -> logger.tracev("expected user group id = {0}", i));
         }
 
-        return expectedGroups.removeAll(groups); // may change expectedGroups so that it has needed to be instantiated.
+        return groups.stream().anyMatch(expectedGroups::contains);
     }
 
-    private Set<String> instantiateGroupsForMatching() {
-        List<String> groups = configuration.getGroups();
-        if (groups == null) return null;
-        return new HashSet<>(groups);
+    private GroupModel resolveGroup(String group) {
+        if (group == null) return null;
+
+        RealmModel realm = session.getContext().getRealm();
+
+        // the configured groups are resolved regardless of the groups the user performing the request is allowed to view
+        return AdminPermissionsSchema.runWithoutAuthorization(session, () -> {
+            // a value with a leading slash is the full path of the group, otherwise it is the name of a top level group
+            if (group.startsWith("/")) {
+                return KeycloakModelUtils.findGroupByPath(session, realm, group);
+            }
+            return session.groups().getGroupByName(realm, null, group);
+        });
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesConditionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesConditionTest.java
@@ -27,6 +27,8 @@ import jakarta.ws.rs.BadRequestException;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.admin.client.CreatedResponseUtil;
+import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
 import org.keycloak.authentication.authenticators.client.JWTClientSecretAuthenticator;
 import org.keycloak.authentication.authenticators.client.X509ClientAuthenticator;
@@ -43,6 +45,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.ErrorRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
@@ -96,6 +99,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
 public class ClientPoliciesConditionTest extends AbstractClientPoliciesTest {
+
+    private static final String DUPLICATED_GROUP_PARENT_NAME = "duplicate-source-groups-parent";
 
     @Page
     protected OAuthGrantPage grantPage;
@@ -293,6 +298,71 @@ public class ClientPoliciesConditionTest extends AbstractClientPoliciesTest {
             });
         } catch (Exception e) {
             fail();
+        }
+    }
+
+    @Test
+    public void testClientUpdateSourceGroupsConditionMatchesFullGroupPath() throws Exception {
+        // register profiles
+        String json = (new ClientProfilesBuilder()).addProfile(
+                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Den Andre Profil")
+                        .addExecutor(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID,
+                                createSecureClientAuthenticatorExecutorConfig(
+                                        List.of(JWTClientAuthenticator.PROVIDER_ID),
+                                        null)
+                        )
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // make manage-clients a member of the subgroup /duplicate-source-groups-parent/topGroup, whose name
+        // duplicates the one of the top level group /topGroup the create-clients user belongs to
+        RealmResource realm = adminClient.realm(REALM_NAME);
+        GroupRepresentation parentGroup = new GroupRepresentation();
+        parentGroup.setName(DUPLICATED_GROUP_PARENT_NAME);
+        String parentGroupId = CreatedResponseUtil.getCreatedId(realm.groups().add(parentGroup));
+        testContext.getOrCreateCleanup(REALM_NAME).addGroupId(parentGroupId);
+        GroupRepresentation duplicatedGroup = new GroupRepresentation();
+        duplicatedGroup.setName("topGroup");
+        String duplicatedGroupId = CreatedResponseUtil.getCreatedId(realm.groups().group(parentGroupId).subGroup(duplicatedGroup));
+        String userId = realm.users().search("manage-clients", true).get(0).getId();
+        realm.users().get(userId).joinGroup(duplicatedGroupId);
+
+        // a simple name only matches the top level group, the subgroup with the duplicated name is not matched
+        updateClientUpdateSourceGroupsPolicy("topGroup");
+        authCreateClients();
+        assertClientRegistrationFails();
+        authManageClients();
+        createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+        });
+
+        // the subgroup is matched when it is configured by its full path
+        updateClientUpdateSourceGroupsPolicy("/" + DUPLICATED_GROUP_PARENT_NAME + "/topGroup");
+        authManageClients();
+        assertClientRegistrationFails();
+        authCreateClients();
+        createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+        });
+    }
+
+    private void updateClientUpdateSourceGroupsPolicy(String group) throws Exception {
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Den Andre Politik", Boolean.TRUE)
+                        .addCondition(ClientUpdaterSourceGroupsConditionFactory.PROVIDER_ID,
+                                createClientUpdateSourceGroupsConditionConfig(List.of(group)))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+    }
+
+    private void assertClientRegistrationFails() throws Exception {
+        try {
+            createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+            });
+            fail();
+        } catch (ClientRegistrationException e) {
+            assertEquals(ERR_MSG_CLIENT_REG_FAIL, e.getMessage());
         }
     }
 


### PR DESCRIPTION
Closes #51281

The `client-updater-source-groups` condition matched the groups by simple name, but group names are not unique, `/topGroup` and `/other/topGroup` were treated as the same group. 

With the PR the condition now matches the full group path but values without a leading slash are still read as top level groups, so `topGroup` keeps matching `/topGroup`. Only conditions pointing at a subgroup by its leaf name need to be updated to the full path. I added a note in the breaking changes section.

Is this acceptable as a breaking change?
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
