### PR TITLE
fix: allow for non-optimized start to use truncated timestamps

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -88,7 +88,7 @@ public class Picocli {
 
     static final String PROVIDER_TIMESTAMP_ERROR = "A provider JAR was updated since the last build, please rebuild for this to be fully utilized.";
     static final String PROVIDER_TIMESTAMP_WARNING = "A provider jar has a different timestamp than when the optimized container image was created. If you are changing provider jars after the build, you must run another build to properly account for those modifications.";
-    static final String KC_PROVIDER_FILE_PREFIX = "kc.provider.file.";
+    public static final String KC_PROVIDER_FILE_PREFIX = "kc.provider.file.";
     public static final String ARG_PREFIX = "--";
     public static final String ARG_SHORT_PREFIX = "-";
     public static final String NO_PARAM_LABEL = "none";
@@ -376,7 +376,7 @@ public class Picocli {
         }
     }
 
-    static boolean timestampChanged(String oldValue, String newValue) {
+    public static boolean timestampChanged(String oldValue, String newValue) {
         long longNewValue = Long.valueOf(newValue);
         long longOldValue = Long.valueOf(oldValue);
         // docker commonly truncates to the second at runtime, so we'll allow that special case
@@ -873,7 +873,7 @@ public class Picocli {
         );
     }
 
-    private static void checkChangesInBuildOptions(TriConsumer<String, String, String> valueChanged) {
+    public void checkChangesInBuildOptions(TriConsumer<String, String, String> valueChanged) {
         var current = getNonPersistedBuildTimeOptions();
         var persisted = Configuration.getRawPersistedProperties();
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
@@ -20,6 +20,7 @@ package org.keycloak.quarkus.runtime.cli.command;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.Picocli;
@@ -63,17 +64,24 @@ public abstract class AbstractAutoBuildCommand extends AbstractCommand {
         return Optional.empty();
     }
 
-    static boolean requiresReAugmentation() {
+    boolean requiresReAugmentation() {
         Map<String, String> rawPersistedProperties = Configuration.getRawPersistedProperties();
         if (rawPersistedProperties.isEmpty()) {
             return true; // no build yet
         }
-        var current = Picocli.getNonPersistedBuildTimeOptions();
-
         // everything but the optimized value must match
-        String key = Configuration.KC_OPTIMIZED;
-        Optional.ofNullable(rawPersistedProperties.get(key)).ifPresentOrElse(value -> current.put(key, value), () -> current.remove(key));
-        return !rawPersistedProperties.equals(current);
+        AtomicBoolean changed = new AtomicBoolean();
+        picocli.checkChangesInBuildOptions((key, oldValue, newValue) -> {
+            if (key.equals(Configuration.KC_OPTIMIZED)) {
+                return;
+            }
+            if (key.startsWith(Picocli.KC_PROVIDER_FILE_PREFIX) && oldValue != null && newValue != null
+                    && !Picocli.timestampChanged(oldValue, newValue) && Configuration.isOptimized()) {
+                return;
+            }
+            changed.set(true);
+        });
+        return changed.get();
     }
 
     private void runReAugmentation() {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -33,6 +34,7 @@ import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.KeycloakMain;
 import org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand;
 import org.keycloak.quarkus.runtime.configuration.AbstractConfigurationTest;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.ManagementPropertyMappers;
@@ -749,6 +751,48 @@ public class PicocliTest extends AbstractConfigurationTest {
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
         assertEquals(nonRunningPicocli.getErrString(), CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertTrue(nonRunningPicocli.getOutString().contains(Picocli.PROVIDER_TIMESTAMP_WARNING));
+    }
+    
+    @Test
+    public void testStartNotOptimizedProviderUnchanged() {
+        Path conf = Paths.get("src/test/resources/");
+        Path tmp = Paths.get("target/home-trunc-ts");
+        Environment.setHomeDir(tmp);
+        try {
+            FileUtils.copyDirectory(conf.toFile(), tmp.toFile());
+            
+            Path path = tmp.resolve("providers/some.jar");
+            
+            // make sure the last modified time has millis
+            if (Files.getLastModifiedTime(path).toMillis() % 1000 == 0) {
+                Files.setLastModifiedTime(path, FileTime.fromMillis(Files.getLastModifiedTime(path).toMillis() + 1));
+            }
+            
+            var nonRunningPicocli = build("build", "--db=dev-file");
+            var buildProps = (Map)nonRunningPicocli.getBuildProps();
+            
+            // after the build truncate - like docker or a zip
+            Files.setLastModifiedTime(path, FileTime.fromMillis(Files.getLastModifiedTime(path).toMillis() / 1000 * 1000));
+            
+            nonRunningPicocli = pseudoLaunch("start", "--http-enabled=true", "--hostname-strict=false", "--db=dev-file");
+            
+            // start with no other changes should be fine
+            assertEquals(nonRunningPicocli.getErrString(), CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+            assertFalse(nonRunningPicocli.getOutString().contains(Picocli.PROVIDER_TIMESTAMP_WARNING));
+
+            // start with non-optimized, now a rebuild is required
+            onAfter();
+            buildProps.remove(Configuration.KC_OPTIMIZED);
+            Environment.setHomeDir(tmp);
+            addPersistedConfigValues(buildProps);
+            Environment.setRebuildCheck(true);
+            nonRunningPicocli = pseudoLaunch("start", "--http-enabled=true", "--hostname-strict=false", "--db=dev-file");
+            assertEquals(nonRunningPicocli.getErrString(), AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            Environment.setHomeDir(conf);
+        }
     }
 
     @Test


### PR DESCRIPTION
closes: #51701 

Narrowly addresses the user issue. I recall we had previous discussions where we didn't want to simply truncate to seconds on the provider jars, but this is starting to get a little involved so I'd be open to doing that as well.

The idea here is that either with a zip or docker create an optimized distribution, then run a start command without --optimized and it would still use the current optimized augmentation if the only thing that differs are that the current timestamps are truncated.



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
