### PR TITLE
Handle concurrent delete for on-insert-do-nothing path

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -76,14 +76,19 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
             return createRootAuthenticationSession(realm);
         }
         var em = getEntityManager();
-        em.createNamedQuery("insertRootAuthSessionIfAbsent")
-                .setParameter("id", id)
-                .setParameter("realmId", realm.getId())
-                .setParameter("timestamp", Time.currentTimeSeconds())
-                .executeUpdate();
-        var entity = em.find(RootAuthenticationSessionEntity.class, id, LockModeType.PESSIMISTIC_WRITE);
-        if (entity == null) {
-            throw new ModelException("Unable to create or find root authentication session with id '" + id + "'");
+        // INSERT ON CONFLICT DO NOTHING does not lock the conflicting row, so a concurrent DELETE
+        // could remove it between the INSERT and the subsequent find. Retry if this happens.
+        RootAuthenticationSessionEntity entity;
+        for (;;) {
+            em.createNamedQuery("insertRootAuthSessionIfAbsent")
+                    .setParameter("id", id)
+                    .setParameter("realmId", realm.getId())
+                    .setParameter("timestamp", Time.currentTimeSeconds())
+                    .executeUpdate();
+            entity = em.find(RootAuthenticationSessionEntity.class, id, LockModeType.PESSIMISTIC_WRITE);
+            if (entity != null) {
+                break;
+            }
         }
         if (!Objects.equals(realm.getId(), entity.getRealmId())) {
             throw new ModelException("Another root authentication session with id '" + id + "' already exists in other realm");

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
@@ -161,7 +161,10 @@ class RootAuthenticationSessionAdapter implements RootAuthenticationSessionModel
 
     @Override
     public void removeAuthenticationSessionByTabId(String tabId) {
-        session.getProvider(JpaConnectionProvider.class).getEntityManager().remove(entity.getAuthenticationSessions().remove(tabId));
+        var removed = entity.getAuthenticationSessions().remove(tabId);
+        if (removed != null) {
+            session.getProvider(JpaConnectionProvider.class).getEntityManager().remove(removed);
+        }
         if (adapters != null) {
             adapters.remove(tabId);
         }

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/JpaUserLoginFailureProvider.java
@@ -93,18 +93,27 @@ public class JpaUserLoginFailureProvider implements UserLoginFailureProvider {
     @Override
     public UserLoginFailureModel addUserLoginFailure(RealmModel realm, String userId) {
         var em = getEntityManager();
-        int inserted = em.createNamedQuery("insertLoginFailure")
-                .setParameter("realmId", realm.getId())
-                .setParameter("userId", userId)
-                .executeUpdate();
         var key = new LoginFailureKey(realm.getId(), userId);
         notInDatabaseCache.remove(key);
-        var entity = inserted == 0
-                ? em.find(LoginFailureEntity.class, key, LockModeType.PESSIMISTIC_WRITE)
-                : em.find(LoginFailureEntity.class, key);
+        // INSERT ON CONFLICT DO NOTHING does not lock the conflicting row, so a concurrent DELETE
+        // could remove it between the INSERT and the subsequent find. Retry if this happens.
+        LoginFailureEntity entity;
+        boolean inserted;
+        for (;;) {
+            int rows = em.createNamedQuery("insertLoginFailure")
+                    .setParameter("realmId", realm.getId())
+                    .setParameter("userId", userId)
+                    .executeUpdate();
+            inserted = rows > 0;
+            entity = inserted
+                    ? em.find(LoginFailureEntity.class, key)
+                    : em.find(LoginFailureEntity.class, key, LockModeType.PESSIMISTIC_WRITE);
+            if (entity != null) {
+                break;
+            }
+        }
         UserLoginFailureModel model = new UserLoginFailureAdapter(em, entity);
-        if (inserted == 0 && isExpired(realm, entity)) {
-            // The entity already existed but is expired — clear its stale data so new failure counting starts fresh.
+        if (!inserted && isExpired(realm, entity)) {
             model.clearPrimaryAndSecondaryAuthFailures();
         }
         entityInSession.put(key, model);

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/AuthenticationSessionTest.java
@@ -343,6 +343,42 @@ public class AuthenticationSessionTest extends KeycloakModelTest {
     }
 
     @Test
+    public void testRemoveAbsentTabId() {
+        AtomicReference<String> rootAuthSessionId = new AtomicReference<>();
+        List<String> tabIds = withRealm(realmId, (session, realm) -> {
+            RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().createRootAuthenticationSession(realm);
+            rootAuthSessionId.set(rootAuthSession.getId());
+            ClientModel client = realm.getClientByClientId("test-app");
+            return IntStream.range(0, 3)
+                    .mapToObj(i -> rootAuthSession.createAuthenticationSession(client))
+                    .map(AuthenticationSessionModel::getTabId)
+                    .collect(Collectors.toList());
+        });
+
+        withRealm(realmId, (session, realm) -> {
+            RootAuthenticationSessionModel rootAuthSession = session.authenticationSessions().getRootAuthenticationSession(realm, rootAuthSessionId.get());
+
+            // removing a tab ID that was never added must not throw
+            rootAuthSession.removeAuthenticationSessionByTabId("nonexistent-tab-id");
+
+            // all original sessions must still be present
+            assertThat(rootAuthSession.getAuthenticationSessions(), Matchers.aMapWithSize(3));
+
+            // remove a real tab, then remove it again (double-remove)
+            rootAuthSession.removeAuthenticationSessionByTabId(tabIds.get(0));
+            rootAuthSession.removeAuthenticationSessionByTabId(tabIds.get(0));
+
+            // remaining sessions are intact
+            assertThat(rootAuthSession.getAuthenticationSessions(), Matchers.aMapWithSize(2));
+            ClientModel client = realm.getClientByClientId("test-app");
+            Assert.assertNotNull(rootAuthSession.getAuthenticationSession(client, tabIds.get(1)));
+            Assert.assertNotNull(rootAuthSession.getAuthenticationSession(client, tabIds.get(2)));
+
+            return null;
+        });
+    }
+
+    @Test
     public void testCrossRealmIsolation() {
         // Create a second realm
         var realmBId = inComittedTransaction(s -> {


### PR DESCRIPTION
Closes #52610

## Design decisions

**Retry loop instead of error propagation.** The previous code threw `ModelException` (auth sessions) or would `NullPointerException` (login failures) when `em.find()` returned `null` after the INSERT. A retry loop is preferred because the race condition is transient — the conflicting DELETE has already committed, so the next INSERT will succeed. An unbounded `for (;;)` is safe here: the loop can only iterate more than once if a DELETE removes the just-inserted row, which requires a concurrent bulk delete operation to be in progress at exactly the right moment. In practice, this means at most two iterations.

**PESSIMISTIC_WRITE only on the conflict path.** In `addUserLoginFailure`, `em.find` uses `PESSIMISTIC_WRITE` only when the INSERT did not insert (i.e., the row already existed). When the INSERT succeeded, we know we own the row and no lock is needed. This preserves the existing locking behavior.

**Null guard over retry for `removeAuthenticationSessionByTabId`.** Unlike the INSERT paths, this is a simple remove-from-map operation. A null guard is sufficient — if the tab ID was already removed (by a concurrent request or by expiration), there is nothing to do.

**`OutboxStore` not changed.** The cluster event `OutboxStore` has the same INSERT ON CONFLICT pattern but already handles `null` gracefully by falling back to a generated ID. No change needed there.