### PR TITLE
Cross-check if testcontainer reuse is enabled in the environment

### DIFF
--- a/test-framework/docs/RUNNING_TESTS.md
+++ b/test-framework/docs/RUNNING_TESTS.md
@@ -80,7 +80,10 @@ tests faster.
 
 To enable re-use use the `KC_TEST_DATABASE_REUSE=true` option. 
 
-For containers, you also have to [enable reuse for Testcontainers](https://java.testcontainers.org/features/reuse/) (`TESTCONTAINERS_REUSE_ENABLE=true`). 
+For containers, you also have to [enable reuse for Testcontainers](https://java.testcontainers.org/features/reuse/).
+Add `testcontainers.reuse.enable=true` to `~/.testcontainers.properties`, or set the environment variable
+`TESTCONTAINERS_REUSE_ENABLE=true`. Note that this must be a real environment variable — putting it in `.env.test`
+has no effect because Testcontainers reads `System.getenv()` directly.
 
 ### Remote Database
 

--- a/test-framework/test-containers/src/main/java/org/keycloak/testframework/database/AbstractContainerTestDatabase.java
+++ b/test-framework/test-containers/src/main/java/org/keycloak/testframework/database/AbstractContainerTestDatabase.java
@@ -11,6 +11,7 @@ import org.keycloak.testframework.logging.JBossContainerLogConsumer;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 public abstract class AbstractContainerTestDatabase implements TestDatabase {
 
@@ -29,6 +30,14 @@ public abstract class AbstractContainerTestDatabase implements TestDatabase {
             this.reuse = false;
         } else {
             this.reuse = reuseConfigured;
+        }
+
+        if (reuse && !TestcontainersConfiguration.getInstance().environmentSupportsReuse()) {
+            throw new RuntimeException(
+                    "KC_TEST_DATABASE_REUSE is enabled, but testcontainers reuse is not configured. " +
+                    "Set testcontainers.reuse.enable=true in ~/.testcontainers.properties " +
+                    "or set the environment variable TESTCONTAINERS_REUSE_ENABLE=true. " +
+                    "Note: TESTCONTAINERS_REUSE_ENABLE must be a real environment variable, not a .env.test entry.");
         }
 
         container = createContainer();


### PR DESCRIPTION
Closes #52710

## Summary

When `KC_TEST_DATABASE_REUSE=true` is set but Testcontainers reuse is not enabled at the library level, the container silently starts fresh every run. This PR adds a fail-fast check that throws a clear error message before the container is created.

## Changes

- **`AbstractContainerTestDatabase.start()`**: After determining `reuse=true`, checks `TestcontainersConfiguration.getInstance().environmentSupportsReuse()`. If it returns `false`, throws a `RuntimeException` with instructions on how to enable reuse.
- **`RUNNING_TESTS.md`**: Clarifies that `TESTCONTAINERS_REUSE_ENABLE` must be a real environment variable or set in `~/.testcontainers.properties` — putting it in `.env.test` has no effect because Testcontainers reads `System.getenv()` directly, not SmallRye Config.

## Decisions

- **Fail-fast with `RuntimeException`** rather than logging a warning and falling back to non-reuse. A silent fallback is exactly the current behavior that makes this hard to diagnose. Failing immediately surfaces the misconfiguration.
- **No unit test**: The check depends on `TestcontainersConfiguration.getInstance()` which reads `~/.testcontainers.properties` and `System.getenv()` — neither can be reliably controlled in a unit test without mocking. The check is 4 lines of straightforward code; manual verification is sufficient.

## Assumptions

- `TestcontainersConfiguration.getInstance().environmentSupportsReuse()` is a stable public API in Testcontainers. It has been available since Testcontainers 1.x and is the canonical way to check reuse support.