### PR TITLE
fix(broker): Allows cross session email validation (#52604)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpDetectExistingBrokerUserAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpDetectExistingBrokerUserAuthenticator.java
@@ -25,6 +25,7 @@ import org.keycloak.authentication.authenticators.broker.util.SerializedBrokered
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
+import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -32,6 +33,8 @@ import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.messages.Messages;
 
 import org.jboss.logging.Logger;
+
+import static org.keycloak.authentication.actiontoken.idpverifyemail.IdpVerifyAccountLinkActionTokenHandler.runIfUserVerified;
 
 public class IdpDetectExistingBrokerUserAuthenticator extends IdpCreateUserIfUniqueAuthenticator {
 
@@ -73,10 +76,22 @@ public class IdpDetectExistingBrokerUserAuthenticator extends IdpCreateUserIfUni
             logger.debugf("Duplication detected. There is already existing user with %s '%s' .",
                     duplication.getDuplicateAttributeName(), duplication.getDuplicateAttributeValue());
 
+            UserModel user = context.getSession().users().getUserById(realm, duplication.getExistingUserId());
+            IdentityProviderModel broker = brokerContext.getIdpConfig();
+
+            runIfUserVerified(context.getSession(), user, broker, brokerContext.getBrokerUserId(),
+                    () -> {
+                        context.setUser(user);
+                        context.getAuthenticationSession().setAuthNote(
+                                IdpEmailVerificationAuthenticator.VERIFY_ACCOUNT_IDP_USERNAME,
+                                brokerContext.getUsername()
+                        );
+                    });
+
             // Set duplicated user, so next authenticators can deal with it
             context.getAuthenticationSession().setAuthNote(EXISTING_USER_INFO, duplication.serialize());
-
             context.success();
+
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginDetectExistingUserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginDetectExistingUserTest.java
@@ -1,28 +1,55 @@
 package org.keycloak.testsuite.broker;
 
+import java.util.Map;
+
 import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authentication.authenticators.broker.IdpAutoLinkAuthenticatorFactory;
 import org.keycloak.authentication.authenticators.broker.IdpDetectExistingBrokerUserAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.broker.IdpEmailVerificationAuthenticatorFactory;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderSyncMode;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.realm.AuthenticationExecutionBuilder;
 import org.keycloak.testsuite.util.AccountHelper;
+import org.keycloak.testsuite.util.MailServer;
+import org.keycloak.testsuite.util.MailServerConfiguration;
+import org.keycloak.testsuite.util.SecondBrowser;
 
+import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import static org.keycloak.testsuite.broker.BrokerTestConstants.USER_EMAIL;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+import static org.keycloak.testsuite.util.AdminEventPaths.authAddExecutionPath;
+import static org.keycloak.testsuite.util.MailAssert.assertEmailAndGetUrl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KcOidcFirstBrokerLoginDetectExistingUserTest extends AbstractInitializedBaseBrokerTest {
+
+    @Drone
+    @SecondBrowser
+    protected WebDriver driver2;
+
+    @Rule
+    public MailServer mail = new MailServer();
+
+    private static final String DETECT_EXISTING_FLOW_ALIAS = "detectExistingUserFlow";
 
     @Override
     protected BrokerConfiguration getBrokerConfiguration() {
@@ -39,7 +66,7 @@ public class KcOidcFirstBrokerLoginDetectExistingUserTest extends AbstractInitia
         AuthenticationManagementResource authMgmtResource = consumerRealm.flows();
 
         // Creates detectExistingUserFlow
-        String detectExistingFlowAlias = "detectExistingUserFlow";
+        String detectExistingFlowAlias = DETECT_EXISTING_FLOW_ALIAS;
         final AuthenticationFlowRepresentation authenticationFlowRepresentation = newFlow(detectExistingFlowAlias, detectExistingFlowAlias, "basic-flow", true, false);
         authMgmtResource.createFlow(authenticationFlowRepresentation);
 
@@ -137,4 +164,86 @@ public class KcOidcFirstBrokerLoginDetectExistingUserTest extends AbstractInitia
         assertEquals(userRepresentation.getFirstName(), firstname, "Firstname is not correct");
         assertEquals(userRepresentation.getLastName(), lastname, "Lastname is not correct");
     }
+
+    @Test
+    public void testLinkAccountByEmailVerificationDifferentBrowser() {
+        AuthenticationManagementResource authMgmtResource = adminClient.realm(bc.consumerRealmName()).flows();
+        String emailVerificationExecutionId = addEmailVerificationExecution(authMgmtResource);
+
+        try {
+            RealmResource realm = adminClient.realm(bc.consumerRealmName());
+            RealmRepresentation realmRep = realm.toRepresentation();
+
+            realmRep.setVerifyEmail(true);
+
+            realm.update(realmRep);
+
+            IdentityProviderRepresentation idpRep = identityProviderResource.toRepresentation();
+
+            idpRep.setTrustEmail(false);
+
+            identityProviderResource.update(idpRep);
+
+            configureSMTPServer();
+
+            // to avoid update profile required action
+            RealmResource providerRealm = adminClient.realm(bc.providerRealmName());
+            UserRepresentation brokerUser = providerRealm.users().search(bc.getUserLogin()).get(0);
+            brokerUser.setFirstName("f");
+            brokerUser.setLastName("l");
+            providerRealm.users().get(brokerUser.getId()).update(brokerUser);
+            // creates a user in the consumer realm to link the account
+            brokerUser.setId(null);
+            realm.users().create(brokerUser).close();
+
+            // link the account
+            oauth.client("broker-app");
+            oauth.realm(bc.consumerRealmName());
+            oauth.openLoginForm();
+            logInWithBroker(bc);
+            String verificationUrl = assertEmailAndGetUrl(mail.getLastReceivedMessage(), MailServerConfiguration.FROM, USER_EMAIL,
+                    "Someone wants to link your");
+            assertNotNull(verificationUrl);
+
+            // confirm the email using a different browser
+            driver2.navigate().to(verificationUrl.trim());
+            driver2.findElement(By.linkText("» Click here to proceed")).click();
+
+            // clear cookies to start a fresh browser instance and try to log in again
+            driver.manage().deleteAllCookies();
+            oauth.realm(bc.consumerRealmName());
+            oauth.openLoginForm();
+            waitForPage(driver, "sign in to", true);
+            loginPage.clickSocial(bc.getIDPAlias());
+            waitForPage(driver, "sign in to", true);
+            loginPage.login(bc.getUserPassword());
+            Assertions.assertTrue(oauth.parseLoginResponse().isSuccess());
+        } finally {
+            if (emailVerificationExecutionId != null) {
+                authMgmtResource.removeExecution(emailVerificationExecutionId);
+            }
+        }
+    }
+
+    private String addEmailVerificationExecution(AuthenticationManagementResource authMgmtResource) {
+        // Uses the same endpoint resolved by AdminEventPaths.authAddExecutionPath(flowAlias).
+        String addExecutionPath = authAddExecutionPath(DETECT_EXISTING_FLOW_ALIAS);
+        assertNotNull(addExecutionPath);
+
+        authMgmtResource.addExecution(DETECT_EXISTING_FLOW_ALIAS, Map.of("provider", IdpEmailVerificationAuthenticatorFactory.PROVIDER_ID));
+
+        AuthenticationExecutionInfoRepresentation addedExecution = authMgmtResource.getExecutions(DETECT_EXISTING_FLOW_ALIAS).stream()
+                .filter(execution -> IdpEmailVerificationAuthenticatorFactory.PROVIDER_ID.equals(execution.getProviderId()))
+                .findFirst()
+                .orElse(null);
+
+        if (addedExecution != null) {
+            addedExecution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
+            authMgmtResource.updateExecutions(DETECT_EXISTING_FLOW_ALIAS, addedExecution);
+            return addedExecution.getId();
+        }
+
+        return null;
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginDetectExistingUserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginDetectExistingUserTest.java
@@ -230,7 +230,9 @@ public class KcOidcFirstBrokerLoginDetectExistingUserTest extends AbstractInitia
         String addExecutionPath = authAddExecutionPath(DETECT_EXISTING_FLOW_ALIAS);
         assertNotNull(addExecutionPath);
 
-        authMgmtResource.addExecution(DETECT_EXISTING_FLOW_ALIAS, Map.of("provider", IdpEmailVerificationAuthenticatorFactory.PROVIDER_ID));
+        authMgmtResource.addExecution(DETECT_EXISTING_FLOW_ALIAS, Map.of(
+                "provider", IdpEmailVerificationAuthenticatorFactory.PROVIDER_ID,
+                "priority", 15));
 
         AuthenticationExecutionInfoRepresentation addedExecution = authMgmtResource.getExecutions(DETECT_EXISTING_FLOW_ALIAS).stream()
                 .filter(execution -> IdpEmailVerificationAuthenticatorFactory.PROVIDER_ID.equals(execution.getProviderId()))


### PR DESCRIPTION
Fixes #52604

Allows cross session email validation when using IdpDetectExistingBrokerUserAuthentication instead of IdpCreateUserIfUniqueAuthenticator
