### PR TITLE
Allow multiple audiences for JWT Authorization Grant

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
@@ -175,7 +175,7 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
             if (validAudiences == null) {
                 validAudiences = jwtAuthorizationGrantProvider.getAllowedAudienceForJWTGrant();
             }
-            authorizationGrantContext.validateTokenAudience(validAudiences, false);
+            authorizationGrantContext.validateTokenAudience(validAudiences, true);
 
             RootAuthenticationSessionModel rootAuthSession = new AuthenticationSessionManager(session).createAuthenticationSession(realm, false);
             AuthenticationSessionModel authSession = createSessionModel(rootAuthSession, user, client, scopeParam);

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/AbstractJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/AbstractJWTAuthorizationGrantTest.java
@@ -152,19 +152,26 @@ public abstract class AbstractJWTAuthorizationGrantTest extends BaseAbstractJWTA
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
         assertFailure("Invalid token audience", response, events.poll());
 
-        // Multiple audiences does not work
+        // Multiple audiences works if at least one matches
         JsonWebToken jwtToken = createAuthorizationGrantToken("basic-user-id", oAuthClient.getEndpoints().getIssuer(), IDP_ISSUER);
         jwtToken.addAudience("fake");
         jwt = getIdentityProvider().encodeToken(jwtToken);
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        assertFailure("Multiple audiences not allowed", response, events.poll());
+        assertSuccess("test-app", response);
 
-        // Multiple audiences does not work (even if both are valid)
+        // Multiple audiences works if both are valid
         jwtToken = createAuthorizationGrantToken("basic-user-id", oAuthClient.getEndpoints().getIssuer(), IDP_ISSUER);
         jwtToken.addAudience(oAuthClient.getEndpoints().getToken());
         jwt = getIdentityProvider().encodeToken(jwtToken);
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        assertFailure("Multiple audiences not allowed", response, events.poll());
+        assertSuccess("test-app", response);
+
+        // Multiple audiences fails if none match
+        jwtToken = createAuthorizationGrantToken("basic-user-id", "fake1", IDP_ISSUER);
+        jwtToken.addAudience("fake2");
+        jwt = getIdentityProvider().encodeToken(jwtToken);
+        response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
+        assertFailure("Invalid token audience", response, events.poll());
     }
 
     @Test
@@ -415,12 +422,19 @@ public abstract class AbstractJWTAuthorizationGrantTest extends BaseAbstractJWTA
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
         assertFailure("Invalid token audience", response, events.poll());
 
-        // test two audiences are always wrong
-        JsonWebToken jwtToken = createDefaultAuthorizationGrantToken();
-        jwtToken.addAudience("allowed-aud2");
+        // test multiple audiences works if one matches
+        JsonWebToken jwtToken = createAuthorizationGrantToken("basic-user-id", "allowed-aud1", IDP_ISSUER);
+        jwtToken.addAudience("other-aud");
         jwt = getIdentityProvider().encodeToken(jwtToken);
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        assertFailure("Multiple audiences not allowed", response, events.poll());
+        assertSuccess("test-app", response);
+
+        // test multiple audiences fails if none match
+        jwtToken = createAuthorizationGrantToken("basic-user-id", "other-aud1", IDP_ISSUER);
+        jwtToken.addAudience("other-aud2");
+        jwt = getIdentityProvider().encodeToken(jwtToken);
+        response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
+        assertFailure("Invalid token audience", response, events.poll());
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
@@ -113,12 +113,19 @@ public class OIDCIdentityProviderJWTAuthorizationGrantTest extends AbstractJWTAu
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
         assertFailure("Invalid token audience", response, events.poll());
 
-        // test two audiences are always wrong
-        JsonWebToken jwtToken = createAuthorizationGrantToken("basic-user-id", "test-client", IDP_ISSUER);
-        jwtToken.addAudience("allowed-aud2");
+        // test multiple audiences works if one matches
+        JsonWebToken jwtToken = createAuthorizationGrantToken("basic-user-id", "allowed-aud1", IDP_ISSUER);
+        jwtToken.addAudience("other-aud");
         jwt = getIdentityProvider().encodeToken(jwtToken);
         response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        assertFailure("Multiple audiences not allowed", response, events.poll());
+        assertSuccess("test-app", response);
+
+        // test multiple audiences fails if none match
+        jwtToken = createAuthorizationGrantToken("basic-user-id", "test-client", IDP_ISSUER);
+        jwtToken.addAudience("other-aud");
+        jwt = getIdentityProvider().encodeToken(jwtToken);
+        response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
+        assertFailure("Invalid token audience", response, events.poll());
     }
 
     public static class JWTAuthorizationGrantRealmConfig extends AbstractJWTAuthorizationGrantTest.JWTAuthorizationGrantRealmConfig {


### PR DESCRIPTION
The standard https://datatracker.ietf.org/doc/html/rfc7523#section-3 states that the JWT must contain an "aud" claim that contains the specified audience. Unlike private_key_jwt and client_secret_jwt client auth, it does not enforce a singular audience value.

This allows tokens that target multiple audiences (e.g. an API, and Keycloak) to be used for JWT-AG

Closes #52631

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
