### PR TITLE
Do not leak organization/account existence during identity-first login

### DIFF
--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -59,8 +59,11 @@ import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.validation.Validation;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.Booleans;
+
+import org.jboss.logging.Logger;
 
 import static org.keycloak.authentication.AuthenticatorUtil.isSSOAuthentication;
 import static org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.USER_SET_BEFORE_USERNAME_PASSWORD_AUTH;
@@ -72,6 +75,8 @@ import static org.keycloak.organization.utils.Organizations.resolveHomeBroker;
 import static org.keycloak.utils.StringUtil.isBlank;
 
 public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
+
+    private static final Logger logger = Logger.getLogger(OrganizationAuthenticator.class);
 
     private final KeycloakSession session;
     private final WebAuthnConditionalUIAuthenticator webauthnAuth;
@@ -137,8 +142,8 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
 
         if (user == null && isBlank(username)) {
             initialChallenge(context, form -> {
-                form.addError(new FormMessage(UserModel.USERNAME, Messages.INVALID_USERNAME));
-                return form.createLoginUsername();
+                form.addError(new FormMessage(Validation.FIELD_PASSWORD, Messages.INVALID_USER));
+                return form.createLoginUsernamePassword();
             });
             return;
         }
@@ -192,11 +197,15 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         }
 
         if (tryRedirectBroker(context, organization, user, username, domain)) {
+            logger.debugf("Organization authenticator: auto-redirected to broker for organization %s (user known=%s)",
+                    organization.getAlias(), user != null);
             return;
         }
 
         if (user == null) {
-            unknownUserChallenge(context, organization, realm, domain != null);
+            logger.debugf("Organization authenticator: unknown user for organization %s, delegating to generic challenge", organization.getAlias());
+            unknownUserChallenge(context, organization, realm, username);
+
             return;
         }
 
@@ -324,6 +333,9 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             return true;
         }
 
+        logger.debugf("Organization authenticator: domain %s matched organization %s but no auto-redirect idp configured (idpAlias=%s, autoRedirect=%s)",
+                domain, organization.getAlias(), idpAlias, matching.isAutoRedirect());
+
         return false;
     }
 
@@ -346,7 +358,7 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         return user;
     }
 
-    private void unknownUserChallenge(AuthenticationFlowContext context, OrganizationModel organization, RealmModel realm, boolean domainMatch) {
+    private void unknownUserChallenge(AuthenticationFlowContext context, OrganizationModel organization, RealmModel realm, String username) {
         // the user does not exist and is authenticating in the scope of the organization, show the identity-first login page and the
         // public organization brokers for selection
         LoginFormsProvider form = context.form()
@@ -372,15 +384,18 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
                     return attributes;
                 });
 
-        if (domainMatch) {
-            form.addError(new FormMessage("Your email domain matches an organization but you don't have an account yet."));
-        }
-
         // user is null, setup webauthn data if enabled
         if (webauthnAuth.isPasskeysEnabled()) {
             webauthnAuth.fillContextForm(context);
         }
-        context.challenge(form.createLoginUsername());
+
+        if (username != null) {
+            AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+            authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
+            authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.USERNAME_HIDDEN, Boolean.TRUE.toString());
+        }
+
+        context.challenge(form.createLoginUsernamePassword());
     }
 
     private void initialChallenge(AuthenticationFlowContext context) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -60,6 +60,9 @@ public class LoginPage extends LanguageComboboxAwarePage {
     @FindBy(id = "rememberMe")
     private WebElement rememberMe;
 
+    @FindBy(id = "reset-login")
+    protected WebElement resetLoginButton;
+
     @FindBy(name = "login")
     protected WebElement submitButton;
 
@@ -154,6 +157,10 @@ public class LoginPage extends LanguageComboboxAwarePage {
         return !driver.findElements(By.id("username")).isEmpty();
     }
 
+    public boolean isAttemptedUsernameInputPresent() {
+        return !driver.findElements(By.id("kc-attempted-username")).isEmpty();
+    }
+
     public boolean isEmailInputPresent() {
         return !driver.findElements(By.id("email")).isEmpty();
     }
@@ -176,6 +183,10 @@ public class LoginPage extends LanguageComboboxAwarePage {
 
     public void cancel() {
         cancelButton.click();
+    }
+
+    public void resetLogin() {
+        resetLoginButton.click();
     }
 
     public String getInputError() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -110,11 +110,11 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
         openIdentityFirstLoginPage("user@neworg.org", false, null, false, false);
 
-        Assertions.assertTrue(loginPage.isUsernameInputPresent());
+        Assertions.assertTrue(loginPage.isAttemptedUsernameInputPresent());
         // registration link shown
         Assertions.assertTrue(loginPage.isRegisterLinkPresent());
-        // no need for password because the user does not exist
-        Assertions.assertFalse(loginPage.isPasswordInputPresent());
+        // password field shown regardless of whether the user exists, to avoid leaking user/org existence
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
         Assertions.assertFalse(loginPage.isSocialButtonPresent(idpRep.getAlias()));
     }
 
@@ -128,9 +128,11 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
         openIdentityFirstLoginPage("user@neworg.org", false, null, false, false);
 
-        Assertions.assertEquals("Your email domain matches an organization but you don't have an account yet.", loginPage.getError());
-        Assertions.assertTrue(loginPage.isUsernameInputPresent());
-        Assertions.assertFalse(loginPage.isPasswordInputPresent());
+        // no leaking error message that would reveal whether the domain matches an organization
+        Assertions.assertNull(loginPage.getError());
+        Assertions.assertTrue(loginPage.isAttemptedUsernameInputPresent());
+        // password field shown regardless of whether the user exists, to avoid leaking user/org existence
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
         Assertions.assertTrue(loginPage.isSocialButtonPresent(idpRep.getAlias()));
 
         // no self-registration link because the user should register through the broker
@@ -144,11 +146,53 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
         openIdentityFirstLoginPage("user@neworg.org", false, null, false, false);
 
-        Assertions.assertTrue(driver.getPageSource().contains("Your email domain matches an organization but you don't have an account yet."));
-        Assertions.assertTrue(loginPage.isUsernameInputPresent());
-        Assertions.assertFalse(loginPage.isPasswordInputPresent());
+        // no error message leaked at all (generic form, same as for an unmatched domain)
+        Assertions.assertNull(loginPage.getError());
+        Assertions.assertTrue(loginPage.isAttemptedUsernameInputPresent());
+        // password field shown regardless of whether the user exists, to avoid leaking user/org existence
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
         // self-registration link shown because there is no public broker and user can choose to register
         Assertions.assertTrue(loginPage.isRegisterLinkPresent());
+    }
+
+    @Test
+    public void testUnknownUserMatchingOrgDomainShowsGenericInvalidCredentialsError() {
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+        clearDomainRouting(organization);
+
+        openIdentityFirstLoginPage("user@neworg.org", false, null, false, false);
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
+
+        // attempt to log in as a user that does not exist; the resulting error must be the same
+        // generic invalid-credentials message shown for a known user with a wrong password, so that
+        // submitting credentials does not reveal whether the account (or the organization) exists
+        loginPage.login("some-password");
+        Assertions.assertEquals("Invalid username or password.", loginPage.getInputError());
+    }
+
+    @Test
+    public void testKnownUserWrongPasswordShowsGenericInvalidCredentialsError() {
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+        assertBrokerRegistration(organization, bc.getUserLogin(), bc.getUserEmail());
+
+        // set the user's credentials so that authenticating by password is offered
+        UserRepresentation user = managedRealm.admin().users().searchByEmail(bc.getUserEmail(), true).get(0);
+        AdminApiUtil.resetUserPassword(realmsResouce().realm(bc.consumerRealmName()).users().get(user.getId()), "updated-password", false);
+
+        // logout to force the user to authenticate again
+        UserRepresentation account = getUserRepresentation(bc.getUserEmail());
+        realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
+        realmsResouce().realm(bc.providerRealmName()).logoutAll();
+
+        oauth.client("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+        loginPage.loginUsername(bc.getUserEmail());
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
+
+        // attempt to log in with the wrong password; same generic error as for an unknown user
+        loginPage.login("wrong-password");
+        Assertions.assertEquals("Invalid username or password.", loginPage.getInputError());
     }
 
     @Test
@@ -822,14 +866,17 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
         openIdentityFirstLoginPage(bc.getUserEmail(), false, idp.getAlias(), false, false);
 
-        Assertions.assertFalse(loginPage.isPasswordInputPresent());
-        Assertions.assertTrue(driver.getPageSource().contains("Your email domain matches an organization but you don't have an account yet."));
+        // password field shown regardless of whether the user exists, to avoid leaking user/org existence
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
+        // no error message leaked at all (generic form, same as for an unmatched domain)
+        Assertions.assertNull(loginPage.getError());
         Assertions.assertTrue(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
 
         openIdentityFirstLoginPage(bc.getUserEmail(), false, idp.getAlias(), false, false);
 
-        Assertions.assertFalse(loginPage.isPasswordInputPresent());
-        Assertions.assertTrue(driver.getPageSource().contains("Your email domain matches an organization but you don't have an account yet."));
+        Assertions.assertTrue(loginPage.isPasswordInputPresent());
+        // no error message leaked at all (generic form, same as for an unmatched domain)
+        Assertions.assertNull(loginPage.getError());
         Assertions.assertTrue(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
     }
 
@@ -919,10 +966,10 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         // Test with subdomain - should NOT automatically redirect since wildcard is disabled
         // The subdomain email doesn't match the exact domain, so no redirect should occur
         String subdomainEmail = "user@sub.neworg.org";
-        
+
         // With exact match only, subdomain won't match, so user sees standard login
         openIdentityFirstLoginPage(subdomainEmail, false, null, false, false);
-        
+
         // Verify we're on the login page (no automatic redirect happened)
         assertTrue(driver.getCurrentUrl().contains("/realms/" + bc.consumerRealmName()));
     }
@@ -945,9 +992,9 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
         // Test with exact domain match - should still work
         openIdentityFirstLoginPage(bc.getUserEmail(), true, idp.getAlias(), false, false);
-        
+
         loginOrgIdp(bc.getUserEmail(), bc.getUserEmail(), true, true);
-        
+
         assertIsMember(bc.getUserEmail(), organization);
     }
 
@@ -1008,14 +1055,16 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         oauth.realm(bc.consumerRealmName());
         oauth.openLoginForm();
         loginPage.loginUsername("user@org-0.org");
-        Assertions.assertTrue(driver.getPageSource().contains("Your email domain matches an organization but you don't have an account yet."));
+        // no error message leaked at all (generic form, same as for an unmatched domain)
+        Assertions.assertNull(loginPage.getError());
         Assertions.assertTrue(loginPage.isSocialButtonPresent(org0Broker.getAlias()));
         Assertions.assertFalse(loginPage.isSocialButtonPresent(org1Broker.getAlias()));
 
         oauth.realm(bc.consumerRealmName());
         oauth.openLoginForm();
         loginPage.loginUsername("user@org-1.org");
-        Assertions.assertTrue(driver.getPageSource().contains("Your email domain matches an organization but you don't have an account yet."));
+        // no error message leaked at all (generic form, same as for an unmatched domain)
+        Assertions.assertNull(loginPage.getError());
         Assertions.assertTrue(loginPage.isSocialButtonPresent(org1Broker.getAlias()));
         Assertions.assertFalse(loginPage.isSocialButtonPresent(org0Broker.getAlias()));
     }
@@ -1288,9 +1337,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         assertTrue(loginPage.isSocialButtonPresent(orgIdp.getAlias()));
         assertFalse(loginPage.isSocialButtonPresent(realmIdp.getAlias()));
 
-        driver.navigate().back();
-        // chrome requires refresh, otherwise Sign in button is not active
-        driver.navigate().refresh();
+        loginPage.resetLogin();
 
         loginPage.loginUsername("test");
         // both realm and org idps because the user does not map to any organization


### PR DESCRIPTION
OrganizationAuthenticator no longer shows a distinct challenge (leaking message, username-only re-prompt, visible org broker) when an email domain matches an organization but no account exists. It now redirects to SSO when auto-redirect is configured, otherwise falls through to the same generic username/password form and generic invalid-credentials error used for unmatched domains and known users.

Closes #52676