### PR TITLE
Use Locale.ROOT for password denylist case normalization

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProvider.java
@@ -1,5 +1,7 @@
 package org.keycloak.policy;
 
+import java.util.Locale;
+
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -45,7 +47,7 @@ public class DenylistPasswordPolicyProvider implements PasswordPolicyProvider {
 
     PasswordDenylist denylist = (FileBasedPasswordDenylist) policyConfig;
 
-    if (!denylist.contains(password.toLowerCase())) {
+    if (!denylist.contains(password.toLowerCase(Locale.ROOT))) {
       return null;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/DenylistPasswordPolicyProviderFactory.java
@@ -472,7 +472,7 @@ public class DenylistPasswordPolicyProviderFactory implements PasswordPolicyProv
 
         protected void insertPasswordsInto(BloomFilter<String> filter) throws IOException {
             try (BufferedReader br = newReader(path)) {
-                br.lines().map(String::toLowerCase).forEach(filter::put);
+                br.lines().map(s -> s.toLowerCase(Locale.ROOT)).forEach(filter::put);
             }
         }
 


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This PR makes password denylist / blacklist comparisons in root locale.

Without explicit locale the JVMs default locale is used. In Turkish locale `"I".toLowerCase()` returns `ı` instead of `i`. This could allow deny-listed password to pass the check. In practice this problem cannot be triggered, because Keycloak does not start under Turkish locale at all.

Fixes #52664