### PR TITLE
Document and test SCIM user creation behavior with federation providers

### DIFF
--- a/docs/documentation/server_admin/topics/scim/managing-users.adoc
+++ b/docs/documentation/server_admin/topics/scim/managing-users.adoc
@@ -112,6 +112,13 @@ description of the validation error.
 If a user with the same `userName` already exists, the API returns a `409 Conflict` response with
 `scimType: "uniqueness"`.
 
+NOTE: User creation through SCIM follows the same rules as user creation through the Admin REST API. If the realm
+has a user storage provider (for example, LDAP) configured to synchronize registrations, the new user may be created
+in that external provider instead of in the local {project_name} database. If the provider does not import users
+into the local database, the created user is not retrievable through subsequent SCIM `GET`, list, search, or
+`DELETE` requests, even though the `POST` request itself succeeds. This is a known limitation of the current
+version of the SCIM API - see the notes on federated users under "Listing users" and "Deleting a user" below.
+
 == Retrieving a user
 
 To retrieve a user by ID:
@@ -409,3 +416,7 @@ curl -X DELETE http://localhost:8080/realms/myrealm/scim/v2/Users/{id} \
 ----
 
 A successful deletion returns a `204 No Content` response with no body.
+
+NOTE: Like other SCIM operations, `DELETE` only operates on users that can be resolved from local storage. Deleting
+a user that was created in a federation provider but was never imported into the local {project_name} database
+returns a `404 Not Found` response, even if creation of that user through SCIM previously succeeded.

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FederatedUserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FederatedUserTest.java
@@ -5,17 +5,21 @@ import java.util.stream.Collectors;
 
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.scim.client.ResourceFilter;
+import org.keycloak.scim.client.ScimClientException;
 import org.keycloak.scim.protocol.response.ListResponse;
 import org.keycloak.scim.resource.user.User;
+import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.util.ApiUtil;
 
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.storage.UserStorageProviderModel.IMPORT_ENABLED;
@@ -25,13 +29,27 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests that verify SCIM search behavior with non-imported federated users.
+ * Tests that verify SCIM behavior with users backed by a user storage (federation) provider.
+ *
+ * SCIM read operations (GET, list, search) only ever consider locally stored users - see
+ * {@link org.keycloak.scim.model.user.UserResourceTypeProvider}. Write operations (POST /Users),
+ * however, go through the same {@code UserProfile.create()} -&gt; {@code session.users().addUser()}
+ * path used by the regular Admin REST API, so a user storage provider that intercepts registration
+ * (a "sync registration" provider, such as LDAP with write-back enabled) may end up creating the
+ * user outside of local storage. If that provider also does not import users into the local
+ * database, the newly created user becomes unreachable via any subsequent SCIM operation, even
+ * though the initial POST succeeded. This is a documented limitation of this version of the SCIM
+ * API - see the "Creating a user" and "Deleting a user" sections of the SCIM server admin guide.
  *
  * @see <a href="https://github.com/keycloak/keycloak/issues/51343">Issue 51343</a>
+ * @see <a href="https://github.com/keycloak/keycloak/issues/51735">Issue 51735</a>
  */
 @KeycloakIntegrationTest(config = FederatedUserTest.FederatedUserServerConfig.class)
 public class FederatedUserTest extends AbstractScimTest {
@@ -95,6 +113,81 @@ public class FederatedUserTest extends AbstractScimTest {
         }
     }
 
+    /**
+     * When the federation provider does not intercept registration (sync registration disabled),
+     * SCIM user creation must behave exactly as if no federation provider was configured: the user
+     * is created locally and is fully manageable (found via GET/search, and deletable) regardless
+     * of the provider's import setting.
+     */
+    @Test
+    public void testCreateWithoutSyncRegistration() {
+        String federationComponentId = registerFederationProvider(false, false);
+        try {
+            User created = createScimUser("no-sync-user");
+            assertNotNull(created);
+            assertTrue(StorageId.isLocalStorage(created.getId()),
+                    "User should be created in local storage when the federation provider does not synchronize registrations");
+
+            assertNotNull(client.users().get(created.getId()), "Locally created user should be retrievable via GET");
+            assertThat(toUserNames(client.users().getAll()), hasItem("no-sync-user"));
+
+            client.users().delete(created.getId());
+            assertNull(client.users().get(created.getId()), "User should no longer be found after deletion");
+        } finally {
+            realm.admin().components().component(federationComponentId).remove();
+        }
+    }
+
+    /**
+     * When the federation provider synchronizes registrations and imports users, the local database
+     * row is created synchronously as part of the same call - there is no separate sync step - so the
+     * created user is immediately visible, searchable, and deletable via SCIM.
+     */
+    @Test
+    public void testCreateWithSyncRegistrationAndImportEnabled() {
+        String federationComponentId = registerFederationProvider(true, true);
+        try {
+            User created = createScimUser("sync-import-user");
+            assertNotNull(created);
+
+            User fetched = client.users().get(created.getId());
+            assertNotNull(fetched, "Federated user should be immediately visible via GET when import is enabled");
+            assertEquals("sync-import-user", fetched.getUserName());
+            assertThat(toUserNames(client.users().getAll()), hasItem("sync-import-user"));
+
+            client.users().delete(created.getId());
+            assertNull(client.users().get(created.getId()), "User should no longer be found after deletion");
+        } finally {
+            realm.admin().components().component(federationComponentId).remove();
+        }
+    }
+
+    /**
+     * When the federation provider synchronizes registrations but does not import users, SCIM user
+     * creation still succeeds (mirroring the regular Admin API), but the user is stored only in the
+     * external provider. As a result, the created user is unreachable via any subsequent SCIM
+     * operation: GET and search do not find it, and DELETE returns 404 - since the local-storage-only
+     * lookup used to resolve the user for deletion cannot find it either.
+     */
+    @Test
+    public void testCreateWithSyncRegistrationAndImportDisabled() {
+        String federationComponentId = registerFederationProvider(true, false);
+        try {
+            User created = createScimUser("sync-no-import-user");
+            assertNotNull(created, "Creation succeeds even though the user is not imported locally");
+            assertFalse(StorageId.isLocalStorage(created.getId()));
+
+            assertNull(client.users().get(created.getId()), "GET should not find a non-imported federated user");
+            assertThat(toUserNames(client.users().getAll()), not(hasItem("sync-no-import-user")));
+
+            ScimClientException exception = assertThrows(ScimClientException.class, () -> client.users().delete(created.getId()));
+            assertEquals(HttpStatus.SC_NOT_FOUND, exception.getError().getStatusInt(),
+                    "DELETE should return 404 for a non-imported federated user");
+        } finally {
+            realm.admin().components().component(federationComponentId).remove();
+        }
+    }
+
     private List<String> toUserNames(ListResponse<User> response) {
         return response.getResources().stream()
                 .map(User::getUserName)
@@ -109,14 +202,26 @@ public class FederatedUserTest extends AbstractScimTest {
         assertNotNull(user);
     }
 
+    private User createScimUser(String username) {
+        User user = new User();
+        user.setUserName(username);
+        user.setActive(true);
+        return client.users().create(user);
+    }
+
     private String registerFederationProvider() {
+        return registerFederationProvider(true, false);
+    }
+
+    private String registerFederationProvider(boolean syncRegistrations, boolean importEnabled) {
         ComponentRepresentation provider = new ComponentRepresentation();
         provider.setName("test-user-federation");
         provider.setProviderId(PROVIDER_ID);
         provider.setProviderType(UserStorageProvider.class.getName());
         provider.setConfig(new MultivaluedHashMap<String, String>());
         provider.getConfig().putSingle("priority", Integer.toString(0));
-        provider.getConfig().putSingle(IMPORT_ENABLED, Boolean.toString(false));
+        provider.getConfig().putSingle(IMPORT_ENABLED, Boolean.toString(importEnabled));
+        provider.getConfig().putSingle(LDAPConstants.SYNC_REGISTRATIONS, Boolean.toString(syncRegistrations));
 
         return ApiUtil.getCreatedId(realm.admin().components().add(provider));
     }

--- a/tests/custom-providers/src/main/java/org/keycloak/tests/providers/federation/UserMapStorage.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/tests/providers/federation/UserMapStorage.java
@@ -69,6 +69,7 @@ public class UserMapStorage implements UserLookupProvider, UserStorageProvider, 
     protected KeycloakSession session;
     protected EditMode editMode;
     private transient Boolean importEnabled;
+    private transient Boolean syncRegistrationsEnabled;
 
     public static final AtomicInteger allocations = new AtomicInteger(0);
     public static final AtomicInteger closings = new AtomicInteger(0);
@@ -219,6 +220,12 @@ public class UserMapStorage implements UserLookupProvider, UserStorageProvider, 
 
     @Override
     public UserModel addUser(RealmModel realm, String username) {
+        if (!isSyncRegistrationsEnabled()) {
+            // let UserStorageManager fall back to creating the user in local storage,
+            // mirroring LDAPStorageProvider.synchronizeRegistrations() returning false
+            return null;
+        }
+
         if (editMode == EditMode.READ_ONLY) {
             throw new ReadOnlyException("Federated storage is not writable");
         }
@@ -264,6 +271,14 @@ public class UserMapStorage implements UserLookupProvider, UserStorageProvider, 
     public void setImportEnabled(boolean flag) {
         importEnabled = flag;
         model.getConfig().putSingle(IMPORT_ENABLED, Boolean.toString(flag));
+    }
+
+    public boolean isSyncRegistrationsEnabled() {
+        if (syncRegistrationsEnabled == null) {
+            String val = model.getConfig().getFirst(LDAPConstants.SYNC_REGISTRATIONS);
+            syncRegistrationsEnabled = val == null || Boolean.parseBoolean(val);
+        }
+        return syncRegistrationsEnabled;
     }
 
     @Override

--- a/tests/custom-providers/src/main/java/org/keycloak/tests/providers/federation/UserMapStorageFactory.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/tests/providers/federation/UserMapStorageFactory.java
@@ -27,6 +27,7 @@ import org.keycloak.Config;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.LDAPConstants;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.storage.UserStorageProviderFactory;
 
@@ -46,6 +47,12 @@ public class UserMapStorageFactory implements UserStorageProviderFactory<UserMap
                 "This is some attribute",
                 ProviderConfigProperty.STRING_TYPE, null);
         configProperties.add(attr);
+
+        ProviderConfigProperty syncRegistrations = new ProviderConfigProperty(LDAPConstants.SYNC_REGISTRATIONS, "Sync Registrations",
+                "Whether new users should be added to this provider's backing store. When disabled, user creation falls "
+                        + "through to local storage, mirroring LDAPStorageProvider.synchronizeRegistrations().",
+                ProviderConfigProperty.BOOLEAN_TYPE, true);
+        configProperties.add(syncRegistrations);
     }
 
     private final Map<String, String> userPasswords = new ConcurrentHashMap<>();


### PR DESCRIPTION
SCIM POST /Users shares the same creation path as the Admin REST API (UserProfile.create() -> session.users().addUser()), so a user storage provider with sync registration enabled can create the user outside of local storage. If that provider does not import users, the created user becomes unreachable via subsequent SCIM GET/search/DELETE requests. This is accepted as a documented limitation of this version of the SCIM API rather than changed in code.

- Extend the custom-providers UserMapStorage test fixture with a SYNC_REGISTRATIONS gate (mirroring LDAPStorageProvider), defaulting to enabled to preserve existing behavior for current consumers.
- Add FederatedUserTest coverage for the three relevant variations: no sync registration (created locally), sync registration with import enabled (federated but immediately visible), and sync registration with import disabled (created but unreachable via SCIM).
- Document the limitation in the SCIM server admin guide's "Creating a user" and "Deleting a user" sections.

Closes #51735

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
